### PR TITLE
Update gitrepository_v1.json with github provider support

### DIFF
--- a/source.toolkit.fluxcd.io/gitrepository_v1.json
+++ b/source.toolkit.fluxcd.io/gitrepository_v1.json
@@ -61,10 +61,11 @@
           "type": "string"
         },
         "provider": {
-          "description": "Provider used for authentication, can be 'azure', 'generic'.\nWhen not specified, defaults to 'generic'.",
+          "description": "Provider used for authentication, can be 'azure', 'github', 'generic'.\nWhen not specified, defaults to 'generic'.",
           "enum": [
             "generic",
-            "azure"
+            "azure",
+            "github"
           ],
           "type": "string"
         },


### PR DESCRIPTION
We started experimenting with `github` as a provider for our source git repository and our CI pipelines started to fail. It looks like the `github` provider is not included in the CRD but it is a valid option now: https://fluxcd.io/flux/components/source/gitrepositories/#provider

You can also see it in their own CRD: https://github.com/fluxcd/source-controller/blob/main/config/crd/bases/source.toolkit.fluxcd.io_gitrepositories.yaml#L106-L114