### PR TITLE
chore: update postgres zalando schemas

### DIFF
--- a/acid.zalan.do/operatorconfiguration_v1.json
+++ b/acid.zalan.do/operatorconfiguration_v1.json
@@ -30,7 +30,7 @@
         },
         "docker_image": {
           "type": "string",
-          "default": "ghcr.io/zalando/spilo-16:3.3-p1"
+          "default": "ghcr.io/zalando/spilo-17:4.0-p2"
         },
         "enable_crd_registration": {
           "type": "boolean",
@@ -163,11 +163,11 @@
             },
             "minimal_major_version": {
               "type": "string",
-              "default": "12"
+              "default": "13"
             },
             "target_major_version": {
               "type": "string",
-              "default": "16"
+              "default": "17"
             }
           },
           "additionalProperties": false
@@ -462,35 +462,35 @@
           "properties": {
             "default_cpu_limit": {
               "type": "string",
-              "pattern": "^(\\d+m|\\d+(\\.\\d{1,3})?)$"
+              "pattern": "^(\\d+m|\\d+(\\.\\d{1,3})?)$|^$"
             },
             "default_cpu_request": {
               "type": "string",
-              "pattern": "^(\\d+m|\\d+(\\.\\d{1,3})?)$"
+              "pattern": "^(\\d+m|\\d+(\\.\\d{1,3})?)$|^$"
             },
             "default_memory_limit": {
               "type": "string",
-              "pattern": "^(\\d+(e\\d+)?|\\d+(\\.\\d+)?(e\\d+)?[EPTGMK]i?)$"
+              "pattern": "^(\\d+(e\\d+)?|\\d+(\\.\\d+)?(e\\d+)?[EPTGMK]i?)$|^$"
             },
             "default_memory_request": {
               "type": "string",
-              "pattern": "^(\\d+(e\\d+)?|\\d+(\\.\\d+)?(e\\d+)?[EPTGMK]i?)$"
+              "pattern": "^(\\d+(e\\d+)?|\\d+(\\.\\d+)?(e\\d+)?[EPTGMK]i?)$|^$"
             },
             "max_cpu_request": {
               "type": "string",
-              "pattern": "^(\\d+m|\\d+(\\.\\d{1,3})?)$"
+              "pattern": "^(\\d+m|\\d+(\\.\\d{1,3})?)$|^$"
             },
             "max_memory_request": {
               "type": "string",
-              "pattern": "^(\\d+(e\\d+)?|\\d+(\\.\\d+)?(e\\d+)?[EPTGMK]i?)$"
+              "pattern": "^(\\d+(e\\d+)?|\\d+(\\.\\d+)?(e\\d+)?[EPTGMK]i?)$|^$"
             },
             "min_cpu_limit": {
               "type": "string",
-              "pattern": "^(\\d+m|\\d+(\\.\\d{1,3})?)$"
+              "pattern": "^(\\d+m|\\d+(\\.\\d{1,3})?)$|^$"
             },
             "min_memory_limit": {
               "type": "string",
-              "pattern": "^(\\d+(e\\d+)?|\\d+(\\.\\d+)?(e\\d+)?[EPTGMK]i?)$"
+              "pattern": "^(\\d+(e\\d+)?|\\d+(\\.\\d+)?(e\\d+)?[EPTGMK]i?)$|^$"
             }
           },
           "additionalProperties": false

--- a/acid.zalan.do/postgresql_v1.json
+++ b/acid.zalan.do/postgresql_v1.json
@@ -472,11 +472,11 @@
             "version": {
               "type": "string",
               "enum": [
-                "12",
                 "13",
                 "14",
                 "15",
-                "16"
+                "16",
+                "17"
               ]
             },
             "parameters": {
@@ -661,6 +661,10 @@
               "batchSize": {
                 "type": "integer"
               },
+              "cpu": {
+                "type": "string",
+                "pattern": "^(\\d+m|\\d+(\\.\\d{1,3})?)$"
+              },
               "database": {
                 "type": "string"
               },
@@ -672,6 +676,10 @@
                 "additionalProperties": {
                   "type": "string"
                 }
+              },
+              "memory": {
+                "type": "string",
+                "pattern": "^(\\d+(e\\d+)?|\\d+(\\.\\d+)?(e\\d+)?[EPTGMK]i?)$"
               },
               "tables": {
                 "type": "object",
@@ -686,6 +694,9 @@
                     },
                     "idColumn": {
                       "type": "string"
+                    },
+                    "ignoreRecovery": {
+                      "type": "boolean"
                     },
                     "payloadColumn": {
                       "type": "string"


### PR DESCRIPTION
Identically as in https://github.com/datreeio/CRDs-catalog/pull/392, regenerated the Schemas for the Zalando Postgres Operator after the release of version 1.14.0: https://github.com/zalando/postgres-operator/releases/tag/v1.14.0

Reference: https://github.com/zalando/postgres-operator/tree/master/charts/postgres-operator/crds
Source: https://github.com/zalando/postgres-operator/tree/master