### PR TITLE
Update rook.io CRD

### DIFF
--- a/ceph.rook.io/cephblockpool_v1.json
+++ b/ceph.rook.io/cephblockpool_v1.json
@@ -41,6 +41,10 @@
           "nullable": true,
           "type": "string"
         },
+        "enableCrushUpdates": {
+          "description": "Allow rook operator to change the pool CRUSH tunables once the pool is created",
+          "type": "boolean"
+        },
         "enableRBDStats": {
           "description": "EnableRBDStats is used to enable gathering of statistics for all RBD images in the pool",
           "type": "boolean"
@@ -295,7 +299,7 @@
           "type": "object"
         },
         "mirroringInfo": {
-          "description": "MirroringInfoSpec is the status of the pool mirroring",
+          "description": "MirroringInfoSpec is the status of the pool/radosnamespace mirroring",
           "properties": {
             "details": {
               "type": "string"
@@ -350,7 +354,7 @@
           "additionalProperties": false
         },
         "mirroringStatus": {
-          "description": "MirroringStatusSpec is the status of the pool mirroring",
+          "description": "MirroringStatusSpec is the status of the pool/radosNamespace mirroring",
           "properties": {
             "details": {
               "description": "Details contains potential status errors",
@@ -431,6 +435,10 @@
         "phase": {
           "description": "ConditionType represent a resource's status",
           "type": "string"
+        },
+        "poolID": {
+          "description": "optional",
+          "type": "integer"
         },
         "snapshotScheduleStatus": {
           "description": "SnapshotScheduleStatusSpec is the status of the snapshot schedule",

--- a/ceph.rook.io/cephblockpoolradosnamespace_v1.json
+++ b/ceph.rook.io/cephblockpoolradosnamespace_v1.json
@@ -25,6 +25,52 @@
             }
           ]
         },
+        "mirroring": {
+          "description": "Mirroring configuration of CephBlockPoolRadosNamespace",
+          "properties": {
+            "mode": {
+              "description": "Mode is the mirroring mode; either pool or image",
+              "enum": [
+                "",
+                "pool",
+                "image"
+              ],
+              "type": "string"
+            },
+            "remoteNamespace": {
+              "description": "RemoteNamespace is the name of the CephBlockPoolRadosNamespace on the secondary cluster CephBlockPool",
+              "type": "string"
+            },
+            "snapshotSchedules": {
+              "description": "SnapshotSchedules is the scheduling of snapshot for mirrored images",
+              "items": {
+                "description": "SnapshotScheduleSpec represents the snapshot scheduling settings of a mirrored pool",
+                "properties": {
+                  "interval": {
+                    "description": "Interval represent the periodicity of the snapshot.",
+                    "type": "string"
+                  },
+                  "path": {
+                    "description": "Path is the path to snapshot, only valid for CephFS",
+                    "type": "string"
+                  },
+                  "startTime": {
+                    "description": "StartTime indicates when to start the snapshot",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "mode"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
         "name": {
           "description": "The name of the CephBlockPoolRadosNamespaceSpec namespace. If not set, the default is the name of the CR.",
           "type": "string",
@@ -52,9 +98,200 @@
           "nullable": true,
           "type": "object"
         },
+        "mirroringInfo": {
+          "description": "MirroringInfoSpec is the status of the pool/radosnamespace mirroring",
+          "properties": {
+            "details": {
+              "type": "string"
+            },
+            "lastChanged": {
+              "type": "string"
+            },
+            "lastChecked": {
+              "type": "string"
+            },
+            "mode": {
+              "description": "Mode is the mirroring mode",
+              "type": "string"
+            },
+            "peers": {
+              "description": "Peers are the list of peer sites connected to that cluster",
+              "items": {
+                "description": "PeersSpec contains peer details",
+                "properties": {
+                  "client_name": {
+                    "description": "ClientName is the CephX user used to connect to the peer",
+                    "type": "string"
+                  },
+                  "direction": {
+                    "description": "Direction is the peer mirroring direction",
+                    "type": "string"
+                  },
+                  "mirror_uuid": {
+                    "description": "MirrorUUID is the mirror UUID",
+                    "type": "string"
+                  },
+                  "site_name": {
+                    "description": "SiteName is the current site name",
+                    "type": "string"
+                  },
+                  "uuid": {
+                    "description": "UUID is the peer UUID",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "site_name": {
+              "description": "SiteName is the current site name",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "mirroringStatus": {
+          "description": "MirroringStatusSpec is the status of the pool/radosNamespace mirroring",
+          "properties": {
+            "details": {
+              "description": "Details contains potential status errors",
+              "type": "string"
+            },
+            "lastChanged": {
+              "description": "LastChanged is the last time time the status last changed",
+              "type": "string"
+            },
+            "lastChecked": {
+              "description": "LastChecked is the last time time the status was checked",
+              "type": "string"
+            },
+            "summary": {
+              "description": "Summary is the mirroring status summary",
+              "properties": {
+                "daemon_health": {
+                  "description": "DaemonHealth is the health of the mirroring daemon",
+                  "type": "string"
+                },
+                "health": {
+                  "description": "Health is the mirroring health",
+                  "type": "string"
+                },
+                "image_health": {
+                  "description": "ImageHealth is the health of the mirrored image",
+                  "type": "string"
+                },
+                "states": {
+                  "description": "States is the various state for all mirrored images",
+                  "nullable": true,
+                  "properties": {
+                    "error": {
+                      "description": "Error is when the mirroring state is errored",
+                      "type": "integer"
+                    },
+                    "replaying": {
+                      "description": "Replaying is when the replay of the mirroring journal is on-going",
+                      "type": "integer"
+                    },
+                    "starting_replay": {
+                      "description": "StartingReplay is when the replay of the mirroring journal starts",
+                      "type": "integer"
+                    },
+                    "stopped": {
+                      "description": "Stopped is when the mirroring state is stopped",
+                      "type": "integer"
+                    },
+                    "stopping_replay": {
+                      "description": "StopReplaying is when the replay of the mirroring journal stops",
+                      "type": "integer"
+                    },
+                    "syncing": {
+                      "description": "Syncing is when the image is syncing",
+                      "type": "integer"
+                    },
+                    "unknown": {
+                      "description": "Unknown is when the mirroring state is unknown",
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
         "phase": {
           "description": "ConditionType represent a resource's status",
           "type": "string"
+        },
+        "snapshotScheduleStatus": {
+          "description": "SnapshotScheduleStatusSpec is the status of the snapshot schedule",
+          "properties": {
+            "details": {
+              "description": "Details contains potential status errors",
+              "type": "string"
+            },
+            "lastChanged": {
+              "description": "LastChanged is the last time time the status last changed",
+              "type": "string"
+            },
+            "lastChecked": {
+              "description": "LastChecked is the last time time the status was checked",
+              "type": "string"
+            },
+            "snapshotSchedules": {
+              "description": "SnapshotSchedules is the list of snapshots scheduled",
+              "items": {
+                "description": "SnapshotSchedulesSpec is the list of snapshot scheduled for images in a pool",
+                "properties": {
+                  "image": {
+                    "description": "Image is the mirrored image",
+                    "type": "string"
+                  },
+                  "items": {
+                    "description": "Items is the list schedules times for a given snapshot",
+                    "items": {
+                      "description": "SnapshotSchedule is a schedule",
+                      "properties": {
+                        "interval": {
+                          "description": "Interval is the interval in which snapshots will be taken",
+                          "type": "string"
+                        },
+                        "start_time": {
+                          "description": "StartTime is the snapshot starting time",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
+                  "namespace": {
+                    "description": "Namespace is the RADOS namespace the image is part of",
+                    "type": "string"
+                  },
+                  "pool": {
+                    "description": "Pool is the pool name",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "nullable": true,
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
         }
       },
       "type": "object",

--- a/ceph.rook.io/cephcluster_v1.json
+++ b/ceph.rook.io/cephcluster_v1.json
@@ -342,14 +342,15 @@
                     "description": "Probe describes a health check to be performed against a container to determine whether it is\nalive or ready to receive traffic.",
                     "properties": {
                       "exec": {
-                        "description": "Exec specifies the action to take.",
+                        "description": "Exec specifies a command to execute in the container.",
                         "properties": {
                           "command": {
                             "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
                             "items": {
                               "type": "string"
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           }
                         },
                         "type": "object",
@@ -361,7 +362,7 @@
                         "type": "integer"
                       },
                       "grpc": {
-                        "description": "GRPC specifies an action involving a GRPC port.",
+                        "description": "GRPC specifies a GRPC HealthCheckRequest.",
                         "properties": {
                           "port": {
                             "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
@@ -369,7 +370,8 @@
                             "type": "integer"
                           },
                           "service": {
-                            "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                            "default": "",
+                            "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
                             "type": "string"
                           }
                         },
@@ -380,7 +382,7 @@
                         "additionalProperties": false
                       },
                       "httpGet": {
-                        "description": "HTTPGet specifies the http request to perform.",
+                        "description": "HTTPGet specifies an HTTP GET request to perform.",
                         "properties": {
                           "host": {
                             "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
@@ -407,7 +409,8 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "path": {
                             "description": "Path to access on the HTTP server.",
@@ -452,7 +455,7 @@
                         "type": "integer"
                       },
                       "tcpSocket": {
-                        "description": "TCPSocket specifies an action involving a TCP port.",
+                        "description": "TCPSocket specifies a connection to a TCP port.",
                         "properties": {
                           "host": {
                             "description": "Optional: Host name to connect to, defaults to the pod IP.",
@@ -509,14 +512,15 @@
                     "description": "Probe describes a health check to be performed against a container to determine whether it is\nalive or ready to receive traffic.",
                     "properties": {
                       "exec": {
-                        "description": "Exec specifies the action to take.",
+                        "description": "Exec specifies a command to execute in the container.",
                         "properties": {
                           "command": {
                             "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
                             "items": {
                               "type": "string"
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           }
                         },
                         "type": "object",
@@ -528,7 +532,7 @@
                         "type": "integer"
                       },
                       "grpc": {
-                        "description": "GRPC specifies an action involving a GRPC port.",
+                        "description": "GRPC specifies a GRPC HealthCheckRequest.",
                         "properties": {
                           "port": {
                             "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
@@ -536,7 +540,8 @@
                             "type": "integer"
                           },
                           "service": {
-                            "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                            "default": "",
+                            "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
                             "type": "string"
                           }
                         },
@@ -547,7 +552,7 @@
                         "additionalProperties": false
                       },
                       "httpGet": {
-                        "description": "HTTPGet specifies the http request to perform.",
+                        "description": "HTTPGet specifies an HTTP GET request to perform.",
                         "properties": {
                           "host": {
                             "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
@@ -574,7 +579,8 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "path": {
                             "description": "Path to access on the HTTP server.",
@@ -619,7 +625,7 @@
                         "type": "integer"
                       },
                       "tcpSocket": {
-                        "description": "TCPSocket specifies an action involving a TCP port.",
+                        "description": "TCPSocket specifies a connection to a TCP port.",
                         "properties": {
                           "host": {
                             "description": "Optional: Host name to connect to, defaults to the pod IP.",
@@ -747,6 +753,7 @@
                           "",
                           "crush-compat",
                           "upmap",
+                          "read",
                           "upmap-read"
                         ],
                         "type": "string"
@@ -849,7 +856,8 @@
                                 "items": {
                                   "type": "string"
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "dataSource": {
                                 "description": "dataSource field can be used to specify either:\n* An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)\n* An existing PVC (PersistentVolumeClaim)\nIf the provisioner or an external controller can support the specified data source,\nit will create a new volume based on the contents of the specified data source.\nWhen the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,\nand dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.\nIf the namespace is specified, then dataSourceRef will not be copied to dataSource.",
@@ -962,7 +970,8 @@
                                           "items": {
                                             "type": "string"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       },
                                       "required": [
@@ -972,7 +981,8 @@
                                       "type": "object",
                                       "additionalProperties": false
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "matchLabels": {
                                     "additionalProperties": {
@@ -991,7 +1001,7 @@
                                 "type": "string"
                               },
                               "volumeAttributesClassName": {
-                                "description": "volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.\nIf specified, the CSI driver will create or update the volume with the attributes defined\nin the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,\nit can be changed after the claim is created. An empty string value means that no VolumeAttributesClass\nwill be applied to the claim but it's not allowed to reset this field to empty string once it is set.\nIf unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass\nwill be set by the persistentvolume controller if it exists.\nIf the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be\nset to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource\nexists.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#volumeattributesclass\n(Alpha) Using this field requires the VolumeAttributesClass feature gate to be enabled.",
+                                "description": "volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.\nIf specified, the CSI driver will create or update the volume with the attributes defined\nin the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,\nit can be changed after the claim is created. An empty string value means that no VolumeAttributesClass\nwill be applied to the claim but it's not allowed to reset this field to empty string once it is set.\nIf unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass\nwill be set by the persistentvolume controller if it exists.\nIf the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be\nset to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource\nexists.\nMore info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/\n(Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).",
                                 "type": "string"
                               },
                               "volumeMode": {
@@ -1064,7 +1074,8 @@
                       "items": {
                         "type": "string"
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     },
                     "dataSource": {
                       "description": "dataSource field can be used to specify either:\n* An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)\n* An existing PVC (PersistentVolumeClaim)\nIf the provisioner or an external controller can support the specified data source,\nit will create a new volume based on the contents of the specified data source.\nWhen the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,\nand dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.\nIf the namespace is specified, then dataSourceRef will not be copied to dataSource.",
@@ -1177,7 +1188,8 @@
                                 "items": {
                                   "type": "string"
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               }
                             },
                             "required": [
@@ -1187,7 +1199,8 @@
                             "type": "object",
                             "additionalProperties": false
                           },
-                          "type": "array"
+                          "type": "array",
+                          "x-kubernetes-list-type": "atomic"
                         },
                         "matchLabels": {
                           "additionalProperties": {
@@ -1206,7 +1219,7 @@
                       "type": "string"
                     },
                     "volumeAttributesClassName": {
-                      "description": "volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.\nIf specified, the CSI driver will create or update the volume with the attributes defined\nin the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,\nit can be changed after the claim is created. An empty string value means that no VolumeAttributesClass\nwill be applied to the claim but it's not allowed to reset this field to empty string once it is set.\nIf unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass\nwill be set by the persistentvolume controller if it exists.\nIf the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be\nset to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource\nexists.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#volumeattributesclass\n(Alpha) Using this field requires the VolumeAttributesClass feature gate to be enabled.",
+                      "description": "volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.\nIf specified, the CSI driver will create or update the volume with the attributes defined\nin the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,\nit can be changed after the claim is created. An empty string value means that no VolumeAttributesClass\nwill be applied to the claim but it's not allowed to reset this field to empty string once it is set.\nIf unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass\nwill be set by the persistentvolume controller if it exists.\nIf the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be\nset to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource\nexists.\nMore info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/\n(Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).",
                       "type": "string"
                     },
                     "volumeMode": {
@@ -1281,7 +1294,8 @@
                             "items": {
                               "type": "string"
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "dataSource": {
                             "description": "dataSource field can be used to specify either:\n* An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)\n* An existing PVC (PersistentVolumeClaim)\nIf the provisioner or an external controller can support the specified data source,\nit will create a new volume based on the contents of the specified data source.\nWhen the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,\nand dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.\nIf the namespace is specified, then dataSourceRef will not be copied to dataSource.",
@@ -1394,7 +1408,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -1404,7 +1419,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchLabels": {
                                 "additionalProperties": {
@@ -1423,7 +1439,7 @@
                             "type": "string"
                           },
                           "volumeAttributesClassName": {
-                            "description": "volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.\nIf specified, the CSI driver will create or update the volume with the attributes defined\nin the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,\nit can be changed after the claim is created. An empty string value means that no VolumeAttributesClass\nwill be applied to the claim but it's not allowed to reset this field to empty string once it is set.\nIf unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass\nwill be set by the persistentvolume controller if it exists.\nIf the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be\nset to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource\nexists.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#volumeattributesclass\n(Alpha) Using this field requires the VolumeAttributesClass feature gate to be enabled.",
+                            "description": "volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.\nIf specified, the CSI driver will create or update the volume with the attributes defined\nin the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,\nit can be changed after the claim is created. An empty string value means that no VolumeAttributesClass\nwill be applied to the claim but it's not allowed to reset this field to empty string once it is set.\nIf unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass\nwill be set by the persistentvolume controller if it exists.\nIf the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be\nset to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource\nexists.\nMore info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/\n(Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).",
                             "type": "string"
                           },
                           "volumeMode": {
@@ -1471,6 +1487,25 @@
               "description": "Enabled determines whether to create the prometheus rules for the ceph cluster. If true, the prometheus\ntypes must exist or the creation will fail. Default is false.",
               "type": "boolean"
             },
+            "exporter": {
+              "description": "Ceph exporter configuration",
+              "properties": {
+                "perfCountersPrioLimit": {
+                  "default": 5,
+                  "description": "Only performance counters greater than or equal to this option are fetched",
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "statsPeriodSeconds": {
+                  "default": 5,
+                  "description": "Time to wait before sending requests again to exporter server (seconds)",
+                  "format": "int64",
+                  "type": "integer"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
             "externalMgrEndpoints": {
               "description": "ExternalMgrEndpoints points to an existing Ceph prometheus exporter endpoint",
               "items": {
@@ -1496,7 +1531,7 @@
                         "type": "string"
                       },
                       "fieldPath": {
-                        "description": "If referring to a piece of an object instead of an entire object, this string\nshould contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].\nFor example, if the object reference is to a container within a pod, this would take on a value like:\n\"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered\nthe event) or if no container name is specified \"spec.containers[2]\" (container with\nindex 2 in this pod). This syntax is chosen only to have some well-defined way of\nreferencing a part of an object.\nTODO: this design is not final and this field is subject to change in the future.",
+                        "description": "If referring to a piece of an object instead of an entire object, this string\nshould contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].\nFor example, if the object reference is to a container within a pod, this would take on a value like:\n\"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered\nthe event) or if no container name is specified \"spec.containers[2]\" (container with\nindex 2 in this pod). This syntax is chosen only to have some well-defined way of\nreferencing a part of an object.",
                         "type": "string"
                       },
                       "kind": {
@@ -1570,7 +1605,7 @@
                 "cluster": {
                   "description": "Cluster defines a list of CIDRs to use for Ceph cluster network communication.",
                   "items": {
-                    "description": "An IPv4 or IPv6 network CIDR.\n\n\nThis naive kubebuilder regex provides immediate feedback for some typos and for a common problem\ncase where the range spec is forgotten (e.g., /24). Rook does in-depth validation in code.",
+                    "description": "An IPv4 or IPv6 network CIDR.\n\nThis naive kubebuilder regex provides immediate feedback for some typos and for a common problem\ncase where the range spec is forgotten (e.g., /24). Rook does in-depth validation in code.",
                     "pattern": "^[0-9a-fA-F:.]{2,}\\/[0-9]{1,3}$",
                     "type": "string"
                   },
@@ -1579,7 +1614,7 @@
                 "public": {
                   "description": "Public defines a list of CIDRs to use for Ceph public network communication.",
                   "items": {
-                    "description": "An IPv4 or IPv6 network CIDR.\n\n\nThis naive kubebuilder regex provides immediate feedback for some typos and for a common problem\ncase where the range spec is forgotten (e.g., /24). Rook does in-depth validation in code.",
+                    "description": "An IPv4 or IPv6 network CIDR.\n\nThis naive kubebuilder regex provides immediate feedback for some typos and for a common problem\ncase where the range spec is forgotten (e.g., /24). Rook does in-depth validation in code.",
                     "pattern": "^[0-9a-fA-F:.]{2,}\\/[0-9]{1,3}$",
                     "type": "string"
                   },
@@ -1677,7 +1712,7 @@
               "additionalProperties": {
                 "type": "string"
               },
-              "description": "Selectors define NetworkAttachmentDefinitions to be used for Ceph public and/or cluster\nnetworks when the \"multus\" network provider is used. This config section is not used for\nother network providers.\n\n\nValid keys are \"public\" and \"cluster\". Refer to Ceph networking documentation for more:\nhttps://docs.ceph.com/en/reef/rados/configuration/network-config-ref/\n\n\nRefer to Multus network annotation documentation for help selecting values:\nhttps://github.com/k8snetworkplumbingwg/multus-cni/blob/master/docs/how-to-use.md#run-pod-with-network-annotation\n\n\nRook will make a best-effort attempt to automatically detect CIDR address ranges for given\nnetwork attachment definitions. Rook's methods are robust but may be imprecise for\nsufficiently complicated networks. Rook's auto-detection process obtains a new IP address\nlease for each CephCluster reconcile. If Rook fails to detect, incorrectly detects, only\npartially detects, or if underlying networks do not support reusing old IP addresses, it is\nbest to use the 'addressRanges' config section to specify CIDR ranges for the Ceph cluster.\n\n\nAs a contrived example, one can use a theoretical Kubernetes-wide network for Ceph client\ntraffic and a theoretical Rook-only network for Ceph replication traffic as shown:\n  selectors:\n    public: \"default/cluster-fast-net\"\n    cluster: \"rook-ceph/ceph-backend-net\"",
+              "description": "Selectors define NetworkAttachmentDefinitions to be used for Ceph public and/or cluster\nnetworks when the \"multus\" network provider is used. This config section is not used for\nother network providers.\n\nValid keys are \"public\" and \"cluster\". Refer to Ceph networking documentation for more:\nhttps://docs.ceph.com/en/latest/rados/configuration/network-config-ref/\n\nRefer to Multus network annotation documentation for help selecting values:\nhttps://github.com/k8snetworkplumbingwg/multus-cni/blob/master/docs/how-to-use.md#run-pod-with-network-annotation\n\nRook will make a best-effort attempt to automatically detect CIDR address ranges for given\nnetwork attachment definitions. Rook's methods are robust but may be imprecise for\nsufficiently complicated networks. Rook's auto-detection process obtains a new IP address\nlease for each CephCluster reconcile. If Rook fails to detect, incorrectly detects, only\npartially detects, or if underlying networks do not support reusing old IP addresses, it is\nbest to use the 'addressRanges' config section to specify CIDR ranges for the Ceph cluster.\n\nAs a contrived example, one can use a theoretical Kubernetes-wide network for Ceph client\ntraffic and a theoretical Rook-only network for Ceph replication traffic as shown:\n  selectors:\n    public: \"default/cluster-fast-net\"\n    cluster: \"rook-ceph/ceph-backend-net\"",
               "nullable": true,
               "type": "object"
             }
@@ -1719,7 +1754,8 @@
                                     "items": {
                                       "type": "string"
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   }
                                 },
                                 "required": [
@@ -1729,7 +1765,8 @@
                                 "type": "object",
                                 "additionalProperties": false
                               },
-                              "type": "array"
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "matchFields": {
                               "items": {
@@ -1744,7 +1781,8 @@
                                     "items": {
                                       "type": "string"
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   }
                                 },
                                 "required": [
@@ -1754,7 +1792,8 @@
                                 "type": "object",
                                 "additionalProperties": false
                               },
-                              "type": "array"
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
                             }
                           },
                           "type": "object",
@@ -1773,7 +1812,8 @@
                       "type": "object",
                       "additionalProperties": false
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   },
                   "requiredDuringSchedulingIgnoredDuringExecution": {
                     "properties": {
@@ -1793,7 +1833,8 @@
                                     "items": {
                                       "type": "string"
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   }
                                 },
                                 "required": [
@@ -1803,7 +1844,8 @@
                                 "type": "object",
                                 "additionalProperties": false
                               },
-                              "type": "array"
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "matchFields": {
                               "items": {
@@ -1818,7 +1860,8 @@
                                     "items": {
                                       "type": "string"
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   }
                                 },
                                 "required": [
@@ -1828,14 +1871,16 @@
                                 "type": "object",
                                 "additionalProperties": false
                               },
-                              "type": "array"
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
                             }
                           },
                           "type": "object",
                           "x-kubernetes-map-type": "atomic",
                           "additionalProperties": false
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       }
                     },
                     "required": [
@@ -1871,7 +1916,8 @@
                                         "items": {
                                           "type": "string"
                                         },
-                                        "type": "array"
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
                                       }
                                     },
                                     "required": [
@@ -1881,7 +1927,8 @@
                                     "type": "object",
                                     "additionalProperties": false
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "matchLabels": {
                                   "additionalProperties": {
@@ -1923,7 +1970,8 @@
                                         "items": {
                                           "type": "string"
                                         },
-                                        "type": "array"
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
                                       }
                                     },
                                     "required": [
@@ -1933,7 +1981,8 @@
                                     "type": "object",
                                     "additionalProperties": false
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "matchLabels": {
                                   "additionalProperties": {
@@ -1950,7 +1999,8 @@
                               "items": {
                                 "type": "string"
                               },
-                              "type": "array"
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "topologyKey": {
                               "type": "string"
@@ -1974,7 +2024,8 @@
                       "type": "object",
                       "additionalProperties": false
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   },
                   "requiredDuringSchedulingIgnoredDuringExecution": {
                     "items": {
@@ -1994,7 +2045,8 @@
                                     "items": {
                                       "type": "string"
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   }
                                 },
                                 "required": [
@@ -2004,7 +2056,8 @@
                                 "type": "object",
                                 "additionalProperties": false
                               },
-                              "type": "array"
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "matchLabels": {
                               "additionalProperties": {
@@ -2046,7 +2099,8 @@
                                     "items": {
                                       "type": "string"
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   }
                                 },
                                 "required": [
@@ -2056,7 +2110,8 @@
                                 "type": "object",
                                 "additionalProperties": false
                               },
-                              "type": "array"
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "matchLabels": {
                               "additionalProperties": {
@@ -2073,7 +2128,8 @@
                           "items": {
                             "type": "string"
                           },
-                          "type": "array"
+                          "type": "array",
+                          "x-kubernetes-list-type": "atomic"
                         },
                         "topologyKey": {
                           "type": "string"
@@ -2085,7 +2141,8 @@
                       "type": "object",
                       "additionalProperties": false
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   }
                 },
                 "type": "object",
@@ -2113,7 +2170,8 @@
                                         "items": {
                                           "type": "string"
                                         },
-                                        "type": "array"
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
                                       }
                                     },
                                     "required": [
@@ -2123,7 +2181,8 @@
                                     "type": "object",
                                     "additionalProperties": false
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "matchLabels": {
                                   "additionalProperties": {
@@ -2165,7 +2224,8 @@
                                         "items": {
                                           "type": "string"
                                         },
-                                        "type": "array"
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
                                       }
                                     },
                                     "required": [
@@ -2175,7 +2235,8 @@
                                     "type": "object",
                                     "additionalProperties": false
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "matchLabels": {
                                   "additionalProperties": {
@@ -2192,7 +2253,8 @@
                               "items": {
                                 "type": "string"
                               },
-                              "type": "array"
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "topologyKey": {
                               "type": "string"
@@ -2216,7 +2278,8 @@
                       "type": "object",
                       "additionalProperties": false
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   },
                   "requiredDuringSchedulingIgnoredDuringExecution": {
                     "items": {
@@ -2236,7 +2299,8 @@
                                     "items": {
                                       "type": "string"
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   }
                                 },
                                 "required": [
@@ -2246,7 +2310,8 @@
                                 "type": "object",
                                 "additionalProperties": false
                               },
-                              "type": "array"
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "matchLabels": {
                               "additionalProperties": {
@@ -2288,7 +2353,8 @@
                                     "items": {
                                       "type": "string"
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   }
                                 },
                                 "required": [
@@ -2298,7 +2364,8 @@
                                 "type": "object",
                                 "additionalProperties": false
                               },
-                              "type": "array"
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "matchLabels": {
                               "additionalProperties": {
@@ -2315,7 +2382,8 @@
                           "items": {
                             "type": "string"
                           },
-                          "type": "array"
+                          "type": "array",
+                          "x-kubernetes-list-type": "atomic"
                         },
                         "topologyKey": {
                           "type": "string"
@@ -2327,7 +2395,8 @@
                       "type": "object",
                       "additionalProperties": false
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   }
                 },
                 "type": "object",
@@ -2376,7 +2445,8 @@
                                 "items": {
                                   "type": "string"
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               }
                             },
                             "required": [
@@ -2386,7 +2456,8 @@
                             "type": "object",
                             "additionalProperties": false
                           },
-                          "type": "array"
+                          "type": "array",
+                          "x-kubernetes-list-type": "atomic"
                         },
                         "matchLabels": {
                           "additionalProperties": {
@@ -2463,12 +2534,16 @@
             "description": "ResourceRequirements describes the compute resource requirements.",
             "properties": {
               "claims": {
-                "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\n\nThis field is immutable. It can only be set for containers.",
+                "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
                 "items": {
                   "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
                   "properties": {
                     "name": {
                       "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
+                      "type": "string"
+                    },
+                    "request": {
+                      "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
                       "type": "string"
                     }
                   },
@@ -2579,6 +2654,14 @@
           "description": "A spec for available storage in the cluster and how it should be used",
           "nullable": true,
           "properties": {
+            "allowDeviceClassUpdate": {
+              "description": "Whether to allow updating the device class after the OSD is initially provisioned",
+              "type": "boolean"
+            },
+            "allowOsdCrushWeightUpdate": {
+              "description": "Whether Rook will resize the OSD CRUSH weight when the OSD PVC size is increased.\nThis allows cluster data to be rebalanced to make most effective use of new OSD space.\nThe default is false since data rebalancing can cause temporary cluster slowdown.",
+              "type": "boolean"
+            },
             "backfillFullRatio": {
               "description": "BackfillFullRatio is the ratio at which the cluster is too full for backfill. Backfill will be disabled if above this threshold. Default is 0.90.",
               "maximum": 1,
@@ -2639,6 +2722,18 @@
               "minimum": 0,
               "nullable": true,
               "type": "number"
+            },
+            "migration": {
+              "description": "Migration handles the OSD migration",
+              "properties": {
+                "confirmation": {
+                  "description": "A user confirmation to migrate the OSDs. It destroys each OSD one at a time, cleans up the backing disk\nand prepares OSD with same ID on that disk",
+                  "pattern": "^$|^yes-really-migrate-osds$",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
             },
             "nearFullRatio": {
               "description": "NearFullRatio is the ratio at which the cluster is considered nearly full and will raise a ceph health warning. Default is 0.85.",
@@ -2702,12 +2797,16 @@
                     "nullable": true,
                     "properties": {
                       "claims": {
-                        "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\n\nThis field is immutable. It can only be set for containers.",
+                        "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
                         "items": {
                           "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
                           "properties": {
                             "name": {
                               "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
+                              "type": "string"
+                            },
+                            "request": {
+                              "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
                               "type": "string"
                             }
                           },
@@ -2808,7 +2907,8 @@
                               "items": {
                                 "type": "string"
                               },
-                              "type": "array"
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "dataSource": {
                               "description": "dataSource field can be used to specify either:\n* An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)\n* An existing PVC (PersistentVolumeClaim)\nIf the provisioner or an external controller can support the specified data source,\nit will create a new volume based on the contents of the specified data source.\nWhen the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,\nand dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.\nIf the namespace is specified, then dataSourceRef will not be copied to dataSource.",
@@ -2921,7 +3021,8 @@
                                         "items": {
                                           "type": "string"
                                         },
-                                        "type": "array"
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
                                       }
                                     },
                                     "required": [
@@ -2931,7 +3032,8 @@
                                     "type": "object",
                                     "additionalProperties": false
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "matchLabels": {
                                   "additionalProperties": {
@@ -2950,7 +3052,7 @@
                               "type": "string"
                             },
                             "volumeAttributesClassName": {
-                              "description": "volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.\nIf specified, the CSI driver will create or update the volume with the attributes defined\nin the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,\nit can be changed after the claim is created. An empty string value means that no VolumeAttributesClass\nwill be applied to the claim but it's not allowed to reset this field to empty string once it is set.\nIf unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass\nwill be set by the persistentvolume controller if it exists.\nIf the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be\nset to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource\nexists.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#volumeattributesclass\n(Alpha) Using this field requires the VolumeAttributesClass feature gate to be enabled.",
+                              "description": "volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.\nIf specified, the CSI driver will create or update the volume with the attributes defined\nin the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,\nit can be changed after the claim is created. An empty string value means that no VolumeAttributesClass\nwill be applied to the claim but it's not allowed to reset this field to empty string once it is set.\nIf unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass\nwill be set by the persistentvolume controller if it exists.\nIf the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be\nset to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource\nexists.\nMore info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/\n(Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).",
                               "type": "string"
                             },
                             "volumeMode": {
@@ -2981,6 +3083,10 @@
             "onlyApplyOSDPlacement": {
               "type": "boolean"
             },
+            "scheduleAlways": {
+              "description": "Whether to always schedule OSDs on a node even if the node is not currently scheduleable or ready",
+              "type": "boolean"
+            },
             "storageClassDeviceSets": {
               "items": {
                 "description": "StorageClassDeviceSet is a storage class device set",
@@ -3005,7 +3111,6 @@
                   },
                   "name": {
                     "description": "Name is a unique identifier for the set",
-                    "maxLength": 40,
                     "type": "string"
                   },
                   "placement": {
@@ -3031,7 +3136,8 @@
                                             "items": {
                                               "type": "string"
                                             },
-                                            "type": "array"
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
                                           }
                                         },
                                         "required": [
@@ -3041,7 +3147,8 @@
                                         "type": "object",
                                         "additionalProperties": false
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "matchFields": {
                                       "items": {
@@ -3056,7 +3163,8 @@
                                             "items": {
                                               "type": "string"
                                             },
-                                            "type": "array"
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
                                           }
                                         },
                                         "required": [
@@ -3066,7 +3174,8 @@
                                         "type": "object",
                                         "additionalProperties": false
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "type": "object",
@@ -3085,7 +3194,8 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "requiredDuringSchedulingIgnoredDuringExecution": {
                             "properties": {
@@ -3105,7 +3215,8 @@
                                             "items": {
                                               "type": "string"
                                             },
-                                            "type": "array"
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
                                           }
                                         },
                                         "required": [
@@ -3115,7 +3226,8 @@
                                         "type": "object",
                                         "additionalProperties": false
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "matchFields": {
                                       "items": {
@@ -3130,7 +3242,8 @@
                                             "items": {
                                               "type": "string"
                                             },
-                                            "type": "array"
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
                                           }
                                         },
                                         "required": [
@@ -3140,14 +3253,16 @@
                                         "type": "object",
                                         "additionalProperties": false
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "type": "object",
                                   "x-kubernetes-map-type": "atomic",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               }
                             },
                             "required": [
@@ -3183,7 +3298,8 @@
                                                 "items": {
                                                   "type": "string"
                                                 },
-                                                "type": "array"
+                                                "type": "array",
+                                                "x-kubernetes-list-type": "atomic"
                                               }
                                             },
                                             "required": [
@@ -3193,7 +3309,8 @@
                                             "type": "object",
                                             "additionalProperties": false
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "matchLabels": {
                                           "additionalProperties": {
@@ -3235,7 +3352,8 @@
                                                 "items": {
                                                   "type": "string"
                                                 },
-                                                "type": "array"
+                                                "type": "array",
+                                                "x-kubernetes-list-type": "atomic"
                                               }
                                             },
                                             "required": [
@@ -3245,7 +3363,8 @@
                                             "type": "object",
                                             "additionalProperties": false
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "matchLabels": {
                                           "additionalProperties": {
@@ -3262,7 +3381,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "topologyKey": {
                                       "type": "string"
@@ -3286,7 +3406,8 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "requiredDuringSchedulingIgnoredDuringExecution": {
                             "items": {
@@ -3306,7 +3427,8 @@
                                             "items": {
                                               "type": "string"
                                             },
-                                            "type": "array"
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
                                           }
                                         },
                                         "required": [
@@ -3316,7 +3438,8 @@
                                         "type": "object",
                                         "additionalProperties": false
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "matchLabels": {
                                       "additionalProperties": {
@@ -3358,7 +3481,8 @@
                                             "items": {
                                               "type": "string"
                                             },
-                                            "type": "array"
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
                                           }
                                         },
                                         "required": [
@@ -3368,7 +3492,8 @@
                                         "type": "object",
                                         "additionalProperties": false
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "matchLabels": {
                                       "additionalProperties": {
@@ -3385,7 +3510,8 @@
                                   "items": {
                                     "type": "string"
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "topologyKey": {
                                   "type": "string"
@@ -3397,7 +3523,8 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           }
                         },
                         "type": "object",
@@ -3425,7 +3552,8 @@
                                                 "items": {
                                                   "type": "string"
                                                 },
-                                                "type": "array"
+                                                "type": "array",
+                                                "x-kubernetes-list-type": "atomic"
                                               }
                                             },
                                             "required": [
@@ -3435,7 +3563,8 @@
                                             "type": "object",
                                             "additionalProperties": false
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "matchLabels": {
                                           "additionalProperties": {
@@ -3477,7 +3606,8 @@
                                                 "items": {
                                                   "type": "string"
                                                 },
-                                                "type": "array"
+                                                "type": "array",
+                                                "x-kubernetes-list-type": "atomic"
                                               }
                                             },
                                             "required": [
@@ -3487,7 +3617,8 @@
                                             "type": "object",
                                             "additionalProperties": false
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "matchLabels": {
                                           "additionalProperties": {
@@ -3504,7 +3635,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "topologyKey": {
                                       "type": "string"
@@ -3528,7 +3660,8 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "requiredDuringSchedulingIgnoredDuringExecution": {
                             "items": {
@@ -3548,7 +3681,8 @@
                                             "items": {
                                               "type": "string"
                                             },
-                                            "type": "array"
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
                                           }
                                         },
                                         "required": [
@@ -3558,7 +3692,8 @@
                                         "type": "object",
                                         "additionalProperties": false
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "matchLabels": {
                                       "additionalProperties": {
@@ -3600,7 +3735,8 @@
                                             "items": {
                                               "type": "string"
                                             },
-                                            "type": "array"
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
                                           }
                                         },
                                         "required": [
@@ -3610,7 +3746,8 @@
                                         "type": "object",
                                         "additionalProperties": false
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "matchLabels": {
                                       "additionalProperties": {
@@ -3627,7 +3764,8 @@
                                   "items": {
                                     "type": "string"
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "topologyKey": {
                                   "type": "string"
@@ -3639,7 +3777,8 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           }
                         },
                         "type": "object",
@@ -3688,7 +3827,8 @@
                                         "items": {
                                           "type": "string"
                                         },
-                                        "type": "array"
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
                                       }
                                     },
                                     "required": [
@@ -3698,7 +3838,8 @@
                                     "type": "object",
                                     "additionalProperties": false
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "matchLabels": {
                                   "additionalProperties": {
@@ -3781,7 +3922,8 @@
                                             "items": {
                                               "type": "string"
                                             },
-                                            "type": "array"
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
                                           }
                                         },
                                         "required": [
@@ -3791,7 +3933,8 @@
                                         "type": "object",
                                         "additionalProperties": false
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "matchFields": {
                                       "items": {
@@ -3806,7 +3949,8 @@
                                             "items": {
                                               "type": "string"
                                             },
-                                            "type": "array"
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
                                           }
                                         },
                                         "required": [
@@ -3816,7 +3960,8 @@
                                         "type": "object",
                                         "additionalProperties": false
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "type": "object",
@@ -3835,7 +3980,8 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "requiredDuringSchedulingIgnoredDuringExecution": {
                             "properties": {
@@ -3855,7 +4001,8 @@
                                             "items": {
                                               "type": "string"
                                             },
-                                            "type": "array"
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
                                           }
                                         },
                                         "required": [
@@ -3865,7 +4012,8 @@
                                         "type": "object",
                                         "additionalProperties": false
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "matchFields": {
                                       "items": {
@@ -3880,7 +4028,8 @@
                                             "items": {
                                               "type": "string"
                                             },
-                                            "type": "array"
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
                                           }
                                         },
                                         "required": [
@@ -3890,14 +4039,16 @@
                                         "type": "object",
                                         "additionalProperties": false
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "type": "object",
                                   "x-kubernetes-map-type": "atomic",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               }
                             },
                             "required": [
@@ -3933,7 +4084,8 @@
                                                 "items": {
                                                   "type": "string"
                                                 },
-                                                "type": "array"
+                                                "type": "array",
+                                                "x-kubernetes-list-type": "atomic"
                                               }
                                             },
                                             "required": [
@@ -3943,7 +4095,8 @@
                                             "type": "object",
                                             "additionalProperties": false
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "matchLabels": {
                                           "additionalProperties": {
@@ -3985,7 +4138,8 @@
                                                 "items": {
                                                   "type": "string"
                                                 },
-                                                "type": "array"
+                                                "type": "array",
+                                                "x-kubernetes-list-type": "atomic"
                                               }
                                             },
                                             "required": [
@@ -3995,7 +4149,8 @@
                                             "type": "object",
                                             "additionalProperties": false
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "matchLabels": {
                                           "additionalProperties": {
@@ -4012,7 +4167,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "topologyKey": {
                                       "type": "string"
@@ -4036,7 +4192,8 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "requiredDuringSchedulingIgnoredDuringExecution": {
                             "items": {
@@ -4056,7 +4213,8 @@
                                             "items": {
                                               "type": "string"
                                             },
-                                            "type": "array"
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
                                           }
                                         },
                                         "required": [
@@ -4066,7 +4224,8 @@
                                         "type": "object",
                                         "additionalProperties": false
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "matchLabels": {
                                       "additionalProperties": {
@@ -4108,7 +4267,8 @@
                                             "items": {
                                               "type": "string"
                                             },
-                                            "type": "array"
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
                                           }
                                         },
                                         "required": [
@@ -4118,7 +4278,8 @@
                                         "type": "object",
                                         "additionalProperties": false
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "matchLabels": {
                                       "additionalProperties": {
@@ -4135,7 +4296,8 @@
                                   "items": {
                                     "type": "string"
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "topologyKey": {
                                   "type": "string"
@@ -4147,7 +4309,8 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           }
                         },
                         "type": "object",
@@ -4175,7 +4338,8 @@
                                                 "items": {
                                                   "type": "string"
                                                 },
-                                                "type": "array"
+                                                "type": "array",
+                                                "x-kubernetes-list-type": "atomic"
                                               }
                                             },
                                             "required": [
@@ -4185,7 +4349,8 @@
                                             "type": "object",
                                             "additionalProperties": false
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "matchLabels": {
                                           "additionalProperties": {
@@ -4227,7 +4392,8 @@
                                                 "items": {
                                                   "type": "string"
                                                 },
-                                                "type": "array"
+                                                "type": "array",
+                                                "x-kubernetes-list-type": "atomic"
                                               }
                                             },
                                             "required": [
@@ -4237,7 +4403,8 @@
                                             "type": "object",
                                             "additionalProperties": false
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "matchLabels": {
                                           "additionalProperties": {
@@ -4254,7 +4421,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "topologyKey": {
                                       "type": "string"
@@ -4278,7 +4446,8 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "requiredDuringSchedulingIgnoredDuringExecution": {
                             "items": {
@@ -4298,7 +4467,8 @@
                                             "items": {
                                               "type": "string"
                                             },
-                                            "type": "array"
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
                                           }
                                         },
                                         "required": [
@@ -4308,7 +4478,8 @@
                                         "type": "object",
                                         "additionalProperties": false
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "matchLabels": {
                                       "additionalProperties": {
@@ -4350,7 +4521,8 @@
                                             "items": {
                                               "type": "string"
                                             },
-                                            "type": "array"
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
                                           }
                                         },
                                         "required": [
@@ -4360,7 +4532,8 @@
                                         "type": "object",
                                         "additionalProperties": false
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "matchLabels": {
                                       "additionalProperties": {
@@ -4377,7 +4550,8 @@
                                   "items": {
                                     "type": "string"
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "topologyKey": {
                                   "type": "string"
@@ -4389,7 +4563,8 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           }
                         },
                         "type": "object",
@@ -4438,7 +4613,8 @@
                                         "items": {
                                           "type": "string"
                                         },
-                                        "type": "array"
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
                                       }
                                     },
                                     "required": [
@@ -4448,7 +4624,8 @@
                                     "type": "object",
                                     "additionalProperties": false
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "matchLabels": {
                                   "additionalProperties": {
@@ -4509,12 +4686,16 @@
                     "nullable": true,
                     "properties": {
                       "claims": {
-                        "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\n\nThis field is immutable. It can only be set for containers.",
+                        "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
                         "items": {
                           "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
                           "properties": {
                             "name": {
                               "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
+                              "type": "string"
+                            },
+                            "request": {
+                              "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
                               "type": "string"
                             }
                           },
@@ -4624,7 +4805,8 @@
                               "items": {
                                 "type": "string"
                               },
-                              "type": "array"
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "dataSource": {
                               "description": "dataSource field can be used to specify either:\n* An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)\n* An existing PVC (PersistentVolumeClaim)\nIf the provisioner or an external controller can support the specified data source,\nit will create a new volume based on the contents of the specified data source.\nWhen the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,\nand dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.\nIf the namespace is specified, then dataSourceRef will not be copied to dataSource.",
@@ -4737,7 +4919,8 @@
                                         "items": {
                                           "type": "string"
                                         },
-                                        "type": "array"
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
                                       }
                                     },
                                     "required": [
@@ -4747,7 +4930,8 @@
                                     "type": "object",
                                     "additionalProperties": false
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "matchLabels": {
                                   "additionalProperties": {
@@ -4766,7 +4950,7 @@
                               "type": "string"
                             },
                             "volumeAttributesClassName": {
-                              "description": "volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.\nIf specified, the CSI driver will create or update the volume with the attributes defined\nin the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,\nit can be changed after the claim is created. An empty string value means that no VolumeAttributesClass\nwill be applied to the claim but it's not allowed to reset this field to empty string once it is set.\nIf unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass\nwill be set by the persistentvolume controller if it exists.\nIf the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be\nset to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource\nexists.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#volumeattributesclass\n(Alpha) Using this field requires the VolumeAttributesClass feature gate to be enabled.",
+                              "description": "volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.\nIf specified, the CSI driver will create or update the volume with the attributes defined\nin the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,\nit can be changed after the claim is created. An empty string value means that no VolumeAttributesClass\nwill be applied to the claim but it's not allowed to reset this field to empty string once it is set.\nIf unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass\nwill be set by the persistentvolume controller if it exists.\nIf the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be\nset to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource\nexists.\nMore info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/\n(Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).",
                               "type": "string"
                             },
                             "volumeMode": {
@@ -4870,7 +5054,8 @@
                         "items": {
                           "type": "string"
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "dataSource": {
                         "description": "dataSource field can be used to specify either:\n* An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)\n* An existing PVC (PersistentVolumeClaim)\nIf the provisioner or an external controller can support the specified data source,\nit will create a new volume based on the contents of the specified data source.\nWhen the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,\nand dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.\nIf the namespace is specified, then dataSourceRef will not be copied to dataSource.",
@@ -4983,7 +5168,8 @@
                                   "items": {
                                     "type": "string"
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               },
                               "required": [
@@ -4993,7 +5179,8 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "matchLabels": {
                             "additionalProperties": {
@@ -5012,7 +5199,7 @@
                         "type": "string"
                       },
                       "volumeAttributesClassName": {
-                        "description": "volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.\nIf specified, the CSI driver will create or update the volume with the attributes defined\nin the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,\nit can be changed after the claim is created. An empty string value means that no VolumeAttributesClass\nwill be applied to the claim but it's not allowed to reset this field to empty string once it is set.\nIf unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass\nwill be set by the persistentvolume controller if it exists.\nIf the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be\nset to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource\nexists.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#volumeattributesclass\n(Alpha) Using this field requires the VolumeAttributesClass feature gate to be enabled.",
+                        "description": "volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.\nIf specified, the CSI driver will create or update the volume with the attributes defined\nin the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,\nit can be changed after the claim is created. An empty string value means that no VolumeAttributesClass\nwill be applied to the claim but it's not allowed to reset this field to empty string once it is set.\nIf unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass\nwill be set by the persistentvolume controller if it exists.\nIf the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be\nset to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource\nexists.\nMore info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/\n(Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).",
                         "type": "string"
                       },
                       "volumeMode": {
@@ -5257,6 +5444,16 @@
             "osd": {
               "description": "OSDStatus represents OSD status of the ceph Cluster",
               "properties": {
+                "migrationStatus": {
+                  "description": "MigrationStatus status represents the current status of any OSD migration.",
+                  "properties": {
+                    "pending": {
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
                 "storeType": {
                   "additionalProperties": {
                     "type": "integer"

--- a/ceph.rook.io/cephcosidriver_v1.json
+++ b/ceph.rook.io/cephcosidriver_v1.json
@@ -54,7 +54,8 @@
                                   "items": {
                                     "type": "string"
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               },
                               "required": [
@@ -64,7 +65,8 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "matchFields": {
                             "items": {
@@ -79,7 +81,8 @@
                                   "items": {
                                     "type": "string"
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               },
                               "required": [
@@ -89,7 +92,8 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           }
                         },
                         "type": "object",
@@ -108,7 +112,8 @@
                     "type": "object",
                     "additionalProperties": false
                   },
-                  "type": "array"
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
                 },
                 "requiredDuringSchedulingIgnoredDuringExecution": {
                   "properties": {
@@ -128,7 +133,8 @@
                                   "items": {
                                     "type": "string"
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               },
                               "required": [
@@ -138,7 +144,8 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "matchFields": {
                             "items": {
@@ -153,7 +160,8 @@
                                   "items": {
                                     "type": "string"
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               },
                               "required": [
@@ -163,14 +171,16 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           }
                         },
                         "type": "object",
                         "x-kubernetes-map-type": "atomic",
                         "additionalProperties": false
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     }
                   },
                   "required": [
@@ -206,7 +216,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -216,7 +227,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchLabels": {
                                 "additionalProperties": {
@@ -258,7 +270,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -268,7 +281,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchLabels": {
                                 "additionalProperties": {
@@ -285,7 +299,8 @@
                             "items": {
                               "type": "string"
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "topologyKey": {
                             "type": "string"
@@ -309,7 +324,8 @@
                     "type": "object",
                     "additionalProperties": false
                   },
-                  "type": "array"
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
                 },
                 "requiredDuringSchedulingIgnoredDuringExecution": {
                   "items": {
@@ -329,7 +345,8 @@
                                   "items": {
                                     "type": "string"
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               },
                               "required": [
@@ -339,7 +356,8 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "matchLabels": {
                             "additionalProperties": {
@@ -381,7 +399,8 @@
                                   "items": {
                                     "type": "string"
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               },
                               "required": [
@@ -391,7 +410,8 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "matchLabels": {
                             "additionalProperties": {
@@ -408,7 +428,8 @@
                         "items": {
                           "type": "string"
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "topologyKey": {
                         "type": "string"
@@ -420,7 +441,8 @@
                     "type": "object",
                     "additionalProperties": false
                   },
-                  "type": "array"
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
                 }
               },
               "type": "object",
@@ -448,7 +470,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -458,7 +481,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchLabels": {
                                 "additionalProperties": {
@@ -500,7 +524,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -510,7 +535,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchLabels": {
                                 "additionalProperties": {
@@ -527,7 +553,8 @@
                             "items": {
                               "type": "string"
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "topologyKey": {
                             "type": "string"
@@ -551,7 +578,8 @@
                     "type": "object",
                     "additionalProperties": false
                   },
-                  "type": "array"
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
                 },
                 "requiredDuringSchedulingIgnoredDuringExecution": {
                   "items": {
@@ -571,7 +599,8 @@
                                   "items": {
                                     "type": "string"
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               },
                               "required": [
@@ -581,7 +610,8 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "matchLabels": {
                             "additionalProperties": {
@@ -623,7 +653,8 @@
                                   "items": {
                                     "type": "string"
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               },
                               "required": [
@@ -633,7 +664,8 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "matchLabels": {
                             "additionalProperties": {
@@ -650,7 +682,8 @@
                         "items": {
                           "type": "string"
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "topologyKey": {
                         "type": "string"
@@ -662,7 +695,8 @@
                     "type": "object",
                     "additionalProperties": false
                   },
-                  "type": "array"
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
                 }
               },
               "type": "object",
@@ -711,7 +745,8 @@
                               "items": {
                                 "type": "string"
                               },
-                              "type": "array"
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
                             }
                           },
                           "required": [
@@ -721,7 +756,8 @@
                           "type": "object",
                           "additionalProperties": false
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "matchLabels": {
                         "additionalProperties": {
@@ -780,12 +816,16 @@
           "description": "Resources is the resource requirements for the COSI driver",
           "properties": {
             "claims": {
-              "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\n\nThis field is immutable. It can only be set for containers.",
+              "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
               "items": {
                 "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
                 "properties": {
                   "name": {
                     "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
+                    "type": "string"
+                  },
+                  "request": {
+                    "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
                     "type": "string"
                   }
                 },

--- a/ceph.rook.io/cephfilesystem_v1.json
+++ b/ceph.rook.io/cephfilesystem_v1.json
@@ -46,6 +46,10 @@
                 "nullable": true,
                 "type": "string"
               },
+              "enableCrushUpdates": {
+                "description": "Allow rook operator to change the pool CRUSH tunables once the pool is created",
+                "type": "boolean"
+              },
               "enableRBDStats": {
                 "description": "EnableRBDStats is used to enable gathering of statistics for all RBD images in the pool",
                 "type": "boolean"
@@ -285,6 +289,10 @@
               "nullable": true,
               "type": "string"
             },
+            "enableCrushUpdates": {
+              "description": "Allow rook operator to change the pool CRUSH tunables once the pool is created",
+              "type": "boolean"
+            },
             "enableRBDStats": {
               "description": "EnableRBDStats is used to enable gathering of statistics for all RBD images in the pool",
               "type": "boolean"
@@ -370,6 +378,10 @@
               },
               "type": "object",
               "additionalProperties": false
+            },
+            "name": {
+              "description": "Name of the pool",
+              "type": "string"
             },
             "parameters": {
               "additionalProperties": {
@@ -530,14 +542,15 @@
                   "description": "Probe describes a health check to be performed against a container to determine whether it is\nalive or ready to receive traffic.",
                   "properties": {
                     "exec": {
-                      "description": "Exec specifies the action to take.",
+                      "description": "Exec specifies a command to execute in the container.",
                       "properties": {
                         "command": {
                           "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
                           "items": {
                             "type": "string"
                           },
-                          "type": "array"
+                          "type": "array",
+                          "x-kubernetes-list-type": "atomic"
                         }
                       },
                       "type": "object",
@@ -549,7 +562,7 @@
                       "type": "integer"
                     },
                     "grpc": {
-                      "description": "GRPC specifies an action involving a GRPC port.",
+                      "description": "GRPC specifies a GRPC HealthCheckRequest.",
                       "properties": {
                         "port": {
                           "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
@@ -557,7 +570,8 @@
                           "type": "integer"
                         },
                         "service": {
-                          "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                          "default": "",
+                          "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
                           "type": "string"
                         }
                       },
@@ -568,7 +582,7 @@
                       "additionalProperties": false
                     },
                     "httpGet": {
-                      "description": "HTTPGet specifies the http request to perform.",
+                      "description": "HTTPGet specifies an HTTP GET request to perform.",
                       "properties": {
                         "host": {
                           "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
@@ -595,7 +609,8 @@
                             "type": "object",
                             "additionalProperties": false
                           },
-                          "type": "array"
+                          "type": "array",
+                          "x-kubernetes-list-type": "atomic"
                         },
                         "path": {
                           "description": "Path to access on the HTTP server.",
@@ -640,7 +655,7 @@
                       "type": "integer"
                     },
                     "tcpSocket": {
-                      "description": "TCPSocket specifies an action involving a TCP port.",
+                      "description": "TCPSocket specifies a connection to a TCP port.",
                       "properties": {
                         "host": {
                           "description": "Optional: Host name to connect to, defaults to the pod IP.",
@@ -705,7 +720,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -715,7 +731,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchFields": {
                                 "items": {
@@ -730,7 +747,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -740,7 +758,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               }
                             },
                             "type": "object",
@@ -759,7 +778,8 @@
                         "type": "object",
                         "additionalProperties": false
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     },
                     "requiredDuringSchedulingIgnoredDuringExecution": {
                       "properties": {
@@ -779,7 +799,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -789,7 +810,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchFields": {
                                 "items": {
@@ -804,7 +826,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -814,14 +837,16 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               }
                             },
                             "type": "object",
                             "x-kubernetes-map-type": "atomic",
                             "additionalProperties": false
                           },
-                          "type": "array"
+                          "type": "array",
+                          "x-kubernetes-list-type": "atomic"
                         }
                       },
                       "required": [
@@ -857,7 +882,8 @@
                                           "items": {
                                             "type": "string"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       },
                                       "required": [
@@ -867,7 +893,8 @@
                                       "type": "object",
                                       "additionalProperties": false
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "matchLabels": {
                                     "additionalProperties": {
@@ -909,7 +936,8 @@
                                           "items": {
                                             "type": "string"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       },
                                       "required": [
@@ -919,7 +947,8 @@
                                       "type": "object",
                                       "additionalProperties": false
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "matchLabels": {
                                     "additionalProperties": {
@@ -936,7 +965,8 @@
                                 "items": {
                                   "type": "string"
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "topologyKey": {
                                 "type": "string"
@@ -960,7 +990,8 @@
                         "type": "object",
                         "additionalProperties": false
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     },
                     "requiredDuringSchedulingIgnoredDuringExecution": {
                       "items": {
@@ -980,7 +1011,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -990,7 +1022,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchLabels": {
                                 "additionalProperties": {
@@ -1032,7 +1065,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -1042,7 +1076,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchLabels": {
                                 "additionalProperties": {
@@ -1059,7 +1094,8 @@
                             "items": {
                               "type": "string"
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "topologyKey": {
                             "type": "string"
@@ -1071,7 +1107,8 @@
                         "type": "object",
                         "additionalProperties": false
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     }
                   },
                   "type": "object",
@@ -1099,7 +1136,8 @@
                                           "items": {
                                             "type": "string"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       },
                                       "required": [
@@ -1109,7 +1147,8 @@
                                       "type": "object",
                                       "additionalProperties": false
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "matchLabels": {
                                     "additionalProperties": {
@@ -1151,7 +1190,8 @@
                                           "items": {
                                             "type": "string"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       },
                                       "required": [
@@ -1161,7 +1201,8 @@
                                       "type": "object",
                                       "additionalProperties": false
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "matchLabels": {
                                     "additionalProperties": {
@@ -1178,7 +1219,8 @@
                                 "items": {
                                   "type": "string"
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "topologyKey": {
                                 "type": "string"
@@ -1202,7 +1244,8 @@
                         "type": "object",
                         "additionalProperties": false
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     },
                     "requiredDuringSchedulingIgnoredDuringExecution": {
                       "items": {
@@ -1222,7 +1265,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -1232,7 +1276,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchLabels": {
                                 "additionalProperties": {
@@ -1274,7 +1319,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -1284,7 +1330,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchLabels": {
                                 "additionalProperties": {
@@ -1301,7 +1348,8 @@
                             "items": {
                               "type": "string"
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "topologyKey": {
                             "type": "string"
@@ -1313,7 +1361,8 @@
                         "type": "object",
                         "additionalProperties": false
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     }
                   },
                   "type": "object",
@@ -1362,7 +1411,8 @@
                                   "items": {
                                     "type": "string"
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               },
                               "required": [
@@ -1372,7 +1422,8 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "matchLabels": {
                             "additionalProperties": {
@@ -1437,12 +1488,16 @@
               "nullable": true,
               "properties": {
                 "claims": {
-                  "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\n\nThis field is immutable. It can only be set for containers.",
+                  "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
                   "items": {
                     "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
                     "properties": {
                       "name": {
                         "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
+                        "type": "string"
+                      },
+                      "request": {
+                        "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
                         "type": "string"
                       }
                     },
@@ -1506,14 +1561,15 @@
                   "description": "Probe describes a health check to be performed against a container to determine whether it is\nalive or ready to receive traffic.",
                   "properties": {
                     "exec": {
-                      "description": "Exec specifies the action to take.",
+                      "description": "Exec specifies a command to execute in the container.",
                       "properties": {
                         "command": {
                           "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
                           "items": {
                             "type": "string"
                           },
-                          "type": "array"
+                          "type": "array",
+                          "x-kubernetes-list-type": "atomic"
                         }
                       },
                       "type": "object",
@@ -1525,7 +1581,7 @@
                       "type": "integer"
                     },
                     "grpc": {
-                      "description": "GRPC specifies an action involving a GRPC port.",
+                      "description": "GRPC specifies a GRPC HealthCheckRequest.",
                       "properties": {
                         "port": {
                           "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
@@ -1533,7 +1589,8 @@
                           "type": "integer"
                         },
                         "service": {
-                          "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                          "default": "",
+                          "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
                           "type": "string"
                         }
                       },
@@ -1544,7 +1601,7 @@
                       "additionalProperties": false
                     },
                     "httpGet": {
-                      "description": "HTTPGet specifies the http request to perform.",
+                      "description": "HTTPGet specifies an HTTP GET request to perform.",
                       "properties": {
                         "host": {
                           "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
@@ -1571,7 +1628,8 @@
                             "type": "object",
                             "additionalProperties": false
                           },
-                          "type": "array"
+                          "type": "array",
+                          "x-kubernetes-list-type": "atomic"
                         },
                         "path": {
                           "description": "Path to access on the HTTP server.",
@@ -1616,7 +1674,7 @@
                       "type": "integer"
                     },
                     "tcpSocket": {
-                      "description": "TCPSocket specifies an action involving a TCP port.",
+                      "description": "TCPSocket specifies a connection to a TCP port.",
                       "properties": {
                         "host": {
                           "description": "Optional: Host name to connect to, defaults to the pod IP.",
@@ -1736,6 +1794,10 @@
         },
         "preserveFilesystemOnDelete": {
           "description": "Preserve the fs in the cluster on CephFilesystem CR deletion. Setting this to true automatically implies PreservePoolsOnDelete is true.",
+          "type": "boolean"
+        },
+        "preservePoolNames": {
+          "description": "Preserve pool names as specified",
           "type": "boolean"
         },
         "preservePoolsOnDelete": {

--- a/ceph.rook.io/cephfilesystemmirror_v1.json
+++ b/ceph.rook.io/cephfilesystemmirror_v1.json
@@ -54,7 +54,8 @@
                                   "items": {
                                     "type": "string"
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               },
                               "required": [
@@ -64,7 +65,8 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "matchFields": {
                             "items": {
@@ -79,7 +81,8 @@
                                   "items": {
                                     "type": "string"
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               },
                               "required": [
@@ -89,7 +92,8 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           }
                         },
                         "type": "object",
@@ -108,7 +112,8 @@
                     "type": "object",
                     "additionalProperties": false
                   },
-                  "type": "array"
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
                 },
                 "requiredDuringSchedulingIgnoredDuringExecution": {
                   "properties": {
@@ -128,7 +133,8 @@
                                   "items": {
                                     "type": "string"
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               },
                               "required": [
@@ -138,7 +144,8 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "matchFields": {
                             "items": {
@@ -153,7 +160,8 @@
                                   "items": {
                                     "type": "string"
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               },
                               "required": [
@@ -163,14 +171,16 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           }
                         },
                         "type": "object",
                         "x-kubernetes-map-type": "atomic",
                         "additionalProperties": false
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     }
                   },
                   "required": [
@@ -206,7 +216,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -216,7 +227,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchLabels": {
                                 "additionalProperties": {
@@ -258,7 +270,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -268,7 +281,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchLabels": {
                                 "additionalProperties": {
@@ -285,7 +299,8 @@
                             "items": {
                               "type": "string"
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "topologyKey": {
                             "type": "string"
@@ -309,7 +324,8 @@
                     "type": "object",
                     "additionalProperties": false
                   },
-                  "type": "array"
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
                 },
                 "requiredDuringSchedulingIgnoredDuringExecution": {
                   "items": {
@@ -329,7 +345,8 @@
                                   "items": {
                                     "type": "string"
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               },
                               "required": [
@@ -339,7 +356,8 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "matchLabels": {
                             "additionalProperties": {
@@ -381,7 +399,8 @@
                                   "items": {
                                     "type": "string"
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               },
                               "required": [
@@ -391,7 +410,8 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "matchLabels": {
                             "additionalProperties": {
@@ -408,7 +428,8 @@
                         "items": {
                           "type": "string"
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "topologyKey": {
                         "type": "string"
@@ -420,7 +441,8 @@
                     "type": "object",
                     "additionalProperties": false
                   },
-                  "type": "array"
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
                 }
               },
               "type": "object",
@@ -448,7 +470,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -458,7 +481,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchLabels": {
                                 "additionalProperties": {
@@ -500,7 +524,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -510,7 +535,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchLabels": {
                                 "additionalProperties": {
@@ -527,7 +553,8 @@
                             "items": {
                               "type": "string"
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "topologyKey": {
                             "type": "string"
@@ -551,7 +578,8 @@
                     "type": "object",
                     "additionalProperties": false
                   },
-                  "type": "array"
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
                 },
                 "requiredDuringSchedulingIgnoredDuringExecution": {
                   "items": {
@@ -571,7 +599,8 @@
                                   "items": {
                                     "type": "string"
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               },
                               "required": [
@@ -581,7 +610,8 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "matchLabels": {
                             "additionalProperties": {
@@ -623,7 +653,8 @@
                                   "items": {
                                     "type": "string"
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               },
                               "required": [
@@ -633,7 +664,8 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "matchLabels": {
                             "additionalProperties": {
@@ -650,7 +682,8 @@
                         "items": {
                           "type": "string"
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "topologyKey": {
                         "type": "string"
@@ -662,7 +695,8 @@
                     "type": "object",
                     "additionalProperties": false
                   },
-                  "type": "array"
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
                 }
               },
               "type": "object",
@@ -711,7 +745,8 @@
                               "items": {
                                 "type": "string"
                               },
-                              "type": "array"
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
                             }
                           },
                           "required": [
@@ -721,7 +756,8 @@
                           "type": "object",
                           "additionalProperties": false
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "matchLabels": {
                         "additionalProperties": {
@@ -785,12 +821,16 @@
           "nullable": true,
           "properties": {
             "claims": {
-              "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\n\nThis field is immutable. It can only be set for containers.",
+              "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
               "items": {
                 "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
                 "properties": {
                   "name": {
                     "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
+                    "type": "string"
+                  },
+                  "request": {
+                    "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
                     "type": "string"
                   }
                 },

--- a/ceph.rook.io/cephnfs_v1.json
+++ b/ceph.rook.io/cephnfs_v1.json
@@ -40,7 +40,7 @@
               "nullable": true,
               "properties": {
                 "configFiles": {
-                  "description": "ConfigFiles defines where the Kerberos configuration should be sourced from. Config files\nwill be placed into the `/etc/krb5.conf.rook/` directory.\n\n\nIf this is left empty, Rook will not add any files. This allows you to manage the files\nyourself however you wish. For example, you may build them into your custom Ceph container\nimage or use the Vault agent injector to securely add the files via annotations on the\nCephNFS spec (passed to the NFS server pods).\n\n\nRook configures Kerberos to log to stderr. We suggest removing logging sections from config\nfiles to avoid consuming unnecessary disk space from logging to files.",
+                  "description": "ConfigFiles defines where the Kerberos configuration should be sourced from. Config files\nwill be placed into the `/etc/krb5.conf.rook/` directory.\n\nIf this is left empty, Rook will not add any files. This allows you to manage the files\nyourself however you wish. For example, you may build them into your custom Ceph container\nimage or use the Vault agent injector to securely add the files via annotations on the\nCephNFS spec (passed to the NFS server pods).\n\nRook configures Kerberos to log to stderr. We suggest removing logging sections from config\nfiles to avoid consuming unnecessary disk space from logging to files.",
                   "properties": {
                     "volumeSource": {
                       "properties": {
@@ -71,9 +71,11 @@
                                 "type": "object",
                                 "additionalProperties": false
                               },
-                              "type": "array"
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "name": {
+                              "default": "",
                               "type": "string"
                             },
                             "optional": {
@@ -161,7 +163,8 @@
                                                   "items": {
                                                     "type": "string"
                                                   },
-                                                  "type": "array"
+                                                  "type": "array",
+                                                  "x-kubernetes-list-type": "atomic"
                                                 }
                                               },
                                               "required": [
@@ -171,7 +174,8 @@
                                               "type": "object",
                                               "additionalProperties": false
                                             },
-                                            "type": "array"
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
                                           },
                                           "matchLabels": {
                                             "additionalProperties": {
@@ -226,9 +230,11 @@
                                           "type": "object",
                                           "additionalProperties": false
                                         },
-                                        "type": "array"
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
                                       },
                                       "name": {
+                                        "default": "",
                                         "type": "string"
                                       },
                                       "optional": {
@@ -302,7 +308,8 @@
                                           "type": "object",
                                           "additionalProperties": false
                                         },
-                                        "type": "array"
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
                                       }
                                     },
                                     "type": "object",
@@ -331,9 +338,11 @@
                                           "type": "object",
                                           "additionalProperties": false
                                         },
-                                        "type": "array"
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
                                       },
                                       "name": {
+                                        "default": "",
                                         "type": "string"
                                       },
                                       "optional": {
@@ -367,7 +376,8 @@
                                 "type": "object",
                                 "additionalProperties": false
                               },
-                              "type": "array"
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
                             }
                           },
                           "type": "object",
@@ -400,7 +410,8 @@
                                 "type": "object",
                                 "additionalProperties": false
                               },
-                              "type": "array"
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "optional": {
                               "type": "boolean"
@@ -456,9 +467,11 @@
                                 "type": "object",
                                 "additionalProperties": false
                               },
-                              "type": "array"
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "name": {
+                              "default": "",
                               "type": "string"
                             },
                             "optional": {
@@ -546,7 +559,8 @@
                                                   "items": {
                                                     "type": "string"
                                                   },
-                                                  "type": "array"
+                                                  "type": "array",
+                                                  "x-kubernetes-list-type": "atomic"
                                                 }
                                               },
                                               "required": [
@@ -556,7 +570,8 @@
                                               "type": "object",
                                               "additionalProperties": false
                                             },
-                                            "type": "array"
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
                                           },
                                           "matchLabels": {
                                             "additionalProperties": {
@@ -611,9 +626,11 @@
                                           "type": "object",
                                           "additionalProperties": false
                                         },
-                                        "type": "array"
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
                                       },
                                       "name": {
+                                        "default": "",
                                         "type": "string"
                                       },
                                       "optional": {
@@ -687,7 +704,8 @@
                                           "type": "object",
                                           "additionalProperties": false
                                         },
-                                        "type": "array"
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
                                       }
                                     },
                                     "type": "object",
@@ -716,9 +734,11 @@
                                           "type": "object",
                                           "additionalProperties": false
                                         },
-                                        "type": "array"
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
                                       },
                                       "name": {
+                                        "default": "",
                                         "type": "string"
                                       },
                                       "optional": {
@@ -752,7 +772,8 @@
                                 "type": "object",
                                 "additionalProperties": false
                               },
-                              "type": "array"
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
                             }
                           },
                           "type": "object",
@@ -785,7 +806,8 @@
                                 "type": "object",
                                 "additionalProperties": false
                               },
-                              "type": "array"
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "optional": {
                               "type": "boolean"
@@ -822,12 +844,12 @@
                   "description": "Sidecar tells Rook to run SSSD in a sidecar alongside the NFS-Ganesha server in each NFS pod.",
                   "properties": {
                     "additionalFiles": {
-                      "description": "AdditionalFiles defines any number of additional files that should be mounted into the SSSD\nsidecar. These files may be referenced by the sssd.conf config file.",
+                      "description": "AdditionalFiles defines any number of additional files that should be mounted into the SSSD\nsidecar with a directory root of `/etc/sssd/rook-additional/`.\nThese files may be referenced by the sssd.conf config file.",
                       "items": {
-                        "description": "SSSDSidecarAdditionalFile represents the source from where additional files for the the SSSD\nconfiguration should come from and are made available.",
+                        "description": "AdditionalVolumeMount represents the source from where additional files in pod containers\nshould come from and what subdirectory they are made available in.",
                         "properties": {
                           "subPath": {
-                            "description": "SubPath defines the sub-path in `/etc/sssd/rook-additional/` where the additional file(s)\nwill be placed. Each subPath definition must be unique and must not contain ':'.",
+                            "description": "SubPath defines the sub-path (subdirectory) of the directory root where the volumeSource will\nbe mounted. All files/keys in the volume source's volume will be mounted to the subdirectory.\nThis is not the same as the Kubernetes `subPath` volume mount option.\nEach subPath definition must be unique and must not contain ':'.",
                             "minLength": 1,
                             "pattern": "^[^:]+$",
                             "type": "string"
@@ -861,9 +883,11 @@
                                       "type": "object",
                                       "additionalProperties": false
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "name": {
+                                    "default": "",
                                     "type": "string"
                                   },
                                   "optional": {
@@ -951,7 +975,8 @@
                                                         "items": {
                                                           "type": "string"
                                                         },
-                                                        "type": "array"
+                                                        "type": "array",
+                                                        "x-kubernetes-list-type": "atomic"
                                                       }
                                                     },
                                                     "required": [
@@ -961,7 +986,8 @@
                                                     "type": "object",
                                                     "additionalProperties": false
                                                   },
-                                                  "type": "array"
+                                                  "type": "array",
+                                                  "x-kubernetes-list-type": "atomic"
                                                 },
                                                 "matchLabels": {
                                                   "additionalProperties": {
@@ -1016,9 +1042,11 @@
                                                 "type": "object",
                                                 "additionalProperties": false
                                               },
-                                              "type": "array"
+                                              "type": "array",
+                                              "x-kubernetes-list-type": "atomic"
                                             },
                                             "name": {
+                                              "default": "",
                                               "type": "string"
                                             },
                                             "optional": {
@@ -1092,7 +1120,8 @@
                                                 "type": "object",
                                                 "additionalProperties": false
                                               },
-                                              "type": "array"
+                                              "type": "array",
+                                              "x-kubernetes-list-type": "atomic"
                                             }
                                           },
                                           "type": "object",
@@ -1121,9 +1150,11 @@
                                                 "type": "object",
                                                 "additionalProperties": false
                                               },
-                                              "type": "array"
+                                              "type": "array",
+                                              "x-kubernetes-list-type": "atomic"
                                             },
                                             "name": {
+                                              "default": "",
                                               "type": "string"
                                             },
                                             "optional": {
@@ -1157,7 +1188,8 @@
                                       "type": "object",
                                       "additionalProperties": false
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   }
                                 },
                                 "type": "object",
@@ -1190,7 +1222,8 @@
                                       "type": "object",
                                       "additionalProperties": false
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "optional": {
                                     "type": "boolean"
@@ -1231,12 +1264,16 @@
                       "description": "Resources allow specifying resource requests/limits on the SSSD sidecar container.",
                       "properties": {
                         "claims": {
-                          "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\n\nThis field is immutable. It can only be set for containers.",
+                          "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
                           "items": {
                             "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
                             "properties": {
                               "name": {
                                 "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
+                                "type": "string"
+                              },
+                              "request": {
+                                "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
                                 "type": "string"
                               }
                             },
@@ -1320,9 +1357,11 @@
                                     "type": "object",
                                     "additionalProperties": false
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "name": {
+                                  "default": "",
                                   "type": "string"
                                 },
                                 "optional": {
@@ -1410,7 +1449,8 @@
                                                       "items": {
                                                         "type": "string"
                                                       },
-                                                      "type": "array"
+                                                      "type": "array",
+                                                      "x-kubernetes-list-type": "atomic"
                                                     }
                                                   },
                                                   "required": [
@@ -1420,7 +1460,8 @@
                                                   "type": "object",
                                                   "additionalProperties": false
                                                 },
-                                                "type": "array"
+                                                "type": "array",
+                                                "x-kubernetes-list-type": "atomic"
                                               },
                                               "matchLabels": {
                                                 "additionalProperties": {
@@ -1475,9 +1516,11 @@
                                               "type": "object",
                                               "additionalProperties": false
                                             },
-                                            "type": "array"
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
                                           },
                                           "name": {
+                                            "default": "",
                                             "type": "string"
                                           },
                                           "optional": {
@@ -1551,7 +1594,8 @@
                                               "type": "object",
                                               "additionalProperties": false
                                             },
-                                            "type": "array"
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
                                           }
                                         },
                                         "type": "object",
@@ -1580,9 +1624,11 @@
                                               "type": "object",
                                               "additionalProperties": false
                                             },
-                                            "type": "array"
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
                                           },
                                           "name": {
+                                            "default": "",
                                             "type": "string"
                                           },
                                           "optional": {
@@ -1616,7 +1662,8 @@
                                     "type": "object",
                                     "additionalProperties": false
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               },
                               "type": "object",
@@ -1649,7 +1696,8 @@
                                     "type": "object",
                                     "additionalProperties": false
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "optional": {
                                   "type": "boolean"
@@ -1725,14 +1773,15 @@
                   "description": "Probe describes a health check to be performed against a container to determine whether it is\nalive or ready to receive traffic.",
                   "properties": {
                     "exec": {
-                      "description": "Exec specifies the action to take.",
+                      "description": "Exec specifies a command to execute in the container.",
                       "properties": {
                         "command": {
                           "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
                           "items": {
                             "type": "string"
                           },
-                          "type": "array"
+                          "type": "array",
+                          "x-kubernetes-list-type": "atomic"
                         }
                       },
                       "type": "object",
@@ -1744,7 +1793,7 @@
                       "type": "integer"
                     },
                     "grpc": {
-                      "description": "GRPC specifies an action involving a GRPC port.",
+                      "description": "GRPC specifies a GRPC HealthCheckRequest.",
                       "properties": {
                         "port": {
                           "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
@@ -1752,7 +1801,8 @@
                           "type": "integer"
                         },
                         "service": {
-                          "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                          "default": "",
+                          "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
                           "type": "string"
                         }
                       },
@@ -1763,7 +1813,7 @@
                       "additionalProperties": false
                     },
                     "httpGet": {
-                      "description": "HTTPGet specifies the http request to perform.",
+                      "description": "HTTPGet specifies an HTTP GET request to perform.",
                       "properties": {
                         "host": {
                           "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
@@ -1790,7 +1840,8 @@
                             "type": "object",
                             "additionalProperties": false
                           },
-                          "type": "array"
+                          "type": "array",
+                          "x-kubernetes-list-type": "atomic"
                         },
                         "path": {
                           "description": "Path to access on the HTTP server.",
@@ -1835,7 +1886,7 @@
                       "type": "integer"
                     },
                     "tcpSocket": {
-                      "description": "TCPSocket specifies an action involving a TCP port.",
+                      "description": "TCPSocket specifies a connection to a TCP port.",
                       "properties": {
                         "host": {
                           "description": "Optional: Host name to connect to, defaults to the pod IP.",
@@ -1904,7 +1955,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -1914,7 +1966,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchFields": {
                                 "items": {
@@ -1929,7 +1982,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -1939,7 +1993,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               }
                             },
                             "type": "object",
@@ -1958,7 +2013,8 @@
                         "type": "object",
                         "additionalProperties": false
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     },
                     "requiredDuringSchedulingIgnoredDuringExecution": {
                       "properties": {
@@ -1978,7 +2034,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -1988,7 +2045,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchFields": {
                                 "items": {
@@ -2003,7 +2061,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -2013,14 +2072,16 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               }
                             },
                             "type": "object",
                             "x-kubernetes-map-type": "atomic",
                             "additionalProperties": false
                           },
-                          "type": "array"
+                          "type": "array",
+                          "x-kubernetes-list-type": "atomic"
                         }
                       },
                       "required": [
@@ -2056,7 +2117,8 @@
                                           "items": {
                                             "type": "string"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       },
                                       "required": [
@@ -2066,7 +2128,8 @@
                                       "type": "object",
                                       "additionalProperties": false
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "matchLabels": {
                                     "additionalProperties": {
@@ -2108,7 +2171,8 @@
                                           "items": {
                                             "type": "string"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       },
                                       "required": [
@@ -2118,7 +2182,8 @@
                                       "type": "object",
                                       "additionalProperties": false
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "matchLabels": {
                                     "additionalProperties": {
@@ -2135,7 +2200,8 @@
                                 "items": {
                                   "type": "string"
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "topologyKey": {
                                 "type": "string"
@@ -2159,7 +2225,8 @@
                         "type": "object",
                         "additionalProperties": false
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     },
                     "requiredDuringSchedulingIgnoredDuringExecution": {
                       "items": {
@@ -2179,7 +2246,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -2189,7 +2257,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchLabels": {
                                 "additionalProperties": {
@@ -2231,7 +2300,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -2241,7 +2311,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchLabels": {
                                 "additionalProperties": {
@@ -2258,7 +2329,8 @@
                             "items": {
                               "type": "string"
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "topologyKey": {
                             "type": "string"
@@ -2270,7 +2342,8 @@
                         "type": "object",
                         "additionalProperties": false
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     }
                   },
                   "type": "object",
@@ -2298,7 +2371,8 @@
                                           "items": {
                                             "type": "string"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       },
                                       "required": [
@@ -2308,7 +2382,8 @@
                                       "type": "object",
                                       "additionalProperties": false
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "matchLabels": {
                                     "additionalProperties": {
@@ -2350,7 +2425,8 @@
                                           "items": {
                                             "type": "string"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       },
                                       "required": [
@@ -2360,7 +2436,8 @@
                                       "type": "object",
                                       "additionalProperties": false
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "matchLabels": {
                                     "additionalProperties": {
@@ -2377,7 +2454,8 @@
                                 "items": {
                                   "type": "string"
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "topologyKey": {
                                 "type": "string"
@@ -2401,7 +2479,8 @@
                         "type": "object",
                         "additionalProperties": false
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     },
                     "requiredDuringSchedulingIgnoredDuringExecution": {
                       "items": {
@@ -2421,7 +2500,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -2431,7 +2511,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchLabels": {
                                 "additionalProperties": {
@@ -2473,7 +2554,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -2483,7 +2565,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchLabels": {
                                 "additionalProperties": {
@@ -2500,7 +2583,8 @@
                             "items": {
                               "type": "string"
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "topologyKey": {
                             "type": "string"
@@ -2512,7 +2596,8 @@
                         "type": "object",
                         "additionalProperties": false
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     }
                   },
                   "type": "object",
@@ -2561,7 +2646,8 @@
                                   "items": {
                                     "type": "string"
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               },
                               "required": [
@@ -2571,7 +2657,8 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "matchLabels": {
                             "additionalProperties": {
@@ -2636,12 +2723,16 @@
               "nullable": true,
               "properties": {
                 "claims": {
-                  "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\n\nThis field is immutable. It can only be set for containers.",
+                  "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
                   "items": {
                     "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
                     "properties": {
                       "name": {
                         "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
+                        "type": "string"
+                      },
+                      "request": {
+                        "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
                         "type": "string"
                       }
                     },

--- a/ceph.rook.io/cephobjectstore_v1.json
+++ b/ceph.rook.io/cephobjectstore_v1.json
@@ -22,6 +22,55 @@
           },
           "type": "array"
         },
+        "auth": {
+          "description": "The authentication configuration",
+          "properties": {
+            "keystone": {
+              "description": "The spec for Keystone",
+              "nullable": true,
+              "properties": {
+                "acceptedRoles": {
+                  "description": "The roles requires to serve requests.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "implicitTenants": {
+                  "description": "Create new users in their own tenants of the same name. Possible values are true, false, swift and s3. The latter have the effect of splitting the identity space such that only the indicated protocol will use implicit tenants.",
+                  "type": "string"
+                },
+                "revocationInterval": {
+                  "description": "The number of seconds between token revocation checks.",
+                  "nullable": true,
+                  "type": "integer"
+                },
+                "serviceUserSecretName": {
+                  "description": "The name of the secret containing the credentials for the service user account used by RGW. It has to be in the same namespace as the object store resource.",
+                  "type": "string"
+                },
+                "tokenCacheSize": {
+                  "description": "The maximum number of entries in each Keystone token cache.",
+                  "nullable": true,
+                  "type": "integer"
+                },
+                "url": {
+                  "description": "The URL for the Keystone server.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "acceptedRoles",
+                "serviceUserSecretName",
+                "url"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
         "dataPool": {
           "description": "The data pool settings",
           "nullable": true,
@@ -51,6 +100,10 @@
               "description": "The device class the OSD should set to for use in the pool",
               "nullable": true,
               "type": "string"
+            },
+            "enableCrushUpdates": {
+              "description": "Allow rook operator to change the pool CRUSH tunables once the pool is created",
+              "type": "boolean"
             },
             "enableRBDStats": {
               "description": "EnableRBDStats is used to enable gathering of statistics for all RBD images in the pool",
@@ -258,6 +311,412 @@
           "description": "The rgw pod info",
           "nullable": true,
           "properties": {
+            "additionalVolumeMounts": {
+              "description": "AdditionalVolumeMounts allows additional volumes to be mounted to the RGW pod.\nThe root directory for each additional volume mount is `/var/rgw`.\nExample: for an additional mount at subPath `ldap`, mounted from a secret that has key\n`bindpass.secret`, the file would reside at `/var/rgw/ldap/bindpass.secret`.",
+              "items": {
+                "description": "AdditionalVolumeMount represents the source from where additional files in pod containers\nshould come from and what subdirectory they are made available in.",
+                "properties": {
+                  "subPath": {
+                    "description": "SubPath defines the sub-path (subdirectory) of the directory root where the volumeSource will\nbe mounted. All files/keys in the volume source's volume will be mounted to the subdirectory.\nThis is not the same as the Kubernetes `subPath` volume mount option.\nEach subPath definition must be unique and must not contain ':'.",
+                    "minLength": 1,
+                    "pattern": "^[^:]+$",
+                    "type": "string"
+                  },
+                  "volumeSource": {
+                    "properties": {
+                      "configMap": {
+                        "properties": {
+                          "defaultMode": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "items": {
+                            "items": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "mode": {
+                                  "format": "int32",
+                                  "type": "integer"
+                                },
+                                "path": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "path"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "name": {
+                            "default": "",
+                            "type": "string"
+                          },
+                          "optional": {
+                            "type": "boolean"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "emptyDir": {
+                        "properties": {
+                          "medium": {
+                            "type": "string"
+                          },
+                          "sizeLimit": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                            "x-kubernetes-int-or-string": true
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "hostPath": {
+                        "properties": {
+                          "path": {
+                            "type": "string"
+                          },
+                          "type": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "path"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "persistentVolumeClaim": {
+                        "properties": {
+                          "claimName": {
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "claimName"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "projected": {
+                        "properties": {
+                          "defaultMode": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "sources": {
+                            "items": {
+                              "properties": {
+                                "clusterTrustBundle": {
+                                  "properties": {
+                                    "labelSelector": {
+                                      "properties": {
+                                        "matchExpressions": {
+                                          "items": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "operator": {
+                                                "type": "string"
+                                              },
+                                              "values": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array",
+                                                "x-kubernetes-list-type": "atomic"
+                                              }
+                                            },
+                                            "required": [
+                                              "key",
+                                              "operator"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
+                                        },
+                                        "matchLabels": {
+                                          "additionalProperties": {
+                                            "type": "string"
+                                          },
+                                          "type": "object"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "x-kubernetes-map-type": "atomic",
+                                      "additionalProperties": false
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    },
+                                    "path": {
+                                      "type": "string"
+                                    },
+                                    "signerName": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "path"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "configMap": {
+                                  "properties": {
+                                    "items": {
+                                      "items": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "mode": {
+                                            "format": "int32",
+                                            "type": "integer"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "key",
+                                          "path"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    },
+                                    "name": {
+                                      "default": "",
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                },
+                                "downwardAPI": {
+                                  "properties": {
+                                    "items": {
+                                      "items": {
+                                        "properties": {
+                                          "fieldRef": {
+                                            "properties": {
+                                              "apiVersion": {
+                                                "type": "string"
+                                              },
+                                              "fieldPath": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "fieldPath"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "additionalProperties": false
+                                          },
+                                          "mode": {
+                                            "format": "int32",
+                                            "type": "integer"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "resourceFieldRef": {
+                                            "properties": {
+                                              "containerName": {
+                                                "type": "string"
+                                              },
+                                              "divisor": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "integer"
+                                                  },
+                                                  {
+                                                    "type": "string"
+                                                  }
+                                                ],
+                                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                                "x-kubernetes-int-or-string": true
+                                              },
+                                              "resource": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "resource"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "required": [
+                                          "path"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "secret": {
+                                  "properties": {
+                                    "items": {
+                                      "items": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "mode": {
+                                            "format": "int32",
+                                            "type": "integer"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "key",
+                                          "path"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    },
+                                    "name": {
+                                      "default": "",
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                },
+                                "serviceAccountToken": {
+                                  "properties": {
+                                    "audience": {
+                                      "type": "string"
+                                    },
+                                    "expirationSeconds": {
+                                      "format": "int64",
+                                      "type": "integer"
+                                    },
+                                    "path": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "path"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "secret": {
+                        "properties": {
+                          "defaultMode": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "items": {
+                            "items": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "mode": {
+                                  "format": "int32",
+                                  "type": "integer"
+                                },
+                                "path": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "path"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "optional": {
+                            "type": "boolean"
+                          },
+                          "secretName": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "required": [
+                  "subPath",
+                  "volumeSource"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
             "annotations": {
               "additionalProperties": {
                 "type": "string"
@@ -324,6 +783,79 @@
               "type": "object",
               "x-kubernetes-preserve-unknown-fields": true
             },
+            "opsLogSidecar": {
+              "description": "Enable enhanced operation Logs for S3 in a sidecar named ops-log",
+              "nullable": true,
+              "properties": {
+                "resources": {
+                  "description": "Resources represents the way to specify resource requirements for the ops-log sidecar",
+                  "properties": {
+                    "claims": {
+                      "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
+                      "items": {
+                        "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                        "properties": {
+                          "name": {
+                            "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
+                            "type": "string"
+                          },
+                          "request": {
+                            "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array",
+                      "x-kubernetes-list-map-keys": [
+                        "name"
+                      ],
+                      "x-kubernetes-list-type": "map"
+                    },
+                    "limits": {
+                      "additionalProperties": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                      "type": "object"
+                    },
+                    "requests": {
+                      "additionalProperties": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                      "type": "object"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
             "placement": {
               "nullable": true,
               "properties": {
@@ -347,7 +879,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -357,7 +890,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchFields": {
                                 "items": {
@@ -372,7 +906,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -382,7 +917,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               }
                             },
                             "type": "object",
@@ -401,7 +937,8 @@
                         "type": "object",
                         "additionalProperties": false
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     },
                     "requiredDuringSchedulingIgnoredDuringExecution": {
                       "properties": {
@@ -421,7 +958,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -431,7 +969,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchFields": {
                                 "items": {
@@ -446,7 +985,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -456,14 +996,16 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               }
                             },
                             "type": "object",
                             "x-kubernetes-map-type": "atomic",
                             "additionalProperties": false
                           },
-                          "type": "array"
+                          "type": "array",
+                          "x-kubernetes-list-type": "atomic"
                         }
                       },
                       "required": [
@@ -499,7 +1041,8 @@
                                           "items": {
                                             "type": "string"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       },
                                       "required": [
@@ -509,7 +1052,8 @@
                                       "type": "object",
                                       "additionalProperties": false
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "matchLabels": {
                                     "additionalProperties": {
@@ -551,7 +1095,8 @@
                                           "items": {
                                             "type": "string"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       },
                                       "required": [
@@ -561,7 +1106,8 @@
                                       "type": "object",
                                       "additionalProperties": false
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "matchLabels": {
                                     "additionalProperties": {
@@ -578,7 +1124,8 @@
                                 "items": {
                                   "type": "string"
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "topologyKey": {
                                 "type": "string"
@@ -602,7 +1149,8 @@
                         "type": "object",
                         "additionalProperties": false
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     },
                     "requiredDuringSchedulingIgnoredDuringExecution": {
                       "items": {
@@ -622,7 +1170,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -632,7 +1181,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchLabels": {
                                 "additionalProperties": {
@@ -674,7 +1224,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -684,7 +1235,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchLabels": {
                                 "additionalProperties": {
@@ -701,7 +1253,8 @@
                             "items": {
                               "type": "string"
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "topologyKey": {
                             "type": "string"
@@ -713,7 +1266,8 @@
                         "type": "object",
                         "additionalProperties": false
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     }
                   },
                   "type": "object",
@@ -741,7 +1295,8 @@
                                           "items": {
                                             "type": "string"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       },
                                       "required": [
@@ -751,7 +1306,8 @@
                                       "type": "object",
                                       "additionalProperties": false
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "matchLabels": {
                                     "additionalProperties": {
@@ -793,7 +1349,8 @@
                                           "items": {
                                             "type": "string"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       },
                                       "required": [
@@ -803,7 +1360,8 @@
                                       "type": "object",
                                       "additionalProperties": false
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "matchLabels": {
                                     "additionalProperties": {
@@ -820,7 +1378,8 @@
                                 "items": {
                                   "type": "string"
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "topologyKey": {
                                 "type": "string"
@@ -844,7 +1403,8 @@
                         "type": "object",
                         "additionalProperties": false
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     },
                     "requiredDuringSchedulingIgnoredDuringExecution": {
                       "items": {
@@ -864,7 +1424,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -874,7 +1435,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchLabels": {
                                 "additionalProperties": {
@@ -916,7 +1478,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -926,7 +1489,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchLabels": {
                                 "additionalProperties": {
@@ -943,7 +1507,8 @@
                             "items": {
                               "type": "string"
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "topologyKey": {
                             "type": "string"
@@ -955,7 +1520,8 @@
                         "type": "object",
                         "additionalProperties": false
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     }
                   },
                   "type": "object",
@@ -1004,7 +1570,8 @@
                                   "items": {
                                     "type": "string"
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               },
                               "required": [
@@ -1014,7 +1581,8 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "matchLabels": {
                             "additionalProperties": {
@@ -1084,12 +1652,16 @@
               "nullable": true,
               "properties": {
                 "claims": {
-                  "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\n\nThis field is immutable. It can only be set for containers.",
+                  "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
                   "items": {
                     "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
                     "properties": {
                       "name": {
                         "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
+                        "type": "string"
+                      },
+                      "request": {
+                        "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
                         "type": "string"
                       }
                     },
@@ -1142,6 +1714,22 @@
               "x-kubernetes-preserve-unknown-fields": true,
               "additionalProperties": false
             },
+            "rgwCommandFlags": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "RgwCommandFlags sets Ceph RGW config values for the gateway clients that serve this object\nstore. Values are modified at RGW startup, resulting in RGW pod restarts.\nThis feature is intended for advanced users. It allows breaking configurations to be easily\napplied. Use with caution.",
+              "nullable": true,
+              "type": "object"
+            },
+            "rgwConfig": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "RgwConfig sets Ceph RGW config values for the gateway clients that serve this object store.\nValues are modified at runtime without RGW restart.\nThis feature is intended for advanced users. It allows breaking configurations to be easily\napplied. Use with caution.",
+              "nullable": true,
+              "type": "object"
+            },
             "securePort": {
               "description": "The port the rgw service will be listening on (https)",
               "format": "int32",
@@ -1189,14 +1777,15 @@
                   "description": "Probe describes a health check to be performed against a container to determine whether it is\nalive or ready to receive traffic.",
                   "properties": {
                     "exec": {
-                      "description": "Exec specifies the action to take.",
+                      "description": "Exec specifies a command to execute in the container.",
                       "properties": {
                         "command": {
                           "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
                           "items": {
                             "type": "string"
                           },
-                          "type": "array"
+                          "type": "array",
+                          "x-kubernetes-list-type": "atomic"
                         }
                       },
                       "type": "object",
@@ -1208,7 +1797,7 @@
                       "type": "integer"
                     },
                     "grpc": {
-                      "description": "GRPC specifies an action involving a GRPC port.",
+                      "description": "GRPC specifies a GRPC HealthCheckRequest.",
                       "properties": {
                         "port": {
                           "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
@@ -1216,7 +1805,8 @@
                           "type": "integer"
                         },
                         "service": {
-                          "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                          "default": "",
+                          "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
                           "type": "string"
                         }
                       },
@@ -1227,7 +1817,7 @@
                       "additionalProperties": false
                     },
                     "httpGet": {
-                      "description": "HTTPGet specifies the http request to perform.",
+                      "description": "HTTPGet specifies an HTTP GET request to perform.",
                       "properties": {
                         "host": {
                           "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
@@ -1254,7 +1844,8 @@
                             "type": "object",
                             "additionalProperties": false
                           },
-                          "type": "array"
+                          "type": "array",
+                          "x-kubernetes-list-type": "atomic"
                         },
                         "path": {
                           "description": "Path to access on the HTTP server.",
@@ -1299,7 +1890,7 @@
                       "type": "integer"
                     },
                     "tcpSocket": {
-                      "description": "TCPSocket specifies an action involving a TCP port.",
+                      "description": "TCPSocket specifies a connection to a TCP port.",
                       "properties": {
                         "host": {
                           "description": "Optional: Host name to connect to, defaults to the pod IP.",
@@ -1353,14 +1944,15 @@
                   "description": "Probe describes a health check to be performed against a container to determine whether it is\nalive or ready to receive traffic.",
                   "properties": {
                     "exec": {
-                      "description": "Exec specifies the action to take.",
+                      "description": "Exec specifies a command to execute in the container.",
                       "properties": {
                         "command": {
                           "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
                           "items": {
                             "type": "string"
                           },
-                          "type": "array"
+                          "type": "array",
+                          "x-kubernetes-list-type": "atomic"
                         }
                       },
                       "type": "object",
@@ -1372,7 +1964,7 @@
                       "type": "integer"
                     },
                     "grpc": {
-                      "description": "GRPC specifies an action involving a GRPC port.",
+                      "description": "GRPC specifies a GRPC HealthCheckRequest.",
                       "properties": {
                         "port": {
                           "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
@@ -1380,7 +1972,8 @@
                           "type": "integer"
                         },
                         "service": {
-                          "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                          "default": "",
+                          "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
                           "type": "string"
                         }
                       },
@@ -1391,7 +1984,7 @@
                       "additionalProperties": false
                     },
                     "httpGet": {
-                      "description": "HTTPGet specifies the http request to perform.",
+                      "description": "HTTPGet specifies an HTTP GET request to perform.",
                       "properties": {
                         "host": {
                           "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
@@ -1418,7 +2011,8 @@
                             "type": "object",
                             "additionalProperties": false
                           },
-                          "type": "array"
+                          "type": "array",
+                          "x-kubernetes-list-type": "atomic"
                         },
                         "path": {
                           "description": "Path to access on the HTTP server.",
@@ -1463,7 +2057,7 @@
                       "type": "integer"
                     },
                     "tcpSocket": {
-                      "description": "TCPSocket specifies an action involving a TCP port.",
+                      "description": "TCPSocket specifies a connection to a TCP port.",
                       "properties": {
                         "host": {
                           "description": "Optional: Host name to connect to, defaults to the pod IP.",
@@ -1510,10 +2104,40 @@
           "additionalProperties": false
         },
         "hosting": {
-          "description": "Hosting settings for the object store",
+          "description": "Hosting settings for the object store.\nA common use case for hosting configuration is to inform Rook of endpoints that support DNS\nwildcards, which in turn allows virtual host-style bucket addressing.",
+          "nullable": true,
           "properties": {
+            "advertiseEndpoint": {
+              "description": "AdvertiseEndpoint is the default endpoint Rook will return for resources dependent on this\nobject store. This endpoint will be returned to CephObjectStoreUsers, Object Bucket Claims,\nand COSI Buckets/Accesses.\nBy default, Rook returns the endpoint for the object store's Kubernetes service using HTTPS\nwith `gateway.securePort` if it is defined (otherwise, HTTP with `gateway.port`).",
+              "nullable": true,
+              "properties": {
+                "dnsName": {
+                  "description": "DnsName is the DNS name (in RFC-1123 format) of the endpoint.\nIf the DNS name corresponds to an endpoint with DNS wildcard support, do not include the\nwildcard itself in the list of hostnames.\nE.g., use \"mystore.example.com\" instead of \"*.mystore.example.com\".",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "port": {
+                  "description": "Port is the port on which S3 connections can be made for this endpoint.",
+                  "format": "int32",
+                  "maximum": 65535,
+                  "minimum": 1,
+                  "type": "integer"
+                },
+                "useTls": {
+                  "description": "UseTls defines whether the endpoint uses TLS (HTTPS) or not (HTTP).",
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "dnsName",
+                "port",
+                "useTls"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
             "dnsNames": {
-              "description": "A list of DNS names in which bucket can be accessed via virtual host path. These names need to valid according RFC-1123.\nEach domain requires wildcard support like ingress loadbalancer.\nDo not include the wildcard itself in the list of hostnames (e.g. use \"mystore.example.com\" instead of \"*.mystore.example.com\").\nAdd all hostnames including user-created Kubernetes Service endpoints to the list.\nCephObjectStore Service Endpoints and CephObjectZone customEndpoints are automatically added to the list.\nThe feature is supported only for Ceph v18 and later versions.",
+              "description": "A list of DNS host names on which object store gateways will accept client S3 connections.\nWhen specified, object store gateways will reject client S3 connections to hostnames that are\nnot present in this list, so include all endpoints.\nThe object store's advertiseEndpoint and Kubernetes service endpoint, plus CephObjectZone\n`customEndpoints` are automatically added to the list but may be set here again if desired.\nEach DNS name must be valid according RFC-1123.\nIf the DNS name corresponds to an endpoint with DNS wildcard support, do not include the\nwildcard itself in the list of hostnames.\nE.g., use \"mystore.example.com\" instead of \"*.mystore.example.com\".",
               "items": {
                 "type": "string"
               },
@@ -1552,6 +2176,10 @@
               "description": "The device class the OSD should set to for use in the pool",
               "nullable": true,
               "type": "string"
+            },
+            "enableCrushUpdates": {
+              "description": "Allow rook operator to change the pool CRUSH tunables once the pool is created",
+              "type": "boolean"
             },
             "enableRBDStats": {
               "description": "EnableRBDStats is used to enable gathering of statistics for all RBD images in the pool",
@@ -1759,6 +2387,72 @@
           "description": "Preserve pools on object store deletion",
           "type": "boolean"
         },
+        "protocols": {
+          "description": "The protocol specification",
+          "properties": {
+            "enableAPIs": {
+              "description": "Represents RGW 'rgw_enable_apis' config option. See: https://docs.ceph.com/en/reef/radosgw/config-ref/#confval-rgw_enable_apis\nIf no value provided then all APIs will be enabled: s3, s3website, swift, swift_auth, admin, sts, iam, notifications\nIf enabled APIs are set, all remaining APIs will be disabled.\nThis option overrides S3.Enabled value.",
+              "items": {
+                "enum": [
+                  "s3",
+                  "s3website",
+                  "swift",
+                  "swift_auth",
+                  "admin",
+                  "sts",
+                  "iam",
+                  "notifications"
+                ],
+                "type": "string"
+              },
+              "nullable": true,
+              "type": "array"
+            },
+            "s3": {
+              "description": "The spec for S3",
+              "nullable": true,
+              "properties": {
+                "authUseKeystone": {
+                  "description": "Whether to use Keystone for authentication. This option maps directly to the rgw_s3_auth_use_keystone option. Enabling it allows generating S3 credentials via an OpenStack API call, see the docs. If not given, the defaults of the corresponding RGW option apply.",
+                  "nullable": true,
+                  "type": "boolean"
+                },
+                "enabled": {
+                  "description": "Deprecated: use protocol.enableAPIs instead.\nWhether to enable S3. This defaults to true (even if protocols.s3 is not present in the CRD). This maintains backwards compatibility \u2013 by default S3 is enabled.",
+                  "nullable": true,
+                  "type": "boolean"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "swift": {
+              "description": "The spec for Swift",
+              "nullable": true,
+              "properties": {
+                "accountInUrl": {
+                  "description": "Whether or not the Swift account name should be included in the Swift API URL. If set to false (the default), then the Swift API will listen on a URL formed like http://host:port/<rgw_swift_url_prefix>/v1. If set to true, the Swift API URL will be http://host:port/<rgw_swift_url_prefix>/v1/AUTH_<account_name>. You must set this option to true (and update the Keystone service catalog) if you want radosgw to support publicly-readable containers and temporary URLs.",
+                  "nullable": true,
+                  "type": "boolean"
+                },
+                "urlPrefix": {
+                  "description": "The URL prefix for the Swift API, to distinguish it from the S3 API endpoint. The default is swift, which makes the Swift API available at the URL http://host:port/swift/v1 (or http://host:port/swift/v1/AUTH_%(tenant_id)s if rgw swift account in url is enabled).",
+                  "nullable": true,
+                  "type": "string"
+                },
+                "versioningEnabled": {
+                  "description": "Enables the Object Versioning of OpenStack Object Storage API. This allows clients to put the X-Versions-Location attribute on containers that should be versioned.",
+                  "nullable": true,
+                  "type": "boolean"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
         "security": {
           "description": "Security represents security settings",
           "nullable": true,
@@ -1850,15 +2544,75 @@
                 }
               ]
             },
+            "poolPlacements": {
+              "description": "PoolPlacements control which Pools are associated with a particular RGW bucket.\nOnce PoolPlacements are defined, RGW client will be able to associate pool\nwith ObjectStore bucket by providing \"<LocationConstraint>\" during s3 bucket creation\nor \"X-Storage-Policy\" header during swift container creation.\nSee: https://docs.ceph.com/en/latest/radosgw/placement/#placement-targets\nPoolPlacement with name: \"default\" will be used as a default pool if no option\nis provided during bucket creation.\nIf default placement is not provided, spec.sharedPools.dataPoolName and spec.sharedPools.MetadataPoolName will be used as default pools.\nIf spec.sharedPools are also empty, then RGW pools (spec.dataPool and spec.metadataPool) will be used as defaults.",
+              "items": {
+                "properties": {
+                  "dataNonECPoolName": {
+                    "description": "The data pool used to store ObjectStore data that cannot use erasure coding (ex: multi-part uploads).\nIf dataPoolName is not erasure coded, then there is no need for dataNonECPoolName.",
+                    "type": "string"
+                  },
+                  "dataPoolName": {
+                    "description": "The data pool used to store ObjectStore objects data.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "default": {
+                    "description": "Sets given placement as default. Only one placement in the list can be marked as default.\nDefault is false.",
+                    "type": "boolean"
+                  },
+                  "metadataPoolName": {
+                    "description": "The metadata pool used to store ObjectStore bucket index.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "Pool placement name. Name can be arbitrary. Placement with name \"default\" will be used as default.",
+                    "minLength": 1,
+                    "pattern": "^[a-zA-Z0-9._/-]+$",
+                    "type": "string"
+                  },
+                  "storageClasses": {
+                    "description": "StorageClasses can be selected by user to override dataPoolName during object creation.\nEach placement has default STANDARD StorageClass pointing to dataPoolName.\nThis list allows defining additional StorageClasses on top of default STANDARD storage class.",
+                    "items": {
+                      "properties": {
+                        "dataPoolName": {
+                          "description": "DataPoolName is the data pool used to store ObjectStore objects data.",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name is the StorageClass name. Ceph allows arbitrary name for StorageClasses,\nhowever most clients/libs insist on AWS names so it is recommended to use\none of the valid x-amz-storage-class values for better compatibility:\nREDUCED_REDUNDANCY | STANDARD_IA | ONEZONE_IA | INTELLIGENT_TIERING | GLACIER | DEEP_ARCHIVE | OUTPOSTS | GLACIER_IR | SNOW | EXPRESS_ONEZONE\nSee AWS docs: https://aws.amazon.com/de/s3/storage-classes/",
+                          "minLength": 1,
+                          "pattern": "^[a-zA-Z0-9._/-]+$",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "dataPoolName",
+                        "name"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "dataPoolName",
+                  "metadataPoolName",
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
             "preserveRadosNamespaceDataOnDelete": {
               "description": "Whether the RADOS namespaces should be preserved on deletion of the object store",
               "type": "boolean"
             }
           },
-          "required": [
-            "dataPoolName",
-            "metadataPoolName"
-          ],
           "type": "object",
           "additionalProperties": false
         },

--- a/ceph.rook.io/cephobjectstoreuser_v1.json
+++ b/ceph.rook.io/cephobjectstoreuser_v1.json
@@ -20,7 +20,7 @@
           "nullable": true,
           "properties": {
             "amz-cache": {
-              "description": "Add capabilities for user to send request to RGW Cache API header. Documented in https://docs.ceph.com/en/quincy/radosgw/rgw-cache/#cache-api",
+              "description": "Add capabilities for user to send request to RGW Cache API header. Documented in https://docs.ceph.com/en/latest/radosgw/rgw-cache/#cache-api",
               "enum": [
                 "*",
                 "read",

--- a/ceph.rook.io/cephobjectzone_v1.json
+++ b/ceph.rook.io/cephobjectzone_v1.json
@@ -16,7 +16,7 @@
       "description": "ObjectZoneSpec represent the spec of an ObjectZone",
       "properties": {
         "customEndpoints": {
-          "description": "If this zone cannot be accessed from other peer Ceph clusters via the ClusterIP Service\nendpoint created by Rook, you must set this to the externally reachable endpoint(s). You may\ninclude the port in the definition. For example: \"https://my-object-store.my-domain.net:443\".\nIn many cases, you should set this to the endpoint of the ingress resource that makes the\nCephObjectStore associated with this CephObjectStoreZone reachable to peer clusters.\nThe list can have one or more endpoints pointing to different RGW servers in the zone.\n\n\nIf a CephObjectStore endpoint is omitted from this list, that object store's gateways will\nnot receive multisite replication data\n(see CephObjectStore.spec.gateway.disableMultisiteSyncTraffic).",
+          "description": "If this zone cannot be accessed from other peer Ceph clusters via the ClusterIP Service\nendpoint created by Rook, you must set this to the externally reachable endpoint(s). You may\ninclude the port in the definition. For example: \"https://my-object-store.my-domain.net:443\".\nIn many cases, you should set this to the endpoint of the ingress resource that makes the\nCephObjectStore associated with this CephObjectStoreZone reachable to peer clusters.\nThe list can have one or more endpoints pointing to different RGW servers in the zone.\n\nIf a CephObjectStore endpoint is omitted from this list, that object store's gateways will\nnot receive multisite replication data\n(see CephObjectStore.spec.gateway.disableMultisiteSyncTraffic).",
           "items": {
             "type": "string"
           },
@@ -52,6 +52,10 @@
               "description": "The device class the OSD should set to for use in the pool",
               "nullable": true,
               "type": "string"
+            },
+            "enableCrushUpdates": {
+              "description": "Allow rook operator to change the pool CRUSH tunables once the pool is created",
+              "type": "boolean"
             },
             "enableRBDStats": {
               "description": "EnableRBDStats is used to enable gathering of statistics for all RBD images in the pool",
@@ -285,6 +289,10 @@
               "nullable": true,
               "type": "string"
             },
+            "enableCrushUpdates": {
+              "description": "Allow rook operator to change the pool CRUSH tunables once the pool is created",
+              "type": "boolean"
+            },
             "enableRBDStats": {
               "description": "EnableRBDStats is used to enable gathering of statistics for all RBD images in the pool",
               "type": "boolean"
@@ -516,15 +524,75 @@
                 }
               ]
             },
+            "poolPlacements": {
+              "description": "PoolPlacements control which Pools are associated with a particular RGW bucket.\nOnce PoolPlacements are defined, RGW client will be able to associate pool\nwith ObjectStore bucket by providing \"<LocationConstraint>\" during s3 bucket creation\nor \"X-Storage-Policy\" header during swift container creation.\nSee: https://docs.ceph.com/en/latest/radosgw/placement/#placement-targets\nPoolPlacement with name: \"default\" will be used as a default pool if no option\nis provided during bucket creation.\nIf default placement is not provided, spec.sharedPools.dataPoolName and spec.sharedPools.MetadataPoolName will be used as default pools.\nIf spec.sharedPools are also empty, then RGW pools (spec.dataPool and spec.metadataPool) will be used as defaults.",
+              "items": {
+                "properties": {
+                  "dataNonECPoolName": {
+                    "description": "The data pool used to store ObjectStore data that cannot use erasure coding (ex: multi-part uploads).\nIf dataPoolName is not erasure coded, then there is no need for dataNonECPoolName.",
+                    "type": "string"
+                  },
+                  "dataPoolName": {
+                    "description": "The data pool used to store ObjectStore objects data.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "default": {
+                    "description": "Sets given placement as default. Only one placement in the list can be marked as default.\nDefault is false.",
+                    "type": "boolean"
+                  },
+                  "metadataPoolName": {
+                    "description": "The metadata pool used to store ObjectStore bucket index.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "Pool placement name. Name can be arbitrary. Placement with name \"default\" will be used as default.",
+                    "minLength": 1,
+                    "pattern": "^[a-zA-Z0-9._/-]+$",
+                    "type": "string"
+                  },
+                  "storageClasses": {
+                    "description": "StorageClasses can be selected by user to override dataPoolName during object creation.\nEach placement has default STANDARD StorageClass pointing to dataPoolName.\nThis list allows defining additional StorageClasses on top of default STANDARD storage class.",
+                    "items": {
+                      "properties": {
+                        "dataPoolName": {
+                          "description": "DataPoolName is the data pool used to store ObjectStore objects data.",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name is the StorageClass name. Ceph allows arbitrary name for StorageClasses,\nhowever most clients/libs insist on AWS names so it is recommended to use\none of the valid x-amz-storage-class values for better compatibility:\nREDUCED_REDUNDANCY | STANDARD_IA | ONEZONE_IA | INTELLIGENT_TIERING | GLACIER | DEEP_ARCHIVE | OUTPOSTS | GLACIER_IR | SNOW | EXPRESS_ONEZONE\nSee AWS docs: https://aws.amazon.com/de/s3/storage-classes/",
+                          "minLength": 1,
+                          "pattern": "^[a-zA-Z0-9._/-]+$",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "dataPoolName",
+                        "name"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "dataPoolName",
+                  "metadataPoolName",
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
             "preserveRadosNamespaceDataOnDelete": {
               "description": "Whether the RADOS namespaces should be preserved on deletion of the object store",
               "type": "boolean"
             }
           },
-          "required": [
-            "dataPoolName",
-            "metadataPoolName"
-          ],
           "type": "object",
           "additionalProperties": false
         },
@@ -534,8 +602,6 @@
         }
       },
       "required": [
-        "dataPool",
-        "metadataPool",
         "zoneGroup"
       ],
       "type": "object",

--- a/ceph.rook.io/cephrbdmirror_v1.json
+++ b/ceph.rook.io/cephrbdmirror_v1.json
@@ -76,7 +76,8 @@
                                   "items": {
                                     "type": "string"
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               },
                               "required": [
@@ -86,7 +87,8 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "matchFields": {
                             "items": {
@@ -101,7 +103,8 @@
                                   "items": {
                                     "type": "string"
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               },
                               "required": [
@@ -111,7 +114,8 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           }
                         },
                         "type": "object",
@@ -130,7 +134,8 @@
                     "type": "object",
                     "additionalProperties": false
                   },
-                  "type": "array"
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
                 },
                 "requiredDuringSchedulingIgnoredDuringExecution": {
                   "properties": {
@@ -150,7 +155,8 @@
                                   "items": {
                                     "type": "string"
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               },
                               "required": [
@@ -160,7 +166,8 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "matchFields": {
                             "items": {
@@ -175,7 +182,8 @@
                                   "items": {
                                     "type": "string"
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               },
                               "required": [
@@ -185,14 +193,16 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           }
                         },
                         "type": "object",
                         "x-kubernetes-map-type": "atomic",
                         "additionalProperties": false
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     }
                   },
                   "required": [
@@ -228,7 +238,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -238,7 +249,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchLabels": {
                                 "additionalProperties": {
@@ -280,7 +292,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -290,7 +303,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchLabels": {
                                 "additionalProperties": {
@@ -307,7 +321,8 @@
                             "items": {
                               "type": "string"
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "topologyKey": {
                             "type": "string"
@@ -331,7 +346,8 @@
                     "type": "object",
                     "additionalProperties": false
                   },
-                  "type": "array"
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
                 },
                 "requiredDuringSchedulingIgnoredDuringExecution": {
                   "items": {
@@ -351,7 +367,8 @@
                                   "items": {
                                     "type": "string"
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               },
                               "required": [
@@ -361,7 +378,8 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "matchLabels": {
                             "additionalProperties": {
@@ -403,7 +421,8 @@
                                   "items": {
                                     "type": "string"
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               },
                               "required": [
@@ -413,7 +432,8 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "matchLabels": {
                             "additionalProperties": {
@@ -430,7 +450,8 @@
                         "items": {
                           "type": "string"
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "topologyKey": {
                         "type": "string"
@@ -442,7 +463,8 @@
                     "type": "object",
                     "additionalProperties": false
                   },
-                  "type": "array"
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
                 }
               },
               "type": "object",
@@ -470,7 +492,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -480,7 +503,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchLabels": {
                                 "additionalProperties": {
@@ -522,7 +546,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -532,7 +557,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchLabels": {
                                 "additionalProperties": {
@@ -549,7 +575,8 @@
                             "items": {
                               "type": "string"
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "topologyKey": {
                             "type": "string"
@@ -573,7 +600,8 @@
                     "type": "object",
                     "additionalProperties": false
                   },
-                  "type": "array"
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
                 },
                 "requiredDuringSchedulingIgnoredDuringExecution": {
                   "items": {
@@ -593,7 +621,8 @@
                                   "items": {
                                     "type": "string"
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               },
                               "required": [
@@ -603,7 +632,8 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "matchLabels": {
                             "additionalProperties": {
@@ -645,7 +675,8 @@
                                   "items": {
                                     "type": "string"
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               },
                               "required": [
@@ -655,7 +686,8 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "matchLabels": {
                             "additionalProperties": {
@@ -672,7 +704,8 @@
                         "items": {
                           "type": "string"
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "topologyKey": {
                         "type": "string"
@@ -684,7 +717,8 @@
                     "type": "object",
                     "additionalProperties": false
                   },
-                  "type": "array"
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
                 }
               },
               "type": "object",
@@ -733,7 +767,8 @@
                               "items": {
                                 "type": "string"
                               },
-                              "type": "array"
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
                             }
                           },
                           "required": [
@@ -743,7 +778,8 @@
                           "type": "object",
                           "additionalProperties": false
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "matchLabels": {
                         "additionalProperties": {
@@ -808,12 +844,16 @@
           "nullable": true,
           "properties": {
             "claims": {
-              "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\n\nThis field is immutable. It can only be set for containers.",
+              "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
               "items": {
                 "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
                 "properties": {
                   "name": {
                     "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
+                    "type": "string"
+                  },
+                  "request": {
+                    "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
                     "type": "string"
                   }
                 },

--- a/objectbucket.io/objectbucket_v1alpha1.json
+++ b/objectbucket.io/objectbucket_v1alpha1.json
@@ -1,0 +1,67 @@
+{
+  "type": "object",
+  "properties": {
+    "spec": {
+      "type": "object",
+      "properties": {
+        "storageClassName": {
+          "type": "string"
+        },
+        "endpoint": {
+          "type": "object",
+          "nullable": true,
+          "properties": {
+            "bucketHost": {
+              "type": "string"
+            },
+            "bucketPort": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "bucketName": {
+              "type": "string"
+            },
+            "region": {
+              "type": "string"
+            },
+            "subRegion": {
+              "type": "string"
+            },
+            "additionalConfig": {
+              "type": "object",
+              "nullable": true,
+              "x-kubernetes-preserve-unknown-fields": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "authentication": {
+          "type": "object",
+          "nullable": true,
+          "items": {
+            "type": "object",
+            "x-kubernetes-preserve-unknown-fields": true
+          }
+        },
+        "additionalState": {
+          "type": "object",
+          "nullable": true,
+          "x-kubernetes-preserve-unknown-fields": true
+        },
+        "reclaimPolicy": {
+          "type": "string"
+        },
+        "claimRef": {
+          "type": "object",
+          "nullable": true,
+          "x-kubernetes-preserve-unknown-fields": true
+        }
+      },
+      "additionalProperties": false
+    },
+    "status": {
+      "type": "object",
+      "x-kubernetes-preserve-unknown-fields": true
+    }
+  }
+}

--- a/objectbucket.io/objectbucketclaim_v1alpha1.json
+++ b/objectbucket.io/objectbucketclaim_v1alpha1.json
@@ -1,0 +1,32 @@
+{
+  "type": "object",
+  "properties": {
+    "spec": {
+      "type": "object",
+      "properties": {
+        "storageClassName": {
+          "type": "string"
+        },
+        "bucketName": {
+          "type": "string"
+        },
+        "generateBucketName": {
+          "type": "string"
+        },
+        "additionalConfig": {
+          "type": "object",
+          "nullable": true,
+          "x-kubernetes-preserve-unknown-fields": true
+        },
+        "objectBucketName": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "status": {
+      "type": "object",
+      "x-kubernetes-preserve-unknown-fields": true
+    }
+  }
+}


### PR DESCRIPTION
Follow https://github.com/datreeio/CRDs-catalog/pull/436

Generated with:
```
git clone https://github.com/rook/rook.git --depth 1 --branch v1.16.0 && \
         export FILENAME_FORMAT="{fullgroup}__{kind}_{version}" && \
         make crds -C rook && \
         echo '{"Values": {"crds": {"enabled": true}}}' | gomplate -c .=stdin:///in.json -f rook/deploy/charts/rook-ceph/templates/resources.yaml > crd.yaml && \
         curl -s https://raw.githubusercontent.com/yannh/kubeconform/master/scripts/openapi2jsonschema.py | \
         python3 ~/Repos/kubeconform/scripts/openapi2jsonschema.py crd.yaml | \
         awk '{ print $(NF) }' | \
         xargs -I {} sh -c 'f=$0; mkdir -p $(dirname $(echo $f | sed "s|__|/|")) && \
         mv $f $(echo $f | sed "s|__|/|")' '{}' && \
         rm crd.yaml && \
         rm -rf rook
```

note:
- final crds are not stored in the repositories. https://github.com/rook/rook/blob/master/deploy/examples/crds.yaml
- crds are generated with this target: https://github.com/rook/rook/blob/v1.16.0/Makefile#L182-L186
- gomplate is used here because crds are generated in the helm chart with templating, see https://github.com/rook/rook/blob/v1.16.0/build/crds/build-crds.sh#L77