### PR TITLE
feat: Add flux operator CRDs

### DIFF
--- a/fluxcd.controlplane.io/fluxinstance_v1.json
+++ b/fluxcd.controlplane.io/fluxinstance_v1.json
@@ -1,0 +1,448 @@
+{
+  "description": "FluxInstance is the Schema for the fluxinstances API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "FluxInstanceSpec defines the desired state of FluxInstance",
+      "properties": {
+        "cluster": {
+          "description": "Cluster holds the specification of the Kubernetes cluster.",
+          "properties": {
+            "domain": {
+              "default": "cluster.local",
+              "description": "Domain is the cluster domain used for generating the FQDN of services.\nDefaults to 'cluster.local'.",
+              "type": "string"
+            },
+            "multitenant": {
+              "description": "Multitenant enables the multitenancy lockdown.",
+              "type": "boolean"
+            },
+            "networkPolicy": {
+              "default": true,
+              "description": "NetworkPolicy restricts network access to the current namespace.\nDefaults to true.",
+              "type": "boolean"
+            },
+            "tenantDefaultServiceAccount": {
+              "description": "TenantDefaultServiceAccount is the name of the service account\nto use as default when the multitenant lockdown is enabled.\nDefaults to the 'default' service account from the tenant namespace.",
+              "type": "string"
+            },
+            "type": {
+              "default": "kubernetes",
+              "description": "Type specifies the distro of the Kubernetes cluster.\nDefaults to 'kubernetes'.",
+              "enum": [
+                "kubernetes",
+                "openshift",
+                "aws",
+                "azure",
+                "gcp"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "domain",
+            "networkPolicy"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "commonMetadata": {
+          "description": "CommonMetadata specifies the common labels and annotations that are\napplied to all resources. Any existing label or annotation will be\noverridden if its key matches a common one.",
+          "properties": {
+            "annotations": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "Annotations to be added to the object's metadata.",
+              "type": "object"
+            },
+            "labels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "Labels to be added to the object's metadata.",
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "components": {
+          "description": "Components is the list of controllers to install.\nDefaults to all controllers.",
+          "items": {
+            "description": "Component is the name of a controller to install.",
+            "enum": [
+              "source-controller",
+              "kustomize-controller",
+              "helm-controller",
+              "notification-controller",
+              "image-reflector-controller",
+              "image-automation-controller"
+            ],
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "distribution": {
+          "description": "Distribution specifies the version and container registry to pull images from.",
+          "properties": {
+            "artifact": {
+              "description": "Artifact is the URL to the OCI artifact containing\nthe latest Kubernetes manifests for the distribution,\ne.g. 'oci://ghcr.io/controlplaneio-fluxcd/flux-operator-manifests:latest'.",
+              "pattern": "^oci://.*$",
+              "type": "string"
+            },
+            "artifactPullSecret": {
+              "description": "ArtifactPullSecret is the name of the Kubernetes secret\nto use for pulling the Kubernetes manifests for the distribution specified in the Artifact field.",
+              "type": "string"
+            },
+            "imagePullSecret": {
+              "description": "ImagePullSecret is the name of the Kubernetes secret\nto use for pulling images.",
+              "type": "string"
+            },
+            "registry": {
+              "description": "Registry address to pull the distribution images from\ne.g. 'ghcr.io/fluxcd'.",
+              "type": "string"
+            },
+            "version": {
+              "description": "Version semver expression e.g. '2.x', '2.3.x'.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "registry",
+            "version"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "kustomize": {
+          "description": "Kustomize holds a set of patches that can be applied to the\nFlux installation, to customize the way Flux operates.",
+          "properties": {
+            "patches": {
+              "description": "Strategic merge and JSON patches, defined as inline YAML objects,\ncapable of targeting objects based on kind, label and annotation selectors.",
+              "items": {
+                "description": "Patch contains an inline StrategicMerge or JSON6902 patch, and the target the patch should\nbe applied to.",
+                "properties": {
+                  "patch": {
+                    "description": "Patch contains an inline StrategicMerge patch or an inline JSON6902 patch with\nan array of operation objects.",
+                    "type": "string"
+                  },
+                  "target": {
+                    "description": "Target points to the resources that the patch document should be applied to.",
+                    "properties": {
+                      "annotationSelector": {
+                        "description": "AnnotationSelector is a string that follows the label selection expression\nhttps://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api\nIt matches with the resource annotations.",
+                        "type": "string"
+                      },
+                      "group": {
+                        "description": "Group is the API group to select resources from.\nTogether with Version and Kind it is capable of unambiguously identifying and/or selecting resources.\nhttps://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md",
+                        "type": "string"
+                      },
+                      "kind": {
+                        "description": "Kind of the API Group to select resources from.\nTogether with Group and Version it is capable of unambiguously\nidentifying and/or selecting resources.\nhttps://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md",
+                        "type": "string"
+                      },
+                      "labelSelector": {
+                        "description": "LabelSelector is a string that follows the label selection expression\nhttps://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api\nIt matches with the resource labels.",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "Name to match resources with.",
+                        "type": "string"
+                      },
+                      "namespace": {
+                        "description": "Namespace to select resources from.",
+                        "type": "string"
+                      },
+                      "version": {
+                        "description": "Version of the API Group to select resources from.\nTogether with Group and Kind it is capable of unambiguously identifying and/or selecting resources.\nhttps://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "required": [
+                  "patch"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "migrateResources": {
+          "default": true,
+          "description": "MigrateResources instructs the controller to migrate the Flux custom resources\nfrom the previous version to the latest API version specified in the CRD.\nDefaults to true.",
+          "type": "boolean"
+        },
+        "sharding": {
+          "description": "Sharding holds the specification of the sharding configuration.",
+          "properties": {
+            "key": {
+              "default": "sharding.fluxcd.io/key",
+              "description": "Key is the label key used to shard the resources.",
+              "type": "string"
+            },
+            "shards": {
+              "description": "Shards is the list of shard names.",
+              "items": {
+                "type": "string"
+              },
+              "minItems": 1,
+              "type": "array"
+            }
+          },
+          "required": [
+            "shards"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "storage": {
+          "description": "Storage holds the specification of the source-controller\npersistent volume claim.",
+          "properties": {
+            "class": {
+              "description": "Class is the storage class to use for the PVC.",
+              "type": "string"
+            },
+            "size": {
+              "description": "Size is the size of the PVC.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "class",
+            "size"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "sync": {
+          "description": "Sync specifies the source for the cluster sync operation.\nWhen set, a Flux source (GitRepository, OCIRepository or Bucket)\nand Flux Kustomization are created to sync the cluster state\nwith the source repository.",
+          "properties": {
+            "interval": {
+              "default": "1m",
+              "description": "Interval is the time between syncs.",
+              "pattern": "^([0-9]+(\\.[0-9]+)?(ms|s|m|h))+$",
+              "type": "string"
+            },
+            "kind": {
+              "description": "Kind is the kind of the source.",
+              "enum": [
+                "OCIRepository",
+                "GitRepository",
+                "Bucket"
+              ],
+              "type": "string"
+            },
+            "name": {
+              "description": "Name is the name of the Flux source and kustomization resources.\nWhen not specified, the name is set to the namespace name of the FluxInstance.",
+              "maxLength": 63,
+              "type": "string",
+              "x-kubernetes-validations": [
+                {
+                  "message": "Sync name is immutable",
+                  "rule": "self == oldSelf"
+                }
+              ]
+            },
+            "path": {
+              "description": "Path is the path to the source directory containing\nthe kustomize overlay or plain Kubernetes manifests.",
+              "type": "string"
+            },
+            "pullSecret": {
+              "description": "PullSecret specifies the Kubernetes Secret containing the\nauthentication credentials for the source.\nFor Git over HTTP/S sources, the secret must contain username and password fields.\nFor Git over SSH sources, the secret must contain known_hosts and identity fields.\nFor OCI sources, the secret must be of type kubernetes.io/dockerconfigjson.\nFor Bucket sources, the secret must contain accesskey and secretkey fields.",
+              "type": "string"
+            },
+            "ref": {
+              "description": "Ref is the source reference, can be a Git ref name e.g. 'refs/heads/main',\nan OCI tag e.g. 'latest' or a bucket name e.g. 'flux'.",
+              "type": "string"
+            },
+            "url": {
+              "description": "URL is the source URL, can be a Git repository HTTP/S or SSH address,\nan OCI repository address or a Bucket endpoint.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "path",
+            "ref",
+            "url"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "wait": {
+          "default": true,
+          "description": "Wait instructs the controller to check the health of all the reconciled\nresources. Defaults to true.",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "distribution"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "FluxInstanceStatus defines the observed state of FluxInstance",
+      "properties": {
+        "components": {
+          "description": "Components contains the container images used by the components.",
+          "items": {
+            "description": "ComponentImage represents a container image used by a component.",
+            "properties": {
+              "digest": {
+                "description": "Digest of the container image.",
+                "type": "string"
+              },
+              "name": {
+                "description": "Name of the component.",
+                "type": "string"
+              },
+              "repository": {
+                "description": "Repository address of the container image.",
+                "type": "string"
+              },
+              "tag": {
+                "description": "Tag of the container image.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "repository",
+              "tag"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "conditions": {
+          "description": "Conditions contains the readiness conditions of the object.",
+          "items": {
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
+                "maxLength": 32768,
+                "type": "string"
+              },
+              "observedGeneration": {
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
+                "format": "int64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "reason": {
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
+                "maxLength": 1024,
+                "minLength": 1,
+                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
+                "type": "string"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "enum": [
+                  "True",
+                  "False",
+                  "Unknown"
+                ],
+                "type": "string"
+              },
+              "type": {
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
+                "maxLength": 316,
+                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "message",
+              "reason",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "inventory": {
+          "description": "Inventory contains a list of Kubernetes resource object references\nlast applied on the cluster.",
+          "properties": {
+            "entries": {
+              "description": "Entries of Kubernetes resource object references.",
+              "items": {
+                "description": "ResourceRef contains the information necessary to locate a resource within a cluster.",
+                "properties": {
+                  "id": {
+                    "description": "ID is the string representation of the Kubernetes resource object's metadata,\nin the format '<namespace>_<name>_<group>_<kind>'.",
+                    "type": "string"
+                  },
+                  "v": {
+                    "description": "Version is the API version of the Kubernetes resource object's kind.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "id",
+                  "v"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "entries"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "lastAppliedRevision": {
+          "description": "LastAppliedRevision is the version and digest of the\ndistribution config that was last reconcile.",
+          "type": "string"
+        },
+        "lastArtifactRevision": {
+          "description": "LastArtifactRevision is the digest of the last pulled\ndistribution artifact.",
+          "type": "string"
+        },
+        "lastAttemptedRevision": {
+          "description": "LastAttemptedRevision is the version and digest of the\ndistribution config that was last attempted to reconcile.",
+          "type": "string"
+        },
+        "lastHandledReconcileAt": {
+          "description": "LastHandledReconcileAt holds the value of the most recent\nreconcile request value, so a change of the annotation value\ncan be detected.",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/fluxcd.controlplane.io/fluxreport_v1.json
+++ b/fluxcd.controlplane.io/fluxreport_v1.json
@@ -1,0 +1,237 @@
+{
+  "description": "FluxReport is the Schema for the fluxreports API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "FluxReportSpec defines the observed state of a Flux installation.",
+      "properties": {
+        "components": {
+          "description": "ComponentsStatus is the status of the Flux controller deployments.",
+          "items": {
+            "description": "FluxComponentStatus defines the observed state of a Flux component.",
+            "properties": {
+              "image": {
+                "description": "Image is the container image of the Flux component.",
+                "type": "string"
+              },
+              "name": {
+                "description": "Name is the name of the Flux component.",
+                "type": "string"
+              },
+              "ready": {
+                "description": "Ready is the readiness status of the Flux component.",
+                "type": "boolean"
+              },
+              "status": {
+                "description": "Status is a human-readable message indicating details\nabout the Flux component observed state.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "image",
+              "name",
+              "ready",
+              "status"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "distribution": {
+          "description": "Distribution is the version information of the Flux installation.",
+          "properties": {
+            "entitlement": {
+              "description": "Entitlement is the entitlement verification status.",
+              "type": "string"
+            },
+            "managedBy": {
+              "description": "ManagedBy is the name of the operator managing the Flux instance.",
+              "type": "string"
+            },
+            "status": {
+              "description": "Status is a human-readable message indicating details\nabout the distribution observed state.",
+              "type": "string"
+            },
+            "version": {
+              "description": "Version is the version of the Flux instance.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "entitlement",
+            "status"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "reconcilers": {
+          "description": "ReconcilersStatus is the list of Flux reconcilers and\ntheir statistics grouped by API kind.",
+          "items": {
+            "description": "FluxReconcilerStatus defines the observed state of a Flux reconciler.",
+            "properties": {
+              "apiVersion": {
+                "description": "APIVersion is the API version of the Flux resource.",
+                "type": "string"
+              },
+              "kind": {
+                "description": "Kind is the kind of the Flux resource.",
+                "type": "string"
+              },
+              "stats": {
+                "description": "Stats is the reconcile statics of the Flux resource kind.",
+                "properties": {
+                  "failing": {
+                    "description": "Failing is the number of reconciled\nresources in the Failing state.",
+                    "type": "integer"
+                  },
+                  "running": {
+                    "description": "Running is the number of reconciled\nresources in the Running state.",
+                    "type": "integer"
+                  },
+                  "suspended": {
+                    "description": "Suspended is the number of reconciled\nresources in the Suspended state.",
+                    "type": "integer"
+                  },
+                  "totalSize": {
+                    "description": "TotalSize is the total size of the artifacts in storage.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "failing",
+                  "running",
+                  "suspended"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "apiVersion",
+              "kind"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "sync": {
+          "description": "SyncStatus is the status of the cluster sync\nSource and Kustomization resources.",
+          "properties": {
+            "id": {
+              "description": "ID is the identifier of the sync.",
+              "type": "string"
+            },
+            "path": {
+              "description": "Path is the kustomize path of the sync.",
+              "type": "string"
+            },
+            "ready": {
+              "description": "Ready is the readiness status of the sync.",
+              "type": "boolean"
+            },
+            "source": {
+              "description": "Source is the URL of the source repository.",
+              "type": "string"
+            },
+            "status": {
+              "description": "Status is a human-readable message indicating details\nabout the sync observed state.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "id",
+            "ready",
+            "status"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "distribution"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "FluxReportStatus defines the readiness of a FluxReport.",
+      "properties": {
+        "conditions": {
+          "description": "Conditions contains the readiness conditions of the object.",
+          "items": {
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
+                "maxLength": 32768,
+                "type": "string"
+              },
+              "observedGeneration": {
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
+                "format": "int64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "reason": {
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
+                "maxLength": 1024,
+                "minLength": 1,
+                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
+                "type": "string"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "enum": [
+                  "True",
+                  "False",
+                  "Unknown"
+                ],
+                "type": "string"
+              },
+              "type": {
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
+                "maxLength": 316,
+                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "message",
+              "reason",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "lastHandledReconcileAt": {
+          "description": "LastHandledReconcileAt holds the value of the most recent\nreconcile request value, so a change of the annotation value\ncan be detected.",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/fluxcd.controlplane.io/resourceset_v1.json
+++ b/fluxcd.controlplane.io/resourceset_v1.json
@@ -1,0 +1,248 @@
+{
+  "description": "ResourceSet is the Schema for the ResourceSets API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "ResourceSetSpec defines the desired state of ResourceSet",
+      "properties": {
+        "commonMetadata": {
+          "description": "CommonMetadata specifies the common labels and annotations that are\napplied to all resources. Any existing label or annotation will be\noverridden if its key matches a common one.",
+          "properties": {
+            "annotations": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "Annotations to be added to the object's metadata.",
+              "type": "object"
+            },
+            "labels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "Labels to be added to the object's metadata.",
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "dependsOn": {
+          "description": "DependsOn specifies the list of Kubernetes resources that must\nexist on the cluster before the reconciliation process starts.",
+          "items": {
+            "description": "Dependency defines a ResourceSet dependency on a Kubernetes resource.",
+            "properties": {
+              "apiVersion": {
+                "description": "APIVersion of the resource to depend on.",
+                "type": "string"
+              },
+              "kind": {
+                "description": "Kind of the resource to depend on.",
+                "type": "string"
+              },
+              "name": {
+                "description": "Name of the resource to depend on.",
+                "type": "string"
+              },
+              "namespace": {
+                "description": "Namespace of the resource to depend on.",
+                "type": "string"
+              },
+              "ready": {
+                "description": "Ready checks if the resource Ready status condition is true.",
+                "type": "boolean"
+              },
+              "readyExpr": {
+                "description": "ReadyExpr checks if the resource satisfies the given CEL expression.\nThe expression replaces the default readiness check and\nis only evaluated if Ready is set to 'true'.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "apiVersion",
+              "kind",
+              "name"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "inputs": {
+          "description": "Inputs contains the list of ResourceSet inputs.",
+          "items": {
+            "additionalProperties": {
+              "x-kubernetes-preserve-unknown-fields": true
+            },
+            "description": "ResourceSetInput defines the key-value pairs of the ResourceSet input.",
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "inputsFrom": {
+          "description": "InputsFrom contains the list of references to input providers.\nWhen set, the inputs are fetched from the providers and concatenated\nwith the in-line inputs defined in the ResourceSet.",
+          "items": {
+            "properties": {
+              "apiVersion": {
+                "description": "APIVersion of the input provider resource.\nWhen not set, the APIVersion of the ResourceSet is used.",
+                "type": "string"
+              },
+              "kind": {
+                "description": "Kind of the input provider resource.",
+                "enum": [
+                  "ResourceSetInputProvider"
+                ],
+                "type": "string"
+              },
+              "name": {
+                "description": "Name of the input provider resource.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "kind",
+              "name"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "resources": {
+          "description": "Resources contains the list of Kubernetes resources to reconcile.",
+          "items": {
+            "x-kubernetes-preserve-unknown-fields": true
+          },
+          "type": "array"
+        },
+        "resourcesTemplate": {
+          "description": "ResourcesTemplate is a Go template that generates the list of\nKubernetes resources to reconcile. The template is rendered\nas multi-document YAML, the resources should be separated by '---'.\nWhen both Resources and ResourcesTemplate are set, the resulting\nobjects are merged and deduplicated, with the ones from Resources taking precedence.",
+          "type": "string"
+        },
+        "serviceAccountName": {
+          "description": "The name of the Kubernetes service account to impersonate\nwhen reconciling the generated resources.",
+          "type": "string"
+        },
+        "wait": {
+          "description": "Wait instructs the controller to check the health\nof all the reconciled resources.",
+          "type": "boolean"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "ResourceSetStatus defines the observed state of ResourceSet.",
+      "properties": {
+        "conditions": {
+          "description": "Conditions contains the readiness conditions of the object.",
+          "items": {
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
+                "maxLength": 32768,
+                "type": "string"
+              },
+              "observedGeneration": {
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
+                "format": "int64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "reason": {
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
+                "maxLength": 1024,
+                "minLength": 1,
+                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
+                "type": "string"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "enum": [
+                  "True",
+                  "False",
+                  "Unknown"
+                ],
+                "type": "string"
+              },
+              "type": {
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
+                "maxLength": 316,
+                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "message",
+              "reason",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "inventory": {
+          "description": "Inventory contains a list of Kubernetes resource object references\nlast applied on the cluster.",
+          "properties": {
+            "entries": {
+              "description": "Entries of Kubernetes resource object references.",
+              "items": {
+                "description": "ResourceRef contains the information necessary to locate a resource within a cluster.",
+                "properties": {
+                  "id": {
+                    "description": "ID is the string representation of the Kubernetes resource object's metadata,\nin the format '<namespace>_<name>_<group>_<kind>'.",
+                    "type": "string"
+                  },
+                  "v": {
+                    "description": "Version is the API version of the Kubernetes resource object's kind.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "id",
+                  "v"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "entries"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "lastAppliedRevision": {
+          "description": "LastAppliedRevision is the digest of the\ngenerated resources that were last reconcile.",
+          "type": "string"
+        },
+        "lastHandledReconcileAt": {
+          "description": "LastHandledReconcileAt holds the value of the most recent\nreconcile request value, so a change of the annotation value\ncan be detected.",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/fluxcd.controlplane.io/resourcesetinputprovider_v1.json
+++ b/fluxcd.controlplane.io/resourcesetinputprovider_v1.json
@@ -1,0 +1,186 @@
+{
+  "description": "ResourceSetInputProvider is the Schema for the ResourceSetInputProviders API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "ResourceSetInputProviderSpec defines the desired state of ResourceSetInputProvider",
+      "properties": {
+        "certSecretRef": {
+          "description": "CertSecretRef specifies the Kubernetes Secret containing either or both of\n\n- a PEM-encoded CA certificate (`ca.crt`)\n- a PEM-encoded client certificate (`tls.crt`) and private key (`tls.key`)\n\nWhen connecting to a Git provider that uses self-signed certificates, the CA certificate\nmust be set in the Secret under the 'ca.crt' key to establish the trust relationship.",
+          "properties": {
+            "name": {
+              "description": "Name of the referent.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "defaultValues": {
+          "additionalProperties": {
+            "x-kubernetes-preserve-unknown-fields": true
+          },
+          "description": "DefaultValues contains the default values for the inputs.\nThese values are used to populate the inputs when the provider\nresponse does not contain them.",
+          "type": "object"
+        },
+        "filter": {
+          "description": "Filter defines the filter to apply to the input provider response.",
+          "properties": {
+            "excludeBranch": {
+              "description": "ExcludeBranch specifies the regular expression to filter the branches\nthat the input provider should exclude.",
+              "type": "string"
+            },
+            "includeBranch": {
+              "description": "IncludeBranch specifies the regular expression to filter the branches\nthat the input provider should include.",
+              "type": "string"
+            },
+            "labels": {
+              "description": "Labels specifies the list of labels to filter the input provider response.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "limit": {
+              "description": "Limit specifies the maximum number of input sets to return.\nWhen not set, the default limit is 100.",
+              "type": "integer"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "secretRef": {
+          "description": "SecretRef specifies the Kubernetes Secret containing the basic-auth credentials\nto access the input provider. The secret must contain the keys\n'username' and 'password'.\nWhen connecting to a Git provider, the password should be a personal access token\nthat grants read-only access to the repository.",
+          "properties": {
+            "name": {
+              "description": "Name of the referent.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "type": {
+          "description": "Type specifies the type of the input provider.",
+          "enum": [
+            "GitHubBranch",
+            "GitHubPullRequest",
+            "GitLabBranch",
+            "GitLabMergeRequest"
+          ],
+          "type": "string"
+        },
+        "url": {
+          "description": "URL specifies the HTTP/S address of the input provider API.\nWhen connecting to a Git provider, the URL should point to the repository address.",
+          "pattern": "^(http|https)://.*$",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "url"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "ResourceSetInputProviderStatus defines the observed state of ResourceSetInputProvider.",
+      "properties": {
+        "conditions": {
+          "description": "Conditions contains the readiness conditions of the object.",
+          "items": {
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
+                "maxLength": 32768,
+                "type": "string"
+              },
+              "observedGeneration": {
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
+                "format": "int64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "reason": {
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
+                "maxLength": 1024,
+                "minLength": 1,
+                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
+                "type": "string"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "enum": [
+                  "True",
+                  "False",
+                  "Unknown"
+                ],
+                "type": "string"
+              },
+              "type": {
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
+                "maxLength": 316,
+                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "message",
+              "reason",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "exportedInputs": {
+          "description": "ExportedInputs contains the list of inputs exported by the provider.",
+          "items": {
+            "additionalProperties": {
+              "x-kubernetes-preserve-unknown-fields": true
+            },
+            "description": "ResourceSetInput defines the key-value pairs of the ResourceSet input.",
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "lastExportedRevision": {
+          "description": "LastExportedRevision is the digest of the\ninputs that were last reconcile.",
+          "type": "string"
+        },
+        "lastHandledReconcileAt": {
+          "description": "LastHandledReconcileAt holds the value of the most recent\nreconcile request value, so a change of the annotation value\ncan be detected.",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}


### PR DESCRIPTION
[Flux](https://github.com/fluxcd/flux2) can be managed by a [flux-operator](https://github.com/controlplaneio-fluxcd/flux-operator) using CRDs.

CRDs extracted using:
```
kubeconform/scripts/openapi2jsonschema.py https://raw.githubusercontent.com/controlplaneio-fluxcd/flux-operator/refs/heads/main/config/crd/bases/fluxcd.controlplane.io_fluxinstances.yaml
kubeconform/scripts/openapi2jsonschema.py https://raw.githubusercontent.com/controlplaneio-fluxcd/flux-operator/refs/heads/main/config/crd/bases/fluxcd.controlplane.io_fluxreports.yaml
kubeconform/scripts/openapi2jsonschema.py https://raw.githubusercontent.com/controlplaneio-fluxcd/flux-operator/refs/heads/main/config/crd/bases/fluxcd.controlplane.io_resourcesetinputproviders.yaml
kubeconform/scripts/openapi2jsonschema.py https://raw.githubusercontent.com/controlplaneio-fluxcd/flux-operator/refs/heads/main/config/crd/bases/fluxcd.controlplane.io_resourcesets.yaml
```
