### PR TITLE
Auto update index yaml

### DIFF
--- a/Utilities/auto-update-index.py
+++ b/Utilities/auto-update-index.py
@@ -6,44 +6,97 @@ import os
 from typing import List
 import argparse
 from concurrent.futures import ProcessPoolExecutor
+from typing import Dict, Union
+
+class ListDumper(yaml.Dumper):
+    def increase_indent(self, flow=False, indentless=False):
+        return super(ListDumper, self).increase_indent(flow, False)
 
 class Crd:
-    def __init__(self, group: str, name: str, kind: str, api_version: str, description: str):
+    def __init__(self, group: str, name: str, kind: str, api_version: str, filename: str):
         self.group = group
         self.name = name
         self.kind = kind
         self.api_version = api_version
-        self.description = description
+        self.filename = filename
 
 class YamlDataStructure:
     def __init__(self):
-        self.data = {}
+        self.data: Dict[str, List[Crd]] = {} 
 
     def add_entry(self, entry: Crd):
         if entry.group not in self.data:
             self.data[entry.group] = []
-        self.data[entry.group].append({
-            entry.name: {
-                "kind": entry.kind,
-                "apiVersion": entry.api_version,
-                "description": entry.description
-            }
-        })
+        self.data[entry.group].append(entry)
 
     def save_to_yaml(self, file_path: str):
+        raw_data: Dict[str, List[Dict[str, str]]] = {}
+        for groupKey, group in self.data.items():
+            raw_data[groupKey] = []
+            for crd in group:
+                raw_data[groupKey].append({
+                    "name": crd.name,
+                    "kind": crd.kind,
+                    "apiVersion": crd.api_version,
+                    "filename": crd.filename
+                })
+
         with open(file_path, "w") as file:
-            yaml.dump(self.data, file, default_flow_style=False)
+            yaml.dump(raw_data, file, Dumper=ListDumper)
+
+    def load_index_file(self, file: str):
+        yaml_data: Union[Dict[str, List[Dict[str, str]]], None]
+        with open(file, "r") as f:
+            yaml_data = yaml.safe_load(f)
+        if yaml_data is None:
+            return
+
+        for groupKey, group in yaml_data.items():
+            for crd in group:
+                self.add_entry(Crd(
+                    group=groupKey,
+                    name=crd["name"],
+                    kind=crd["kind"],
+                    api_version=crd["apiVersion"],
+                    filename=crd["filename"]
+                    ))
+
+
+    def prune_removed_files(self, source_dir: str):
+        nRemoved = 0
+        groupKeys = list(self.data.keys())
+        for key in groupKeys:
+            group = self.data[key]
+            filePaths = [os.path.join(source_dir, entry.filename) for entry in group]
+            doKeep = [os.path.isfile(filePath) for filePath in filePaths]
+            self.data[key] = [entry for entry, keep in zip(group, doKeep) if keep]
+            nRemoved += len([1 for keep in doKeep if not keep])
+        return nRemoved
+
+class SubResult_CrdCollection:
+    def __init__(self, list: List[Crd], nSkipped: int):
+        self.list: List[Crd] = list
+        self.nSkipped = nSkipped
+        self.nUpdated = len(list)
+
+def strip_dot_slash(str: str) -> str:
+    return str.lstrip("./")
 
 def list_dirs_in_src_dir(src: str) -> List[str]:
-    entries = [os.path.join(src, name) for name in os.listdir(src)]
+    entries = [strip_dot_slash(os.path.join(src, name)) for name in os.listdir(src)]
     return [dir for dir in entries if os.path.isdir(dir)]
 
-def CreateCrds(dir: str) -> List[Crd]:
+def CreateCrds(dir: str, org_data: YamlDataStructure) -> SubResult_CrdCollection:
     print(f"Processing directory {dir}")
     groupName = os.path.basename(dir)
     listing = [os.path.join(dir, file) for file in os.listdir(dir)]
+    org_data_group = org_data.data.get(groupName, [])
+    skip = [any(crd.filename == file for crd in org_data_group) for file in listing]
+    nSkipped = len([1 for s in skip if s])
+    listing = [file for file, skip in zip(listing, skip) if not skip]
     crds = [CreateCrdEntry(groupName, file) for file in listing if os.path.isfile(file) and file.endswith(".json")]
-    return [crd for crd in crds if crd != None]
+    crds = [crd for crd in crds if crd != None]
+    return SubResult_CrdCollection(crds, nSkipped)
 
 def GetFileDescription(file: str) -> str:
     with open(file, "r") as f:
@@ -54,7 +107,7 @@ def SearchForKindInDescription(lowercaseKind: str, description: str) -> str:
     lowercase_description = description.lower()
     offset = lowercase_description.find(lowercaseKind)
     if offset == -1:
-        return ""
+        return lowercaseKind
     return description[offset:offset + len(lowercaseKind)]
 
 def CreateCrdEntry(group: str, filepath: str):
@@ -77,34 +130,41 @@ def CreateCrdEntry(group: str, filepath: str):
       name=f"{name}_{version}",
       kind=kind,
       api_version=f"{group}/{version}",
-      description=description
+      filename=filepath
     )
 
-# Example usage
 if __name__ == "__main__":
-    yaml_structure = YamlDataStructure()
-
     parser = argparse.ArgumentParser(description="Generate an index.yaml file from CRDs in a source directory.")
     parser.add_argument("source_directory", type=str, help="Path to the source directory containing CRDs.")
-    parser.add_argument("output_file", type=str, help="Path to the output YAML file.")
+    parser.add_argument("index_file", type=str, help="Path to index.yaml to edit.")
     args = parser.parse_args()
 
     source = args.source_directory
-    output_file = args.output_file
+    index_file = args.index_file
+
+    data = YamlDataStructure()
+    if os.path.exists(index_file):
+        data.load_index_file(index_file)
+    nRemoved = data.prune_removed_files(source)
 
     directories = list_dirs_in_src_dir(source)
     crd_entries: List[Crd] = []
+    nSkipped = 0
     with ProcessPoolExecutor() as executor:
-        future_dir_crds = {executor.submit(CreateCrds, dir): dir for dir in directories}
+        future_dir_crds = {executor.submit(CreateCrds, dir, data): dir for dir in directories}
         for future in future_dir_crds:
             try:
-                dir_crds = future.result()
-                if dir_crds:
-                    crd_entries.extend(dir_crds)
+                partial_result = future.result()
+                nSkipped += partial_result.nSkipped
+                if partial_result.nUpdated > 0:
+                    crd_entries.extend(partial_result.list)
             except Exception as e:
                 print(f"Error processing file {future_dir_crds[future]}: {e}", file=sys.stderr)
 
     for crd in crd_entries:
-        yaml_structure.add_entry(crd)
-    yaml_structure.save_to_yaml(output_file)
-    print(f"YAML file saved as {output_file}.")
+        data.add_entry(crd)
+    data.save_to_yaml(index_file)
+    print(f"YAML file saved as {index_file}.")
+    print(f"Skipped {nSkipped} files.")
+    print(f"Added {len(crd_entries)} files.")
+    print(f"Removed {nRemoved} files.")

--- a/Utilities/auto-update-index.py
+++ b/Utilities/auto-update-index.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+
+import sys
+import yaml
+import os
+from typing import List
+import argparse
+
+class Crd:
+    def __init__(self, group: str, name: str, kind: str, api_version: str, description: str):
+        self.group = group
+        self.name = name
+        self.kind = kind
+        self.api_version = api_version
+        self.description = description
+
+class YamlDataStructure:
+    def __init__(self):
+        self.data = {}
+
+    def add_entry(self, entry: Crd):
+        if entry.group not in self.data:
+            self.data[entry.group] = []
+        self.data[entry.group].append({
+            entry.name: {
+                "kind": entry.kind,
+                "apiVersion": entry.api_version,
+                "description": entry.description
+            }
+        })
+
+    def save_to_yaml(self, file_path: str):
+        with open(file_path, "w") as file:
+            yaml.dump(self.data, file, default_flow_style=False)
+
+def list_dirs_in_src_dir(src: str) -> List[str]:
+    entries = [os.path.join(src, name) for name in os.listdir(src)]
+    return [dir for dir in entries if os.path.isdir(dir)]
+
+from typing import Generator
+
+def CreateCrds(dir: str) -> Generator[Crd, None, None]:
+    groupName = os.path.basename(dir)
+    listing = [os.path.join(dir, file) for file in os.listdir(dir)]
+    files = [file for file in listing if os.path.isfile(file) and file.endswith(".json")]
+    for file in files:
+        entry = CreateCrdEntry(groupName, file)
+        if entry != None:
+            yield entry
+
+def GetFileDescription(file: str) -> str:
+    with open(file, "r") as f:
+        data = yaml.safe_load(f)
+        return data.get("description", "")
+
+def SearchForKindInDescription(lowercaseKind: str, description: str) -> str:
+    lowercase_description = description.lower()
+    offset = lowercase_description.find(lowercaseKind)
+    if offset == -1:
+        return ""
+    return description[offset:offset + len(lowercaseKind)]
+
+def CreateCrdEntry(group: str, filepath: str):
+    file_basename = os.path.basename(filepath)
+
+    # file ends with .json. Strip this away
+    filename = file_basename.split(".")[0]
+
+    parts = filename.split('_')
+    if len(parts) != 2:
+      print(f"Error: Unexpected file name format: {filename}", file=sys.stderr)
+      return None
+    name, version = parts
+    
+    description = GetFileDescription(filepath)
+    kind = SearchForKindInDescription(name, description)
+
+    return Crd(
+      group=group,
+      name=f"{name}_{version}",
+      kind=kind,
+      api_version=f"{group}/{version}",
+      description=description
+    )
+
+# Example usage
+if __name__ == "__main__":
+    yaml_structure = YamlDataStructure()
+
+    parser = argparse.ArgumentParser(description="Generate an index.yaml file from CRDs in a source directory.")
+    parser.add_argument("source_directory", type=str, help="Path to the source directory containing CRDs.")
+    parser.add_argument("output_file", type=str, help="Path to the output YAML file.")
+    args = parser.parse_args()
+
+    source = args.source_directory
+    output_file = args.output_file
+
+    # List directories in the source directory
+    directories = list_dirs_in_src_dir(source)
+    for dir in directories:
+        print(f"Processing directory: {dir}")
+        for crd in CreateCrds(dir):
+            yaml_structure.add_entry(crd)
+    yaml_structure.save_to_yaml(output_file)
+    print(f"YAML file saved as {output_file}.")

--- a/Utilities/convert.py
+++ b/Utilities/convert.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+
+import sys
+import yaml
+import os
+import argparse
+
+class ListDumper(yaml.Dumper):
+    def increase_indent(self, flow=False, indentless=False):
+        return super(ListDumper, self).increase_indent(flow, False)
+
+class NewCrd:
+    def __init__(self, group: str, name: str, kind: str, api_version: str, filename: str):
+        self.group = group
+        self.name = name
+        self.kind = kind
+        self.api_version = api_version
+        self.filename = filename
+
+class NewYamlDataStructure:
+    def __init__(self):
+        self.data = {}
+
+    def add_entry(self, entry: NewCrd):
+        if entry.group not in self.data:
+            self.data[entry.group] = []
+        self.data[entry.group].append({
+            "name": entry.name,
+            "kind": entry.kind,
+            "apiVersion": entry.api_version,
+            "filename": entry.filename
+        })
+
+    def save_to_yaml(self, file_path: str):
+        with open(file_path, "w") as file:
+            yaml.dump(self.data, file, Dumper=ListDumper)
+
+class OldYamlDataStructure:
+    def __init__(self):
+        self.data = {}
+
+    def load_from_file(self, file_path: str):
+        with open(file_path, "r") as file:
+            self.data = yaml.safe_load(file)
+
+def guess_filename(group: str, name: str) -> str:
+    result = f"{group}/{name}.json"
+    if not os.path.exists(result):
+        print(f"Warning: The file '{result}' does not exist.")
+        return ""
+    return result
+
+def convert_old_to_new(old_data: OldYamlDataStructure) -> NewYamlDataStructure:
+    new_data = NewYamlDataStructure()
+    for groupKey, group in old_data.data.items():
+        kindsContainer = group["kinds"]
+        for idx, kinds in enumerate(kindsContainer):
+            for name, crds in kinds.items():
+                filename = guess_filename(groupKey, name)
+                new_data.add_entry(NewCrd(
+                    group=groupKey,
+                    name=name,
+                    kind=crds["kind"],
+                    api_version=crds["apiVersion"],
+                    filename=filename
+                ))
+
+    return new_data
+
+def parse_arguments():
+    parser = argparse.ArgumentParser(description="Convert CRD YAML files to a new structure.")
+    parser.add_argument("input_file", type=str, help="Path to the input YAML file.")
+    return parser.parse_args()
+
+if __name__ == "__main__":
+    args = parse_arguments()
+    input_file = args.input_file
+
+    if not os.path.exists(input_file):
+        print(f"Error: The file '{input_file}' does not exist.")
+        sys.exit(1)
+
+    old_data = OldYamlDataStructure()
+    old_data.load_from_file(input_file)
+    new_data = convert_old_to_new(old_data)
+    new_data.save_to_yaml(input_file)

--- a/index.yaml
+++ b/index.yaml
@@ -1,712 +1,438 @@
-argoproj.io:
-  org: argo
-  githubOrg: argoproj
-  kinds:
-    - analysisrun_v1alpha1:
-        kind: AnalysisRun
-        apiVersion: argoproj.io/v1alpha1
-        lastUpdated: "2022-05-06"
-        repo: argo-rollouts
-        permitLink: 3f5960efc21b5d8db44cbf20b779ab74d6fdaa99/manifests/crds/analysis-run-crd.yaml
-    - analysistemplate_v1alpha1:
-        kind: AnalysisTemplate
-        apiVersion: argoproj.io/v1alpha1
-        lastUpdated: "2022-05-06"
-        repo: argo-rollouts
-        permitLink: 3f5960efc21b5d8db44cbf20b779ab74d6fdaa99/manifests/crds/analysis-template-crd.yaml
-    - application_v1alpha1:
-        kind: Application
-        apiVersion: argoproj.io/v1alpha1
-        lastUpdated: "2022-05-06"
-        repo: argo-cd
-        permitLink: 3966e508905037e031f25bf599a3e65c6f4b9fb0/manifests/crds/application-crd.yaml
-    - applicationset_v1alpha1:
-        kind: ApplicationSet
-        apiVersion: argoproj.io/v1alpha1
-        lastUpdated: "2022-05-06"
-        repo: argo-cd
-        permitLink: 3966e508905037e031f25bf599a3e65c6f4b9fb0/manifests/crds/applicationset-crd.yaml
-    - appproject_v1alpha1:
-        kind: AppProject
-        apiVersion: argoproj.io/v1alpha1
-        lastUpdated: "2022-05-06"
-        repo: argo-cd
-        permitLink: 3966e508905037e031f25bf599a3e65c6f4b9fb0/manifests/crds/appproject-crd.yaml
-    - clusteranalysistemplate_v1alpha1:
-        kind: ClusterAnalysisTemplate
-        apiVersion: argoproj.io/v1alpha1
-        lastUpdated: "2022-05-06"
-        repo: argo-rollouts
-        permitLink: 3f5960efc21b5d8db44cbf20b779ab74d6fdaa99/manifests/crds/cluster-analysis-template-crd.yaml
-    - clusterworkflowtemplate_v1alpha1:
-        kind: ClusterWorkflowTemplate
-        apiVersion: argoproj.io/v1alpha1
-        lastUpdated: "2022-05-06"
-        repo: argo-workflows
-        permitLink: 37a3eb375410dd778d44f9965d9ec4465f1011d9/manifests/base/crds/full/argoproj.io_clusterworkflowtemplates.yaml
-    - cronworkflow_v1alpha1:
-        kind: CronWorkflow
-        apiVersion: argoproj.io/v1alpha1
-        lastUpdated: "2022-05-06"
-        repo: argo-workflows
-        permitLink: 37a3eb375410dd778d44f9965d9ec4465f1011d9/manifests/base/crds/full/argoproj.io_cronworkflows.yaml
-    - experiment_v1alpha1:
-        kind: Experiment
-        apiVersion: argoproj.io/v1alpha1
-        lastUpdated: "2022-05-06"
-        repo: argo-rollouts
-        permitLink: 3f5960efc21b5d8db44cbf20b779ab74d6fdaa99/manifests/crds/experiment-crd.yaml
-    - rollout_v1alpha1:
-        kind: Rollout
-        apiVersion: argoproj.io/v1alpha1
-        lastUpdated: "2022-05-06"
-        repo: argo-rollouts
-        permitLink: 3f5960efc21b5d8db44cbf20b779ab74d6fdaa99/manifests/crds/rollout-crd.yaml
-    - workflows_v1alpha1:
-        kind: Workflow
-        apiVersion: argoproj.io/v1alpha1
-        lastUpdated: "2022-05-06"
-        repo: argo-workflows
-        permitLink: 37a3eb375410dd778d44f9965d9ec4465f1011d9/manifests/base/crds/full/argoproj.io_workflows.yaml
-    - workfloweventbindings_v1alpha1:
-        kind: WorkflowEventBinding
-        apiVersion: argoproj.io/v1alpha1
-        lastUpdated: "2022-05-06"
-        repo: argo-workflows
-        permitLink: 37a3eb375410dd778d44f9965d9ec4465f1011d9/manifests/base/crds/full/argoproj.io_workfloweventbindings.yaml
-    - workflowtasksets_v1alpha1:
-        kind: WorkflowTaskSet
-        apiVersion: argoproj.io/v1alpha1
-        lastUpdated: "2022-05-06"
-        repo: argo-workflows
-        permitLink: 37a3eb375410dd778d44f9965d9ec4465f1011d9/manifests/base/crds/full/argoproj.io_workflowtasksets.yaml
-    - workflowtaskresults_v1alpha1:
-        kind: WorkflowTaskResult
-        apiVersion: argoproj.io/v1alpha1
-        lastUpdated: "2022-05-06"
-        repo: argo-workflows
-        permitLink: 37a3eb375410dd778d44f9965d9ec4465f1011d9/manifests/base/crds/full/argoproj.io_workflowtaskresults.yaml
-    - workflowtemplate_v1alpha1:
-        kind: WorkflowTemplate
-        apiVersion: argoproj.io/v1alpha1
-        lastUpdated: "2022-05-06"
-        repo: argo-workflows
-        permitLink: 37a3eb375410dd778d44f9965d9ec4465f1011d9/manifests/base/crds/full/argoproj.io_workflowtemplates.yaml
-bitnami.com:
-  org: bitnami
-  githubOrg: bitnami-labs
-  kinds:
-    - sealedsecret_v1alpha1:
-        kind: SealedSecret
-        apiVersion: bitnami.com/v1alpha1
-        lastUpdated: "2022-05-06"
-        repo: sealed-secrets
-        permitLink: 148de81f109dc0d1f946cfe4dfb0d64b7af0b091/helm/sealed-secrets/crds/sealedsecret-crd.yaml
+actions.summerwind.dev:
+  - apiVersion: actions.summerwind.dev/v1alpha1
+    filename: ''
+    kind: HorizontalRunnerAutoscaler
+    name: actions.summerwind.dev_v1alpha1
+  - apiVersion: actions.summerwind.dev/v1alpha1
+    filename: actions.summerwind.dev/runner_v1alpha1.json
+    kind: Runner
+    name: runner_v1alpha1
+  - apiVersion: actions.summerwind.dev/v1alpha1
+    filename: actions.summerwind.dev/runnerdeployment_v1alpha1.json
+    kind: RunnerDeployment
+    name: runnerdeployment_v1alpha1
+  - apiVersion: actions.summerwind.dev/v1alpha1
+    filename: actions.summerwind.dev/runnerreplicaset_v1alpha1.json
+    kind: RunnerReplicaSet
+    name: runnerreplicaset_v1alpha1
+  - apiVersion: actions.summerwind.dev/v1alpha1
+    filename: actions.summerwind.dev/runnerset_v1alpha1.json
+    kind: RunnerSet
+    name: runnerset_v1alpha1
 agent.k8s.elastic.co:
-  org: elastic
-  githubOrg: elastic
-  kinds:
-    - agent_v1alpha1:
-        kind: Agent
-        apiVersion: agent.k8s.elastic.co/v1alpha1
-        lastUpdated: "2022-05-06"
-        repo: cloud-on-k8s
-        permitLink: 34c69748021ccb9a369e51d31019717a97175a9d/config/crds/v1/all-crds.yaml
+  - apiVersion: agent.k8s.elastic.co/v1alpha1
+    filename: agent.k8s.elastic.co/agent_v1alpha1.json
+    kind: Agent
+    name: agent_v1alpha1
 apm.k8s.elastic.co:
-  org: elastic
-  githubOrg: elastic
-  kinds:
-    - apmserver_v1:
-        kind: ApmServer
-        apiVersion: apm.k8s.elastic.co/v1
-        lastUpdated: "2022-05-06"
-        repo: cloud-on-k8s
-        permitLink: 34c69748021ccb9a369e51d31019717a97175a9d/config/crds/v1/all-crds.yaml
-    - apmserver_v1beta1:
-        kind: ApmServer
-        apiVersion: apm.k8s.elastic.co/v1beta1
-        lastUpdated: "2022-05-06"
-        repo: cloud-on-k8s
-        permitLink: 34c69748021ccb9a369e51d31019717a97175a9d/config/crds/v1/all-crds.yaml
-    - apmserver_v1alpha1:
-        kind: ApmServer
-        apiVersion: apm.k8s.elastic.co/v1alpha1
-        lastUpdated: "2022-05-06"
-        repo: cloud-on-k8s
-        permitLink: 34c69748021ccb9a369e51d31019717a97175a9d/config/crds/v1/all-crds.yaml
+  - apiVersion: apm.k8s.elastic.co/v1
+    filename: apm.k8s.elastic.co/apmserver_v1.json
+    kind: ApmServer
+    name: apmserver_v1
+  - apiVersion: apm.k8s.elastic.co/v1beta1
+    filename: apm.k8s.elastic.co/apmserver_v1beta1.json
+    kind: ApmServer
+    name: apmserver_v1beta1
+  - apiVersion: apm.k8s.elastic.co/v1alpha1
+    filename: apm.k8s.elastic.co/apmserver_v1alpha1.json
+    kind: ApmServer
+    name: apmserver_v1alpha1
+argoproj.io:
+  - apiVersion: argoproj.io/v1alpha1
+    filename: argoproj.io/analysisrun_v1alpha1.json
+    kind: AnalysisRun
+    name: analysisrun_v1alpha1
+  - apiVersion: argoproj.io/v1alpha1
+    filename: argoproj.io/analysistemplate_v1alpha1.json
+    kind: AnalysisTemplate
+    name: analysistemplate_v1alpha1
+  - apiVersion: argoproj.io/v1alpha1
+    filename: argoproj.io/application_v1alpha1.json
+    kind: Application
+    name: application_v1alpha1
+  - apiVersion: argoproj.io/v1alpha1
+    filename: argoproj.io/applicationset_v1alpha1.json
+    kind: ApplicationSet
+    name: applicationset_v1alpha1
+  - apiVersion: argoproj.io/v1alpha1
+    filename: argoproj.io/appproject_v1alpha1.json
+    kind: AppProject
+    name: appproject_v1alpha1
+  - apiVersion: argoproj.io/v1alpha1
+    filename: argoproj.io/clusteranalysistemplate_v1alpha1.json
+    kind: ClusterAnalysisTemplate
+    name: clusteranalysistemplate_v1alpha1
+  - apiVersion: argoproj.io/v1alpha1
+    filename: argoproj.io/clusterworkflowtemplate_v1alpha1.json
+    kind: ClusterWorkflowTemplate
+    name: clusterworkflowtemplate_v1alpha1
+  - apiVersion: argoproj.io/v1alpha1
+    filename: argoproj.io/cronworkflow_v1alpha1.json
+    kind: CronWorkflow
+    name: cronworkflow_v1alpha1
+  - apiVersion: argoproj.io/v1alpha1
+    filename: argoproj.io/experiment_v1alpha1.json
+    kind: Experiment
+    name: experiment_v1alpha1
+  - apiVersion: argoproj.io/v1alpha1
+    filename: argoproj.io/rollout_v1alpha1.json
+    kind: Rollout
+    name: rollout_v1alpha1
+  - apiVersion: argoproj.io/v1alpha1
+    filename: ''
+    kind: Workflow
+    name: workflows_v1alpha1
+  - apiVersion: argoproj.io/v1alpha1
+    filename: ''
+    kind: WorkflowEventBinding
+    name: workfloweventbindings_v1alpha1
+  - apiVersion: argoproj.io/v1alpha1
+    filename: ''
+    kind: WorkflowTaskSet
+    name: workflowtasksets_v1alpha1
+  - apiVersion: argoproj.io/v1alpha1
+    filename: ''
+    kind: WorkflowTaskResult
+    name: workflowtaskresults_v1alpha1
+  - apiVersion: argoproj.io/v1alpha1
+    filename: argoproj.io/workflowtemplate_v1alpha1.json
+    kind: WorkflowTemplate
+    name: workflowtemplate_v1alpha1
 beat.k8s.elastic.co:
-  org: elastic
-  githubOrg: elastic
-  kinds:          
-    - beat_v1beta1:
-        kind: Beat
-        apiVersion: beat.k8s.elastic.co/v1beta1
-        lastUpdated: "2022-05-06"
-        repo: cloud-on-k8s
-        permitLink: 34c69748021ccb9a369e51d31019717a97175a9d/config/crds/v1/all-crds.yaml
+  - apiVersion: beat.k8s.elastic.co/v1beta1
+    filename: beat.k8s.elastic.co/beat_v1beta1.json
+    kind: Beat
+    name: beat_v1beta1
+bitnami.com:
+  - apiVersion: bitnami.com/v1alpha1
+    filename: bitnami.com/sealedsecret_v1alpha1.json
+    kind: SealedSecret
+    name: sealedsecret_v1alpha1
 elasticsearch.k8s.elastic.co:
-  org: elastic
-  githubOrg: elastic
-  kinds:
-    - elasticsearch_v1alpha1:
-        kind: Elasticsearch
-        apiVersion: elasticsearch.k8s.elastic.co/v1alpha1
-        lastUpdated: "2022-05-06"
-        repo: cloud-on-k8s
-        permitLink: 34c69748021ccb9a369e51d31019717a97175a9d/config/crds/v1/all-crds.yaml
-    - elasticsearch_v1beta1:
-        kind: Elasticsearch
-        apiVersion: elasticsearch.k8s.elastic.co/v1beta1
-        lastUpdated: "2022-05-06"
-        repo: cloud-on-k8s
-        permitLink: 34c69748021ccb9a369e51d31019717a97175a9d/config/crds/v1/all-crds.yaml
-    - elasticsearch_v1:
-        kind: Elasticsearch
-        apiVersion: elasticsearch.k8s.elastic.co/v1
-        lastUpdated: "2022-05-06"
-        repo: cloud-on-k8s
-        permitLink: 34c69748021ccb9a369e51d31019717a97175a9d/config/crds/v1/all-crds.yaml
-maps.k8s.elastic.co:
-  org: elastic
-  githubOrg: elastic
-  kinds:
-    - elasticsearch_v1alpha1:
-        kind: ElasticMapsServer
-        apiVersion: maps.k8s.elastic.co/v1alpha1
-        lastUpdated: "2022-05-06"
-        repo: cloud-on-k8s
-        permitLink: 34c69748021ccb9a369e51d31019717a97175a9d/config/crds/v1/all-crds.yaml
+  - apiVersion: elasticsearch.k8s.elastic.co/v1alpha1
+    filename: elasticsearch.k8s.elastic.co/elasticsearch_v1alpha1.json
+    kind: Elasticsearch
+    name: elasticsearch_v1alpha1
+  - apiVersion: elasticsearch.k8s.elastic.co/v1beta1
+    filename: elasticsearch.k8s.elastic.co/elasticsearch_v1beta1.json
+    kind: Elasticsearch
+    name: elasticsearch_v1beta1
+  - apiVersion: elasticsearch.k8s.elastic.co/v1
+    filename: elasticsearch.k8s.elastic.co/elasticsearch_v1.json
+    kind: Elasticsearch
+    name: elasticsearch_v1
 enterprisesearch.k8s.elastic.co:
-  org: elastic
-  githubOrg: elastic
-  kinds: 
-    - enterprisesearch_v1beta1:
-        kind: EnterpriseSearch
-        apiVersion: enterprisesearch.k8s.elastic.co/v1beta1
-        lastUpdated: "2022-05-06"
-        repo: cloud-on-k8s
-        permitLink: 34c69748021ccb9a369e51d31019717a97175a9d/config/crds/v1/all-crds.yaml
-    - enterprisesearch_v1:
-        kind: EnterpriseSearch
-        apiVersion: enterprisesearch.k8s.elastic.co/v1
-        lastUpdated: "2022-05-06"
-        repo: cloud-on-k8s
-        permitLink: 34c69748021ccb9a369e51d31019717a97175a9d/config/crds/v1/all-crds.yaml
-kibana.k8s.elastic.co:
-  org: elastic
-  githubOrg: elastic
-  kinds: 
-    - kibana_v1alpha1:
-        kind: Kibana
-        apiVersion: kibana.k8s.elastic.co/v1alpha1
-        lastUpdated: "2022-05-06"
-        repo: cloud-on-k8s
-        permitLink: 34c69748021ccb9a369e51d31019717a97175a9d/config/crds/v1/all-crds.yaml
-    - kibana_v1beta1:
-        kind: Kibana
-        apiVersion: kibana.k8s.elastic.co/v1beta1
-        lastUpdated: "2022-05-06"
-        repo: cloud-on-k8s
-        permitLink: 34c69748021ccb9a369e51d31019717a97175a9d/config/crds/v1/all-crds.yaml
-    - kibana_v1:
-        kind: Kibana
-        apiVersion: kibana.k8s.elastic.co/v1
-        lastUpdated: "2022-05-06"
-        repo: cloud-on-k8s
-        permitLink: 34c69748021ccb9a369e51d31019717a97175a9d/config/crds/v1/all-crds.yaml
-notification.toolkit.fluxcd.io:
-  org: fluxcd
-  githubOrg: fluxcd
-  kinds:
-    - alert_v1beta1:
-        kind: Alert
-        apiVersion: notification.toolkit.fluxcd.io/v1beta1
-        lastUpdated: "2022-06-23"
-        repo: notification-controller
-        permitLink: f946ddda0becc43746b83798afc2195d241cfee8/config/crd/bases/notification.toolkit.fluxcd.io_alerts.yaml
-    - provider_v1beta1:
-        kind: Provider
-        apiVersion: notification.toolkit.fluxcd.io/v1beta1
-        lastUpdated: "2022-06-23"
-        repo: notification-controller
-        permitLink: f946ddda0becc43746b83798afc2195d241cfee8/config/crd/bases/notification.toolkit.fluxcd.io_providers.yaml
-    - receiver_v1beta1:
-        kind: Receiver
-        apiVersion: notification.toolkit.fluxcd.io/v1beta1
-        lastUpdated: "2022-06-23"
-        repo: notification-controller
-        permitLink: f946ddda0becc43746b83798afc2195d241cfee8/config/crd/bases/notification.toolkit.fluxcd.io_receivers.yaml
-source.toolkit.fluxcd.io:
-  org: fluxcd
-  githubOrg: fluxcd
-  kinds:
-    - bucket_v1beta1:
-        kind: Bucket
-        apiVersion: source.toolkit.fluxcd.io/v1beta1
-        lastUpdated: "2022-06-23"
-        repo: source-controller
-        permitLink: 7c07b7a03fdafba280e11c90e36cc4e53f431da6/config/crd/bases/source.toolkit.fluxcd.io_buckets.yaml
-    - buckcket_v1beta2:
-        kind: Bucket
-        apiVersion: source.toolkit.fluxcd.io/v1beta2
-        lastUpdated: "2022-06-23"
-        repo: source-controller
-        permitLink: 7c07b7a03fdafba280e11c90e36cc4e53f431da6/config/crd/bases/source.toolkit.fluxcd.io_buckets.yaml
-    - gitrepository_v1beta1:
-        kind: GitRepository
-        apiVersion: source.toolkit.fluxcd.io/v1beta1
-        lastUpdated: "2022-06-23"
-        repo: source-controller
-        permitLink: 7c07b7a03fdafba280e11c90e36cc4e53f431da6/config/crd/bases/source.toolkit.fluxcd.io_gitrepositories.yaml
-    - gitrepository_v1beta2:
-        kind: GitRepository
-        apiVersion: source.toolkit.fluxcd.io/v1beta1
-        lastUpdated: "2022-06-23"
-        repo: source-controller
-        permitLink: 7c07b7a03fdafba280e11c90e36cc4e53f431da6/config/crd/bases/source.toolkit.fluxcd.io_gitrepositories.yaml
-    - helmchart_v1beta1:
-        kind: HelmChart
-        apiVersion: source.toolkit.fluxcd.io/v1beta1
-        lastUpdated: "2022-06-23"
-        repo: source-controller
-        permitLink: 7c07b7a03fdafba280e11c90e36cc4e53f431da6/config/crd/bases/source.toolkit.fluxcd.io_helmcharts.yaml
-    - helmchart_v1beta2:
-        kind: HelmChart
-        apiVersion: source.toolkit.fluxcd.io/v1beta2
-        lastUpdated: "2022-06-23"
-        repo: source-controller
-        permitLink: 7c07b7a03fdafba280e11c90e36cc4e53f431da6/config/crd/bases/source.toolkit.fluxcd.io_helmcharts.yaml
-    - helmrepository_v1beta1:
-        kind: HelmRepository
-        apiVersion: source.toolkit.fluxcd.io/v1beta1
-        lastUpdated: "2022-06-23"
-        repo: source-controller
-        permitLink: 7c07b7a03fdafba280e11c90e36cc4e53f431da6/config/crd/bases/source.toolkit.fluxcd.io_helmrepositories.yaml
-    - helmrepository_v1beta2:
-        kind: HelmRepository
-        apiVersion: source.toolkit.fluxcd.io/v1beta2
-        lastUpdated: "2022-06-23"
-        repo: source-controller
-        permitLink: 7c07b7a03fdafba280e11c90e36cc4e53f431da6/config/crd/bases/source.toolkit.fluxcd.io_helmrepositories.yaml
-image.toolkit.fluxcd.io:
-  org: fluxcd
-  githubOrg: fluxcd
-  kinds:
-    - imageupdateautomation_v1alpha1:
-        kind: ImageUpdateAutomation
-        apiVersion: image.toolkit.fluxcd.io/v1alpha1
-        lastUpdated: "2022-06-23"
-        repo: image-automation-controller
-        permitLink: dd2a32350e96191cf7488e8c502cb5b89a858a92/config/crd/bases/image.toolkit.fluxcd.io_imageupdateautomations.yaml
-    - imageupdateautomation_v1alpha2:
-        kind: ImageUpdateAutomation
-        apiVersion: image.toolkit.fluxcd.io/v1alpha2
-        lastUpdated: "2022-06-23"
-        repo: image-automation-controller
-        permitLink: dd2a32350e96191cf7488e8c502cb5b89a858a92/config/crd/bases/image.toolkit.fluxcd.io_imageupdateautomations.yaml
-    - imageupdateautomation_v1beta1:
-        kind: ImageUpdateAutomation
-        apiVersion: image.toolkit.fluxcd.io/v1beta1
-        lastUpdated: "2022-06-23"
-        repo: image-automation-controller
-        permitLink: dd2a32350e96191cf7488e8c502cb5b89a858a92/config/crd/bases/image.toolkit.fluxcd.io_imageupdateautomations.yaml
-    - imagepolicy_v1alpha1:
-        kind: ImagePolicy
-        apiVersion: image.toolkit.fluxcd.io/v1alpha1
-        lastUpdated: "2022-06-23"
-        repo: image-reflector-controller
-        permitLink: 5ab6137d06168c45e29f805737ce2215e811cbe9/config/crd/bases/image.toolkit.fluxcd.io_imagepolicies.yaml
-    - imagepolicy_v1alpha2:
-        kind: ImagePolicy
-        apiVersion: image.toolkit.fluxcd.io/v1alpha2
-        lastUpdated: "2022-06-23"
-        repo: image-reflector-controller
-        permitLink: 5ab6137d06168c45e29f805737ce2215e811cbe9/config/crd/bases/image.toolkit.fluxcd.io_imagepolicies.yaml
-    - imagepolicy_v1beta1:
-        kind: ImagePolicy
-        apiVersion: image.toolkit.fluxcd.io/v1beta1
-        lastUpdated: "2022-06-23"
-        repo: image-reflector-controller
-        permitLink: 5ab6137d06168c45e29f805737ce2215e811cbe9/config/crd/bases/image.toolkit.fluxcd.io_imagepolicies.yaml
-    - imagerepository_v1alpha1:
-        kind: ImageRepository
-        apiVersion: image.toolkit.fluxcd.io/v1alpha1
-        lastUpdated: "2022-06-23"
-        repo: image-reflector-controller
-        permitLink: 5ab6137d06168c45e29f805737ce2215e811cbe9/config/crd/bases/image.toolkit.fluxcd.io_imagerepositories.yaml
-    - imagerepository_v1alpha2:
-        kind: ImageRepository
-        apiVersion: image.toolkit.fluxcd.io/v1alpha2
-        lastUpdated: "2022-06-23"
-        repo: image-reflector-controller
-        permitLink: 5ab6137d06168c45e29f805737ce2215e811cbe9/config/crd/bases/image.toolkit.fluxcd.io_imagerepositories.yaml
-    - imagerepository_v1beta1:
-        kind: ImageRepository
-        apiVersion: image.toolkit.fluxcd.io/v1beta1
-        lastUpdated: "2022-06-23"
-        repo: image-reflector-controller
-        permitLink: 5ab6137d06168c45e29f805737ce2215e811cbe9/config/crd/bases/image.toolkit.fluxcd.io_imagerepositories.yaml
+  - apiVersion: enterprisesearch.k8s.elastic.co/v1beta1
+    filename: enterprisesearch.k8s.elastic.co/enterprisesearch_v1beta1.json
+    kind: EnterpriseSearch
+    name: enterprisesearch_v1beta1
+  - apiVersion: enterprisesearch.k8s.elastic.co/v1
+    filename: enterprisesearch.k8s.elastic.co/enterprisesearch_v1.json
+    kind: EnterpriseSearch
+    name: enterprisesearch_v1
 helm.toolkit.fluxcd.io:
-  org: fluxcd
-  githubOrg: fluxcd
-  kinds:        
-    - helmrelease_v1:
-        kind: HelmRelease
-        apiVersion: helm.toolkit.fluxcd.io/v1
-        lastUpdated: "2022-06-23"
-        repo: helm-operator
-        permitLink: a2872bd27b1db16a58f8bc2f8707d4ce1f16e7ae/chart/helm-operator/crds/helmrelease.yaml
-    - helmrelease_v2beta1:
-        kind: HelmRelease
-        apiVersion: helm.toolkit.fluxcd.io/v2beta1
-        lastUpdated: "2022-08-29"
-        repo: helm-controller
-        permitLink: 12dc7d9dcab039bfbf8a555c825a489f3863848e/config/crd/bases/helm.toolkit.fluxcd.io_helmreleases.yaml
-kustomize.toolkit.fluxcd.io:
-  org: fluxcd
-  githubOrg: fluxcd
-  kinds:      
-    - kustomization_v1beta1:
-        kind: Kustomization
-        apiVersion: kustomize.toolkit.fluxcd.io/v1beta1
-        lastUpdated: "2022-06-23"
-        repo: kustomize-controller
-        permitLink: 57a0a1f2387287f9a0e03ed69a0ff599162eb0a9/config/crd/bases/kustomize.toolkit.fluxcd.io_kustomizations.yaml
-    - kustomization_v1beta2:
-        kind: Kustomization
-        apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
-        lastUpdated: "2022-06-23"
-        repo: kustomize-controller
-        permitLink: 57a0a1f2387287f9a0e03ed69a0ff599162eb0a9/config/crd/bases/kustomize.toolkit.fluxcd.io_kustomizations.yaml
-monitoring.coreos.com:
-  org: prometheus
-  githubOrg: prometheus-community
-  kinds:
-    - alertmanager_v1:
-        kind: Alertmanager
-        apiVersion: monitoring.coreos.com/v1
-        lastUpdated: "2022-06-16"
-        repo: helm-charts
-        permitLink: 60ea1c210a9c7678dbaab825271079e0562c98fd/charts/kube-prometheus-stack/crds/crd-alertmanagers.yaml
-    - alertmanagerconfig_v1alpha1:
-        kind: AlertmanagerConfig
-        apiVersion: monitoring.coreos.com/v1alpha1
-        lastUpdated: "2022-06-16"
-        repo: helm-charts
-        permitLink: 60ea1c210a9c7678dbaab825271079e0562c98fd/charts/kube-prometheus-stack/crds/crd-alertmanagerconfigs.yaml
-    - podmonitor_v1:
-        kind: PodMonitor
-        apiVersion: monitoring.coreos.com/v1
-        lastUpdated: "2022-06-16"
-        repo: helm-charts
-        permitLink: 60ea1c210a9c7678dbaab825271079e0562c98fd/charts/kube-prometheus-stack/crds/crd-podmonitors.yaml
-    - probe_v1:
-        kind: Probe
-        apiVersion: monitoring.coreos.com/v1
-        lastUpdated: "2022-06-16"
-        repo: helm-charts
-        permitLink: 60ea1c210a9c7678dbaab825271079e0562c98fd/charts/kube-prometheus-stack/crds/crd-probes.yaml
-    - prometheus_v1:
-        kind: Prometheus
-        apiVersion: monitoring.coreos.com/v1
-        lastUpdated: "2022-06-16"
-        repo: helm-charts
-        permitLink: 60ea1c210a9c7678dbaab825271079e0562c98fd/charts/kube-prometheus-stack/crds/crd-prometheuses.yaml
-    - prometheusrule_v1:
-        kind: PrometheusRule
-        apiVersion: monitoring.coreos.com/v1
-        lastUpdated: "2022-06-16"
-        repo: helm-charts
-        permitLink: 60ea1c210a9c7678dbaab825271079e0562c98fd/charts/kube-prometheus-stack/crds/crd-prometheusrules.yaml
-    - servicemonitor_v1:
-        kind: ServiceMonitor
-        apiVersion: monitoring.coreos.com/v1
-        lastUpdated: "2022-06-16"
-        repo: helm-charts
-        permitLink: 60ea1c210a9c7678dbaab825271079e0562c98fd/charts/kube-prometheus-stack/crds/crd-servicemonitors.yaml
-    - thanosruler_v1:
-        kind: ThanosRuler
-        apiVersion: monitoring.coreos.com/v1
-        lastUpdated: "2022-06-16"
-        repo: helm-charts
-        permitLink: 60ea1c210a9c7678dbaab825271079e0562c98fd/charts/kube-prometheus-stack/crds/crd-thanosrulers.yaml
+  - apiVersion: helm.toolkit.fluxcd.io/v1
+    filename: helm.toolkit.fluxcd.io/helmrelease_v1.json
+    kind: HelmRelease
+    name: helmrelease_v1
+  - apiVersion: helm.toolkit.fluxcd.io/v2beta1
+    filename: helm.toolkit.fluxcd.io/helmrelease_v2beta1.json
+    kind: HelmRelease
+    name: helmrelease_v2beta1
+image.toolkit.fluxcd.io:
+  - apiVersion: image.toolkit.fluxcd.io/v1alpha1
+    filename: image.toolkit.fluxcd.io/imageupdateautomation_v1alpha1.json
+    kind: ImageUpdateAutomation
+    name: imageupdateautomation_v1alpha1
+  - apiVersion: image.toolkit.fluxcd.io/v1alpha2
+    filename: image.toolkit.fluxcd.io/imageupdateautomation_v1alpha2.json
+    kind: ImageUpdateAutomation
+    name: imageupdateautomation_v1alpha2
+  - apiVersion: image.toolkit.fluxcd.io/v1beta1
+    filename: image.toolkit.fluxcd.io/imageupdateautomation_v1beta1.json
+    kind: ImageUpdateAutomation
+    name: imageupdateautomation_v1beta1
+  - apiVersion: image.toolkit.fluxcd.io/v1alpha1
+    filename: image.toolkit.fluxcd.io/imagepolicy_v1alpha1.json
+    kind: ImagePolicy
+    name: imagepolicy_v1alpha1
+  - apiVersion: image.toolkit.fluxcd.io/v1alpha2
+    filename: image.toolkit.fluxcd.io/imagepolicy_v1alpha2.json
+    kind: ImagePolicy
+    name: imagepolicy_v1alpha2
+  - apiVersion: image.toolkit.fluxcd.io/v1beta1
+    filename: image.toolkit.fluxcd.io/imagepolicy_v1beta1.json
+    kind: ImagePolicy
+    name: imagepolicy_v1beta1
+  - apiVersion: image.toolkit.fluxcd.io/v1alpha1
+    filename: image.toolkit.fluxcd.io/imagerepository_v1alpha1.json
+    kind: ImageRepository
+    name: imagerepository_v1alpha1
+  - apiVersion: image.toolkit.fluxcd.io/v1alpha2
+    filename: image.toolkit.fluxcd.io/imagerepository_v1alpha2.json
+    kind: ImageRepository
+    name: imagerepository_v1alpha2
+  - apiVersion: image.toolkit.fluxcd.io/v1beta1
+    filename: image.toolkit.fluxcd.io/imagerepository_v1beta1.json
+    kind: ImageRepository
+    name: imagerepository_v1beta1
 jaegertracing.io:
-  org: jaeger
-  githubOrg: jaegertracing
-  kinds:
-    - jaeger_v1:
-        kind: Jaeger
-        apiVersion: jaegertracing.io/v1
-        lastUpdated: "2022-06-16"
-        repo: jaeger-operator
-        permitLink: 8695866b4c71af5967f2b567c3280757af647561/config/crd/bases/jaegertracing.io_jaegers.yaml
-keda.sh:
-  org: keda
-  githubOrg: kedacore
-  kinds:
-    - clustertriggerauthentication_v1alpha1:
-        apiVersion: keda.sh/v1alpha1
-        kind: ClusterTriggerAuthentication
-        lastUpdated: "2022-06-16"
-        repo: charts
-        permitLink: 9be0a560a269502dde5db7683f62277592253cc2/keda/templates/02-crd-clustertriggerauthentications.yaml
-    - scaledjob_v1alpha1:
-        apiVersion: keda.sh/v1alpha1
-        kind: ScaledJob
-        lastUpdated: "2022-06-16"
-        repo: charts
-        permitLink: 9be0a560a269502dde5db7683f62277592253cc2/keda/templates/03-crd-scaledjobs.keda.sh.yaml
-    - scaledobject_v1alpha1:
-        kind: ScaledObject
-        apiVersion: keda.sh/v1alpha1
-        lastUpdated: "2022-06-16"
-        repo: charts
-        permitLink: 9be0a560a269502dde5db7683f62277592253cc2/keda/templates/04-crd-scaledobjects.keda.sh.yaml
-    - triggerauthentication_v1alpha1:
-        apiVersion: keda.sh/v1alpha1
-        kind: TriggerAuthentication
-        lastUpdated: "2022-06-16"
-        repo: charts
-        permitLink: 9be0a560a269502dde5db7683f62277592253cc2/keda/templates/05-crd-triggerauthentications.keda.sh.yaml
-kubeflow.org:
-  org: kubeflow
-  githubOrg: kubeflow
-  kinds:
-    - profile_v1:
-        kind: Profile
-        apiVersion: kubeflow.org/v1
-        lastUpdated: "2022-06-16"
-        repo: kubeflow
-        permitLink: e6fdf515c09ba1f695d60a87c9c56ba5fb1718e8/components/profile-controller/config/crd/bases/kubeflow.org_profiles.yaml
-    - profile_v1beta1:
-        kind: Profile
-        apiVersion: kubeflow.org/v1beta1
-        lastUpdated: "2022-06-16"
-        repo: kubeflow
-        permitLink: e6fdf515c09ba1f695d60a87c9c56ba5fb1718e8/components/profile-controller/config/crd/bases/kubeflow.org_profiles.yaml
-    - notebook_v1:
-        kind: Notebook
-        apiVersion: kubeflow.org/v1
-        lastUpdated: "2022-06-16"
-        repo: kubeflow
-        permitLink: e6fdf515c09ba1f695d60a87c9c56ba5fb1718e8/components/notebook-controller/config/crd/bases/kubeflow.org_notebooks.yaml
-    - notebook_v1alpha1:
-        kind: Notebook
-        apiVersion: kubeflow.org/v1alpha1
-        lastUpdated: "2022-06-16"
-        repo: kubeflow
-        permitLink: e6fdf515c09ba1f695d60a87c9c56ba5fb1718e8/components/notebook-controller/config/crd/bases/kubeflow.org_notebooks.yaml
-    - notebook_v1beta1:
-        kind: Notebook
-        apiVersion: kubeflow.org/v1beta1
-        lastUpdated: "2022-06-16"
-        repo: kubeflow
-        permitLink: e6fdf515c09ba1f695d60a87c9c56ba5fb1718e8/components/notebook-controller/config/crd/bases/kubeflow.org_notebooks.yaml            
-    - poddefault_v1alpha1:
-        kind: PodDefault
-        apiVersion: kubeflow.org/v1alpha1
-        lastUpdated: "2022-06-16"
-        repo: kubeflow
-        permitLink: 8be0d987f7652ddc91cdabb6049036f5dca6649b/components/admission-webhook/manifests/base/crd.yaml
+  - apiVersion: jaegertracing.io/v1
+    filename: jaegertracing.io/jaeger_v1.json
+    kind: Jaeger
+    name: jaeger_v1
 kafka.strimzi.io:
-  org: strimzi
-  githubOrg: strimzi
-  kinds:
-    - kafka_v1beta2:
-        kind: Kafka
-        apiVersion: kafka.strimzi.io/v1beta2
-        lastUpdated: "2023-04-06"
-        repo: strimzi-kafka-operator
-        permitLink: 0459e7149a837878ced3de5ae1a01198c1e420d5/helm-charts/helm3/strimzi-kafka-operator/crds/040-Crd-kafka.yaml
-    - kafkabridge_v1beta2:
-        kind: KafkaBridge
-        apiVersion: kafka.strimzi.io/v1beta2
-        lastUpdated: "2023-04-06"
-        repo: strimzi-kafka-operator
-        permitLink: 0459e7149a837878ced3de5ae1a01198c1e420d5/helm-charts/helm3/strimzi-kafka-operator/crds/046-Crd-kafkabridge.yaml
-    - kafkaconnect_v1beta2:
-        kind: KafkaConnect
-        apiVersion: kafka.strimzi.io/v1beta2
-        lastUpdated: "2023-04-06"
-        repo: strimzi-kafka-operator
-        permitLink: 0459e7149a837878ced3de5ae1a01198c1e420d5/helm-charts/helm3/strimzi-kafka-operator/crds/041-Crd-kafkaconnect.yaml
-    - kafkaconnector_v1beta2:
-        kind: KafkaConnector
-        apiVersion: kafka.strimzi.io/v1beta2
-        lastUpdated: "2023-04-06"
-        repo: strimzi-kafka-operator
-        permitLink: 0459e7149a837878ced3de5ae1a01198c1e420d5/helm-charts/helm3/strimzi-kafka-operator/crds/047-Crd-kafkaconnector.yaml
-    - kafkamirrormaker_v1beta2:
-        kind: KafkaMirrorMaker
-        apiVersion: kafka.strimzi.io/v1beta2
-        lastUpdated: "2023-04-06"
-        repo: strimzi-kafka-operator
-        permitLink: 0459e7149a837878ced3de5ae1a01198c1e420d5/helm-charts/helm3/strimzi-kafka-operator/crds/045-Crd-kafkamirrormaker.yaml
-    - kafkamirrormaker2_v1beta2:
-        kind: kafka.strimzi.io/v1beta2
-        apiVersion: apiextensions.k8s.io/v1
-        lastUpdated: "2023-04-06"
-        repo: strimzi-kafka-operator
-        permitLink: 0459e7149a837878ced3de5ae1a01198c1e420d5/helm-charts/helm3/strimzi-kafka-operator/crds/048-Crd-kafkamirrormaker2.yaml
-    - kafkarebalance_v1beta2:
-        apiVersion: kafka.strimzi.io/v1beta2
-        kind: KafkaRebalance
-        lastUpdated: "2023-04-06"
-        repo: strimzi-kafka-operator
-        permitLink: 0459e7149a837878ced3de5ae1a01198c1e420d5/helm-charts/helm3/strimzi-kafka-operator/crds/049-Crd-kafkarebalance.yaml
-    - kafkatopic_v1alpha1:
-        apiVersion: kafka.strimzi.io/v1alpha1
-        kind: KafkaTopic
-        lastUpdated: "2023-04-06"
-        repo: strimzi-kafka-operator
-        permitLink: 0459e7149a837878ced3de5ae1a01198c1e420d5/helm-charts/helm3/strimzi-kafka-operator/crds/043-Crd-kafkatopic.yaml
-    - kafkatopic_v1beta1:
-        apiVersion: kafka.strimzi.io/v1beta1
-        kind: KafkaTopic
-        lastUpdated: "2023-04-06"
-        repo: strimzi-kafka-operator
-        permitLink: 0459e7149a837878ced3de5ae1a01198c1e420d5/helm-charts/helm3/strimzi-kafka-operator/crds/043-Crd-kafkatopic.yaml            
-    - kafkatopic_v1beta2:
-        apiVersion: kafka.strimzi.io/v1beta2
-        kind: KafkaTopic
-        lastUpdated: "2023-04-06"
-        repo: strimzi-kafka-operator
-        permitLink: 0459e7149a837878ced3de5ae1a01198c1e420d5/helm-charts/helm3/strimzi-kafka-operator/crds/043-Crd-kafkatopic.yaml                
-    - kafkauser_v1alpha1:
-        apiVersion: kafka.strimzi.io/v1alpha1
-        kind: KafkaUser
-        lastUpdated: "2023-04-06"
-        repo: strimzi-kafka-operator
-        permitLink: 0459e7149a837878ced3de5ae1a01198c1e420d5/helm-charts/helm3/strimzi-kafka-operator/crds/044-Crd-kafkauser.yaml
-    - kafkauser_v1beta1:
-        apiVersion: kafka.strimzi.io/v1beta1
-        kind: KafkaUser
-        lastUpdated: "2023-04-06"
-        repo: strimzi-kafka-operator
-        permitLink: 0459e7149a837878ced3de5ae1a01198c1e420d5/helm-charts/helm3/strimzi-kafka-operator/crds/044-Crd-kafkauser.yaml
-    - kafkauser_v1beta2:
-        apiVersion: kafka.strimzi.io/v1beta2
-        kind: KafkaUser
-        lastUpdated: "2023-04-06"
-        repo: strimzi-kafka-operator
-        permitLink: 0459e7149a837878ced3de5ae1a01198c1e420d5/helm-charts/helm3/strimzi-kafka-operator/crds/044-Crd-kafkauser.yaml          
-    - strimzipodset_v1beta2:
-        apiVersion: kafka.strimzi.io/v1beta2
-        kind: StrimziPodSet
-        lastUpdated: "2023-04-06"
-        repo: strimzi-kafka-operator
-        permitLink: 0459e7149a837878ced3de5ae1a01198c1e420d5/helm-charts/helm3/strimzi-kafka-operator/crds/042-Crd-strimzipodset.yaml
-traefik.containo.us:
-  org: traefik
-  githubOrg: traefik
-  kinds:
-    - ingressroute_v1alpha1:
-        apiVersion: traefik.containo.us/v1alpha1
-        kind: IngressRoute
-        lastUpdated: "2022-06-16"
-        repo: traefik-helm-chart
-        permitLink: ff25058604da2eeee7eac3fec3b1e0e89949c407/traefik/crds/ingressroute.yaml
-    - ingressroutetcp_v1alpha1:
-        apiVersion: traefik.containo.us/v1alpha1
-        kind: IngressRouteTCP
-        lastUpdated: "2022-06-16"
-        repo: traefik-helm-chart
-        permitLink: ff25058604da2eeee7eac3fec3b1e0e89949c407/traefik/crds/ingressroutetcp.yaml
-    - ingressrouteudp_v1alpha1:
-        apiVersion: traefik.containo.us/v1alpha1
-        kind: IngressRouteUDP
-        lastUpdated: "2022-06-16"
-        repo: traefik-helm-chart
-        permitLink: ff25058604da2eeee7eac3fec3b1e0e89949c407/traefik/crds/ingressrouteudp.yaml
-    - middleware_v1alpha1:
-        apiVersion: traefik.containo.us/v1alpha1
-        kind: IngressMiddlewareRoute
-        lastUpdated: "2022-06-16"
-        repo: traefik-helm-chart
-        permitLink: ff25058604da2eeee7eac3fec3b1e0e89949c407/traefik/crds/middlewares.yaml
-    - middlewaretcp_v1alpha1:
-        apiVersion: traefik.containo.us/v1alpha1
-        kind: MiddlewareTCP
-        lastUpdated: "2022-06-16"
-        repo: traefik-helm-chart
-        permitLink: ff25058604da2eeee7eac3fec3b1e0e89949c407/traefik/crds/middlewarestcp.yaml
-    - serverstransport_v1alpha1:
-        apiVersion: traefik.containo.us/v1alpha1
-        kind: ServersTransport
-        lastUpdated: "2022-06-16"
-        repo: traefik-helm-chart
-        permitLink: ff25058604da2eeee7eac3fec3b1e0e89949c407/traefik/crds/serverstransports.yaml
-    - tlsoption_v1alpha1:
-        apiVersion: traefik.containo.us/v1alpha1
-        kind: TLSOption
-        lastUpdated: "2022-06-16"
-        repo: traefik-helm-chart
-        permitLink: ff25058604da2eeee7eac3fec3b1e0e89949c407/traefik/crds/tlsoptions.yaml
-    - tlsstore_v1alpha1:
-        apiVersion: traefik.containo.us/v1alpha1
-        kind: TLSStore
-        lastUpdated: "2022-06-16"
-        repo: traefik-helm-chart
-        permitLink: ff25058604da2eeee7eac3fec3b1e0e89949c407/traefik/crds/tlsstores.yaml
-    - traefikservice_v1alpha1:
-        apiVersion: traefik.containo.us/v1alpha1
-        kind: TraefikService
-        lastUpdated: "2022-06-16"
-        repo: traefik-helm-chart
-        permitLink: ff25058604da2eeee7eac3fec3b1e0e89949c407/traefik/crds/traefikservices.yaml
+  - apiVersion: kafka.strimzi.io/v1beta2
+    filename: kafka.strimzi.io/kafka_v1beta2.json
+    kind: Kafka
+    name: kafka_v1beta2
+  - apiVersion: kafka.strimzi.io/v1beta2
+    filename: kafka.strimzi.io/kafkabridge_v1beta2.json
+    kind: KafkaBridge
+    name: kafkabridge_v1beta2
+  - apiVersion: kafka.strimzi.io/v1beta2
+    filename: kafka.strimzi.io/kafkaconnect_v1beta2.json
+    kind: KafkaConnect
+    name: kafkaconnect_v1beta2
+  - apiVersion: kafka.strimzi.io/v1beta2
+    filename: kafka.strimzi.io/kafkaconnector_v1beta2.json
+    kind: KafkaConnector
+    name: kafkaconnector_v1beta2
+  - apiVersion: kafka.strimzi.io/v1beta2
+    filename: kafka.strimzi.io/kafkamirrormaker_v1beta2.json
+    kind: KafkaMirrorMaker
+    name: kafkamirrormaker_v1beta2
+  - apiVersion: apiextensions.k8s.io/v1
+    filename: kafka.strimzi.io/kafkamirrormaker2_v1beta2.json
+    kind: kafka.strimzi.io/v1beta2
+    name: kafkamirrormaker2_v1beta2
+  - apiVersion: kafka.strimzi.io/v1beta2
+    filename: kafka.strimzi.io/kafkarebalance_v1beta2.json
+    kind: KafkaRebalance
+    name: kafkarebalance_v1beta2
+  - apiVersion: kafka.strimzi.io/v1alpha1
+    filename: kafka.strimzi.io/kafkatopic_v1alpha1.json
+    kind: KafkaTopic
+    name: kafkatopic_v1alpha1
+  - apiVersion: kafka.strimzi.io/v1beta1
+    filename: kafka.strimzi.io/kafkatopic_v1beta1.json
+    kind: KafkaTopic
+    name: kafkatopic_v1beta1
+  - apiVersion: kafka.strimzi.io/v1beta2
+    filename: kafka.strimzi.io/kafkatopic_v1beta2.json
+    kind: KafkaTopic
+    name: kafkatopic_v1beta2
+  - apiVersion: kafka.strimzi.io/v1alpha1
+    filename: kafka.strimzi.io/kafkauser_v1alpha1.json
+    kind: KafkaUser
+    name: kafkauser_v1alpha1
+  - apiVersion: kafka.strimzi.io/v1beta1
+    filename: kafka.strimzi.io/kafkauser_v1beta1.json
+    kind: KafkaUser
+    name: kafkauser_v1beta1
+  - apiVersion: kafka.strimzi.io/v1beta2
+    filename: kafka.strimzi.io/kafkauser_v1beta2.json
+    kind: KafkaUser
+    name: kafkauser_v1beta2
+  - apiVersion: kafka.strimzi.io/v1beta2
+    filename: kafka.strimzi.io/strimzipodset_v1beta2.json
+    kind: StrimziPodSet
+    name: strimzipodset_v1beta2
+keda.sh:
+  - apiVersion: keda.sh/v1alpha1
+    filename: keda.sh/clustertriggerauthentication_v1alpha1.json
+    kind: ClusterTriggerAuthentication
+    name: clustertriggerauthentication_v1alpha1
+  - apiVersion: keda.sh/v1alpha1
+    filename: keda.sh/scaledjob_v1alpha1.json
+    kind: ScaledJob
+    name: scaledjob_v1alpha1
+  - apiVersion: keda.sh/v1alpha1
+    filename: keda.sh/scaledobject_v1alpha1.json
+    kind: ScaledObject
+    name: scaledobject_v1alpha1
+  - apiVersion: keda.sh/v1alpha1
+    filename: keda.sh/triggerauthentication_v1alpha1.json
+    kind: TriggerAuthentication
+    name: triggerauthentication_v1alpha1
+kibana.k8s.elastic.co:
+  - apiVersion: kibana.k8s.elastic.co/v1alpha1
+    filename: kibana.k8s.elastic.co/kibana_v1alpha1.json
+    kind: Kibana
+    name: kibana_v1alpha1
+  - apiVersion: kibana.k8s.elastic.co/v1beta1
+    filename: kibana.k8s.elastic.co/kibana_v1beta1.json
+    kind: Kibana
+    name: kibana_v1beta1
+  - apiVersion: kibana.k8s.elastic.co/v1
+    filename: kibana.k8s.elastic.co/kibana_v1.json
+    kind: Kibana
+    name: kibana_v1
+kubeflow.org:
+  - apiVersion: kubeflow.org/v1
+    filename: kubeflow.org/profile_v1.json
+    kind: Profile
+    name: profile_v1
+  - apiVersion: kubeflow.org/v1beta1
+    filename: kubeflow.org/profile_v1beta1.json
+    kind: Profile
+    name: profile_v1beta1
+  - apiVersion: kubeflow.org/v1
+    filename: kubeflow.org/notebook_v1.json
+    kind: Notebook
+    name: notebook_v1
+  - apiVersion: kubeflow.org/v1alpha1
+    filename: kubeflow.org/notebook_v1alpha1.json
+    kind: Notebook
+    name: notebook_v1alpha1
+  - apiVersion: kubeflow.org/v1beta1
+    filename: kubeflow.org/notebook_v1beta1.json
+    kind: Notebook
+    name: notebook_v1beta1
+  - apiVersion: kubeflow.org/v1alpha1
+    filename: kubeflow.org/poddefault_v1alpha1.json
+    kind: PodDefault
+    name: poddefault_v1alpha1
+kustomize.toolkit.fluxcd.io:
+  - apiVersion: kustomize.toolkit.fluxcd.io/v1beta1
+    filename: kustomize.toolkit.fluxcd.io/kustomization_v1beta1.json
+    kind: Kustomization
+    name: kustomization_v1beta1
+  - apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+    filename: kustomize.toolkit.fluxcd.io/kustomization_v1beta2.json
+    kind: Kustomization
+    name: kustomization_v1beta2
+maps.k8s.elastic.co:
+  - apiVersion: maps.k8s.elastic.co/v1alpha1
+    filename: ''
+    kind: ElasticMapsServer
+    name: elasticsearch_v1alpha1
+monitoring.coreos.com:
+  - apiVersion: monitoring.coreos.com/v1
+    filename: monitoring.coreos.com/alertmanager_v1.json
+    kind: Alertmanager
+    name: alertmanager_v1
+  - apiVersion: monitoring.coreos.com/v1alpha1
+    filename: monitoring.coreos.com/alertmanagerconfig_v1alpha1.json
+    kind: AlertmanagerConfig
+    name: alertmanagerconfig_v1alpha1
+  - apiVersion: monitoring.coreos.com/v1
+    filename: monitoring.coreos.com/podmonitor_v1.json
+    kind: PodMonitor
+    name: podmonitor_v1
+  - apiVersion: monitoring.coreos.com/v1
+    filename: monitoring.coreos.com/probe_v1.json
+    kind: Probe
+    name: probe_v1
+  - apiVersion: monitoring.coreos.com/v1
+    filename: monitoring.coreos.com/prometheus_v1.json
+    kind: Prometheus
+    name: prometheus_v1
+  - apiVersion: monitoring.coreos.com/v1
+    filename: monitoring.coreos.com/prometheusrule_v1.json
+    kind: PrometheusRule
+    name: prometheusrule_v1
+  - apiVersion: monitoring.coreos.com/v1
+    filename: monitoring.coreos.com/servicemonitor_v1.json
+    kind: ServiceMonitor
+    name: servicemonitor_v1
+  - apiVersion: monitoring.coreos.com/v1
+    filename: monitoring.coreos.com/thanosruler_v1.json
+    kind: ThanosRuler
+    name: thanosruler_v1
 networking.gke.io:
-  org: gke
-  githubOrg: GoogleCloudPlatform
-  kinds:
-    - managedcertificate_v1:
-        apiVersion: networking.gke.io/v1
-        kind: ManagedCertificate
-        lastUpdated: "2022-06-16"
-        repo: gke-managed-certs
-        permitLink: b4bbbe4cf108ab28c224b340493a58d893bdf3c6/deploy/managedcertificates-crd.yaml
-    - managedcertificate_v1beta1:
-        apiVersion: networking.gke.io/v1beta1
-        kind: ManagedCertificate
-        lastUpdated: "2022-06-16"
-        repo: gke-managed-certs
-        permitLink: b4bbbe4cf108ab28c224b340493a58d893bdf3c6/deploy/managedcertificates-crd.yaml
-    - managedcertificate_v1beta2:
-        apiVersion: networking.gke.io/v1beta2
-        kind: ManagedCertificate
-        lastUpdated: "2022-07-31"
-        repo: gke-managed-certs
-        permitLink: b4bbbe4cf108ab28c224b340493a58d893bdf3c6/deploy/managedcertificates-crd.yaml
-actions.summerwind.dev:  
-  org: github-action-k8s
-  githubOrg: actions-runner-controller
-  kinds:
-    - actions.summerwind.dev_v1alpha1:
-        apiVersion: actions.summerwind.dev/v1alpha1
-        kind: HorizontalRunnerAutoscaler
-        lastUpdated: "2022-08-18"
-        repo: actions-runner-controller
-        permitLink: 36e95dad477e72cd98c1414817d56697bffd5d4e/config/crd/bases/actions.summerwind.dev_horizontalrunnerautoscalers.yaml
-    - runner_v1alpha1:
-        apiVersion: actions.summerwind.dev/v1alpha1
-        kind: Runner
-        lastUpdated: "2022-08-18"
-        repo: actions-runner-controller
-        permitLink: 36e95dad477e72cd98c1414817d56697bffd5d4e/config/crd/bases/actions.summerwind.dev_runners.yaml
-    - runnerdeployment_v1alpha1:
-        apiVersion: actions.summerwind.dev/v1alpha1
-        kind: RunnerDeployment
-        lastUpdated: "2022-08-18"
-        repo: actions-runner-controller
-        permitLink: 36e95dad477e72cd98c1414817d56697bffd5d4e/config/crd/bases/actions.summerwind.dev_runnerdeployments.yaml
-    - runnerreplicaset_v1alpha1:
-        apiVersion: actions.summerwind.dev/v1alpha1
-        kind: RunnerReplicaSet
-        lastUpdated: "2022-08-18"
-        repo: actions-runner-controller
-        permitLink: 36e95dad477e72cd98c1414817d56697bffd5d4e/config/crd/bases/actions.summerwind.dev_runnerreplicasets.yaml
-    - runnerset_v1alpha1:
-        apiVersion: actions.summerwind.dev/v1alpha1
-        kind: RunnerSet
-        lastUpdated: "2022-08-18"
-        repo: actions-runner-controller
-        permitLink: 36e95dad477e72cd98c1414817d56697bffd5d4e/config/crd/bases/actions.summerwind.dev_runnersets.yaml
+  - apiVersion: networking.gke.io/v1
+    filename: networking.gke.io/managedcertificate_v1.json
+    kind: ManagedCertificate
+    name: managedcertificate_v1
+  - apiVersion: networking.gke.io/v1beta1
+    filename: networking.gke.io/managedcertificate_v1beta1.json
+    kind: ManagedCertificate
+    name: managedcertificate_v1beta1
+  - apiVersion: networking.gke.io/v1beta2
+    filename: networking.gke.io/managedcertificate_v1beta2.json
+    kind: ManagedCertificate
+    name: managedcertificate_v1beta2
+notification.toolkit.fluxcd.io:
+  - apiVersion: notification.toolkit.fluxcd.io/v1beta1
+    filename: notification.toolkit.fluxcd.io/alert_v1beta1.json
+    kind: Alert
+    name: alert_v1beta1
+  - apiVersion: notification.toolkit.fluxcd.io/v1beta1
+    filename: notification.toolkit.fluxcd.io/provider_v1beta1.json
+    kind: Provider
+    name: provider_v1beta1
+  - apiVersion: notification.toolkit.fluxcd.io/v1beta1
+    filename: notification.toolkit.fluxcd.io/receiver_v1beta1.json
+    kind: Receiver
+    name: receiver_v1beta1
+source.toolkit.fluxcd.io:
+  - apiVersion: source.toolkit.fluxcd.io/v1beta1
+    filename: source.toolkit.fluxcd.io/bucket_v1beta1.json
+    kind: Bucket
+    name: bucket_v1beta1
+  - apiVersion: source.toolkit.fluxcd.io/v1beta2
+    filename: ''
+    kind: Bucket
+    name: buckcket_v1beta2
+  - apiVersion: source.toolkit.fluxcd.io/v1beta1
+    filename: source.toolkit.fluxcd.io/gitrepository_v1beta1.json
+    kind: GitRepository
+    name: gitrepository_v1beta1
+  - apiVersion: source.toolkit.fluxcd.io/v1beta1
+    filename: source.toolkit.fluxcd.io/gitrepository_v1beta2.json
+    kind: GitRepository
+    name: gitrepository_v1beta2
+  - apiVersion: source.toolkit.fluxcd.io/v1beta1
+    filename: source.toolkit.fluxcd.io/helmchart_v1beta1.json
+    kind: HelmChart
+    name: helmchart_v1beta1
+  - apiVersion: source.toolkit.fluxcd.io/v1beta2
+    filename: source.toolkit.fluxcd.io/helmchart_v1beta2.json
+    kind: HelmChart
+    name: helmchart_v1beta2
+  - apiVersion: source.toolkit.fluxcd.io/v1beta1
+    filename: source.toolkit.fluxcd.io/helmrepository_v1beta1.json
+    kind: HelmRepository
+    name: helmrepository_v1beta1
+  - apiVersion: source.toolkit.fluxcd.io/v1beta2
+    filename: source.toolkit.fluxcd.io/helmrepository_v1beta2.json
+    kind: HelmRepository
+    name: helmrepository_v1beta2
+traefik.containo.us:
+  - apiVersion: traefik.containo.us/v1alpha1
+    filename: traefik.containo.us/ingressroute_v1alpha1.json
+    kind: IngressRoute
+    name: ingressroute_v1alpha1
+  - apiVersion: traefik.containo.us/v1alpha1
+    filename: traefik.containo.us/ingressroutetcp_v1alpha1.json
+    kind: IngressRouteTCP
+    name: ingressroutetcp_v1alpha1
+  - apiVersion: traefik.containo.us/v1alpha1
+    filename: traefik.containo.us/ingressrouteudp_v1alpha1.json
+    kind: IngressRouteUDP
+    name: ingressrouteudp_v1alpha1
+  - apiVersion: traefik.containo.us/v1alpha1
+    filename: traefik.containo.us/middleware_v1alpha1.json
+    kind: IngressMiddlewareRoute
+    name: middleware_v1alpha1
+  - apiVersion: traefik.containo.us/v1alpha1
+    filename: traefik.containo.us/middlewaretcp_v1alpha1.json
+    kind: MiddlewareTCP
+    name: middlewaretcp_v1alpha1
+  - apiVersion: traefik.containo.us/v1alpha1
+    filename: traefik.containo.us/serverstransport_v1alpha1.json
+    kind: ServersTransport
+    name: serverstransport_v1alpha1
+  - apiVersion: traefik.containo.us/v1alpha1
+    filename: traefik.containo.us/tlsoption_v1alpha1.json
+    kind: TLSOption
+    name: tlsoption_v1alpha1
+  - apiVersion: traefik.containo.us/v1alpha1
+    filename: traefik.containo.us/tlsstore_v1alpha1.json
+    kind: TLSStore
+    name: tlsstore_v1alpha1
+  - apiVersion: traefik.containo.us/v1alpha1
+    filename: traefik.containo.us/traefikservice_v1alpha1.json
+    kind: TraefikService
+    name: traefikservice_v1alpha1

--- a/index.yaml
+++ b/index.yaml
@@ -1,8 +1,94 @@
+aadpodidentity.k8s.io:
+  - apiVersion: aadpodidentity.k8s.io/v1
+    filename: aadpodidentity.k8s.io/azureidentity_v1.json
+    kind: AzureIdentity
+    name: azureidentity_v1
+  - apiVersion: aadpodidentity.k8s.io/v1
+    filename: aadpodidentity.k8s.io/azureidentitybinding_v1.json
+    kind: AzureIdentityBinding
+    name: azureidentitybinding_v1
+  - apiVersion: aadpodidentity.k8s.io/v1
+    filename: aadpodidentity.k8s.io/azurepodidentityexception_v1.json
+    kind: AzurePodIdentityException
+    name: azurepodidentityexception_v1
+  - apiVersion: aadpodidentity.k8s.io/v1
+    filename: aadpodidentity.k8s.io/azureassignedidentity_v1.json
+    kind: AzureAssignedIdentity
+    name: azureassignedidentity_v1
+accesscontextmanager.cnrm.cloud.google.com:
+  - apiVersion: accesscontextmanager.cnrm.cloud.google.com/v1beta1
+    filename: accesscontextmanager.cnrm.cloud.google.com/accesscontextmanagerserviceperimeter_v1beta1.json
+    kind: accesscontextmanagerserviceperimeter
+    name: accesscontextmanagerserviceperimeter_v1beta1
+  - apiVersion: accesscontextmanager.cnrm.cloud.google.com/v1beta1
+    filename: accesscontextmanager.cnrm.cloud.google.com/accesscontextmanageraccesspolicy_v1beta1.json
+    kind: accesscontextmanageraccesspolicy
+    name: accesscontextmanageraccesspolicy_v1beta1
+  - apiVersion: accesscontextmanager.cnrm.cloud.google.com/v1beta1
+    filename: accesscontextmanager.cnrm.cloud.google.com/accesscontextmanageraccesslevel_v1beta1.json
+    kind: accesscontextmanageraccesslevel
+    name: accesscontextmanageraccesslevel_v1beta1
+  - apiVersion: accesscontextmanager.cnrm.cloud.google.com/v1alpha1
+    filename: accesscontextmanager.cnrm.cloud.google.com/accesscontextmanagerserviceperimeterresource_v1alpha1.json
+    kind: accesscontextmanagerserviceperimeterresource
+    name: accesscontextmanagerserviceperimeterresource_v1alpha1
+  - apiVersion: accesscontextmanager.cnrm.cloud.google.com/v1alpha1
+    filename: accesscontextmanager.cnrm.cloud.google.com/accesscontextmanageraccesslevelcondition_v1alpha1.json
+    kind: accesscontextmanageraccesslevelcondition
+    name: accesscontextmanageraccesslevelcondition_v1alpha1
+  - apiVersion: accesscontextmanager.cnrm.cloud.google.com/v1alpha1
+    filename: accesscontextmanager.cnrm.cloud.google.com/accesscontextmanagergcpuseraccessbinding_v1alpha1.json
+    kind: accesscontextmanagergcpuseraccessbinding
+    name: accesscontextmanagergcpuseraccessbinding_v1alpha1
+  - apiVersion: accesscontextmanager.cnrm.cloud.google.com/v1beta1
+    filename: accesscontextmanager.cnrm.cloud.google.com/accesscontextmanagerserviceperimeterresource_v1beta1.json
+    kind: accesscontextmanagerserviceperimeterresource
+    name: accesscontextmanagerserviceperimeterresource_v1beta1
+acid.zalan.do:
+  - apiVersion: acid.zalan.do/v1
+    filename: acid.zalan.do/postgresql_v1.json
+    kind: postgresql
+    name: postgresql_v1
+  - apiVersion: acid.zalan.do/v1
+    filename: acid.zalan.do/operatorconfiguration_v1.json
+    kind: operatorconfiguration
+    name: operatorconfiguration_v1
+  - apiVersion: acid.zalan.do/v1
+    filename: acid.zalan.do/postgresteam_v1.json
+    kind: postgresteam
+    name: postgresteam_v1
+acm.services.k8s.aws:
+  - apiVersion: acm.services.k8s.aws/v1alpha1
+    filename: acm.services.k8s.aws/certificate_v1alpha1.json
+    kind: Certificate
+    name: certificate_v1alpha1
+acme.cert-manager.io:
+  - apiVersion: acme.cert-manager.io/v1
+    filename: acme.cert-manager.io/challenge_v1.json
+    kind: Challenge
+    name: challenge_v1
+  - apiVersion: acme.cert-manager.io/v1
+    filename: acme.cert-manager.io/order_v1.json
+    kind: Order
+    name: order_v1
+actions.github.com:
+  - apiVersion: actions.github.com/v1alpha1
+    filename: actions.github.com/ephemeralrunner_v1alpha1.json
+    kind: EphemeralRunner
+    name: ephemeralrunner_v1alpha1
+  - apiVersion: actions.github.com/v1alpha1
+    filename: actions.github.com/autoscalinglistener_v1alpha1.json
+    kind: AutoscalingListener
+    name: autoscalinglistener_v1alpha1
+  - apiVersion: actions.github.com/v1alpha1
+    filename: actions.github.com/ephemeralrunnerset_v1alpha1.json
+    kind: EphemeralRunnerSet
+    name: ephemeralrunnerset_v1alpha1
+  - apiVersion: actions.github.com/v1alpha1
+    filename: actions.github.com/autoscalingrunnerset_v1alpha1.json
+    kind: AutoscalingRunnerSet
+    name: autoscalingrunnerset_v1alpha1
 actions.summerwind.dev:
-  - apiVersion: actions.summerwind.dev/v1alpha1
-    filename: ''
-    kind: HorizontalRunnerAutoscaler
-    name: actions.summerwind.dev_v1alpha1
   - apiVersion: actions.summerwind.dev/v1alpha1
     filename: actions.summerwind.dev/runner_v1alpha1.json
     kind: Runner
@@ -19,11 +105,529 @@ actions.summerwind.dev:
     filename: actions.summerwind.dev/runnerset_v1alpha1.json
     kind: RunnerSet
     name: runnerset_v1alpha1
+  - apiVersion: actions.summerwind.dev/v1alpha1
+    filename: actions.summerwind.dev/horizontalrunnerautoscaler_v1alpha1.json
+    kind: HorizontalRunnerAutoscaler
+    name: horizontalrunnerautoscaler_v1alpha1
+addons.cluster.x-k8s.io:
+  - apiVersion: addons.cluster.x-k8s.io/v1alpha4
+    filename: addons.cluster.x-k8s.io/clusterresourceset_v1alpha4.json
+    kind: ClusterResourceSet
+    name: clusterresourceset_v1alpha4
+  - apiVersion: addons.cluster.x-k8s.io/v1alpha4
+    filename: addons.cluster.x-k8s.io/clusterresourcesetbinding_v1alpha4.json
+    kind: ClusterResourceSetBinding
+    name: clusterresourcesetbinding_v1alpha4
+  - apiVersion: addons.cluster.x-k8s.io/v1beta1
+    filename: addons.cluster.x-k8s.io/clusterresourcesetbinding_v1beta1.json
+    kind: ClusterResourceSetBinding
+    name: clusterresourcesetbinding_v1beta1
+  - apiVersion: addons.cluster.x-k8s.io/v1alpha3
+    filename: addons.cluster.x-k8s.io/clusterresourcesetbinding_v1alpha3.json
+    kind: ClusterResourceSetBinding
+    name: clusterresourcesetbinding_v1alpha3
+  - apiVersion: addons.cluster.x-k8s.io/v1beta1
+    filename: addons.cluster.x-k8s.io/clusterresourceset_v1beta1.json
+    kind: ClusterResourceSet
+    name: clusterresourceset_v1beta1
+  - apiVersion: addons.cluster.x-k8s.io/v1alpha3
+    filename: addons.cluster.x-k8s.io/clusterresourceset_v1alpha3.json
+    kind: ClusterResourceSet
+    name: clusterresourceset_v1alpha3
 agent.k8s.elastic.co:
   - apiVersion: agent.k8s.elastic.co/v1alpha1
     filename: agent.k8s.elastic.co/agent_v1alpha1.json
     kind: Agent
     name: agent_v1alpha1
+aiven.io:
+  - apiVersion: aiven.io/v1alpha1
+    filename: aiven.io/clickhouseuser_v1alpha1.json
+    kind: ClickhouseUser
+    name: clickhouseuser_v1alpha1
+  - apiVersion: aiven.io/v1alpha1
+    filename: aiven.io/connectionpool_v1alpha1.json
+    kind: ConnectionPool
+    name: connectionpool_v1alpha1
+  - apiVersion: aiven.io/v1alpha1
+    filename: aiven.io/redis_v1alpha1.json
+    kind: Redis
+    name: redis_v1alpha1
+  - apiVersion: aiven.io/v1alpha1
+    filename: aiven.io/projectvpc_v1alpha1.json
+    kind: ProjectVPC
+    name: projectvpc_v1alpha1
+  - apiVersion: aiven.io/v1alpha1
+    filename: aiven.io/kafkaconnect_v1alpha1.json
+    kind: KafkaConnect
+    name: kafkaconnect_v1alpha1
+  - apiVersion: aiven.io/v1alpha1
+    filename: aiven.io/serviceuser_v1alpha1.json
+    kind: ServiceUser
+    name: serviceuser_v1alpha1
+  - apiVersion: aiven.io/v1alpha1
+    filename: aiven.io/kafka_v1alpha1.json
+    kind: Kafka
+    name: kafka_v1alpha1
+  - apiVersion: aiven.io/v1alpha1
+    filename: aiven.io/project_v1alpha1.json
+    kind: Project
+    name: project_v1alpha1
+  - apiVersion: aiven.io/v1alpha1
+    filename: aiven.io/kafkaconnector_v1alpha1.json
+    kind: KafkaConnector
+    name: kafkaconnector_v1alpha1
+  - apiVersion: aiven.io/v1alpha1
+    filename: aiven.io/database_v1alpha1.json
+    kind: Database
+    name: database_v1alpha1
+  - apiVersion: aiven.io/v1alpha1
+    filename: aiven.io/clickhousegrant_v1alpha1.json
+    kind: ClickhouseGrant
+    name: clickhousegrant_v1alpha1
+  - apiVersion: aiven.io/v1alpha1
+    filename: aiven.io/serviceintegration_v1alpha1.json
+    kind: ServiceIntegration
+    name: serviceintegration_v1alpha1
+  - apiVersion: aiven.io/v1alpha1
+    filename: aiven.io/serviceintegrationendpoint_v1alpha1.json
+    kind: ServiceIntegrationEndpoint
+    name: serviceintegrationendpoint_v1alpha1
+  - apiVersion: aiven.io/v1alpha1
+    filename: aiven.io/clickhousedatabase_v1alpha1.json
+    kind: ClickhouseDatabase
+    name: clickhousedatabase_v1alpha1
+  - apiVersion: aiven.io/v1alpha1
+    filename: aiven.io/mysql_v1alpha1.json
+    kind: MySQL
+    name: mysql_v1alpha1
+  - apiVersion: aiven.io/v1alpha1
+    filename: aiven.io/kafkatopic_v1alpha1.json
+    kind: KafkaTopic
+    name: kafkatopic_v1alpha1
+  - apiVersion: aiven.io/v1alpha1
+    filename: aiven.io/clickhouserole_v1alpha1.json
+    kind: ClickhouseRole
+    name: clickhouserole_v1alpha1
+  - apiVersion: aiven.io/v1alpha1
+    filename: aiven.io/clickhouse_v1alpha1.json
+    kind: Clickhouse
+    name: clickhouse_v1alpha1
+  - apiVersion: aiven.io/v1alpha1
+    filename: aiven.io/kafkaschemaregistryacl_v1alpha1.json
+    kind: KafkaSchemaRegistryACL
+    name: kafkaschemaregistryacl_v1alpha1
+  - apiVersion: aiven.io/v1alpha1
+    filename: aiven.io/kafkaschema_v1alpha1.json
+    kind: KafkaSchema
+    name: kafkaschema_v1alpha1
+  - apiVersion: aiven.io/v1alpha1
+    filename: aiven.io/kafkaacl_v1alpha1.json
+    kind: KafkaACL
+    name: kafkaacl_v1alpha1
+  - apiVersion: aiven.io/v1alpha1
+    filename: aiven.io/opensearch_v1alpha1.json
+    kind: OpenSearch
+    name: opensearch_v1alpha1
+  - apiVersion: aiven.io/v1alpha1
+    filename: aiven.io/cassandra_v1alpha1.json
+    kind: Cassandra
+    name: cassandra_v1alpha1
+  - apiVersion: aiven.io/v1alpha1
+    filename: aiven.io/postgresql_v1alpha1.json
+    kind: PostgreSQL
+    name: postgresql_v1alpha1
+alloydb.cnrm.cloud.google.com:
+  - apiVersion: alloydb.cnrm.cloud.google.com/v1beta1
+    filename: alloydb.cnrm.cloud.google.com/alloydbuser_v1beta1.json
+    kind: alloydbuser
+    name: alloydbuser_v1beta1
+  - apiVersion: alloydb.cnrm.cloud.google.com/v1beta1
+    filename: alloydb.cnrm.cloud.google.com/alloydbbackup_v1beta1.json
+    kind: alloydbbackup
+    name: alloydbbackup_v1beta1
+  - apiVersion: alloydb.cnrm.cloud.google.com/v1alpha1
+    filename: alloydb.cnrm.cloud.google.com/alloydbcluster_v1alpha1.json
+    kind: alloydbcluster
+    name: alloydbcluster_v1alpha1
+  - apiVersion: alloydb.cnrm.cloud.google.com/v1alpha1
+    filename: alloydb.cnrm.cloud.google.com/alloydbinstance_v1alpha1.json
+    kind: alloydbinstance
+    name: alloydbinstance_v1alpha1
+  - apiVersion: alloydb.cnrm.cloud.google.com/v1alpha1
+    filename: alloydb.cnrm.cloud.google.com/alloydbbackup_v1alpha1.json
+    kind: alloydbbackup
+    name: alloydbbackup_v1alpha1
+  - apiVersion: alloydb.cnrm.cloud.google.com/v1beta1
+    filename: alloydb.cnrm.cloud.google.com/alloydbcluster_v1beta1.json
+    kind: alloydbcluster
+    name: alloydbcluster_v1beta1
+  - apiVersion: alloydb.cnrm.cloud.google.com/v1beta1
+    filename: alloydb.cnrm.cloud.google.com/alloydbinstance_v1beta1.json
+    kind: alloydbinstance
+    name: alloydbinstance_v1beta1
+anywhere.eks.amazonaws.com:
+  - apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+    filename: anywhere.eks.amazonaws.com/dockerdatacenterconfig_v1alpha1.json
+    kind: DockerDatacenterConfig
+    name: dockerdatacenterconfig_v1alpha1
+  - apiVersion: anywhere.eks.amazonaws.com/v1alpha3
+    filename: anywhere.eks.amazonaws.com/dockermachinepool_v1alpha3.json
+    kind: DockerMachinePool
+    name: dockermachinepool_v1alpha3
+  - apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+    filename: anywhere.eks.amazonaws.com/awsiamconfig_v1alpha1.json
+    kind: AWSIamConfig
+    name: awsiamconfig_v1alpha1
+  - apiVersion: anywhere.eks.amazonaws.com/v1alpha4
+    filename: anywhere.eks.amazonaws.com/dockermachine_v1alpha4.json
+    kind: DockerMachine
+    name: dockermachine_v1alpha4
+  - apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+    filename: anywhere.eks.amazonaws.com/tinkerbelltemplateconfig_v1alpha1.json
+    kind: TinkerbellTemplateConfig
+    name: tinkerbelltemplateconfig_v1alpha1
+  - apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+    filename: anywhere.eks.amazonaws.com/snowippool_v1alpha1.json
+    kind: SnowIPPool
+    name: snowippool_v1alpha1
+  - apiVersion: anywhere.eks.amazonaws.com/v1alpha4
+    filename: anywhere.eks.amazonaws.com/dockercluster_v1alpha4.json
+    kind: DockerCluster
+    name: dockercluster_v1alpha4
+  - apiVersion: anywhere.eks.amazonaws.com/v1beta1
+    filename: anywhere.eks.amazonaws.com/dockermachine_v1beta1.json
+    kind: DockerMachine
+    name: dockermachine_v1beta1
+  - apiVersion: anywhere.eks.amazonaws.com/v1alpha4
+    filename: anywhere.eks.amazonaws.com/clusterclass_v1alpha4.json
+    kind: ClusterClass
+    name: clusterclass_v1alpha4
+  - apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+    filename: anywhere.eks.amazonaws.com/tinkerbelldatacenterconfig_v1alpha1.json
+    kind: TinkerbellDatacenterConfig
+    name: tinkerbelldatacenterconfig_v1alpha1
+  - apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+    filename: anywhere.eks.amazonaws.com/bundles_v1alpha1.json
+    kind: Bundles
+    name: bundles_v1alpha1
+  - apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+    filename: anywhere.eks.amazonaws.com/vspheredatacenterconfig_v1alpha1.json
+    kind: VSphereDatacenterConfig
+    name: vspheredatacenterconfig_v1alpha1
+  - apiVersion: anywhere.eks.amazonaws.com/v1alpha4
+    filename: anywhere.eks.amazonaws.com/clusterresourcesetbinding_v1alpha4.json
+    kind: ClusterResourceSetBinding
+    name: clusterresourcesetbinding_v1alpha4
+  - apiVersion: anywhere.eks.amazonaws.com/v1beta1
+    filename: anywhere.eks.amazonaws.com/clusterresourcesetbinding_v1beta1.json
+    kind: ClusterResourceSetBinding
+    name: clusterresourcesetbinding_v1beta1
+  - apiVersion: anywhere.eks.amazonaws.com/v1beta1
+    filename: anywhere.eks.amazonaws.com/dockermachinetemplate_v1beta1.json
+    kind: DockerMachineTemplate
+    name: dockermachinetemplate_v1beta1
+  - apiVersion: anywhere.eks.amazonaws.com/v1beta1
+    filename: anywhere.eks.amazonaws.com/clusterresourceset_v1beta1.json
+    kind: ClusterResourceSet
+    name: clusterresourceset_v1beta1
+  - apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+    filename: anywhere.eks.amazonaws.com/tinkerbellmachineconfig_v1alpha1.json
+    kind: TinkerbellMachineConfig
+    name: tinkerbellmachineconfig_v1alpha1
+  - apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+    filename: anywhere.eks.amazonaws.com/cloudstackdatacenterconfig_v1alpha1.json
+    kind: CloudStackDatacenterConfig
+    name: cloudstackdatacenterconfig_v1alpha1
+  - apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+    filename: anywhere.eks.amazonaws.com/oidcconfig_v1alpha1.json
+    kind: OIDCConfig
+    name: oidcconfig_v1alpha1
+  - apiVersion: anywhere.eks.amazonaws.com/v1alpha4
+    filename: anywhere.eks.amazonaws.com/clusterresourceset_v1alpha4.json
+    kind: ClusterResourceSet
+    name: clusterresourceset_v1alpha4
+  - apiVersion: anywhere.eks.amazonaws.com/v1alpha3
+    filename: anywhere.eks.amazonaws.com/cluster_v1alpha3.json
+    kind: Cluster
+    name: cluster_v1alpha3
+  - apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+    filename: anywhere.eks.amazonaws.com/snowdatacenterconfig_v1alpha1.json
+    kind: SnowDatacenterConfig
+    name: snowdatacenterconfig_v1alpha1
+  - apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+    filename: anywhere.eks.amazonaws.com/nutanixmachineconfig_v1alpha1.json
+    kind: NutanixMachineConfig
+    name: nutanixmachineconfig_v1alpha1
+  - apiVersion: anywhere.eks.amazonaws.com/v1alpha3
+    filename: anywhere.eks.amazonaws.com/dockermachinetemplate_v1alpha3.json
+    kind: DockerMachineTemplate
+    name: dockermachinetemplate_v1alpha3
+  - apiVersion: anywhere.eks.amazonaws.com/v1alpha3
+    filename: anywhere.eks.amazonaws.com/clusterresourcesetbinding_v1alpha3.json
+    kind: ClusterResourceSetBinding
+    name: clusterresourcesetbinding_v1alpha3
+  - apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+    filename: anywhere.eks.amazonaws.com/nutanixdatacenterconfig_v1alpha1.json
+    kind: NutanixDatacenterConfig
+    name: nutanixdatacenterconfig_v1alpha1
+  - apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+    filename: anywhere.eks.amazonaws.com/awsdatacenterconfig_v1alpha1.json
+    kind: AWSDatacenterConfig
+    name: awsdatacenterconfig_v1alpha1
+  - apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+    filename: anywhere.eks.amazonaws.com/fluxconfig_v1alpha1.json
+    kind: FluxConfig
+    name: fluxconfig_v1alpha1
+  - apiVersion: anywhere.eks.amazonaws.com/v1alpha3
+    filename: anywhere.eks.amazonaws.com/dockercluster_v1alpha3.json
+    kind: DockerCluster
+    name: dockercluster_v1alpha3
+  - apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+    filename: anywhere.eks.amazonaws.com/cluster_v1alpha1.json
+    kind: Cluster
+    name: cluster_v1alpha1
+  - apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+    filename: anywhere.eks.amazonaws.com/snowmachineconfig_v1alpha1.json
+    kind: SnowMachineConfig
+    name: snowmachineconfig_v1alpha1
+  - apiVersion: anywhere.eks.amazonaws.com/v1beta1
+    filename: anywhere.eks.amazonaws.com/cluster_v1beta1.json
+    kind: Cluster
+    name: cluster_v1beta1
+  - apiVersion: anywhere.eks.amazonaws.com/v1beta1
+    filename: anywhere.eks.amazonaws.com/clusterclass_v1beta1.json
+    kind: ClusterClass
+    name: clusterclass_v1beta1
+  - apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+    filename: anywhere.eks.amazonaws.com/cloudstackmachineconfig_v1alpha1.json
+    kind: CloudStackMachineConfig
+    name: cloudstackmachineconfig_v1alpha1
+  - apiVersion: anywhere.eks.amazonaws.com/v1alpha4
+    filename: anywhere.eks.amazonaws.com/dockermachinepool_v1alpha4.json
+    kind: DockerMachinePool
+    name: dockermachinepool_v1alpha4
+  - apiVersion: anywhere.eks.amazonaws.com/v1beta1
+    filename: anywhere.eks.amazonaws.com/dockercluster_v1beta1.json
+    kind: DockerCluster
+    name: dockercluster_v1beta1
+  - apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+    filename: anywhere.eks.amazonaws.com/gitopsconfig_v1alpha1.json
+    kind: gitopsconfig
+    name: gitopsconfig_v1alpha1
+  - apiVersion: anywhere.eks.amazonaws.com/v1alpha3
+    filename: anywhere.eks.amazonaws.com/dockermachine_v1alpha3.json
+    kind: DockerMachine
+    name: dockermachine_v1alpha3
+  - apiVersion: anywhere.eks.amazonaws.com/v1
+    filename: anywhere.eks.amazonaws.com/clusterissuer_v1.json
+    kind: ClusterIssuer
+    name: clusterissuer_v1
+  - apiVersion: anywhere.eks.amazonaws.com/v1alpha1
+    filename: anywhere.eks.amazonaws.com/vspheremachineconfig_v1alpha1.json
+    kind: VSphereMachineConfig
+    name: vspheremachineconfig_v1alpha1
+  - apiVersion: anywhere.eks.amazonaws.com/v1alpha4
+    filename: anywhere.eks.amazonaws.com/dockermachinetemplate_v1alpha4.json
+    kind: DockerMachineTemplate
+    name: dockermachinetemplate_v1alpha4
+  - apiVersion: anywhere.eks.amazonaws.com/v1alpha4
+    filename: anywhere.eks.amazonaws.com/cluster_v1alpha4.json
+    kind: Cluster
+    name: cluster_v1alpha4
+  - apiVersion: anywhere.eks.amazonaws.com/v1beta1
+    filename: anywhere.eks.amazonaws.com/dockermachinepool_v1beta1.json
+    kind: DockerMachinePool
+    name: dockermachinepool_v1beta1
+  - apiVersion: anywhere.eks.amazonaws.com/v1alpha3
+    filename: anywhere.eks.amazonaws.com/clusterresourceset_v1alpha3.json
+    kind: ClusterResourceSet
+    name: clusterresourceset_v1alpha3
+  - apiVersion: anywhere.eks.amazonaws.com/v1beta1
+    filename: anywhere.eks.amazonaws.com/dockerclustertemplate_v1beta1.json
+    kind: DockerClusterTemplate
+    name: dockerclustertemplate_v1beta1
+  - apiVersion: anywhere.eks.amazonaws.com/v1alpha4
+    filename: anywhere.eks.amazonaws.com/dockerclustertemplate_v1alpha4.json
+    kind: DockerClusterTemplate
+    name: dockerclustertemplate_v1alpha4
+apiextensions.crossplane.io:
+  - apiVersion: apiextensions.crossplane.io/v1beta1
+    filename: apiextensions.crossplane.io/environmentconfig_v1beta1.json
+    kind: EnvironmentConfig
+    name: environmentconfig_v1beta1
+  - apiVersion: apiextensions.crossplane.io/v1
+    filename: apiextensions.crossplane.io/compositeresourcedefinition_v1.json
+    kind: CompositeResourceDefinition
+    name: compositeresourcedefinition_v1
+  - apiVersion: apiextensions.crossplane.io/v1
+    filename: apiextensions.crossplane.io/compositionrevision_v1.json
+    kind: CompositionRevision
+    name: compositionrevision_v1
+  - apiVersion: apiextensions.crossplane.io/v1
+    filename: apiextensions.crossplane.io/composition_v1.json
+    kind: Composition
+    name: composition_v1
+  - apiVersion: apiextensions.crossplane.io/v1alpha1
+    filename: apiextensions.crossplane.io/compositionrevision_v1alpha1.json
+    kind: CompositionRevision
+    name: compositionrevision_v1alpha1
+  - apiVersion: apiextensions.crossplane.io/v1alpha1
+    filename: apiextensions.crossplane.io/environmentconfig_v1alpha1.json
+    kind: EnvironmentConfig
+    name: environmentconfig_v1alpha1
+  - apiVersion: apiextensions.crossplane.io/v1beta1
+    filename: apiextensions.crossplane.io/usage_v1beta1.json
+    kind: Usage
+    name: usage_v1beta1
+  - apiVersion: apiextensions.crossplane.io/v1alpha1
+    filename: apiextensions.crossplane.io/usage_v1alpha1.json
+    kind: Usage
+    name: usage_v1alpha1
+  - apiVersion: apiextensions.crossplane.io/v1beta1
+    filename: apiextensions.crossplane.io/compositionrevision_v1beta1.json
+    kind: CompositionRevision
+    name: compositionrevision_v1beta1
+apigateway.cnrm.cloud.google.com:
+  - apiVersion: apigateway.cnrm.cloud.google.com/v1alpha1
+    filename: apigateway.cnrm.cloud.google.com/apigatewayapiconfig_v1alpha1.json
+    kind: apigatewayapiconfig
+    name: apigatewayapiconfig_v1alpha1
+  - apiVersion: apigateway.cnrm.cloud.google.com/v1alpha1
+    filename: apigateway.cnrm.cloud.google.com/apigatewaygateway_v1alpha1.json
+    kind: apigatewaygateway
+    name: apigatewaygateway_v1alpha1
+  - apiVersion: apigateway.cnrm.cloud.google.com/v1alpha1
+    filename: apigateway.cnrm.cloud.google.com/apigatewayapi_v1alpha1.json
+    kind: apigatewayapi
+    name: apigatewayapi_v1alpha1
+apigatewayv2.services.k8s.aws:
+  - apiVersion: apigatewayv2.services.k8s.aws/v1alpha1
+    filename: apigatewayv2.services.k8s.aws/deployment_v1alpha1.json
+    kind: Deployment
+    name: deployment_v1alpha1
+  - apiVersion: apigatewayv2.services.k8s.aws/v1alpha1
+    filename: apigatewayv2.services.k8s.aws/api_v1alpha1.json
+    kind: API
+    name: api_v1alpha1
+  - apiVersion: apigatewayv2.services.k8s.aws/v1alpha1
+    filename: apigatewayv2.services.k8s.aws/authorizer_v1alpha1.json
+    kind: Authorizer
+    name: authorizer_v1alpha1
+  - apiVersion: apigatewayv2.services.k8s.aws/v1alpha1
+    filename: apigatewayv2.services.k8s.aws/integration_v1alpha1.json
+    kind: Integration
+    name: integration_v1alpha1
+  - apiVersion: apigatewayv2.services.k8s.aws/v1alpha1
+    filename: apigatewayv2.services.k8s.aws/stage_v1alpha1.json
+    kind: Stage
+    name: stage_v1alpha1
+  - apiVersion: apigatewayv2.services.k8s.aws/v1alpha1
+    filename: apigatewayv2.services.k8s.aws/route_v1alpha1.json
+    kind: Route
+    name: route_v1alpha1
+  - apiVersion: apigatewayv2.services.k8s.aws/v1alpha1
+    filename: apigatewayv2.services.k8s.aws/vpclink_v1alpha1.json
+    kind: VPCLink
+    name: vpclink_v1alpha1
+apigee.cnrm.cloud.google.com:
+  - apiVersion: apigee.cnrm.cloud.google.com/v1alpha1
+    filename: apigee.cnrm.cloud.google.com/apigeeaddonsconfig_v1alpha1.json
+    kind: apigeeaddonsconfig
+    name: apigeeaddonsconfig_v1alpha1
+  - apiVersion: apigee.cnrm.cloud.google.com/v1alpha1
+    filename: apigee.cnrm.cloud.google.com/apigeeendpointattachment_v1alpha1.json
+    kind: apigeeendpointattachment
+    name: apigeeendpointattachment_v1alpha1
+  - apiVersion: apigee.cnrm.cloud.google.com/v1alpha1
+    filename: apigee.cnrm.cloud.google.com/apigeeinstanceattachment_v1alpha1.json
+    kind: apigeeinstanceattachment
+    name: apigeeinstanceattachment_v1alpha1
+  - apiVersion: apigee.cnrm.cloud.google.com/v1beta1
+    filename: apigee.cnrm.cloud.google.com/apigeeenvironment_v1beta1.json
+    kind: apigeeenvironment
+    name: apigeeenvironment_v1beta1
+  - apiVersion: apigee.cnrm.cloud.google.com/v1alpha1
+    filename: apigee.cnrm.cloud.google.com/apigeenataddress_v1alpha1.json
+    kind: apigeenataddress
+    name: apigeenataddress_v1alpha1
+  - apiVersion: apigee.cnrm.cloud.google.com/v1beta1
+    filename: apigee.cnrm.cloud.google.com/apigeeorganization_v1beta1.json
+    kind: apigeeorganization
+    name: apigeeorganization_v1beta1
+  - apiVersion: apigee.cnrm.cloud.google.com/v1alpha1
+    filename: apigee.cnrm.cloud.google.com/apigeeenvgroup_v1alpha1.json
+    kind: apigeeenvgroup
+    name: apigeeenvgroup_v1alpha1
+  - apiVersion: apigee.cnrm.cloud.google.com/v1alpha1
+    filename: apigee.cnrm.cloud.google.com/apigeesyncauthorization_v1alpha1.json
+    kind: apigeesyncauthorization
+    name: apigeesyncauthorization_v1alpha1
+  - apiVersion: apigee.cnrm.cloud.google.com/v1alpha1
+    filename: apigee.cnrm.cloud.google.com/apigeeinstance_v1alpha1.json
+    kind: apigeeinstance
+    name: apigeeinstance_v1alpha1
+  - apiVersion: apigee.cnrm.cloud.google.com/v1alpha1
+    filename: apigee.cnrm.cloud.google.com/apigeeenvgroupattachment_v1alpha1.json
+    kind: apigeeenvgroupattachment
+    name: apigeeenvgroupattachment_v1alpha1
+apikeys.cnrm.cloud.google.com:
+  - apiVersion: apikeys.cnrm.cloud.google.com/v1alpha1
+    filename: apikeys.cnrm.cloud.google.com/apikeyskey_v1alpha1.json
+    kind: APIKeysKey
+    name: apikeyskey_v1alpha1
+apisix.apache.org:
+  - apiVersion: apisix.apache.org/v2
+    filename: apisix.apache.org/apisixroute_v2.json
+    kind: apisixroute
+    name: apisixroute_v2
+  - apiVersion: apisix.apache.org/v2beta3
+    filename: apisix.apache.org/apisixroute_v2beta3.json
+    kind: apisixroute
+    name: apisixroute_v2beta3
+  - apiVersion: apisix.apache.org/v2
+    filename: apisix.apache.org/apisixtls_v2.json
+    kind: ApisixTls
+    name: apisixtls_v2
+  - apiVersion: apisix.apache.org/v2beta3
+    filename: apisix.apache.org/apisixpluginconfig_v2beta3.json
+    kind: apisixpluginconfig
+    name: apisixpluginconfig_v2beta3
+  - apiVersion: apisix.apache.org/v2
+    filename: apisix.apache.org/apisixpluginconfig_v2.json
+    kind: apisixpluginconfig
+    name: apisixpluginconfig_v2
+  - apiVersion: apisix.apache.org/v2beta3
+    filename: apisix.apache.org/apisixupstream_v2beta3.json
+    kind: apisixupstream
+    name: apisixupstream_v2beta3
+  - apiVersion: apisix.apache.org/v2
+    filename: apisix.apache.org/apisixconsumer_v2.json
+    kind: apisixconsumer
+    name: apisixconsumer_v2
+  - apiVersion: apisix.apache.org/v2beta3
+    filename: apisix.apache.org/apisixclusterconfig_v2beta3.json
+    kind: apisixclusterconfig
+    name: apisixclusterconfig_v2beta3
+  - apiVersion: apisix.apache.org/v2beta3
+    filename: apisix.apache.org/apisixconsumer_v2beta3.json
+    kind: apisixconsumer
+    name: apisixconsumer_v2beta3
+  - apiVersion: apisix.apache.org/v2
+    filename: apisix.apache.org/apisixupstream_v2.json
+    kind: apisixupstream
+    name: apisixupstream_v2
+  - apiVersion: apisix.apache.org/v2
+    filename: apisix.apache.org/apisixglobalrule_v2.json
+    kind: apisixglobalrule
+    name: apisixglobalrule_v2
+  - apiVersion: apisix.apache.org/v2
+    filename: apisix.apache.org/apisixclusterconfig_v2.json
+    kind: apisixclusterconfig
+    name: apisixclusterconfig_v2
+  - apiVersion: apisix.apache.org/v2beta3
+    filename: apisix.apache.org/apisixtls_v2beta3.json
+    kind: ApisixTls
+    name: apisixtls_v2beta3
 apm.k8s.elastic.co:
   - apiVersion: apm.k8s.elastic.co/v1
     filename: apm.k8s.elastic.co/apmserver_v1.json
@@ -37,6 +641,240 @@ apm.k8s.elastic.co:
     filename: apm.k8s.elastic.co/apmserver_v1alpha1.json
     kind: ApmServer
     name: apmserver_v1alpha1
+app.redislabs.com:
+  - apiVersion: app.redislabs.com/v1alpha1
+    filename: app.redislabs.com/redisenterprisecluster_v1alpha1.json
+    kind: redisenterprisecluster
+    name: redisenterprisecluster_v1alpha1
+  - apiVersion: app.redislabs.com/v1alpha1
+    filename: app.redislabs.com/redisenterpriseactiveactivedatabase_v1alpha1.json
+    kind: RedisEnterpriseActiveActiveDatabase
+    name: redisenterpriseactiveactivedatabase_v1alpha1
+  - apiVersion: app.redislabs.com/v1alpha1
+    filename: app.redislabs.com/redisenterprisedatabase_v1alpha1.json
+    kind: RedisEnterpriseDatabase
+    name: redisenterprisedatabase_v1alpha1
+  - apiVersion: app.redislabs.com/v1alpha1
+    filename: app.redislabs.com/redisenterpriseremotecluster_v1alpha1.json
+    kind: redisenterpriseremotecluster
+    name: redisenterpriseremotecluster_v1alpha1
+  - apiVersion: app.redislabs.com/v1
+    filename: app.redislabs.com/redisenterprisecluster_v1.json
+    kind: RedisEnterpriseCluster
+    name: redisenterprisecluster_v1
+appcat.vshn.io:
+  - apiVersion: appcat.vshn.io/v1
+    filename: appcat.vshn.io/xobjectbucket_v1.json
+    kind: XObjectBucket
+    name: xobjectbucket_v1
+  - apiVersion: appcat.vshn.io/v1
+    filename: appcat.vshn.io/objectbucket_v1.json
+    kind: ObjectBucket
+    name: objectbucket_v1
+appengine.cnrm.cloud.google.com:
+  - apiVersion: appengine.cnrm.cloud.google.com/v1alpha1
+    filename: appengine.cnrm.cloud.google.com/appenginestandardappversion_v1alpha1.json
+    kind: appenginestandardappversion
+    name: appenginestandardappversion_v1alpha1
+  - apiVersion: appengine.cnrm.cloud.google.com/v1alpha1
+    filename: appengine.cnrm.cloud.google.com/appengineflexibleappversion_v1alpha1.json
+    kind: appengineflexibleappversion
+    name: appengineflexibleappversion_v1alpha1
+  - apiVersion: appengine.cnrm.cloud.google.com/v1alpha1
+    filename: appengine.cnrm.cloud.google.com/appengineservicesplittraffic_v1alpha1.json
+    kind: appengineservicesplittraffic
+    name: appengineservicesplittraffic_v1alpha1
+  - apiVersion: appengine.cnrm.cloud.google.com/v1alpha1
+    filename: appengine.cnrm.cloud.google.com/appenginedomainmapping_v1alpha1.json
+    kind: appenginedomainmapping
+    name: appenginedomainmapping_v1alpha1
+  - apiVersion: appengine.cnrm.cloud.google.com/v1alpha1
+    filename: appengine.cnrm.cloud.google.com/appenginefirewallrule_v1alpha1.json
+    kind: appenginefirewallrule
+    name: appenginefirewallrule_v1alpha1
+applicationautoscaling.services.k8s.aws:
+  - apiVersion: applicationautoscaling.services.k8s.aws/v1alpha1
+    filename: applicationautoscaling.services.k8s.aws/scalabletarget_v1alpha1.json
+    kind: ScalableTarget
+    name: scalabletarget_v1alpha1
+  - apiVersion: applicationautoscaling.services.k8s.aws/v1alpha1
+    filename: applicationautoscaling.services.k8s.aws/scalingpolicy_v1alpha1.json
+    kind: ScalingPolicy
+    name: scalingpolicy_v1alpha1
+appprotect.f5.com:
+  - apiVersion: appprotect.f5.com/v1beta1
+    filename: appprotect.f5.com/aplogconf_v1beta1.json
+    kind: APLogConf
+    name: aplogconf_v1beta1
+  - apiVersion: appprotect.f5.com/v1beta1
+    filename: appprotect.f5.com/appolicy_v1beta1.json
+    kind: APPolicy
+    name: appolicy_v1beta1
+  - apiVersion: appprotect.f5.com/v1beta1
+    filename: appprotect.f5.com/apusersig_v1beta1.json
+    kind: APUserSig
+    name: apusersig_v1beta1
+appprotectdos.f5.com:
+  - apiVersion: appprotectdos.f5.com/v1beta1
+    filename: appprotectdos.f5.com/apdoslogconf_v1beta1.json
+    kind: APDosLogConf
+    name: apdoslogconf_v1beta1
+  - apiVersion: appprotectdos.f5.com/v1beta1
+    filename: appprotectdos.f5.com/apdospolicy_v1beta1.json
+    kind: APDosPolicy
+    name: apdospolicy_v1beta1
+  - apiVersion: appprotectdos.f5.com/v1beta1
+    filename: appprotectdos.f5.com/dosprotectedresource_v1beta1.json
+    kind: DosProtectedResource
+    name: dosprotectedresource_v1beta1
+apps.emqx.io:
+  - apiVersion: apps.emqx.io/v1beta3
+    filename: apps.emqx.io/emqxplugin_v1beta3.json
+    kind: emqxplugin
+    name: emqxplugin_v1beta3
+  - apiVersion: apps.emqx.io/v1beta3
+    filename: apps.emqx.io/emqxbroker_v1beta3.json
+    kind: emqxbroker
+    name: emqxbroker_v1beta3
+  - apiVersion: apps.emqx.io/v1beta3
+    filename: apps.emqx.io/emqxenterprise_v1beta3.json
+    kind: emqxenterprise
+    name: emqxenterprise_v1beta3
+  - apiVersion: apps.emqx.io/v1beta4
+    filename: apps.emqx.io/emqxenterprise_v1beta4.json
+    kind: emqxenterprise
+    name: emqxenterprise_v1beta4
+  - apiVersion: apps.emqx.io/v1beta4
+    filename: apps.emqx.io/emqxbroker_v1beta4.json
+    kind: emqxbroker
+    name: emqxbroker_v1beta4
+  - apiVersion: apps.emqx.io/v1beta4
+    filename: apps.emqx.io/emqxplugin_v1beta4.json
+    kind: emqxplugin
+    name: emqxplugin_v1beta4
+  - apiVersion: apps.emqx.io/v2beta1
+    filename: apps.emqx.io/emqx_v2beta1.json
+    kind: emqx
+    name: emqx_v2beta1
+  - apiVersion: apps.emqx.io/v2alpha1
+    filename: apps.emqx.io/emqx_v2alpha1.json
+    kind: emqx
+    name: emqx_v2alpha1
+apps.gitlab.com:
+  - apiVersion: apps.gitlab.com/v1beta1
+    filename: apps.gitlab.com/gitlab_v1beta1.json
+    kind: GitLab
+    name: gitlab_v1beta1
+aquasecurity.github.io:
+  - apiVersion: aquasecurity.github.io/v1alpha1
+    filename: aquasecurity.github.io/clustersbomreport_v1alpha1.json
+    kind: ClusterSbomReport
+    name: clustersbomreport_v1alpha1
+  - apiVersion: aquasecurity.github.io/v1alpha1
+    filename: aquasecurity.github.io/clustercompliancereport_v1alpha1.json
+    kind: ClusterComplianceReport
+    name: clustercompliancereport_v1alpha1
+  - apiVersion: aquasecurity.github.io/v1alpha1
+    filename: aquasecurity.github.io/rbacassessmentreport_v1alpha1.json
+    kind: RbacAssessmentReport
+    name: rbacassessmentreport_v1alpha1
+  - apiVersion: aquasecurity.github.io/v1alpha1
+    filename: aquasecurity.github.io/vulnerabilityreport_v1alpha1.json
+    kind: VulnerabilityReport
+    name: vulnerabilityreport_v1alpha1
+  - apiVersion: aquasecurity.github.io/v1alpha1
+    filename: aquasecurity.github.io/clusterconfigauditreport_v1alpha1.json
+    kind: ClusterConfigAuditReport
+    name: clusterconfigauditreport_v1alpha1
+  - apiVersion: aquasecurity.github.io/v1alpha1
+    filename: aquasecurity.github.io/infraassessmentreport_v1alpha1.json
+    kind: InfraAssessmentReport
+    name: infraassessmentreport_v1alpha1
+  - apiVersion: aquasecurity.github.io/v1alpha1
+    filename: aquasecurity.github.io/clusterrbacassessmentreport_v1alpha1.json
+    kind: ClusterRbacAssessmentReport
+    name: clusterrbacassessmentreport_v1alpha1
+  - apiVersion: aquasecurity.github.io/v1alpha1
+    filename: aquasecurity.github.io/clustervulnerabilityreport_v1alpha1.json
+    kind: ClusterVulnerabilityReport
+    name: clustervulnerabilityreport_v1alpha1
+  - apiVersion: aquasecurity.github.io/v1alpha1
+    filename: aquasecurity.github.io/clusterinfraassessmentreport_v1alpha1.json
+    kind: ClusterInfraAssessmentReport
+    name: clusterinfraassessmentreport_v1alpha1
+  - apiVersion: aquasecurity.github.io/v1alpha1
+    filename: aquasecurity.github.io/configauditreport_v1alpha1.json
+    kind: ConfigAuditReport
+    name: configauditreport_v1alpha1
+  - apiVersion: aquasecurity.github.io/v1alpha1
+    filename: aquasecurity.github.io/sbomreport_v1alpha1.json
+    kind: SbomReport
+    name: sbomreport_v1alpha1
+  - apiVersion: aquasecurity.github.io/v1alpha1
+    filename: aquasecurity.github.io/exposedsecretreport_v1alpha1.json
+    kind: ExposedSecretReport
+    name: exposedsecretreport_v1alpha1
+argoproj:
+  - apiVersion: argoproj/v1alpha1
+    filename: argoproj/applicationset_v1alpha1.json
+    kind: applicationset
+    name: applicationset_v1alpha1
+  - apiVersion: argoproj/v1alpha1
+    filename: argoproj/clusterworkflowtemplate_v1alpha1.json
+    kind: clusterworkflowtemplate
+    name: clusterworkflowtemplate_v1alpha1
+  - apiVersion: argoproj/v1alpha1
+    filename: argoproj/clusteranalysistemplate_v1alpha1.json
+    kind: clusteranalysistemplate
+    name: clusteranalysistemplate_v1alpha1
+  - apiVersion: argoproj/v1alpha1
+    filename: argoproj/cronworkflow_v1alpha1.json
+    kind: cronworkflow
+    name: cronworkflow_v1alpha1
+  - apiVersion: argoproj/v1alpha1
+    filename: argoproj/workflowtaskresult_v1alpha1.json
+    kind: workflowtaskresult
+    name: workflowtaskresult_v1alpha1
+  - apiVersion: argoproj/v1alpha1
+    filename: argoproj/workfloweventbinding_v1alpha1.json
+    kind: workfloweventbinding
+    name: workfloweventbinding_v1alpha1
+  - apiVersion: argoproj/v1alpha1
+    filename: argoproj/appproject_v1alpha1.json
+    kind: AppProject
+    name: appproject_v1alpha1
+  - apiVersion: argoproj/v1alpha1
+    filename: argoproj/workflowtaskset_v1alpha1.json
+    kind: workflowtaskset
+    name: workflowtaskset_v1alpha1
+  - apiVersion: argoproj/v1alpha1
+    filename: argoproj/rollout_v1alpha1.json
+    kind: rollout
+    name: rollout_v1alpha1
+  - apiVersion: argoproj/v1alpha1
+    filename: argoproj/application_v1alpha1.json
+    kind: Application
+    name: application_v1alpha1
+  - apiVersion: argoproj/v1alpha1
+    filename: argoproj/analysisrun_v1alpha1.json
+    kind: analysisrun
+    name: analysisrun_v1alpha1
+  - apiVersion: argoproj/v1alpha1
+    filename: argoproj/workflow_v1alpha1.json
+    kind: workflow
+    name: workflow_v1alpha1
+  - apiVersion: argoproj/v1alpha1
+    filename: argoproj/analysistemplate_v1alpha1.json
+    kind: analysistemplate
+    name: analysistemplate_v1alpha1
+  - apiVersion: argoproj/v1alpha1
+    filename: argoproj/experiment_v1alpha1.json
+    kind: experiment
+    name: experiment_v1alpha1
+  - apiVersion: argoproj/v1alpha1
+    filename: argoproj/workflowtemplate_v1alpha1.json
+    kind: workflowtemplate
+    name: workflowtemplate_v1alpha1
 argoproj.io:
   - apiVersion: argoproj.io/v1alpha1
     filename: argoproj.io/analysisrun_v1alpha1.json
@@ -79,35 +917,1758 @@ argoproj.io:
     kind: Rollout
     name: rollout_v1alpha1
   - apiVersion: argoproj.io/v1alpha1
-    filename: ''
-    kind: Workflow
-    name: workflows_v1alpha1
-  - apiVersion: argoproj.io/v1alpha1
-    filename: ''
-    kind: WorkflowEventBinding
-    name: workfloweventbindings_v1alpha1
-  - apiVersion: argoproj.io/v1alpha1
-    filename: ''
-    kind: WorkflowTaskSet
-    name: workflowtasksets_v1alpha1
-  - apiVersion: argoproj.io/v1alpha1
-    filename: ''
-    kind: WorkflowTaskResult
-    name: workflowtaskresults_v1alpha1
-  - apiVersion: argoproj.io/v1alpha1
     filename: argoproj.io/workflowtemplate_v1alpha1.json
     kind: WorkflowTemplate
     name: workflowtemplate_v1alpha1
+  - apiVersion: argoproj.io/v1alpha1
+    filename: argoproj.io/workflow_v1alpha1.json
+    kind: workflow
+    name: workflow_v1alpha1
+  - apiVersion: argoproj.io/v1alpha1
+    filename: argoproj.io/workflowartifactgctask_v1alpha1.json
+    kind: workflowartifactgctask
+    name: workflowartifactgctask_v1alpha1
+  - apiVersion: argoproj.io/v1alpha1
+    filename: argoproj.io/eventsource_v1alpha1.json
+    kind: eventsource
+    name: eventsource_v1alpha1
+  - apiVersion: argoproj.io/v1alpha1
+    filename: argoproj.io/sensor_v1alpha1.json
+    kind: sensor
+    name: sensor_v1alpha1
+  - apiVersion: argoproj.io/v1alpha1
+    filename: argoproj.io/workfloweventbinding_v1alpha1.json
+    kind: workfloweventbinding
+    name: workfloweventbinding_v1alpha1
+  - apiVersion: argoproj.io/v1alpha1
+    filename: argoproj.io/workflowtaskresult_v1alpha1.json
+    kind: workflowtaskresult
+    name: workflowtaskresult_v1alpha1
+  - apiVersion: argoproj.io/v1alpha1
+    filename: argoproj.io/eventbus_v1alpha1.json
+    kind: eventbus
+    name: eventbus_v1alpha1
+  - apiVersion: argoproj.io/v1alpha1
+    filename: argoproj.io/workflowtaskset_v1alpha1.json
+    kind: workflowtaskset
+    name: workflowtaskset_v1alpha1
+artifactregistry.cnrm.cloud.google.com:
+  - apiVersion: artifactregistry.cnrm.cloud.google.com/v1beta1
+    filename: artifactregistry.cnrm.cloud.google.com/artifactregistryrepository_v1beta1.json
+    kind: artifactregistryrepository
+    name: artifactregistryrepository_v1beta1
+authentication.concierge.pinniped.dev:
+  - apiVersion: authentication.concierge.pinniped.dev/v1alpha1
+    filename: authentication.concierge.pinniped.dev/jwtauthenticator_v1alpha1.json
+    kind: JWTAuthenticator
+    name: jwtauthenticator_v1alpha1
+  - apiVersion: authentication.concierge.pinniped.dev/v1alpha1
+    filename: authentication.concierge.pinniped.dev/webhookauthenticator_v1alpha1.json
+    kind: WebhookAuthenticator
+    name: webhookauthenticator_v1alpha1
+autopilot.k0sproject.io:
+  - apiVersion: autopilot.k0sproject.io/v1beta2
+    filename: autopilot.k0sproject.io/updateconfig_v1beta2.json
+    kind: updateconfig
+    name: updateconfig_v1beta2
+  - apiVersion: autopilot.k0sproject.io/v1beta2
+    filename: autopilot.k0sproject.io/controlnode_v1beta2.json
+    kind: ControlNode
+    name: controlnode_v1beta2
+  - apiVersion: autopilot.k0sproject.io/v1beta2
+    filename: autopilot.k0sproject.io/plan_v1beta2.json
+    kind: Plan
+    name: plan_v1beta2
+autoscaling.k8s.elastic.co:
+  - apiVersion: autoscaling.k8s.elastic.co/v1alpha1
+    filename: autoscaling.k8s.elastic.co/elasticsearchautoscaler_v1alpha1.json
+    kind: ElasticsearchAutoscaler
+    name: elasticsearchautoscaler_v1alpha1
+autoscaling.k8s.io:
+  - apiVersion: autoscaling.k8s.io/v1beta2
+    filename: autoscaling.k8s.io/verticalpodautoscaler_v1beta2.json
+    kind: VerticalPodAutoscaler
+    name: verticalpodautoscaler_v1beta2
+  - apiVersion: autoscaling.k8s.io/v1
+    filename: autoscaling.k8s.io/verticalpodautoscaler_v1.json
+    kind: VerticalPodAutoscaler
+    name: verticalpodautoscaler_v1
+  - apiVersion: autoscaling.k8s.io/v1beta2
+    filename: autoscaling.k8s.io/verticalpodautoscalercheckpoint_v1beta2.json
+    kind: VerticalPodAutoscalerCheckpoint
+    name: verticalpodautoscalercheckpoint_v1beta2
+  - apiVersion: autoscaling.k8s.io/v1
+    filename: autoscaling.k8s.io/verticalpodautoscalercheckpoint_v1.json
+    kind: VerticalPodAutoscalerCheckpoint
+    name: verticalpodautoscalercheckpoint_v1
+awspca.cert-manager.io:
+  - apiVersion: awspca.cert-manager.io/v1beta1
+    filename: awspca.cert-manager.io/awspcaissuer_v1beta1.json
+    kind: AWSPCAIssuer
+    name: awspcaissuer_v1beta1
+  - apiVersion: awspca.cert-manager.io/v1beta1
+    filename: awspca.cert-manager.io/awspcaclusterissuer_v1beta1.json
+    kind: AWSPCAClusterIssuer
+    name: awspcaclusterissuer_v1beta1
+awsprovider.k8s.io:
+  - apiVersion: awsprovider.k8s.io/v1alpha1
+    filename: awsprovider.k8s.io/awsmachineproviderstatus_v1alpha1.json
+    kind: awsmachineproviderstatus
+    name: awsmachineproviderstatus_v1alpha1
+  - apiVersion: awsprovider.k8s.io/v1alpha1
+    filename: awsprovider.k8s.io/awsclusterproviderspec_v1alpha1.json
+    kind: awsclusterproviderspec
+    name: awsclusterproviderspec_v1alpha1
+  - apiVersion: awsprovider.k8s.io/v1alpha1
+    filename: awsprovider.k8s.io/awsclusterproviderstatus_v1alpha1.json
+    kind: awsclusterproviderstatus
+    name: awsclusterproviderstatus_v1alpha1
+  - apiVersion: awsprovider.k8s.io/v1alpha1
+    filename: awsprovider.k8s.io/awsmachineproviderspec_v1alpha1.json
+    kind: awsmachineproviderspec
+    name: awsmachineproviderspec_v1alpha1
+awx.ansible.com:
+  - apiVersion: awx.ansible.com/v1beta1
+    filename: awx.ansible.com/awx_v1beta1.json
+    kind: AWX
+    name: awx_v1beta1
+  - apiVersion: awx.ansible.com/v1beta1
+    filename: awx.ansible.com/awxrestore_v1beta1.json
+    kind: AWXRestore
+    name: awxrestore_v1beta1
+  - apiVersion: awx.ansible.com/v1alpha1
+    filename: awx.ansible.com/awxmeshingress_v1alpha1.json
+    kind: AWXMeshIngress
+    name: awxmeshingress_v1alpha1
+  - apiVersion: awx.ansible.com/v1beta1
+    filename: awx.ansible.com/awxbackup_v1beta1.json
+    kind: AWXBackup
+    name: awxbackup_v1beta1
+azureprovider.k8s.io:
+  - apiVersion: azureprovider.k8s.io/v1alpha1
+    filename: azureprovider.k8s.io/azuremachineproviderstatus_v1alpha1.json
+    kind: azuremachineproviderstatus
+    name: azuremachineproviderstatus_v1alpha1
+  - apiVersion: azureprovider.k8s.io/v1alpha1
+    filename: azureprovider.k8s.io/azuremachineproviderspec_v1alpha1.json
+    kind: azuremachineproviderspec
+    name: azuremachineproviderspec_v1alpha1
+  - apiVersion: azureprovider.k8s.io/v1alpha1
+    filename: azureprovider.k8s.io/azureclusterproviderstatus_v1alpha1.json
+    kind: azureclusterproviderstatus
+    name: azureclusterproviderstatus_v1alpha1
+  - apiVersion: azureprovider.k8s.io/v1alpha1
+    filename: azureprovider.k8s.io/azureclusterproviderspec_v1alpha1.json
+    kind: azureclusterproviderspec
+    name: azureclusterproviderspec_v1alpha1
 beat.k8s.elastic.co:
   - apiVersion: beat.k8s.elastic.co/v1beta1
     filename: beat.k8s.elastic.co/beat_v1beta1.json
     kind: Beat
     name: beat_v1beta1
+beyondcorp.cnrm.cloud.google.com:
+  - apiVersion: beyondcorp.cnrm.cloud.google.com/v1alpha1
+    filename: beyondcorp.cnrm.cloud.google.com/beyondcorpappgateway_v1alpha1.json
+    kind: beyondcorpappgateway
+    name: beyondcorpappgateway_v1alpha1
+  - apiVersion: beyondcorp.cnrm.cloud.google.com/v1alpha1
+    filename: beyondcorp.cnrm.cloud.google.com/beyondcorpappconnection_v1alpha1.json
+    kind: beyondcorpappconnection
+    name: beyondcorpappconnection_v1alpha1
+  - apiVersion: beyondcorp.cnrm.cloud.google.com/v1alpha1
+    filename: beyondcorp.cnrm.cloud.google.com/beyondcorpappconnector_v1alpha1.json
+    kind: beyondcorpappconnector
+    name: beyondcorpappconnector_v1alpha1
+bigquery.cnrm.cloud.google.com:
+  - apiVersion: bigquery.cnrm.cloud.google.com/v1beta1
+    filename: bigquery.cnrm.cloud.google.com/bigquerytable_v1beta1.json
+    kind: bigquerytable
+    name: bigquerytable_v1beta1
+  - apiVersion: bigquery.cnrm.cloud.google.com/v1beta1
+    filename: bigquery.cnrm.cloud.google.com/bigquerydataset_v1beta1.json
+    kind: BigQueryDataset
+    name: bigquerydataset_v1beta1
+  - apiVersion: bigquery.cnrm.cloud.google.com/v1alpha1
+    filename: bigquery.cnrm.cloud.google.com/bigquerydatasetaccess_v1alpha1.json
+    kind: bigquerydatasetaccess
+    name: bigquerydatasetaccess_v1alpha1
+  - apiVersion: bigquery.cnrm.cloud.google.com/v1beta1
+    filename: bigquery.cnrm.cloud.google.com/bigqueryjob_v1beta1.json
+    kind: bigqueryjob
+    name: bigqueryjob_v1beta1
+  - apiVersion: bigquery.cnrm.cloud.google.com/v1beta1
+    filename: bigquery.cnrm.cloud.google.com/bigqueryroutine_v1beta1.json
+    kind: bigqueryroutine
+    name: bigqueryroutine_v1beta1
+bigqueryanalyticshub.cnrm.cloud.google.com:
+  - apiVersion: bigqueryanalyticshub.cnrm.cloud.google.com/v1alpha1
+    filename: bigqueryanalyticshub.cnrm.cloud.google.com/bigqueryanalyticshublisting_v1alpha1.json
+    kind: BigQueryAnalyticsHubListing
+    name: bigqueryanalyticshublisting_v1alpha1
+  - apiVersion: bigqueryanalyticshub.cnrm.cloud.google.com/v1alpha1
+    filename: bigqueryanalyticshub.cnrm.cloud.google.com/bigqueryanalyticshubdataexchange_v1alpha1.json
+    kind: BigQueryAnalyticsHubDataExchange
+    name: bigqueryanalyticshubdataexchange_v1alpha1
+  - apiVersion: bigqueryanalyticshub.cnrm.cloud.google.com/v1beta1
+    filename: bigqueryanalyticshub.cnrm.cloud.google.com/bigqueryanalyticshubdataexchange_v1beta1.json
+    kind: BigQueryAnalyticsHubDataExchange
+    name: bigqueryanalyticshubdataexchange_v1beta1
+bigqueryconnection.cnrm.cloud.google.com:
+  - apiVersion: bigqueryconnection.cnrm.cloud.google.com/v1alpha1
+    filename: bigqueryconnection.cnrm.cloud.google.com/bigqueryconnectionconnection_v1alpha1.json
+    kind: BigQueryConnectionConnection
+    name: bigqueryconnectionconnection_v1alpha1
+  - apiVersion: bigqueryconnection.cnrm.cloud.google.com/v1beta1
+    filename: bigqueryconnection.cnrm.cloud.google.com/bigqueryconnectionconnection_v1beta1.json
+    kind: BigQueryConnectionConnection
+    name: bigqueryconnectionconnection_v1beta1
+bigquerydatapolicy.cnrm.cloud.google.com:
+  - apiVersion: bigquerydatapolicy.cnrm.cloud.google.com/v1alpha1
+    filename: bigquerydatapolicy.cnrm.cloud.google.com/bigquerydatapolicydatapolicy_v1alpha1.json
+    kind: bigquerydatapolicydatapolicy
+    name: bigquerydatapolicydatapolicy_v1alpha1
+bigquerydatatransfer.cnrm.cloud.google.com:
+  - apiVersion: bigquerydatatransfer.cnrm.cloud.google.com/v1alpha1
+    filename: bigquerydatatransfer.cnrm.cloud.google.com/bigquerydatatransferconfig_v1alpha1.json
+    kind: BigQueryDataTransferConfig
+    name: bigquerydatatransferconfig_v1alpha1
+  - apiVersion: bigquerydatatransfer.cnrm.cloud.google.com/v1beta1
+    filename: bigquerydatatransfer.cnrm.cloud.google.com/bigquerydatatransferconfig_v1beta1.json
+    kind: BigQueryDataTransferConfig
+    name: bigquerydatatransferconfig_v1beta1
+bigqueryreservation.cnrm.cloud.google.com:
+  - apiVersion: bigqueryreservation.cnrm.cloud.google.com/v1alpha1
+    filename: bigqueryreservation.cnrm.cloud.google.com/bigqueryreservationreservation_v1alpha1.json
+    kind: bigqueryreservationreservation
+    name: bigqueryreservationreservation_v1alpha1
+  - apiVersion: bigqueryreservation.cnrm.cloud.google.com/v1alpha1
+    filename: bigqueryreservation.cnrm.cloud.google.com/bigqueryreservationcapacitycommitment_v1alpha1.json
+    kind: bigqueryreservationcapacitycommitment
+    name: bigqueryreservationcapacitycommitment_v1alpha1
+bigtable.cnrm.cloud.google.com:
+  - apiVersion: bigtable.cnrm.cloud.google.com/v1beta1
+    filename: bigtable.cnrm.cloud.google.com/bigtableinstance_v1beta1.json
+    kind: BigtableInstance
+    name: bigtableinstance_v1beta1
+  - apiVersion: bigtable.cnrm.cloud.google.com/v1beta1
+    filename: bigtable.cnrm.cloud.google.com/bigtableappprofile_v1beta1.json
+    kind: bigtableappprofile
+    name: bigtableappprofile_v1beta1
+  - apiVersion: bigtable.cnrm.cloud.google.com/v1beta1
+    filename: bigtable.cnrm.cloud.google.com/bigtablegcpolicy_v1beta1.json
+    kind: bigtablegcpolicy
+    name: bigtablegcpolicy_v1beta1
+  - apiVersion: bigtable.cnrm.cloud.google.com/v1beta1
+    filename: bigtable.cnrm.cloud.google.com/bigtabletable_v1beta1.json
+    kind: bigtabletable
+    name: bigtabletable_v1beta1
+billingbudgets.cnrm.cloud.google.com:
+  - apiVersion: billingbudgets.cnrm.cloud.google.com/v1beta1
+    filename: billingbudgets.cnrm.cloud.google.com/billingbudgetsbudget_v1beta1.json
+    kind: billingbudgetsbudget
+    name: billingbudgetsbudget_v1beta1
+binaryauthorization.cnrm.cloud.google.com:
+  - apiVersion: binaryauthorization.cnrm.cloud.google.com/v1beta1
+    filename: binaryauthorization.cnrm.cloud.google.com/binaryauthorizationpolicy_v1beta1.json
+    kind: binaryauthorizationpolicy
+    name: binaryauthorizationpolicy_v1beta1
+  - apiVersion: binaryauthorization.cnrm.cloud.google.com/v1beta1
+    filename: binaryauthorization.cnrm.cloud.google.com/binaryauthorizationattestor_v1beta1.json
+    kind: binaryauthorizationattestor
+    name: binaryauthorizationattestor_v1beta1
 bitnami.com:
   - apiVersion: bitnami.com/v1alpha1
     filename: bitnami.com/sealedsecret_v1alpha1.json
     kind: SealedSecret
     name: sealedsecret_v1alpha1
+bmc.tinkerbell.org:
+  - apiVersion: bmc.tinkerbell.org/v1alpha1
+    filename: bmc.tinkerbell.org/task_v1alpha1.json
+    kind: Task
+    name: task_v1alpha1
+  - apiVersion: bmc.tinkerbell.org/v1alpha1
+    filename: bmc.tinkerbell.org/machine_v1alpha1.json
+    kind: Machine
+    name: machine_v1alpha1
+  - apiVersion: bmc.tinkerbell.org/v1alpha1
+    filename: bmc.tinkerbell.org/job_v1alpha1.json
+    kind: Job
+    name: job_v1alpha1
+bootstrap.cluster.x-k8s.io:
+  - apiVersion: bootstrap.cluster.x-k8s.io/v1alpha4
+    filename: bootstrap.cluster.x-k8s.io/kubeadmconfig_v1alpha4.json
+    kind: KubeadmConfig
+    name: kubeadmconfig_v1alpha4
+  - apiVersion: bootstrap.cluster.x-k8s.io/v1alpha4
+    filename: bootstrap.cluster.x-k8s.io/eksconfigtemplate_v1alpha4.json
+    kind: EKSConfigTemplate
+    name: eksconfigtemplate_v1alpha4
+  - apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
+    filename: bootstrap.cluster.x-k8s.io/eksconfig_v1alpha3.json
+    kind: EKSConfig
+    name: eksconfig_v1alpha3
+  - apiVersion: bootstrap.cluster.x-k8s.io/v1alpha4
+    filename: bootstrap.cluster.x-k8s.io/kubeadmconfigtemplate_v1alpha4.json
+    kind: KubeadmConfigTemplate
+    name: kubeadmconfigtemplate_v1alpha4
+  - apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
+    filename: bootstrap.cluster.x-k8s.io/eksconfig_v1beta2.json
+    kind: EKSConfig
+    name: eksconfig_v1beta2
+  - apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
+    filename: bootstrap.cluster.x-k8s.io/eksconfigtemplate_v1beta2.json
+    kind: EKSConfigTemplate
+    name: eksconfigtemplate_v1beta2
+  - apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
+    filename: bootstrap.cluster.x-k8s.io/kubeadmconfig_v1alpha3.json
+    kind: KubeadmConfig
+    name: kubeadmconfig_v1alpha3
+  - apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
+    filename: bootstrap.cluster.x-k8s.io/eksconfigtemplate_v1alpha3.json
+    kind: EKSConfigTemplate
+    name: eksconfigtemplate_v1alpha3
+  - apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+    filename: bootstrap.cluster.x-k8s.io/eksconfig_v1beta1.json
+    kind: EKSConfig
+    name: eksconfig_v1beta1
+  - apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+    filename: bootstrap.cluster.x-k8s.io/eksconfigtemplate_v1beta1.json
+    kind: EKSConfigTemplate
+    name: eksconfigtemplate_v1beta1
+  - apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+    filename: bootstrap.cluster.x-k8s.io/kubeadmconfig_v1beta1.json
+    kind: KubeadmConfig
+    name: kubeadmconfig_v1beta1
+  - apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
+    filename: bootstrap.cluster.x-k8s.io/kubeadmconfigtemplate_v1alpha3.json
+    kind: KubeadmConfigTemplate
+    name: kubeadmconfigtemplate_v1alpha3
+  - apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+    filename: bootstrap.cluster.x-k8s.io/kubeadmconfigtemplate_v1beta1.json
+    kind: KubeadmConfigTemplate
+    name: kubeadmconfigtemplate_v1beta1
+  - apiVersion: bootstrap.cluster.x-k8s.io/v1alpha4
+    filename: bootstrap.cluster.x-k8s.io/eksconfig_v1alpha4.json
+    kind: EKSConfig
+    name: eksconfig_v1alpha4
+capsule.clastix.io:
+  - apiVersion: capsule.clastix.io/v1beta2
+    filename: capsule.clastix.io/tenant_v1beta2.json
+    kind: Tenant
+    name: tenant_v1beta2
+  - apiVersion: capsule.clastix.io/v1beta2
+    filename: capsule.clastix.io/capsuleconfiguration_v1beta2.json
+    kind: CapsuleConfiguration
+    name: capsuleconfiguration_v1beta2
+  - apiVersion: capsule.clastix.io/v1beta2
+    filename: capsule.clastix.io/globaltenantresource_v1beta2.json
+    kind: GlobalTenantResource
+    name: globaltenantresource_v1beta2
+  - apiVersion: capsule.clastix.io/v1beta2
+    filename: capsule.clastix.io/tenantresource_v1beta2.json
+    kind: TenantResource
+    name: tenantresource_v1beta2
+  - apiVersion: capsule.clastix.io/v1beta1
+    filename: capsule.clastix.io/tenant_v1beta1.json
+    kind: Tenant
+    name: tenant_v1beta1
+ceph.rook.io:
+  - apiVersion: ceph.rook.io/v1
+    filename: ceph.rook.io/cephbucketnotification_v1.json
+    kind: CephBucketNotification
+    name: cephbucketnotification_v1
+  - apiVersion: ceph.rook.io/v1
+    filename: ceph.rook.io/cephbuckettopic_v1.json
+    kind: CephBucketTopic
+    name: cephbuckettopic_v1
+  - apiVersion: ceph.rook.io/v1
+    filename: ceph.rook.io/cephobjectstore_v1.json
+    kind: CephObjectStore
+    name: cephobjectstore_v1
+  - apiVersion: ceph.rook.io/v1
+    filename: ceph.rook.io/cephobjectzone_v1.json
+    kind: CephObjectZone
+    name: cephobjectzone_v1
+  - apiVersion: ceph.rook.io/v1
+    filename: ceph.rook.io/cephobjectstoreuser_v1.json
+    kind: CephObjectStoreUser
+    name: cephobjectstoreuser_v1
+  - apiVersion: ceph.rook.io/v1
+    filename: ceph.rook.io/cephfilesystem_v1.json
+    kind: CephFilesystem
+    name: cephfilesystem_v1
+  - apiVersion: ceph.rook.io/v1
+    filename: ceph.rook.io/cephfilesystemmirror_v1.json
+    kind: CephFilesystemMirror
+    name: cephfilesystemmirror_v1
+  - apiVersion: ceph.rook.io/v1
+    filename: ceph.rook.io/cephblockpool_v1.json
+    kind: CephBlockPool
+    name: cephblockpool_v1
+  - apiVersion: ceph.rook.io/v1
+    filename: ceph.rook.io/cephnfs_v1.json
+    kind: CephNFS
+    name: cephnfs_v1
+  - apiVersion: ceph.rook.io/v1
+    filename: ceph.rook.io/cephblockpoolradosnamespace_v1.json
+    kind: CephBlockPoolRadosNamespace
+    name: cephblockpoolradosnamespace_v1
+  - apiVersion: ceph.rook.io/v1
+    filename: ceph.rook.io/cephcosidriver_v1.json
+    kind: CephCOSIDriver
+    name: cephcosidriver_v1
+  - apiVersion: ceph.rook.io/v1
+    filename: ceph.rook.io/cephobjectzonegroup_v1.json
+    kind: CephObjectZoneGroup
+    name: cephobjectzonegroup_v1
+  - apiVersion: ceph.rook.io/v1
+    filename: ceph.rook.io/cephobjectrealm_v1.json
+    kind: CephObjectRealm
+    name: cephobjectrealm_v1
+  - apiVersion: ceph.rook.io/v1
+    filename: ceph.rook.io/cephclient_v1.json
+    kind: CephClient
+    name: cephclient_v1
+  - apiVersion: ceph.rook.io/v1
+    filename: ceph.rook.io/cephcluster_v1.json
+    kind: CephCluster
+    name: cephcluster_v1
+  - apiVersion: ceph.rook.io/v1
+    filename: ceph.rook.io/cephrbdmirror_v1.json
+    kind: CephRBDMirror
+    name: cephrbdmirror_v1
+  - apiVersion: ceph.rook.io/v1
+    filename: ceph.rook.io/cephfilesystemsubvolumegroup_v1.json
+    kind: CephFilesystemSubVolumeGroup
+    name: cephfilesystemsubvolumegroup_v1
+cert-manager.io:
+  - apiVersion: cert-manager.io/v1
+    filename: cert-manager.io/certificaterequest_v1.json
+    kind: CertificateRequest
+    name: certificaterequest_v1
+  - apiVersion: cert-manager.io/v1
+    filename: cert-manager.io/issuer_v1.json
+    kind: Issuer
+    name: issuer_v1
+  - apiVersion: cert-manager.io/v1
+    filename: cert-manager.io/clusterissuer_v1.json
+    kind: ClusterIssuer
+    name: clusterissuer_v1
+  - apiVersion: cert-manager.io/v1
+    filename: cert-manager.io/certificate_v1.json
+    kind: Certificate
+    name: certificate_v1
+cert-manager.k8s.cloudflare.com:
+  - apiVersion: cert-manager.k8s.cloudflare.com/v1
+    filename: cert-manager.k8s.cloudflare.com/originissuer_v1.json
+    kind: OriginIssuer
+    name: originissuer_v1
+certificatemanager.cnrm.cloud.google.com:
+  - apiVersion: certificatemanager.cnrm.cloud.google.com/v1alpha1
+    filename: certificatemanager.cnrm.cloud.google.com/certificatemanagercertificate_v1alpha1.json
+    kind: certificatemanagercertificate
+    name: certificatemanagercertificate_v1alpha1
+  - apiVersion: certificatemanager.cnrm.cloud.google.com/v1beta1
+    filename: certificatemanager.cnrm.cloud.google.com/certificatemanagercertificatemapentry_v1beta1.json
+    kind: certificatemanagercertificatemapentry
+    name: certificatemanagercertificatemapentry_v1beta1
+  - apiVersion: certificatemanager.cnrm.cloud.google.com/v1alpha1
+    filename: certificatemanager.cnrm.cloud.google.com/certificatemanagercertificatemapentry_v1alpha1.json
+    kind: certificatemanagercertificatemapentry
+    name: certificatemanagercertificatemapentry_v1alpha1
+  - apiVersion: certificatemanager.cnrm.cloud.google.com/v1beta1
+    filename: certificatemanager.cnrm.cloud.google.com/certificatemanagercertificate_v1beta1.json
+    kind: certificatemanagercertificate
+    name: certificatemanagercertificate_v1beta1
+  - apiVersion: certificatemanager.cnrm.cloud.google.com/v1alpha1
+    filename: certificatemanager.cnrm.cloud.google.com/certificatemanagerdnsauthorization_v1alpha1.json
+    kind: CertificateManagerDNSAuthorization
+    name: certificatemanagerdnsauthorization_v1alpha1
+  - apiVersion: certificatemanager.cnrm.cloud.google.com/v1beta1
+    filename: certificatemanager.cnrm.cloud.google.com/certificatemanagerdnsauthorization_v1beta1.json
+    kind: CertificateManagerDNSAuthorization
+    name: certificatemanagerdnsauthorization_v1beta1
+  - apiVersion: certificatemanager.cnrm.cloud.google.com/v1alpha1
+    filename: certificatemanager.cnrm.cloud.google.com/certificatemanagercertificatemap_v1alpha1.json
+    kind: certificatemanagercertificatemap
+    name: certificatemanagercertificatemap_v1alpha1
+  - apiVersion: certificatemanager.cnrm.cloud.google.com/v1beta1
+    filename: certificatemanager.cnrm.cloud.google.com/certificatemanagercertificatemap_v1beta1.json
+    kind: certificatemanagercertificatemap
+    name: certificatemanagercertificatemap_v1beta1
+chisel-operator.io:
+  - apiVersion: chisel-operator.io/v1
+    filename: chisel-operator.io/exitnodeprovisioner_v1.json
+    kind: ExitNodeProvisioner
+    name: exitnodeprovisioner_v1
+  - apiVersion: chisel-operator.io/v1
+    filename: chisel-operator.io/exitnode_v1.json
+    kind: ExitNode
+    name: exitnode_v1
+cilium.io:
+  - apiVersion: cilium.io/v2
+    filename: cilium.io/ciliumnetworkpolicy_v2.json
+    kind: CiliumNetworkPolicy
+    name: ciliumnetworkpolicy_v2
+  - apiVersion: cilium.io/v2
+    filename: cilium.io/ciliumegressgatewaypolicy_v2.json
+    kind: ciliumegressgatewaypolicy
+    name: ciliumegressgatewaypolicy_v2
+  - apiVersion: cilium.io/v2
+    filename: cilium.io/ciliumlocalredirectpolicy_v2.json
+    kind: CiliumLocalRedirectPolicy
+    name: ciliumlocalredirectpolicy_v2
+  - apiVersion: cilium.io/v2
+    filename: cilium.io/ciliumclusterwideenvoyconfig_v2.json
+    kind: ciliumclusterwideenvoyconfig
+    name: ciliumclusterwideenvoyconfig_v2
+  - apiVersion: cilium.io/v2alpha1
+    filename: cilium.io/ciliumbgppeeringpolicy_v2alpha1.json
+    kind: CiliumBGPPeeringPolicy
+    name: ciliumbgppeeringpolicy_v2alpha1
+  - apiVersion: cilium.io/v2alpha1
+    filename: cilium.io/ciliumcidrgroup_v2alpha1.json
+    kind: CiliumCIDRGroup
+    name: ciliumcidrgroup_v2alpha1
+  - apiVersion: cilium.io/v2
+    filename: cilium.io/ciliumenvoyconfig_v2.json
+    kind: ciliumenvoyconfig
+    name: ciliumenvoyconfig_v2
+  - apiVersion: cilium.io/v2alpha1
+    filename: cilium.io/ciliumpodippool_v2alpha1.json
+    kind: CiliumPodIPPool
+    name: ciliumpodippool_v2alpha1
+  - apiVersion: cilium.io/v2
+    filename: cilium.io/ciliumnodeconfig_v2.json
+    kind: CiliumNodeConfig
+    name: ciliumnodeconfig_v2
+  - apiVersion: cilium.io/v2
+    filename: cilium.io/ciliumexternalworkload_v2.json
+    kind: CiliumExternalWorkload
+    name: ciliumexternalworkload_v2
+  - apiVersion: cilium.io/v2
+    filename: cilium.io/ciliumnode_v2.json
+    kind: CiliumNode
+    name: ciliumnode_v2
+  - apiVersion: cilium.io/v2
+    filename: cilium.io/ciliumidentity_v2.json
+    kind: CiliumIdentity
+    name: ciliumidentity_v2
+  - apiVersion: cilium.io/v2
+    filename: cilium.io/ciliumclusterwidenetworkpolicy_v2.json
+    kind: CiliumClusterwideNetworkPolicy
+    name: ciliumclusterwidenetworkpolicy_v2
+  - apiVersion: cilium.io/v2alpha1
+    filename: cilium.io/ciliumendpointslice_v2alpha1.json
+    kind: CiliumEndpointSlice
+    name: ciliumendpointslice_v2alpha1
+  - apiVersion: cilium.io/v2
+    filename: cilium.io/ciliumendpoint_v2.json
+    kind: CiliumEndpoint
+    name: ciliumendpoint_v2
+  - apiVersion: cilium.io/v2alpha1
+    filename: cilium.io/ciliuml2announcementpolicy_v2alpha1.json
+    kind: CiliumL2AnnouncementPolicy
+    name: ciliuml2announcementpolicy_v2alpha1
+  - apiVersion: cilium.io/v2alpha1
+    filename: cilium.io/ciliumloadbalancerippool_v2alpha1.json
+    kind: CiliumLoadBalancerIPPool
+    name: ciliumloadbalancerippool_v2alpha1
+  - apiVersion: cilium.io/v2alpha1
+    filename: cilium.io/ciliumnodeconfig_v2alpha1.json
+    kind: CiliumNodeConfig
+    name: ciliumnodeconfig_v2alpha1
+cloud.google.com:
+  - apiVersion: cloud.google.com/v1beta1
+    filename: cloud.google.com/backendconfig_v1beta1.json
+    kind: backendconfig
+    name: backendconfig_v1beta1
+  - apiVersion: cloud.google.com/v1
+    filename: cloud.google.com/backendconfig_v1.json
+    kind: backendconfig
+    name: backendconfig_v1
+cloudasset.cnrm.cloud.google.com:
+  - apiVersion: cloudasset.cnrm.cloud.google.com/v1alpha1
+    filename: cloudasset.cnrm.cloud.google.com/cloudassetfolderfeed_v1alpha1.json
+    kind: cloudassetfolderfeed
+    name: cloudassetfolderfeed_v1alpha1
+  - apiVersion: cloudasset.cnrm.cloud.google.com/v1alpha1
+    filename: cloudasset.cnrm.cloud.google.com/cloudassetorganizationfeed_v1alpha1.json
+    kind: cloudassetorganizationfeed
+    name: cloudassetorganizationfeed_v1alpha1
+  - apiVersion: cloudasset.cnrm.cloud.google.com/v1alpha1
+    filename: cloudasset.cnrm.cloud.google.com/cloudassetprojectfeed_v1alpha1.json
+    kind: cloudassetprojectfeed
+    name: cloudassetprojectfeed_v1alpha1
+cloudbuild.cnrm.cloud.google.com:
+  - apiVersion: cloudbuild.cnrm.cloud.google.com/v1beta1
+    filename: cloudbuild.cnrm.cloud.google.com/cloudbuildtrigger_v1beta1.json
+    kind: cloudbuildtrigger
+    name: cloudbuildtrigger_v1beta1
+  - apiVersion: cloudbuild.cnrm.cloud.google.com/v1alpha1
+    filename: cloudbuild.cnrm.cloud.google.com/cloudbuildworkerpool_v1alpha1.json
+    kind: CloudBuildWorkerPool
+    name: cloudbuildworkerpool_v1alpha1
+  - apiVersion: cloudbuild.cnrm.cloud.google.com/v1beta1
+    filename: cloudbuild.cnrm.cloud.google.com/cloudbuildworkerpool_v1beta1.json
+    kind: CloudBuildWorkerPool
+    name: cloudbuildworkerpool_v1beta1
+cloudflare-operator.io:
+  - apiVersion: cloudflare-operator.io/v1
+    filename: cloudflare-operator.io/ip_v1.json
+    kind: IP
+    name: ip_v1
+  - apiVersion: cloudflare-operator.io/v1
+    filename: cloudflare-operator.io/account_v1.json
+    kind: Account
+    name: account_v1
+  - apiVersion: cloudflare-operator.io/v1
+    filename: cloudflare-operator.io/zone_v1.json
+    kind: Zone
+    name: zone_v1
+  - apiVersion: cloudflare-operator.io/v1
+    filename: cloudflare-operator.io/dnsrecord_v1.json
+    kind: DNSRecord
+    name: dnsrecord_v1
+cloudfront.services.k8s.aws:
+  - apiVersion: cloudfront.services.k8s.aws/v1alpha1
+    filename: cloudfront.services.k8s.aws/cachepolicy_v1alpha1.json
+    kind: CachePolicy
+    name: cachepolicy_v1alpha1
+cloudfunctions.cnrm.cloud.google.com:
+  - apiVersion: cloudfunctions.cnrm.cloud.google.com/v1beta1
+    filename: cloudfunctions.cnrm.cloud.google.com/cloudfunctionsfunction_v1beta1.json
+    kind: cloudfunctionsfunction
+    name: cloudfunctionsfunction_v1beta1
+cloudfunctions2.cnrm.cloud.google.com:
+  - apiVersion: cloudfunctions2.cnrm.cloud.google.com/v1alpha1
+    filename: cloudfunctions2.cnrm.cloud.google.com/cloudfunctions2function_v1alpha1.json
+    kind: cloudfunctions2function
+    name: cloudfunctions2function_v1alpha1
+cloudidentity.cnrm.cloud.google.com:
+  - apiVersion: cloudidentity.cnrm.cloud.google.com/v1beta1
+    filename: cloudidentity.cnrm.cloud.google.com/cloudidentitymembership_v1beta1.json
+    kind: cloudidentitymembership
+    name: cloudidentitymembership_v1beta1
+  - apiVersion: cloudidentity.cnrm.cloud.google.com/v1beta1
+    filename: cloudidentity.cnrm.cloud.google.com/cloudidentitygroup_v1beta1.json
+    kind: cloudidentitygroup
+    name: cloudidentitygroup_v1beta1
+cloudids.cnrm.cloud.google.com:
+  - apiVersion: cloudids.cnrm.cloud.google.com/v1alpha1
+    filename: cloudids.cnrm.cloud.google.com/cloudidsendpoint_v1alpha1.json
+    kind: cloudidsendpoint
+    name: cloudidsendpoint_v1alpha1
+  - apiVersion: cloudids.cnrm.cloud.google.com/v1beta1
+    filename: cloudids.cnrm.cloud.google.com/cloudidsendpoint_v1beta1.json
+    kind: cloudidsendpoint
+    name: cloudidsendpoint_v1beta1
+cloudiot.cnrm.cloud.google.com:
+  - apiVersion: cloudiot.cnrm.cloud.google.com/v1alpha1
+    filename: cloudiot.cnrm.cloud.google.com/cloudiotdeviceregistry_v1alpha1.json
+    kind: cloudiotdeviceregistry
+    name: cloudiotdeviceregistry_v1alpha1
+  - apiVersion: cloudiot.cnrm.cloud.google.com/v1alpha1
+    filename: cloudiot.cnrm.cloud.google.com/cloudiotdevice_v1alpha1.json
+    kind: cloudiotdevice
+    name: cloudiotdevice_v1alpha1
+cloudscheduler.cnrm.cloud.google.com:
+  - apiVersion: cloudscheduler.cnrm.cloud.google.com/v1beta1
+    filename: cloudscheduler.cnrm.cloud.google.com/cloudschedulerjob_v1beta1.json
+    kind: cloudschedulerjob
+    name: cloudschedulerjob_v1beta1
+cloudsql.cloud.google.com:
+  - apiVersion: cloudsql.cloud.google.com/v1
+    filename: cloudsql.cloud.google.com/authproxyworkload_v1.json
+    kind: AuthProxyWorkload
+    name: authproxyworkload_v1
+cloudtasks.cnrm.cloud.google.com:
+  - apiVersion: cloudtasks.cnrm.cloud.google.com/v1alpha1
+    filename: cloudtasks.cnrm.cloud.google.com/cloudtasksqueue_v1alpha1.json
+    kind: cloudtasksqueue
+    name: cloudtasksqueue_v1alpha1
+cloudtrail.services.k8s.aws:
+  - apiVersion: cloudtrail.services.k8s.aws/v1alpha1
+    filename: cloudtrail.services.k8s.aws/trail_v1alpha1.json
+    kind: Trail
+    name: trail_v1alpha1
+  - apiVersion: cloudtrail.services.k8s.aws/v1alpha1
+    filename: cloudtrail.services.k8s.aws/eventdatastore_v1alpha1.json
+    kind: EventDataStore
+    name: eventdatastore_v1alpha1
+cloudwatchlogs.services.k8s.aws:
+  - apiVersion: cloudwatchlogs.services.k8s.aws/v1alpha1
+    filename: cloudwatchlogs.services.k8s.aws/loggroup_v1alpha1.json
+    kind: LogGroup
+    name: loggroup_v1alpha1
+cluster.x-k8s.io:
+  - apiVersion: cluster.x-k8s.io/v1beta1
+    filename: cluster.x-k8s.io/machinedeployment_v1beta1.json
+    kind: MachineDeployment
+    name: machinedeployment_v1beta1
+  - apiVersion: cluster.x-k8s.io/v1alpha4
+    filename: cluster.x-k8s.io/clusterclass_v1alpha4.json
+    kind: ClusterClass
+    name: clusterclass_v1alpha4
+  - apiVersion: cluster.x-k8s.io/v1alpha2
+    filename: cluster.x-k8s.io/machine_v1alpha2.json
+    kind: Machine
+    name: machine_v1alpha2
+  - apiVersion: cluster.x-k8s.io/v1alpha4
+    filename: cluster.x-k8s.io/machinehealthcheck_v1alpha4.json
+    kind: MachineHealthCheck
+    name: machinehealthcheck_v1alpha4
+  - apiVersion: cluster.x-k8s.io/v1alpha3
+    filename: cluster.x-k8s.io/machinedeployment_v1alpha3.json
+    kind: MachineDeployment
+    name: machinedeployment_v1alpha3
+  - apiVersion: cluster.x-k8s.io/v1alpha3
+    filename: cluster.x-k8s.io/machineset_v1alpha3.json
+    kind: MachineSet
+    name: machineset_v1alpha3
+  - apiVersion: cluster.x-k8s.io/v1alpha1
+    filename: cluster.x-k8s.io/machineclass_v1alpha1.json
+    kind: machineclass
+    name: machineclass_v1alpha1
+  - apiVersion: cluster.x-k8s.io/v1alpha2
+    filename: cluster.x-k8s.io/cluster_v1alpha2.json
+    kind: Cluster
+    name: cluster_v1alpha2
+  - apiVersion: cluster.x-k8s.io/v1alpha3
+    filename: cluster.x-k8s.io/machine_v1alpha3.json
+    kind: Machine
+    name: machine_v1alpha3
+  - apiVersion: cluster.x-k8s.io/v1beta1
+    filename: cluster.x-k8s.io/machinepool_v1beta1.json
+    kind: MachinePool
+    name: machinepool_v1beta1
+  - apiVersion: cluster.x-k8s.io/v1beta1
+    filename: cluster.x-k8s.io/cluster_v1beta1.json
+    kind: Cluster
+    name: cluster_v1beta1
+  - apiVersion: cluster.x-k8s.io/v1alpha2
+    filename: cluster.x-k8s.io/machinedeployment_v1alpha2.json
+    kind: MachineDeployment
+    name: machinedeployment_v1alpha2
+  - apiVersion: cluster.x-k8s.io/v1alpha2
+    filename: cluster.x-k8s.io/machineset_v1alpha2.json
+    kind: MachineSet
+    name: machineset_v1alpha2
+  - apiVersion: cluster.x-k8s.io/v1alpha3
+    filename: cluster.x-k8s.io/cluster_v1alpha3.json
+    kind: Cluster
+    name: cluster_v1alpha3
+  - apiVersion: cluster.x-k8s.io/v1alpha4
+    filename: cluster.x-k8s.io/machinepool_v1alpha4.json
+    kind: MachinePool
+    name: machinepool_v1alpha4
+  - apiVersion: cluster.x-k8s.io/v1alpha1
+    filename: cluster.x-k8s.io/machine_v1alpha1.json
+    kind: machine
+    name: machine_v1alpha1
+  - apiVersion: cluster.x-k8s.io/v1beta1
+    filename: cluster.x-k8s.io/clusterclass_v1beta1.json
+    kind: ClusterClass
+    name: clusterclass_v1beta1
+  - apiVersion: cluster.x-k8s.io/v1alpha3
+    filename: cluster.x-k8s.io/machinehealthcheck_v1alpha3.json
+    kind: MachineHealthCheck
+    name: machinehealthcheck_v1alpha3
+  - apiVersion: cluster.x-k8s.io/v1alpha4
+    filename: cluster.x-k8s.io/machinedeployment_v1alpha4.json
+    kind: MachineDeployment
+    name: machinedeployment_v1alpha4
+  - apiVersion: cluster.x-k8s.io/v1alpha4
+    filename: cluster.x-k8s.io/machineset_v1alpha4.json
+    kind: MachineSet
+    name: machineset_v1alpha4
+  - apiVersion: cluster.x-k8s.io/v1alpha1
+    filename: cluster.x-k8s.io/cluster_v1alpha1.json
+    kind: cluster
+    name: cluster_v1alpha1
+  - apiVersion: cluster.x-k8s.io/v1beta1
+    filename: cluster.x-k8s.io/machinehealthcheck_v1beta1.json
+    kind: MachineHealthCheck
+    name: machinehealthcheck_v1beta1
+  - apiVersion: cluster.x-k8s.io/v1alpha3
+    filename: cluster.x-k8s.io/machinepool_v1alpha3.json
+    kind: MachinePool
+    name: machinepool_v1alpha3
+  - apiVersion: cluster.x-k8s.io/v1alpha4
+    filename: cluster.x-k8s.io/cluster_v1alpha4.json
+    kind: Cluster
+    name: cluster_v1alpha4
+  - apiVersion: cluster.x-k8s.io/v1beta1
+    filename: cluster.x-k8s.io/machineset_v1beta1.json
+    kind: MachineSet
+    name: machineset_v1beta1
+  - apiVersion: cluster.x-k8s.io/v1beta1
+    filename: cluster.x-k8s.io/machine_v1beta1.json
+    kind: Machine
+    name: machine_v1beta1
+  - apiVersion: cluster.x-k8s.io/v1alpha1
+    filename: cluster.x-k8s.io/machinedeployment_v1alpha1.json
+    kind: machinedeployment
+    name: machinedeployment_v1alpha1
+  - apiVersion: cluster.x-k8s.io/v1alpha4
+    filename: cluster.x-k8s.io/machine_v1alpha4.json
+    kind: Machine
+    name: machine_v1alpha4
+  - apiVersion: cluster.x-k8s.io/v1alpha1
+    filename: cluster.x-k8s.io/machineset_v1alpha1.json
+    kind: machineset
+    name: machineset_v1alpha1
+clusterctl.cluster.x-k8s.io:
+  - apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3
+    filename: clusterctl.cluster.x-k8s.io/provider_v1alpha3.json
+    kind: Provider
+    name: provider_v1alpha3
+clustersecret.io:
+  - apiVersion: clustersecret.io/v1
+    filename: clustersecret.io/clustersecret_v1.json
+    kind: clustersecret
+    name: clustersecret_v1
+compute.cnrm.cloud.google.com:
+  - apiVersion: compute.cnrm.cloud.google.com/v1beta1
+    filename: compute.cnrm.cloud.google.com/computetargetvpngateway_v1beta1.json
+    kind: computetargetvpngateway
+    name: computetargetvpngateway_v1beta1
+  - apiVersion: compute.cnrm.cloud.google.com/v1beta1
+    filename: compute.cnrm.cloud.google.com/computehttphealthcheck_v1beta1.json
+    kind: computehttphealthcheck
+    name: computehttphealthcheck_v1beta1
+  - apiVersion: compute.cnrm.cloud.google.com/v1alpha1
+    filename: compute.cnrm.cloud.google.com/computeorganizationsecuritypolicyrule_v1alpha1.json
+    kind: computeorganizationsecuritypolicyrule
+    name: computeorganizationsecuritypolicyrule_v1alpha1
+  - apiVersion: compute.cnrm.cloud.google.com/v1beta1
+    filename: compute.cnrm.cloud.google.com/computesecuritypolicy_v1beta1.json
+    kind: computesecuritypolicy
+    name: computesecuritypolicy_v1beta1
+  - apiVersion: compute.cnrm.cloud.google.com/v1alpha1
+    filename: compute.cnrm.cloud.google.com/computenetworkfirewallpolicyrule_v1alpha1.json
+    kind: computenetworkfirewallpolicyrule
+    name: computenetworkfirewallpolicyrule_v1alpha1
+  - apiVersion: compute.cnrm.cloud.google.com/v1beta1
+    filename: compute.cnrm.cloud.google.com/computesslcertificate_v1beta1.json
+    kind: computesslcertificate
+    name: computesslcertificate_v1beta1
+  - apiVersion: compute.cnrm.cloud.google.com/v1beta1
+    filename: compute.cnrm.cloud.google.com/computenetworkfirewallpolicy_v1beta1.json
+    kind: computenetworkfirewallpolicy
+    name: computenetworkfirewallpolicy_v1beta1
+  - apiVersion: compute.cnrm.cloud.google.com/v1alpha1
+    filename: compute.cnrm.cloud.google.com/computeorganizationsecuritypolicyassociation_v1alpha1.json
+    kind: computeorganizationsecuritypolicyassociation
+    name: computeorganizationsecuritypolicyassociation_v1alpha1
+  - apiVersion: compute.cnrm.cloud.google.com/v1beta1
+    filename: compute.cnrm.cloud.google.com/computeroute_v1beta1.json
+    kind: computeroute
+    name: computeroute_v1beta1
+  - apiVersion: compute.cnrm.cloud.google.com/v1beta1
+    filename: compute.cnrm.cloud.google.com/computesnapshot_v1beta1.json
+    kind: computesnapshot
+    name: computesnapshot_v1beta1
+  - apiVersion: compute.cnrm.cloud.google.com/v1beta1
+    filename: compute.cnrm.cloud.google.com/computerouternat_v1beta1.json
+    kind: computerouternat
+    name: computerouternat_v1beta1
+  - apiVersion: compute.cnrm.cloud.google.com/v1beta1
+    filename: compute.cnrm.cloud.google.com/computetargethttpsproxy_v1beta1.json
+    kind: computetargethttpsproxy
+    name: computetargethttpsproxy_v1beta1
+  - apiVersion: compute.cnrm.cloud.google.com/v1beta1
+    filename: compute.cnrm.cloud.google.com/computeaddress_v1beta1.json
+    kind: computeaddress
+    name: computeaddress_v1beta1
+  - apiVersion: compute.cnrm.cloud.google.com/v1beta1
+    filename: compute.cnrm.cloud.google.com/computetargetinstance_v1beta1.json
+    kind: computetargetinstance
+    name: computetargetinstance_v1beta1
+  - apiVersion: compute.cnrm.cloud.google.com/v1beta1
+    filename: compute.cnrm.cloud.google.com/computetargetsslproxy_v1beta1.json
+    kind: computetargetsslproxy
+    name: computetargetsslproxy_v1beta1
+  - apiVersion: compute.cnrm.cloud.google.com/v1beta1
+    filename: compute.cnrm.cloud.google.com/computeinterconnectattachment_v1beta1.json
+    kind: computeinterconnectattachment
+    name: computeinterconnectattachment_v1beta1
+  - apiVersion: compute.cnrm.cloud.google.com/v1beta1
+    filename: compute.cnrm.cloud.google.com/computenetwork_v1beta1.json
+    kind: computenetwork
+    name: computenetwork_v1beta1
+  - apiVersion: compute.cnrm.cloud.google.com/v1alpha1
+    filename: compute.cnrm.cloud.google.com/computeregionperinstanceconfig_v1alpha1.json
+    kind: computeregionperinstanceconfig
+    name: computeregionperinstanceconfig_v1alpha1
+  - apiVersion: compute.cnrm.cloud.google.com/v1beta1
+    filename: compute.cnrm.cloud.google.com/computeresourcepolicy_v1beta1.json
+    kind: computeresourcepolicy
+    name: computeresourcepolicy_v1beta1
+  - apiVersion: compute.cnrm.cloud.google.com/v1alpha1
+    filename: compute.cnrm.cloud.google.com/computeperinstanceconfig_v1alpha1.json
+    kind: computeperinstanceconfig
+    name: computeperinstanceconfig_v1alpha1
+  - apiVersion: compute.cnrm.cloud.google.com/v1beta1
+    filename: compute.cnrm.cloud.google.com/computesharedvpchostproject_v1beta1.json
+    kind: computesharedvpchostproject
+    name: computesharedvpchostproject_v1beta1
+  - apiVersion: compute.cnrm.cloud.google.com/v1beta1
+    filename: compute.cnrm.cloud.google.com/computehealthcheck_v1beta1.json
+    kind: computehealthcheck
+    name: computehealthcheck_v1beta1
+  - apiVersion: compute.cnrm.cloud.google.com/v1beta1
+    filename: compute.cnrm.cloud.google.com/computerouter_v1beta1.json
+    kind: computerouter
+    name: computerouter_v1beta1
+  - apiVersion: compute.cnrm.cloud.google.com/v1beta1
+    filename: compute.cnrm.cloud.google.com/computeforwardingrule_v1beta1.json
+    kind: ComputeForwardingRule
+    name: computeforwardingrule_v1beta1
+  - apiVersion: compute.cnrm.cloud.google.com/v1beta1
+    filename: compute.cnrm.cloud.google.com/computenetworkendpointgroup_v1beta1.json
+    kind: computenetworkendpointgroup
+    name: computenetworkendpointgroup_v1beta1
+  - apiVersion: compute.cnrm.cloud.google.com/v1beta1
+    filename: compute.cnrm.cloud.google.com/computebackendbucket_v1beta1.json
+    kind: computebackendbucket
+    name: computebackendbucket_v1beta1
+  - apiVersion: compute.cnrm.cloud.google.com/v1alpha1
+    filename: compute.cnrm.cloud.google.com/computeglobalnetworkendpoint_v1alpha1.json
+    kind: computeglobalnetworkendpoint
+    name: computeglobalnetworkendpoint_v1alpha1
+  - apiVersion: compute.cnrm.cloud.google.com/v1beta1
+    filename: compute.cnrm.cloud.google.com/computerouterpeer_v1beta1.json
+    kind: computerouterpeer
+    name: computerouterpeer_v1beta1
+  - apiVersion: compute.cnrm.cloud.google.com/v1alpha1
+    filename: compute.cnrm.cloud.google.com/computeglobalnetworkendpointgroup_v1alpha1.json
+    kind: computeglobalnetworkendpointgroup
+    name: computeglobalnetworkendpointgroup_v1alpha1
+  - apiVersion: compute.cnrm.cloud.google.com/v1beta1
+    filename: compute.cnrm.cloud.google.com/computeurlmap_v1beta1.json
+    kind: computeurlmap
+    name: computeurlmap_v1beta1
+  - apiVersion: compute.cnrm.cloud.google.com/v1beta1
+    filename: compute.cnrm.cloud.google.com/computesharedvpcserviceproject_v1beta1.json
+    kind: computesharedvpcserviceproject
+    name: computesharedvpcserviceproject_v1beta1
+  - apiVersion: compute.cnrm.cloud.google.com/v1alpha1
+    filename: compute.cnrm.cloud.google.com/computeinstancegroupnamedport_v1alpha1.json
+    kind: computeinstancegroupnamedport
+    name: computeinstancegroupnamedport_v1alpha1
+  - apiVersion: compute.cnrm.cloud.google.com/v1beta1
+    filename: compute.cnrm.cloud.google.com/computedisk_v1beta1.json
+    kind: computedisk
+    name: computedisk_v1beta1
+  - apiVersion: compute.cnrm.cloud.google.com/v1alpha1
+    filename: compute.cnrm.cloud.google.com/computebackendservicesignedurlkey_v1alpha1.json
+    kind: computebackendservicesignedurlkey
+    name: computebackendservicesignedurlkey_v1alpha1
+  - apiVersion: compute.cnrm.cloud.google.com/v1beta1
+    filename: compute.cnrm.cloud.google.com/computeinstancegroupmanager_v1beta1.json
+    kind: computeinstancegroupmanager
+    name: computeinstancegroupmanager_v1beta1
+  - apiVersion: compute.cnrm.cloud.google.com/v1beta1
+    filename: compute.cnrm.cloud.google.com/computefirewallpolicyrule_v1beta1.json
+    kind: ComputeFirewallPolicyRule
+    name: computefirewallpolicyrule_v1beta1
+  - apiVersion: compute.cnrm.cloud.google.com/v1beta1
+    filename: compute.cnrm.cloud.google.com/computeexternalvpngateway_v1beta1.json
+    kind: computeexternalvpngateway
+    name: computeexternalvpngateway_v1beta1
+  - apiVersion: compute.cnrm.cloud.google.com/v1beta1
+    filename: compute.cnrm.cloud.google.com/computebackendservice_v1beta1.json
+    kind: computebackendservice
+    name: computebackendservice_v1beta1
+  - apiVersion: compute.cnrm.cloud.google.com/v1beta1
+    filename: compute.cnrm.cloud.google.com/computepacketmirroring_v1beta1.json
+    kind: computepacketmirroring
+    name: computepacketmirroring_v1beta1
+  - apiVersion: compute.cnrm.cloud.google.com/v1beta1
+    filename: compute.cnrm.cloud.google.com/computevpngateway_v1beta1.json
+    kind: computevpngateway
+    name: computevpngateway_v1beta1
+  - apiVersion: compute.cnrm.cloud.google.com/v1alpha1
+    filename: compute.cnrm.cloud.google.com/computeregiondiskresourcepolicyattachment_v1alpha1.json
+    kind: computeregiondiskresourcepolicyattachment
+    name: computeregiondiskresourcepolicyattachment_v1alpha1
+  - apiVersion: compute.cnrm.cloud.google.com/v1alpha1
+    filename: compute.cnrm.cloud.google.com/computemanagedsslcertificate_v1alpha1.json
+    kind: computemanagedsslcertificate
+    name: computemanagedsslcertificate_v1alpha1
+  - apiVersion: compute.cnrm.cloud.google.com/v1alpha1
+    filename: compute.cnrm.cloud.google.com/computeregionautoscaler_v1alpha1.json
+    kind: computeregionautoscaler
+    name: computeregionautoscaler_v1alpha1
+  - apiVersion: compute.cnrm.cloud.google.com/v1alpha1
+    filename: compute.cnrm.cloud.google.com/computebackendbucketsignedurlkey_v1alpha1.json
+    kind: computebackendbucketsignedurlkey
+    name: computebackendbucketsignedurlkey_v1alpha1
+  - apiVersion: compute.cnrm.cloud.google.com/v1beta1
+    filename: compute.cnrm.cloud.google.com/computeprojectmetadata_v1beta1.json
+    kind: computeprojectmetadata
+    name: computeprojectmetadata_v1beta1
+  - apiVersion: compute.cnrm.cloud.google.com/v1beta1
+    filename: compute.cnrm.cloud.google.com/computereservation_v1beta1.json
+    kind: computereservation
+    name: computereservation_v1beta1
+  - apiVersion: compute.cnrm.cloud.google.com/v1beta1
+    filename: compute.cnrm.cloud.google.com/computetargetgrpcproxy_v1beta1.json
+    kind: computetargetgrpcproxy
+    name: computetargetgrpcproxy_v1beta1
+  - apiVersion: compute.cnrm.cloud.google.com/v1beta1
+    filename: compute.cnrm.cloud.google.com/computenetworkfirewallpolicyassociation_v1beta1.json
+    kind: computenetworkfirewallpolicyassociation
+    name: computenetworkfirewallpolicyassociation_v1beta1
+  - apiVersion: compute.cnrm.cloud.google.com/v1alpha1
+    filename: compute.cnrm.cloud.google.com/computemachineimage_v1alpha1.json
+    kind: computemachineimage
+    name: computemachineimage_v1alpha1
+  - apiVersion: compute.cnrm.cloud.google.com/v1beta1
+    filename: compute.cnrm.cloud.google.com/computeimage_v1beta1.json
+    kind: computeimage
+    name: computeimage_v1beta1
+  - apiVersion: compute.cnrm.cloud.google.com/v1alpha1
+    filename: compute.cnrm.cloud.google.com/computenetworkpeeringroutesconfig_v1alpha1.json
+    kind: computenetworkpeeringroutesconfig
+    name: computenetworkpeeringroutesconfig_v1alpha1
+  - apiVersion: compute.cnrm.cloud.google.com/v1alpha1
+    filename: compute.cnrm.cloud.google.com/computeregionsslpolicy_v1alpha1.json
+    kind: computeregionsslpolicy
+    name: computeregionsslpolicy_v1alpha1
+  - apiVersion: compute.cnrm.cloud.google.com/v1beta1
+    filename: compute.cnrm.cloud.google.com/computerouterinterface_v1beta1.json
+    kind: computerouterinterface
+    name: computerouterinterface_v1beta1
+  - apiVersion: compute.cnrm.cloud.google.com/v1beta1
+    filename: compute.cnrm.cloud.google.com/computesubnetwork_v1beta1.json
+    kind: computesubnetwork
+    name: computesubnetwork_v1beta1
+  - apiVersion: compute.cnrm.cloud.google.com/v1alpha1
+    filename: compute.cnrm.cloud.google.com/computeorganizationsecuritypolicy_v1alpha1.json
+    kind: computeorganizationsecuritypolicy
+    name: computeorganizationsecuritypolicy_v1alpha1
+  - apiVersion: compute.cnrm.cloud.google.com/v1alpha1
+    filename: compute.cnrm.cloud.google.com/computediskresourcepolicyattachment_v1alpha1.json
+    kind: computediskresourcepolicyattachment
+    name: computediskresourcepolicyattachment_v1alpha1
+  - apiVersion: compute.cnrm.cloud.google.com/v1beta1
+    filename: compute.cnrm.cloud.google.com/computeinstancegroup_v1beta1.json
+    kind: computeinstancegroup
+    name: computeinstancegroup_v1beta1
+  - apiVersion: compute.cnrm.cloud.google.com/v1beta1
+    filename: compute.cnrm.cloud.google.com/computefirewallpolicyassociation_v1beta1.json
+    kind: computefirewallpolicyassociation
+    name: computefirewallpolicyassociation_v1beta1
+  - apiVersion: compute.cnrm.cloud.google.com/v1beta1
+    filename: compute.cnrm.cloud.google.com/computefirewallpolicy_v1beta1.json
+    kind: computefirewallpolicy
+    name: computefirewallpolicy_v1beta1
+  - apiVersion: compute.cnrm.cloud.google.com/v1beta1
+    filename: compute.cnrm.cloud.google.com/computetargettcpproxy_v1beta1.json
+    kind: ComputeTargetTCPProxy
+    name: computetargettcpproxy_v1beta1
+  - apiVersion: compute.cnrm.cloud.google.com/v1beta1
+    filename: compute.cnrm.cloud.google.com/computetargetpool_v1beta1.json
+    kind: computetargetpool
+    name: computetargetpool_v1beta1
+  - apiVersion: compute.cnrm.cloud.google.com/v1beta1
+    filename: compute.cnrm.cloud.google.com/computeregionnetworkendpointgroup_v1beta1.json
+    kind: computeregionnetworkendpointgroup
+    name: computeregionnetworkendpointgroup_v1beta1
+  - apiVersion: compute.cnrm.cloud.google.com/v1beta1
+    filename: compute.cnrm.cloud.google.com/computetargethttpproxy_v1beta1.json
+    kind: computetargethttpproxy
+    name: computetargethttpproxy_v1beta1
+  - apiVersion: compute.cnrm.cloud.google.com/v1beta1
+    filename: compute.cnrm.cloud.google.com/computevpntunnel_v1beta1.json
+    kind: computevpntunnel
+    name: computevpntunnel_v1beta1
+  - apiVersion: compute.cnrm.cloud.google.com/v1beta1
+    filename: compute.cnrm.cloud.google.com/computehttpshealthcheck_v1beta1.json
+    kind: computehttpshealthcheck
+    name: computehttpshealthcheck_v1beta1
+  - apiVersion: compute.cnrm.cloud.google.com/v1beta1
+    filename: compute.cnrm.cloud.google.com/computenetworkpeering_v1beta1.json
+    kind: computenetworkpeering
+    name: computenetworkpeering_v1beta1
+  - apiVersion: compute.cnrm.cloud.google.com/v1beta1
+    filename: compute.cnrm.cloud.google.com/computeserviceattachment_v1beta1.json
+    kind: computeserviceattachment
+    name: computeserviceattachment_v1beta1
+  - apiVersion: compute.cnrm.cloud.google.com/v1alpha1
+    filename: compute.cnrm.cloud.google.com/computenetworkendpoint_v1alpha1.json
+    kind: computenetworkendpoint
+    name: computenetworkendpoint_v1alpha1
+  - apiVersion: compute.cnrm.cloud.google.com/v1beta1
+    filename: compute.cnrm.cloud.google.com/computenodetemplate_v1beta1.json
+    kind: computenodetemplate
+    name: computenodetemplate_v1beta1
+  - apiVersion: compute.cnrm.cloud.google.com/v1alpha1
+    filename: compute.cnrm.cloud.google.com/computeautoscaler_v1alpha1.json
+    kind: computeautoscaler
+    name: computeautoscaler_v1alpha1
+  - apiVersion: compute.cnrm.cloud.google.com/v1beta1
+    filename: compute.cnrm.cloud.google.com/computemanagedsslcertificate_v1beta1.json
+    kind: computemanagedsslcertificate
+    name: computemanagedsslcertificate_v1beta1
+  - apiVersion: compute.cnrm.cloud.google.com/v1beta1
+    filename: compute.cnrm.cloud.google.com/computeinstancetemplate_v1beta1.json
+    kind: computeinstancetemplate
+    name: computeinstancetemplate_v1beta1
+  - apiVersion: compute.cnrm.cloud.google.com/v1beta1
+    filename: compute.cnrm.cloud.google.com/computefirewall_v1beta1.json
+    kind: computefirewall
+    name: computefirewall_v1beta1
+  - apiVersion: compute.cnrm.cloud.google.com/v1beta1
+    filename: compute.cnrm.cloud.google.com/computenodegroup_v1beta1.json
+    kind: computenodegroup
+    name: computenodegroup_v1beta1
+  - apiVersion: compute.cnrm.cloud.google.com/v1beta1
+    filename: compute.cnrm.cloud.google.com/computeinstance_v1beta1.json
+    kind: computeinstance
+    name: computeinstance_v1beta1
+  - apiVersion: compute.cnrm.cloud.google.com/v1beta1
+    filename: compute.cnrm.cloud.google.com/computesslpolicy_v1beta1.json
+    kind: computesslpolicy
+    name: computesslpolicy_v1beta1
+config.concierge.pinniped.dev:
+  - apiVersion: config.concierge.pinniped.dev/v1alpha1
+    filename: config.concierge.pinniped.dev/credentialissuer_v1alpha1.json
+    kind: CredentialIssuer
+    name: credentialissuer_v1alpha1
+config.gatekeeper.sh:
+  - apiVersion: config.gatekeeper.sh/v1alpha1
+    filename: config.gatekeeper.sh/config_v1alpha1.json
+    kind: Config
+    name: config_v1alpha1
+config.supervisor.pinniped.dev:
+  - apiVersion: config.supervisor.pinniped.dev/v1alpha1
+    filename: config.supervisor.pinniped.dev/federationdomain_v1alpha1.json
+    kind: FederationDomain
+    name: federationdomain_v1alpha1
+  - apiVersion: config.supervisor.pinniped.dev/v1alpha1
+    filename: config.supervisor.pinniped.dev/oidcclient_v1alpha1.json
+    kind: OIDCClient
+    name: oidcclient_v1alpha1
+configcontroller.cnrm.cloud.google.com:
+  - apiVersion: configcontroller.cnrm.cloud.google.com/v1beta1
+    filename: configcontroller.cnrm.cloud.google.com/configcontrollerinstance_v1beta1.json
+    kind: configcontrollerinstance
+    name: configcontrollerinstance_v1beta1
+configuration.konghq.com:
+  - apiVersion: configuration.konghq.com/v1
+    filename: configuration.konghq.com/kongclusterplugin_v1.json
+    kind: KongClusterPlugin
+    name: kongclusterplugin_v1
+  - apiVersion: configuration.konghq.com/v1
+    filename: configuration.konghq.com/kongingress_v1.json
+    kind: KongIngress
+    name: kongingress_v1
+  - apiVersion: configuration.konghq.com/v1
+    filename: configuration.konghq.com/kongplugin_v1.json
+    kind: KongPlugin
+    name: kongplugin_v1
+  - apiVersion: configuration.konghq.com/v1
+    filename: configuration.konghq.com/kongconsumer_v1.json
+    kind: KongConsumer
+    name: kongconsumer_v1
+  - apiVersion: configuration.konghq.com/v1alpha1
+    filename: configuration.konghq.com/ingressclassparameters_v1alpha1.json
+    kind: IngressClassParameters
+    name: ingressclassparameters_v1alpha1
+  - apiVersion: configuration.konghq.com/v1beta1
+    filename: configuration.konghq.com/udpingress_v1beta1.json
+    kind: UDPIngress
+    name: udpingress_v1beta1
+  - apiVersion: configuration.konghq.com/v1beta1
+    filename: configuration.konghq.com/tcpingress_v1beta1.json
+    kind: TCPIngress
+    name: tcpingress_v1beta1
+container.cnrm.cloud.google.com:
+  - apiVersion: container.cnrm.cloud.google.com/v1beta1
+    filename: container.cnrm.cloud.google.com/containernodepool_v1beta1.json
+    kind: containernodepool
+    name: containernodepool_v1beta1
+  - apiVersion: container.cnrm.cloud.google.com/v1beta1
+    filename: container.cnrm.cloud.google.com/containercluster_v1beta1.json
+    kind: containercluster
+    name: containercluster_v1beta1
+containeranalysis.cnrm.cloud.google.com:
+  - apiVersion: containeranalysis.cnrm.cloud.google.com/v1beta1
+    filename: containeranalysis.cnrm.cloud.google.com/containeranalysisnote_v1beta1.json
+    kind: containeranalysisnote
+    name: containeranalysisnote_v1beta1
+  - apiVersion: containeranalysis.cnrm.cloud.google.com/v1alpha1
+    filename: containeranalysis.cnrm.cloud.google.com/containeranalysisoccurrence_v1alpha1.json
+    kind: containeranalysisoccurrence
+    name: containeranalysisoccurrence_v1alpha1
+containerattached.cnrm.cloud.google.com:
+  - apiVersion: containerattached.cnrm.cloud.google.com/v1beta1
+    filename: containerattached.cnrm.cloud.google.com/containerattachedcluster_v1beta1.json
+    kind: ContainerAttachedCluster
+    name: containerattachedcluster_v1beta1
+controlplane.cluster.x-k8s.io:
+  - apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+    filename: controlplane.cluster.x-k8s.io/awsmanagedcontrolplane_v1beta2.json
+    kind: AWSManagedControlPlane
+    name: awsmanagedcontrolplane_v1beta2
+  - apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
+    filename: controlplane.cluster.x-k8s.io/kubeadmcontrolplane_v1alpha3.json
+    kind: KubeadmControlPlane
+    name: kubeadmcontrolplane_v1alpha3
+  - apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+    filename: controlplane.cluster.x-k8s.io/rosacontrolplane_v1beta2.json
+    kind: ROSAControlPlane
+    name: rosacontrolplane_v1beta2
+  - apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
+    filename: controlplane.cluster.x-k8s.io/awsmanagedcontrolplane_v1alpha3.json
+    kind: AWSManagedControlPlane
+    name: awsmanagedcontrolplane_v1alpha3
+  - apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    filename: controlplane.cluster.x-k8s.io/kubeadmcontrolplane_v1beta1.json
+    kind: KubeadmControlPlane
+    name: kubeadmcontrolplane_v1beta1
+  - apiVersion: controlplane.cluster.x-k8s.io/v1alpha4
+    filename: controlplane.cluster.x-k8s.io/kubeadmcontrolplane_v1alpha4.json
+    kind: KubeadmControlPlane
+    name: kubeadmcontrolplane_v1alpha4
+  - apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    filename: controlplane.cluster.x-k8s.io/awsmanagedcontrolplane_v1beta1.json
+    kind: AWSManagedControlPlane
+    name: awsmanagedcontrolplane_v1beta1
+  - apiVersion: controlplane.cluster.x-k8s.io/v1alpha4
+    filename: controlplane.cluster.x-k8s.io/kubeadmcontrolplanetemplate_v1alpha4.json
+    kind: KubeadmControlPlaneTemplate
+    name: kubeadmcontrolplanetemplate_v1alpha4
+  - apiVersion: controlplane.cluster.x-k8s.io/v1alpha4
+    filename: controlplane.cluster.x-k8s.io/awsmanagedcontrolplane_v1alpha4.json
+    kind: AWSManagedControlPlane
+    name: awsmanagedcontrolplane_v1alpha4
+  - apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    filename: controlplane.cluster.x-k8s.io/kubeadmcontrolplanetemplate_v1beta1.json
+    kind: KubeadmControlPlaneTemplate
+    name: kubeadmcontrolplanetemplate_v1beta1
+core.cnrm.cloud.google.com:
+  - apiVersion: core.cnrm.cloud.google.com/v1beta1
+    filename: core.cnrm.cloud.google.com/configconnector_v1beta1.json
+    kind: ConfigConnector
+    name: configconnector_v1beta1
+  - apiVersion: core.cnrm.cloud.google.com/v1alpha1
+    filename: core.cnrm.cloud.google.com/servicemapping_v1alpha1.json
+    kind: servicemapping
+    name: servicemapping_v1alpha1
+  - apiVersion: core.cnrm.cloud.google.com/v1beta1
+    filename: core.cnrm.cloud.google.com/configconnectorcontext_v1beta1.json
+    kind: ConfigConnectorContext
+    name: configconnectorcontext_v1beta1
+core.strimzi.io:
+  - apiVersion: core.strimzi.io/v1beta2
+    filename: core.strimzi.io/strimzipodset_v1beta2.json
+    kind: strimzipodset
+    name: strimzipodset_v1beta2
+crd.k8s.amazonaws.com:
+  - apiVersion: crd.k8s.amazonaws.com/v1alpha1
+    filename: crd.k8s.amazonaws.com/eniconfig_v1alpha1.json
+    kind: ENIConfig
+    name: eniconfig_v1alpha1
+customize.core.cnrm.cloud.google.com:
+  - apiVersion: customize.core.cnrm.cloud.google.com/v1alpha1
+    filename: customize.core.cnrm.cloud.google.com/controllerresource_v1alpha1.json
+    kind: ControllerResource
+    name: controllerresource_v1alpha1
+  - apiVersion: customize.core.cnrm.cloud.google.com/v1beta1
+    filename: customize.core.cnrm.cloud.google.com/mutatingwebhookconfigurationcustomization_v1beta1.json
+    kind: MutatingWebhookConfigurationCustomization
+    name: mutatingwebhookconfigurationcustomization_v1beta1
+  - apiVersion: customize.core.cnrm.cloud.google.com/v1alpha1
+    filename: customize.core.cnrm.cloud.google.com/mutatingwebhookconfigurationcustomization_v1alpha1.json
+    kind: MutatingWebhookConfigurationCustomization
+    name: mutatingwebhookconfigurationcustomization_v1alpha1
+  - apiVersion: customize.core.cnrm.cloud.google.com/v1beta1
+    filename: customize.core.cnrm.cloud.google.com/validatingwebhookconfigurationcustomization_v1beta1.json
+    kind: ValidatingWebhookConfigurationCustomization
+    name: validatingwebhookconfigurationcustomization_v1beta1
+  - apiVersion: customize.core.cnrm.cloud.google.com/v1alpha1
+    filename: customize.core.cnrm.cloud.google.com/namespacedcontrollerresource_v1alpha1.json
+    kind: NamespacedControllerResource
+    name: namespacedcontrollerresource_v1alpha1
+  - apiVersion: customize.core.cnrm.cloud.google.com/v1beta1
+    filename: customize.core.cnrm.cloud.google.com/namespacedcontrollerresource_v1beta1.json
+    kind: NamespacedControllerResource
+    name: namespacedcontrollerresource_v1beta1
+  - apiVersion: customize.core.cnrm.cloud.google.com/v1alpha1
+    filename: customize.core.cnrm.cloud.google.com/validatingwebhookconfigurationcustomization_v1alpha1.json
+    kind: ValidatingWebhookConfigurationCustomization
+    name: validatingwebhookconfigurationcustomization_v1alpha1
+  - apiVersion: customize.core.cnrm.cloud.google.com/v1beta1
+    filename: customize.core.cnrm.cloud.google.com/controllerresource_v1beta1.json
+    kind: ControllerResource
+    name: controllerresource_v1beta1
+dapr.io:
+  - apiVersion: dapr.io/v1alpha1
+    filename: dapr.io/component_v1alpha1.json
+    kind: Component
+    name: component_v1alpha1
+  - apiVersion: dapr.io/v1alpha1
+    filename: dapr.io/configuration_v1alpha1.json
+    kind: Configuration
+    name: configuration_v1alpha1
+  - apiVersion: dapr.io/v1alpha1
+    filename: dapr.io/subscription_v1alpha1.json
+    kind: Subscription
+    name: subscription_v1alpha1
+  - apiVersion: dapr.io/v2alpha1
+    filename: dapr.io/subscription_v2alpha1.json
+    kind: Subscription
+    name: subscription_v2alpha1
+  - apiVersion: dapr.io/v1alpha1
+    filename: dapr.io/resiliency_v1alpha1.json
+    kind: resiliency
+    name: resiliency_v1alpha1
+databases.spotahome.com:
+  - apiVersion: databases.spotahome.com/v1
+    filename: databases.spotahome.com/redisfailover_v1.json
+    kind: RedisFailover
+    name: redisfailover_v1
+datacatalog.cnrm.cloud.google.com:
+  - apiVersion: datacatalog.cnrm.cloud.google.com/v1alpha1
+    filename: datacatalog.cnrm.cloud.google.com/datacatalogentry_v1alpha1.json
+    kind: datacatalogentry
+    name: datacatalogentry_v1alpha1
+  - apiVersion: datacatalog.cnrm.cloud.google.com/v1alpha1
+    filename: datacatalog.cnrm.cloud.google.com/datacatalogtag_v1alpha1.json
+    kind: datacatalogtag
+    name: datacatalogtag_v1alpha1
+  - apiVersion: datacatalog.cnrm.cloud.google.com/v1beta1
+    filename: datacatalog.cnrm.cloud.google.com/datacatalogpolicytag_v1beta1.json
+    kind: datacatalogpolicytag
+    name: datacatalogpolicytag_v1beta1
+  - apiVersion: datacatalog.cnrm.cloud.google.com/v1beta1
+    filename: datacatalog.cnrm.cloud.google.com/datacatalogtaxonomy_v1beta1.json
+    kind: datacatalogtaxonomy
+    name: datacatalogtaxonomy_v1beta1
+  - apiVersion: datacatalog.cnrm.cloud.google.com/v1alpha1
+    filename: datacatalog.cnrm.cloud.google.com/datacatalogentrygroup_v1alpha1.json
+    kind: datacatalogentrygroup
+    name: datacatalogentrygroup_v1alpha1
+  - apiVersion: datacatalog.cnrm.cloud.google.com/v1alpha1
+    filename: datacatalog.cnrm.cloud.google.com/datacatalogtagtemplate_v1alpha1.json
+    kind: datacatalogtagtemplate
+    name: datacatalogtagtemplate_v1alpha1
+datadoghq.com:
+  - apiVersion: datadoghq.com/v2alpha1
+    filename: datadoghq.com/datadogagent_v2alpha1.json
+    kind: datadogagent
+    name: datadogagent_v2alpha1
+  - apiVersion: datadoghq.com/v1alpha1
+    filename: datadoghq.com/datadogagent_v1alpha1.json
+    kind: datadogagent
+    name: datadogagent_v1alpha1
+  - apiVersion: datadoghq.com/v1alpha1
+    filename: datadoghq.com/datadogmonitor_v1alpha1.json
+    kind: DatadogMonitor
+    name: datadogmonitor_v1alpha1
+  - apiVersion: datadoghq.com/v1alpha1
+    filename: datadoghq.com/datadogmetric_v1alpha1.json
+    kind: DatadogMetric
+    name: datadogmetric_v1alpha1
+  - apiVersion: datadoghq.com/v1alpha1
+    filename: datadoghq.com/datadogpodautoscaler_v1alpha1.json
+    kind: DatadogPodAutoscaler
+    name: datadogpodautoscaler_v1alpha1
+dataflow.cnrm.cloud.google.com:
+  - apiVersion: dataflow.cnrm.cloud.google.com/v1beta1
+    filename: dataflow.cnrm.cloud.google.com/dataflowflextemplatejob_v1beta1.json
+    kind: DataflowFlexTemplateJob
+    name: dataflowflextemplatejob_v1beta1
+  - apiVersion: dataflow.cnrm.cloud.google.com/v1beta1
+    filename: dataflow.cnrm.cloud.google.com/dataflowjob_v1beta1.json
+    kind: dataflowjob
+    name: dataflowjob_v1beta1
+dataform.cnrm.cloud.google.com:
+  - apiVersion: dataform.cnrm.cloud.google.com/v1beta1
+    filename: dataform.cnrm.cloud.google.com/dataformrepository_v1beta1.json
+    kind: DataformRepository
+    name: dataformrepository_v1beta1
+  - apiVersion: dataform.cnrm.cloud.google.com/v1alpha1
+    filename: dataform.cnrm.cloud.google.com/dataformrepository_v1alpha1.json
+    kind: DataformRepository
+    name: dataformrepository_v1alpha1
+datafusion.cnrm.cloud.google.com:
+  - apiVersion: datafusion.cnrm.cloud.google.com/v1beta1
+    filename: datafusion.cnrm.cloud.google.com/datafusioninstance_v1beta1.json
+    kind: datafusioninstance
+    name: datafusioninstance_v1beta1
+dataproc.cnrm.cloud.google.com:
+  - apiVersion: dataproc.cnrm.cloud.google.com/v1beta1
+    filename: dataproc.cnrm.cloud.google.com/dataproccluster_v1beta1.json
+    kind: dataproccluster
+    name: dataproccluster_v1beta1
+  - apiVersion: dataproc.cnrm.cloud.google.com/v1beta1
+    filename: dataproc.cnrm.cloud.google.com/dataprocworkflowtemplate_v1beta1.json
+    kind: dataprocworkflowtemplate
+    name: dataprocworkflowtemplate_v1beta1
+  - apiVersion: dataproc.cnrm.cloud.google.com/v1beta1
+    filename: dataproc.cnrm.cloud.google.com/dataprocautoscalingpolicy_v1beta1.json
+    kind: dataprocautoscalingpolicy
+    name: dataprocautoscalingpolicy_v1beta1
+datastore.cnrm.cloud.google.com:
+  - apiVersion: datastore.cnrm.cloud.google.com/v1alpha1
+    filename: datastore.cnrm.cloud.google.com/datastoreindex_v1alpha1.json
+    kind: datastoreindex
+    name: datastoreindex_v1alpha1
+datastream.cnrm.cloud.google.com:
+  - apiVersion: datastream.cnrm.cloud.google.com/v1alpha1
+    filename: datastream.cnrm.cloud.google.com/datastreamprivateconnection_v1alpha1.json
+    kind: datastreamprivateconnection
+    name: datastreamprivateconnection_v1alpha1
+  - apiVersion: datastream.cnrm.cloud.google.com/v1alpha1
+    filename: datastream.cnrm.cloud.google.com/datastreamstream_v1alpha1.json
+    kind: datastreamstream
+    name: datastreamstream_v1alpha1
+  - apiVersion: datastream.cnrm.cloud.google.com/v1alpha1
+    filename: datastream.cnrm.cloud.google.com/datastreamconnectionprofile_v1alpha1.json
+    kind: datastreamconnectionprofile
+    name: datastreamconnectionprofile_v1alpha1
+dbaas.percona.com:
+  - apiVersion: dbaas.percona.com/v1
+    filename: dbaas.percona.com/databasecluster_v1.json
+    kind: DatabaseCluster
+    name: databasecluster_v1
+  - apiVersion: dbaas.percona.com/v1
+    filename: dbaas.percona.com/databaseclusterrestore_v1.json
+    kind: DatabaseClusterRestore
+    name: databaseclusterrestore_v1
+  - apiVersion: dbaas.percona.com/v1
+    filename: dbaas.percona.com/databaseengine_v1.json
+    kind: DatabaseEngine
+    name: databaseengine_v1
+deploymentmanager.cnrm.cloud.google.com:
+  - apiVersion: deploymentmanager.cnrm.cloud.google.com/v1alpha1
+    filename: deploymentmanager.cnrm.cloud.google.com/deploymentmanagerdeployment_v1alpha1.json
+    kind: deploymentmanagerdeployment
+    name: deploymentmanagerdeployment_v1alpha1
+dex.coreos.com:
+  - apiVersion: dex.coreos.com/v1
+    filename: dex.coreos.com/oauth2client_v1.json
+    kind: oauth2client
+    name: oauth2client_v1
+  - apiVersion: dex.coreos.com/v1
+    filename: dex.coreos.com/authrequest_v1.json
+    kind: authrequest
+    name: authrequest_v1
+  - apiVersion: dex.coreos.com/v1
+    filename: dex.coreos.com/authcode_v1.json
+    kind: authcode
+    name: authcode_v1
+  - apiVersion: dex.coreos.com/v1
+    filename: dex.coreos.com/password_v1.json
+    kind: password
+    name: password_v1
+  - apiVersion: dex.coreos.com/v1
+    filename: dex.coreos.com/refreshtoken_v1.json
+    kind: refreshtoken
+    name: refreshtoken_v1
+  - apiVersion: dex.coreos.com/v1
+    filename: dex.coreos.com/connector_v1.json
+    kind: connector
+    name: connector_v1
+  - apiVersion: dex.coreos.com/v1
+    filename: dex.coreos.com/devicerequest_v1.json
+    kind: devicerequest
+    name: devicerequest_v1
+  - apiVersion: dex.coreos.com/v1
+    filename: dex.coreos.com/offlinesessions_v1.json
+    kind: offlinesessions
+    name: offlinesessions_v1
+  - apiVersion: dex.coreos.com/v1
+    filename: dex.coreos.com/devicetoken_v1.json
+    kind: devicetoken
+    name: devicetoken_v1
+  - apiVersion: dex.coreos.com/v1
+    filename: dex.coreos.com/signingkey_v1.json
+    kind: signingkey
+    name: signingkey_v1
+dialogflow.cnrm.cloud.google.com:
+  - apiVersion: dialogflow.cnrm.cloud.google.com/v1alpha1
+    filename: dialogflow.cnrm.cloud.google.com/dialogflowentitytype_v1alpha1.json
+    kind: dialogflowentitytype
+    name: dialogflowentitytype_v1alpha1
+  - apiVersion: dialogflow.cnrm.cloud.google.com/v1alpha1
+    filename: dialogflow.cnrm.cloud.google.com/dialogflowfulfillment_v1alpha1.json
+    kind: dialogflowfulfillment
+    name: dialogflowfulfillment_v1alpha1
+  - apiVersion: dialogflow.cnrm.cloud.google.com/v1alpha1
+    filename: dialogflow.cnrm.cloud.google.com/dialogflowagent_v1alpha1.json
+    kind: dialogflowagent
+    name: dialogflowagent_v1alpha1
+  - apiVersion: dialogflow.cnrm.cloud.google.com/v1alpha1
+    filename: dialogflow.cnrm.cloud.google.com/dialogflowintent_v1alpha1.json
+    kind: dialogflowintent
+    name: dialogflowintent_v1alpha1
+dialogflowcx.cnrm.cloud.google.com:
+  - apiVersion: dialogflowcx.cnrm.cloud.google.com/v1alpha1
+    filename: dialogflowcx.cnrm.cloud.google.com/dialogflowcxintent_v1alpha1.json
+    kind: dialogflowcxintent
+    name: dialogflowcxintent_v1alpha1
+  - apiVersion: dialogflowcx.cnrm.cloud.google.com/v1alpha1
+    filename: dialogflowcx.cnrm.cloud.google.com/dialogflowcxentitytype_v1alpha1.json
+    kind: dialogflowcxentitytype
+    name: dialogflowcxentitytype_v1alpha1
+  - apiVersion: dialogflowcx.cnrm.cloud.google.com/v1alpha1
+    filename: dialogflowcx.cnrm.cloud.google.com/dialogflowcxflow_v1alpha1.json
+    kind: dialogflowcxflow
+    name: dialogflowcxflow_v1alpha1
+  - apiVersion: dialogflowcx.cnrm.cloud.google.com/v1alpha1
+    filename: dialogflowcx.cnrm.cloud.google.com/dialogflowcxagent_v1alpha1.json
+    kind: dialogflowcxagent
+    name: dialogflowcxagent_v1alpha1
+  - apiVersion: dialogflowcx.cnrm.cloud.google.com/v1alpha1
+    filename: dialogflowcx.cnrm.cloud.google.com/dialogflowcxpage_v1alpha1.json
+    kind: dialogflowcxpage
+    name: dialogflowcxpage_v1alpha1
+  - apiVersion: dialogflowcx.cnrm.cloud.google.com/v1alpha1
+    filename: dialogflowcx.cnrm.cloud.google.com/dialogflowcxwebhook_v1alpha1.json
+    kind: dialogflowcxwebhook
+    name: dialogflowcxwebhook_v1alpha1
+discoveryengine.cnrm.cloud.google.com:
+  - apiVersion: discoveryengine.cnrm.cloud.google.com/v1alpha1
+    filename: discoveryengine.cnrm.cloud.google.com/discoveryenginedatastore_v1alpha1.json
+    kind: DiscoveryEngineDataStore
+    name: discoveryenginedatastore_v1alpha1
+distro.eks.amazonaws.com:
+  - apiVersion: distro.eks.amazonaws.com/v1alpha1
+    filename: distro.eks.amazonaws.com/release_v1alpha1.json
+    kind: Release
+    name: release_v1alpha1
+dlp.cnrm.cloud.google.com:
+  - apiVersion: dlp.cnrm.cloud.google.com/v1beta1
+    filename: dlp.cnrm.cloud.google.com/dlpjobtrigger_v1beta1.json
+    kind: dlpjobtrigger
+    name: dlpjobtrigger_v1beta1
+  - apiVersion: dlp.cnrm.cloud.google.com/v1beta1
+    filename: dlp.cnrm.cloud.google.com/dlpinspecttemplate_v1beta1.json
+    kind: dlpinspecttemplate
+    name: dlpinspecttemplate_v1beta1
+  - apiVersion: dlp.cnrm.cloud.google.com/v1beta1
+    filename: dlp.cnrm.cloud.google.com/dlpstoredinfotype_v1beta1.json
+    kind: dlpstoredinfotype
+    name: dlpstoredinfotype_v1beta1
+  - apiVersion: dlp.cnrm.cloud.google.com/v1beta1
+    filename: dlp.cnrm.cloud.google.com/dlpdeidentifytemplate_v1beta1.json
+    kind: dlpdeidentifytemplate
+    name: dlpdeidentifytemplate_v1beta1
+dns.cnrm.cloud.google.com:
+  - apiVersion: dns.cnrm.cloud.google.com/v1beta1
+    filename: dns.cnrm.cloud.google.com/dnspolicy_v1beta1.json
+    kind: dnspolicy
+    name: dnspolicy_v1beta1
+  - apiVersion: dns.cnrm.cloud.google.com/v1beta1
+    filename: dns.cnrm.cloud.google.com/dnsmanagedzone_v1beta1.json
+    kind: dnsmanagedzone
+    name: dnsmanagedzone_v1beta1
+  - apiVersion: dns.cnrm.cloud.google.com/v1alpha1
+    filename: dns.cnrm.cloud.google.com/dnsresponsepolicyrule_v1alpha1.json
+    kind: dnsresponsepolicyrule
+    name: dnsresponsepolicyrule_v1alpha1
+  - apiVersion: dns.cnrm.cloud.google.com/v1beta1
+    filename: dns.cnrm.cloud.google.com/dnsrecordset_v1beta1.json
+    kind: dnsrecordset
+    name: dnsrecordset_v1beta1
+  - apiVersion: dns.cnrm.cloud.google.com/v1alpha1
+    filename: dns.cnrm.cloud.google.com/dnsresponsepolicy_v1alpha1.json
+    kind: dnsresponsepolicy
+    name: dnsresponsepolicy_v1alpha1
+documentai.cnrm.cloud.google.com:
+  - apiVersion: documentai.cnrm.cloud.google.com/v1alpha1
+    filename: documentai.cnrm.cloud.google.com/documentaiprocessor_v1alpha1.json
+    kind: documentaiprocessor
+    name: documentaiprocessor_v1alpha1
+  - apiVersion: documentai.cnrm.cloud.google.com/v1alpha1
+    filename: documentai.cnrm.cloud.google.com/documentaiprocessordefaultversion_v1alpha1.json
+    kind: documentaiprocessordefaultversion
+    name: documentaiprocessordefaultversion_v1alpha1
+dragonflydb.io:
+  - apiVersion: dragonflydb.io/v1alpha1
+    filename: dragonflydb.io/dragonfly_v1alpha1.json
+    kind: Dragonfly
+    name: dragonfly_v1alpha1
+druid.apache.org:
+  - apiVersion: druid.apache.org/v1alpha1
+    filename: druid.apache.org/druid_v1alpha1.json
+    kind: Druid
+    name: druid_v1alpha1
+  - apiVersion: druid.apache.org/v1alpha1
+    filename: druid.apache.org/druidingestion_v1alpha1.json
+    kind: druidingestion
+    name: druidingestion_v1alpha1
+dynamodb.services.k8s.aws:
+  - apiVersion: dynamodb.services.k8s.aws/v1alpha1
+    filename: dynamodb.services.k8s.aws/backup_v1alpha1.json
+    kind: Backup
+    name: backup_v1alpha1
+  - apiVersion: dynamodb.services.k8s.aws/v1alpha1
+    filename: dynamodb.services.k8s.aws/table_v1alpha1.json
+    kind: Table
+    name: table_v1alpha1
+  - apiVersion: dynamodb.services.k8s.aws/v1alpha1
+    filename: dynamodb.services.k8s.aws/globaltable_v1alpha1.json
+    kind: GlobalTable
+    name: globaltable_v1alpha1
+dynatrace.com:
+  - apiVersion: dynatrace.com/v1alpha1
+    filename: dynatrace.com/edgeconnect_v1alpha1.json
+    kind: EdgeConnect
+    name: edgeconnect_v1alpha1
+  - apiVersion: dynatrace.com/v1alpha1
+    filename: dynatrace.com/dynakube_v1alpha1.json
+    kind: DynaKube
+    name: dynakube_v1alpha1
+  - apiVersion: dynatrace.com/v1beta1
+    filename: dynatrace.com/dynakube_v1beta1.json
+    kind: DynaKube
+    name: dynakube_v1beta1
+ec2.services.k8s.aws:
+  - apiVersion: ec2.services.k8s.aws/v1alpha1
+    filename: ec2.services.k8s.aws/dhcpoptions_v1alpha1.json
+    kind: DHCPOptions
+    name: dhcpoptions_v1alpha1
+  - apiVersion: ec2.services.k8s.aws/v1alpha1
+    filename: ec2.services.k8s.aws/routetable_v1alpha1.json
+    kind: RouteTable
+    name: routetable_v1alpha1
+  - apiVersion: ec2.services.k8s.aws/v1alpha1
+    filename: ec2.services.k8s.aws/transitgateway_v1alpha1.json
+    kind: TransitGateway
+    name: transitgateway_v1alpha1
+  - apiVersion: ec2.services.k8s.aws/v1alpha1
+    filename: ec2.services.k8s.aws/flowlog_v1alpha1.json
+    kind: FlowLog
+    name: flowlog_v1alpha1
+  - apiVersion: ec2.services.k8s.aws/v1alpha1
+    filename: ec2.services.k8s.aws/internetgateway_v1alpha1.json
+    kind: InternetGateway
+    name: internetgateway_v1alpha1
+  - apiVersion: ec2.services.k8s.aws/v1alpha1
+    filename: ec2.services.k8s.aws/vpcendpoint_v1alpha1.json
+    kind: VPCEndpoint
+    name: vpcendpoint_v1alpha1
+  - apiVersion: ec2.services.k8s.aws/v1alpha1
+    filename: ec2.services.k8s.aws/vpc_v1alpha1.json
+    kind: VPC
+    name: vpc_v1alpha1
+  - apiVersion: ec2.services.k8s.aws/v1alpha1
+    filename: ec2.services.k8s.aws/elasticipaddress_v1alpha1.json
+    kind: ElasticIPAddress
+    name: elasticipaddress_v1alpha1
+  - apiVersion: ec2.services.k8s.aws/v1alpha1
+    filename: ec2.services.k8s.aws/instance_v1alpha1.json
+    kind: Instance
+    name: instance_v1alpha1
+  - apiVersion: ec2.services.k8s.aws/v1alpha1
+    filename: ec2.services.k8s.aws/natgateway_v1alpha1.json
+    kind: NATGateway
+    name: natgateway_v1alpha1
+  - apiVersion: ec2.services.k8s.aws/v1alpha1
+    filename: ec2.services.k8s.aws/securitygroup_v1alpha1.json
+    kind: SecurityGroup
+    name: securitygroup_v1alpha1
+  - apiVersion: ec2.services.k8s.aws/v1alpha1
+    filename: ec2.services.k8s.aws/subnet_v1alpha1.json
+    kind: Subnet
+    name: subnet_v1alpha1
+ecr.services.k8s.aws:
+  - apiVersion: ecr.services.k8s.aws/v1alpha1
+    filename: ecr.services.k8s.aws/repository_v1alpha1.json
+    kind: Repository
+    name: repository_v1alpha1
+  - apiVersion: ecr.services.k8s.aws/v1alpha1
+    filename: ecr.services.k8s.aws/pullthroughcacherule_v1alpha1.json
+    kind: PullThroughCacheRule
+    name: pullthroughcacherule_v1alpha1
+edgecontainer.cnrm.cloud.google.com:
+  - apiVersion: edgecontainer.cnrm.cloud.google.com/v1beta1
+    filename: edgecontainer.cnrm.cloud.google.com/edgecontainernodepool_v1beta1.json
+    kind: edgecontainernodepool
+    name: edgecontainernodepool_v1beta1
+  - apiVersion: edgecontainer.cnrm.cloud.google.com/v1beta1
+    filename: edgecontainer.cnrm.cloud.google.com/edgecontainercluster_v1beta1.json
+    kind: edgecontainercluster
+    name: edgecontainercluster_v1beta1
+  - apiVersion: edgecontainer.cnrm.cloud.google.com/v1beta1
+    filename: edgecontainer.cnrm.cloud.google.com/edgecontainervpnconnection_v1beta1.json
+    kind: edgecontainervpnconnection
+    name: edgecontainervpnconnection_v1beta1
+edgenetwork.cnrm.cloud.google.com:
+  - apiVersion: edgenetwork.cnrm.cloud.google.com/v1beta1
+    filename: edgenetwork.cnrm.cloud.google.com/edgenetworksubnet_v1beta1.json
+    kind: edgenetworksubnet
+    name: edgenetworksubnet_v1beta1
+  - apiVersion: edgenetwork.cnrm.cloud.google.com/v1beta1
+    filename: edgenetwork.cnrm.cloud.google.com/edgenetworknetwork_v1beta1.json
+    kind: edgenetworknetwork
+    name: edgenetworknetwork_v1beta1
+eks.amazonaws.com:
+  - apiVersion: eks.amazonaws.com/v1
+    filename: eks.amazonaws.com/targetgroupbinding_v1.json
+    kind: TargetGroupBinding
+    name: targetgroupbinding_v1
+  - apiVersion: eks.amazonaws.com/v1
+    filename: eks.amazonaws.com/nodeclass_v1.json
+    kind: NodeClass
+    name: nodeclass_v1
+  - apiVersion: eks.amazonaws.com/v1
+    filename: eks.amazonaws.com/ingressclassparams_v1.json
+    kind: IngressClassParams
+    name: ingressclassparams_v1
+  - apiVersion: eks.amazonaws.com/v1alpha1
+    filename: eks.amazonaws.com/nodediagnostic_v1alpha1.json
+    kind: NodeDiagnostic
+    name: nodediagnostic_v1alpha1
+eks.services.k8s.aws:
+  - apiVersion: eks.services.k8s.aws/v1alpha1
+    filename: eks.services.k8s.aws/fargateprofile_v1alpha1.json
+    kind: FargateProfile
+    name: fargateprofile_v1alpha1
+  - apiVersion: eks.services.k8s.aws/v1alpha1
+    filename: eks.services.k8s.aws/addon_v1alpha1.json
+    kind: Addon
+    name: addon_v1alpha1
+  - apiVersion: eks.services.k8s.aws/v1alpha1
+    filename: eks.services.k8s.aws/nodegroup_v1alpha1.json
+    kind: Nodegroup
+    name: nodegroup_v1alpha1
+  - apiVersion: eks.services.k8s.aws/v1alpha1
+    filename: eks.services.k8s.aws/cluster_v1alpha1.json
+    kind: Cluster
+    name: cluster_v1alpha1
+elasticache.services.k8s.aws:
+  - apiVersion: elasticache.services.k8s.aws/v1alpha1
+    filename: elasticache.services.k8s.aws/snapshot_v1alpha1.json
+    kind: Snapshot
+    name: snapshot_v1alpha1
+  - apiVersion: elasticache.services.k8s.aws/v1alpha1
+    filename: elasticache.services.k8s.aws/usergroup_v1alpha1.json
+    kind: UserGroup
+    name: usergroup_v1alpha1
+  - apiVersion: elasticache.services.k8s.aws/v1alpha1
+    filename: elasticache.services.k8s.aws/user_v1alpha1.json
+    kind: User
+    name: user_v1alpha1
+  - apiVersion: elasticache.services.k8s.aws/v1alpha1
+    filename: elasticache.services.k8s.aws/replicationgroup_v1alpha1.json
+    kind: ReplicationGroup
+    name: replicationgroup_v1alpha1
+  - apiVersion: elasticache.services.k8s.aws/v1alpha1
+    filename: elasticache.services.k8s.aws/cachesubnetgroup_v1alpha1.json
+    kind: CacheSubnetGroup
+    name: cachesubnetgroup_v1alpha1
+  - apiVersion: elasticache.services.k8s.aws/v1alpha1
+    filename: elasticache.services.k8s.aws/cacheparametergroup_v1alpha1.json
+    kind: CacheParameterGroup
+    name: cacheparametergroup_v1alpha1
 elasticsearch.k8s.elastic.co:
   - apiVersion: elasticsearch.k8s.elastic.co/v1alpha1
     filename: elasticsearch.k8s.elastic.co/elasticsearch_v1alpha1.json
@@ -121,6 +2682,33 @@ elasticsearch.k8s.elastic.co:
     filename: elasticsearch.k8s.elastic.co/elasticsearch_v1.json
     kind: Elasticsearch
     name: elasticsearch_v1
+elbv2.k8s.aws:
+  - apiVersion: elbv2.k8s.aws/v1alpha1
+    filename: elbv2.k8s.aws/targetgroupbinding_v1alpha1.json
+    kind: TargetGroupBinding
+    name: targetgroupbinding_v1alpha1
+  - apiVersion: elbv2.k8s.aws/v1beta1
+    filename: elbv2.k8s.aws/targetgroupbinding_v1beta1.json
+    kind: TargetGroupBinding
+    name: targetgroupbinding_v1beta1
+  - apiVersion: elbv2.k8s.aws/v1beta1
+    filename: elbv2.k8s.aws/ingressclassparams_v1beta1.json
+    kind: IngressClassParams
+    name: ingressclassparams_v1beta1
+emrcontainers.services.k8s.aws:
+  - apiVersion: emrcontainers.services.k8s.aws/v1alpha1
+    filename: emrcontainers.services.k8s.aws/jobrun_v1alpha1.json
+    kind: JobRun
+    name: jobrun_v1alpha1
+  - apiVersion: emrcontainers.services.k8s.aws/v1alpha1
+    filename: emrcontainers.services.k8s.aws/virtualcluster_v1alpha1.json
+    kind: VirtualCluster
+    name: virtualcluster_v1alpha1
+enterprise.gloo.solo.io:
+  - apiVersion: enterprise.gloo.solo.io/v1
+    filename: enterprise.gloo.solo.io/authconfig_v1.json
+    kind: authconfig
+    name: authconfig_v1
 enterprisesearch.k8s.elastic.co:
   - apiVersion: enterprisesearch.k8s.elastic.co/v1beta1
     filename: enterprisesearch.k8s.elastic.co/enterprisesearch_v1beta1.json
@@ -130,6 +2718,821 @@ enterprisesearch.k8s.elastic.co:
     filename: enterprisesearch.k8s.elastic.co/enterprisesearch_v1.json
     kind: EnterpriseSearch
     name: enterprisesearch_v1
+essentialcontacts.cnrm.cloud.google.com:
+  - apiVersion: essentialcontacts.cnrm.cloud.google.com/v1alpha1
+    filename: essentialcontacts.cnrm.cloud.google.com/essentialcontactscontact_v1alpha1.json
+    kind: essentialcontactscontact
+    name: essentialcontactscontact_v1alpha1
+eventarc.cnrm.cloud.google.com:
+  - apiVersion: eventarc.cnrm.cloud.google.com/v1beta1
+    filename: eventarc.cnrm.cloud.google.com/eventarctrigger_v1beta1.json
+    kind: eventarctrigger
+    name: eventarctrigger_v1beta1
+eventbridge.services.k8s.aws:
+  - apiVersion: eventbridge.services.k8s.aws/v1alpha1
+    filename: eventbridge.services.k8s.aws/eventbus_v1alpha1.json
+    kind: EventBus
+    name: eventbus_v1alpha1
+  - apiVersion: eventbridge.services.k8s.aws/v1alpha1
+    filename: eventbridge.services.k8s.aws/archive_v1alpha1.json
+    kind: Archive
+    name: archive_v1alpha1
+  - apiVersion: eventbridge.services.k8s.aws/v1alpha1
+    filename: eventbridge.services.k8s.aws/rule_v1alpha1.json
+    kind: Rule
+    name: rule_v1alpha1
+  - apiVersion: eventbridge.services.k8s.aws/v1alpha1
+    filename: eventbridge.services.k8s.aws/endpoint_v1alpha1.json
+    kind: Endpoint
+    name: endpoint_v1alpha1
+exoscale.appcat.vshn.io:
+  - apiVersion: exoscale.appcat.vshn.io/v1
+    filename: exoscale.appcat.vshn.io/exoscalepostgresql_v1.json
+    kind: ExoscalePostgreSQL
+    name: exoscalepostgresql_v1
+  - apiVersion: exoscale.appcat.vshn.io/v1
+    filename: exoscale.appcat.vshn.io/exoscaleredis_v1.json
+    kind: ExoscaleRedis
+    name: exoscaleredis_v1
+  - apiVersion: exoscale.appcat.vshn.io/v1
+    filename: exoscale.appcat.vshn.io/exoscalemysql_v1.json
+    kind: ExoscaleMySQL
+    name: exoscalemysql_v1
+  - apiVersion: exoscale.appcat.vshn.io/v1
+    filename: exoscale.appcat.vshn.io/exoscalekafka_v1.json
+    kind: ExoscaleKafka
+    name: exoscalekafka_v1
+  - apiVersion: exoscale.appcat.vshn.io/v1
+    filename: exoscale.appcat.vshn.io/exoscaleopensearch_v1.json
+    kind: ExoscaleOpenSearch
+    name: exoscaleopensearch_v1
+expansion.gatekeeper.sh:
+  - apiVersion: expansion.gatekeeper.sh/v1alpha1
+    filename: expansion.gatekeeper.sh/expansiontemplate_v1alpha1.json
+    kind: ExpansionTemplate
+    name: expansiontemplate_v1alpha1
+  - apiVersion: expansion.gatekeeper.sh/v1beta1
+    filename: expansion.gatekeeper.sh/expansiontemplate_v1beta1.json
+    kind: ExpansionTemplate
+    name: expansiontemplate_v1beta1
+extensions.istio.io:
+  - apiVersion: extensions.istio.io/v1alpha1
+    filename: extensions.istio.io/wasmplugin_v1alpha1.json
+    kind: wasmplugin
+    name: wasmplugin_v1alpha1
+external-secrets.io:
+  - apiVersion: external-secrets.io/v1beta1
+    filename: external-secrets.io/clustersecretstore_v1beta1.json
+    kind: ClusterSecretStore
+    name: clustersecretstore_v1beta1
+  - apiVersion: external-secrets.io/v1beta1
+    filename: external-secrets.io/clusterexternalsecret_v1beta1.json
+    kind: ClusterExternalSecret
+    name: clusterexternalsecret_v1beta1
+  - apiVersion: external-secrets.io/v1beta1
+    filename: external-secrets.io/externalsecret_v1beta1.json
+    kind: ExternalSecret
+    name: externalsecret_v1beta1
+  - apiVersion: external-secrets.io/v1alpha1
+    filename: external-secrets.io/pushsecret_v1alpha1.json
+    kind: pushsecret
+    name: pushsecret_v1alpha1
+  - apiVersion: external-secrets.io/v1beta1
+    filename: external-secrets.io/secretstore_v1beta1.json
+    kind: SecretStore
+    name: secretstore_v1beta1
+  - apiVersion: external-secrets.io/v1alpha1
+    filename: external-secrets.io/secretstore_v1alpha1.json
+    kind: SecretStore
+    name: secretstore_v1alpha1
+  - apiVersion: external-secrets.io/v1alpha1
+    filename: external-secrets.io/clustersecretstore_v1alpha1.json
+    kind: ClusterSecretStore
+    name: clustersecretstore_v1alpha1
+  - apiVersion: external-secrets.io/v1alpha1
+    filename: external-secrets.io/externalsecret_v1alpha1.json
+    kind: ExternalSecret
+    name: externalsecret_v1alpha1
+externaldata.gatekeeper.sh:
+  - apiVersion: externaldata.gatekeeper.sh/v1alpha1
+    filename: externaldata.gatekeeper.sh/provider_v1alpha1.json
+    kind: Provider
+    name: provider_v1alpha1
+  - apiVersion: externaldata.gatekeeper.sh/v1beta1
+    filename: externaldata.gatekeeper.sh/provider_v1beta1.json
+    kind: Provider
+    name: provider_v1beta1
+externaldns.k8s.io:
+  - apiVersion: externaldns.k8s.io/v1alpha1
+    filename: externaldns.k8s.io/dnsendpoint_v1alpha1.json
+    kind: dnsendpoint
+    name: dnsendpoint_v1alpha1
+externaldns.nginx.org:
+  - apiVersion: externaldns.nginx.org/v1
+    filename: externaldns.nginx.org/dnsendpoint_v1.json
+    kind: DNSEndpoint
+    name: dnsendpoint_v1
+filestore.cnrm.cloud.google.com:
+  - apiVersion: filestore.cnrm.cloud.google.com/v1alpha1
+    filename: filestore.cnrm.cloud.google.com/filestoresnapshot_v1alpha1.json
+    kind: filestoresnapshot
+    name: filestoresnapshot_v1alpha1
+  - apiVersion: filestore.cnrm.cloud.google.com/v1beta1
+    filename: filestore.cnrm.cloud.google.com/filestoreinstance_v1beta1.json
+    kind: filestoreinstance
+    name: filestoreinstance_v1beta1
+  - apiVersion: filestore.cnrm.cloud.google.com/v1beta1
+    filename: filestore.cnrm.cloud.google.com/filestorebackup_v1beta1.json
+    kind: filestorebackup
+    name: filestorebackup_v1beta1
+firebase.cnrm.cloud.google.com:
+  - apiVersion: firebase.cnrm.cloud.google.com/v1alpha1
+    filename: firebase.cnrm.cloud.google.com/firebaseproject_v1alpha1.json
+    kind: firebaseproject
+    name: firebaseproject_v1alpha1
+  - apiVersion: firebase.cnrm.cloud.google.com/v1alpha1
+    filename: firebase.cnrm.cloud.google.com/firebasewebapp_v1alpha1.json
+    kind: firebasewebapp
+    name: firebasewebapp_v1alpha1
+  - apiVersion: firebase.cnrm.cloud.google.com/v1alpha1
+    filename: firebase.cnrm.cloud.google.com/firebaseandroidapp_v1alpha1.json
+    kind: firebaseandroidapp
+    name: firebaseandroidapp_v1alpha1
+firebasedatabase.cnrm.cloud.google.com:
+  - apiVersion: firebasedatabase.cnrm.cloud.google.com/v1alpha1
+    filename: firebasedatabase.cnrm.cloud.google.com/firebasedatabaseinstance_v1alpha1.json
+    kind: firebasedatabaseinstance
+    name: firebasedatabaseinstance_v1alpha1
+firebasehosting.cnrm.cloud.google.com:
+  - apiVersion: firebasehosting.cnrm.cloud.google.com/v1alpha1
+    filename: firebasehosting.cnrm.cloud.google.com/firebasehostingchannel_v1alpha1.json
+    kind: firebasehostingchannel
+    name: firebasehostingchannel_v1alpha1
+  - apiVersion: firebasehosting.cnrm.cloud.google.com/v1alpha1
+    filename: firebasehosting.cnrm.cloud.google.com/firebasehostingsite_v1alpha1.json
+    kind: firebasehostingsite
+    name: firebasehostingsite_v1alpha1
+firebasestorage.cnrm.cloud.google.com:
+  - apiVersion: firebasestorage.cnrm.cloud.google.com/v1alpha1
+    filename: firebasestorage.cnrm.cloud.google.com/firebasestoragebucket_v1alpha1.json
+    kind: firebasestoragebucket
+    name: firebasestoragebucket_v1alpha1
+firestore.cnrm.cloud.google.com:
+  - apiVersion: firestore.cnrm.cloud.google.com/v1beta1
+    filename: firestore.cnrm.cloud.google.com/firestoreindex_v1beta1.json
+    kind: firestoreindex
+    name: firestoreindex_v1beta1
+  - apiVersion: firestore.cnrm.cloud.google.com/v1alpha1
+    filename: firestore.cnrm.cloud.google.com/firestoredatabase_v1alpha1.json
+    kind: FirestoreDatabase
+    name: firestoredatabase_v1alpha1
+flagger.app:
+  - apiVersion: flagger.app/v1beta1
+    filename: flagger.app/metrictemplate_v1beta1.json
+    kind: MetricTemplate
+    name: metrictemplate_v1beta1
+  - apiVersion: flagger.app/v1beta1
+    filename: flagger.app/alertprovider_v1beta1.json
+    kind: AlertProvider
+    name: alertprovider_v1beta1
+  - apiVersion: flagger.app/v1beta1
+    filename: flagger.app/canary_v1beta1.json
+    kind: Canary
+    name: canary_v1beta1
+flink.apache.org:
+  - apiVersion: flink.apache.org/v1beta1
+    filename: flink.apache.org/flinkdeployment_v1beta1.json
+    kind: flinkdeployment
+    name: flinkdeployment_v1beta1
+  - apiVersion: flink.apache.org/v1beta1
+    filename: flink.apache.org/flinkstatesnapshot_v1beta1.json
+    kind: flinkstatesnapshot
+    name: flinkstatesnapshot_v1beta1
+  - apiVersion: flink.apache.org/v1beta1
+    filename: flink.apache.org/flinksessionjob_v1beta1.json
+    kind: flinksessionjob
+    name: flinksessionjob_v1beta1
+fluentbit.fluent.io:
+  - apiVersion: fluentbit.fluent.io/v1alpha2
+    filename: fluentbit.fluent.io/collector_v1alpha2.json
+    kind: Collector
+    name: collector_v1alpha2
+  - apiVersion: fluentbit.fluent.io/v1alpha2
+    filename: fluentbit.fluent.io/multilineparser_v1alpha2.json
+    kind: MultilineParser
+    name: multilineparser_v1alpha2
+  - apiVersion: fluentbit.fluent.io/v1alpha2
+    filename: fluentbit.fluent.io/clusterfluentbitconfig_v1alpha2.json
+    kind: ClusterFluentBitConfig
+    name: clusterfluentbitconfig_v1alpha2
+  - apiVersion: fluentbit.fluent.io/v1alpha2
+    filename: fluentbit.fluent.io/clustermultilineparser_v1alpha2.json
+    kind: ClusterMultilineParser
+    name: clustermultilineparser_v1alpha2
+  - apiVersion: fluentbit.fluent.io/v1alpha2
+    filename: fluentbit.fluent.io/fluentbitconfig_v1alpha2.json
+    kind: FluentBitConfig
+    name: fluentbitconfig_v1alpha2
+  - apiVersion: fluentbit.fluent.io/v1alpha2
+    filename: fluentbit.fluent.io/clusterinput_v1alpha2.json
+    kind: ClusterInput
+    name: clusterinput_v1alpha2
+  - apiVersion: fluentbit.fluent.io/v1alpha2
+    filename: fluentbit.fluent.io/parser_v1alpha2.json
+    kind: Parser
+    name: parser_v1alpha2
+  - apiVersion: fluentbit.fluent.io/v1alpha2
+    filename: fluentbit.fluent.io/clusterfilter_v1alpha2.json
+    kind: ClusterFilter
+    name: clusterfilter_v1alpha2
+  - apiVersion: fluentbit.fluent.io/v1alpha2
+    filename: fluentbit.fluent.io/output_v1alpha2.json
+    kind: Output
+    name: output_v1alpha2
+  - apiVersion: fluentbit.fluent.io/v1alpha2
+    filename: fluentbit.fluent.io/clusteroutput_v1alpha2.json
+    kind: ClusterOutput
+    name: clusteroutput_v1alpha2
+  - apiVersion: fluentbit.fluent.io/v1alpha2
+    filename: fluentbit.fluent.io/filter_v1alpha2.json
+    kind: Filter
+    name: filter_v1alpha2
+  - apiVersion: fluentbit.fluent.io/v1alpha2
+    filename: fluentbit.fluent.io/fluentbit_v1alpha2.json
+    kind: FluentBit
+    name: fluentbit_v1alpha2
+  - apiVersion: fluentbit.fluent.io/v1alpha2
+    filename: fluentbit.fluent.io/clusterparser_v1alpha2.json
+    kind: ClusterParser
+    name: clusterparser_v1alpha2
+fluentd.fluent.io:
+  - apiVersion: fluentd.fluent.io/v1alpha2
+    filename: fluentd.fluent.io/clusteroutput_v1alpha2.json
+    kind: ClusterOutput
+    name: clusteroutput_v1alpha2
+  - apiVersion: fluentd.fluent.io/v1alpha1
+    filename: fluentd.fluent.io/input_v1alpha1.json
+    kind: Input
+    name: input_v1alpha1
+  - apiVersion: fluentd.fluent.io/v1alpha2
+    filename: fluentd.fluent.io/output_v1alpha2.json
+    kind: Output
+    name: output_v1alpha2
+  - apiVersion: fluentd.fluent.io/v1alpha1
+    filename: fluentd.fluent.io/clusterinput_v1alpha1.json
+    kind: ClusterInput
+    name: clusterinput_v1alpha1
+  - apiVersion: fluentd.fluent.io/v1alpha2
+    filename: fluentd.fluent.io/clusterfilter_v1alpha2.json
+    kind: ClusterFilter
+    name: clusterfilter_v1alpha2
+  - apiVersion: fluentd.fluent.io/v1alpha2
+    filename: fluentd.fluent.io/filter_v1alpha2.json
+    kind: Filter
+    name: filter_v1alpha2
+  - apiVersion: fluentd.fluent.io/v1alpha1
+    filename: fluentd.fluent.io/fluentd_v1alpha1.json
+    kind: Fluentd
+    name: fluentd_v1alpha1
+  - apiVersion: fluentd.fluent.io/v1alpha1
+    filename: fluentd.fluent.io/clusteroutput_v1alpha1.json
+    kind: ClusterOutput
+    name: clusteroutput_v1alpha1
+  - apiVersion: fluentd.fluent.io/v1alpha1
+    filename: fluentd.fluent.io/output_v1alpha1.json
+    kind: Output
+    name: output_v1alpha1
+  - apiVersion: fluentd.fluent.io/v1alpha1
+    filename: fluentd.fluent.io/clusterfluentdconfig_v1alpha1.json
+    kind: ClusterFluentdConfig
+    name: clusterfluentdconfig_v1alpha1
+  - apiVersion: fluentd.fluent.io/v1alpha2
+    filename: fluentd.fluent.io/clusterinput_v1alpha2.json
+    kind: ClusterInput
+    name: clusterinput_v1alpha2
+  - apiVersion: fluentd.fluent.io/v1alpha1
+    filename: fluentd.fluent.io/clusterfilter_v1alpha1.json
+    kind: ClusterFilter
+    name: clusterfilter_v1alpha1
+  - apiVersion: fluentd.fluent.io/v1alpha1
+    filename: fluentd.fluent.io/filter_v1alpha1.json
+    kind: Filter
+    name: filter_v1alpha1
+  - apiVersion: fluentd.fluent.io/v1alpha1
+    filename: fluentd.fluent.io/fluentdconfig_v1alpha1.json
+    kind: FluentdConfig
+    name: fluentdconfig_v1alpha1
+fluxcd.controlplane.io:
+  - apiVersion: fluxcd.controlplane.io/v1
+    filename: fluxcd.controlplane.io/fluxinstance_v1.json
+    kind: FluxInstance
+    name: fluxinstance_v1
+  - apiVersion: fluxcd.controlplane.io/v1
+    filename: fluxcd.controlplane.io/fluxreport_v1.json
+    kind: FluxReport
+    name: fluxreport_v1
+  - apiVersion: fluxcd.controlplane.io/v1
+    filename: fluxcd.controlplane.io/resourcesetinputprovider_v1.json
+    kind: ResourceSetInputProvider
+    name: resourcesetinputprovider_v1
+  - apiVersion: fluxcd.controlplane.io/v1
+    filename: fluxcd.controlplane.io/resourceset_v1.json
+    kind: ResourceSet
+    name: resourceset_v1
+gameservices.cnrm.cloud.google.com:
+  - apiVersion: gameservices.cnrm.cloud.google.com/v1beta1
+    filename: gameservices.cnrm.cloud.google.com/gameservicesrealm_v1beta1.json
+    kind: gameservicesrealm
+    name: gameservicesrealm_v1beta1
+gateway.envoyproxy.io:
+  - apiVersion: gateway.envoyproxy.io/v1alpha1
+    filename: gateway.envoyproxy.io/envoyextensionpolicy_v1alpha1.json
+    kind: EnvoyExtensionPolicy
+    name: envoyextensionpolicy_v1alpha1
+  - apiVersion: gateway.envoyproxy.io/v1alpha1
+    filename: gateway.envoyproxy.io/envoypatchpolicy_v1alpha1.json
+    kind: EnvoyPatchPolicy
+    name: envoypatchpolicy_v1alpha1
+  - apiVersion: gateway.envoyproxy.io/v1alpha1
+    filename: gateway.envoyproxy.io/envoyproxy_v1alpha1.json
+    kind: EnvoyProxy
+    name: envoyproxy_v1alpha1
+  - apiVersion: gateway.envoyproxy.io/v1alpha1
+    filename: gateway.envoyproxy.io/backendtrafficpolicy_v1alpha1.json
+    kind: BackendTrafficPolicy
+    name: backendtrafficpolicy_v1alpha1
+  - apiVersion: gateway.envoyproxy.io/v1alpha1
+    filename: gateway.envoyproxy.io/clienttrafficpolicy_v1alpha1.json
+    kind: ClientTrafficPolicy
+    name: clienttrafficpolicy_v1alpha1
+  - apiVersion: gateway.envoyproxy.io/v1alpha1
+    filename: gateway.envoyproxy.io/httproutefilter_v1alpha1.json
+    kind: HTTPRouteFilter
+    name: httproutefilter_v1alpha1
+  - apiVersion: gateway.envoyproxy.io/v1alpha1
+    filename: gateway.envoyproxy.io/securitypolicy_v1alpha1.json
+    kind: SecurityPolicy
+    name: securitypolicy_v1alpha1
+  - apiVersion: gateway.envoyproxy.io/v1alpha1
+    filename: gateway.envoyproxy.io/backend_v1alpha1.json
+    kind: Backend
+    name: backend_v1alpha1
+gateway.networking.k8s.io:
+  - apiVersion: gateway.networking.k8s.io/v1alpha2
+    filename: gateway.networking.k8s.io/grpcroute_v1alpha2.json
+    kind: GRPCRoute
+    name: grpcroute_v1alpha2
+  - apiVersion: gateway.networking.k8s.io/v1alpha2
+    filename: gateway.networking.k8s.io/tcproute_v1alpha2.json
+    kind: TCPRoute
+    name: tcproute_v1alpha2
+  - apiVersion: gateway.networking.k8s.io/v1alpha2
+    filename: gateway.networking.k8s.io/tlsroute_v1alpha2.json
+    kind: TLSRoute
+    name: tlsroute_v1alpha2
+  - apiVersion: gateway.networking.k8s.io/v1alpha2
+    filename: gateway.networking.k8s.io/backendlbpolicy_v1alpha2.json
+    kind: BackendLBPolicy
+    name: backendlbpolicy_v1alpha2
+  - apiVersion: gateway.networking.k8s.io/v1
+    filename: gateway.networking.k8s.io/gatewayclass_v1.json
+    kind: GatewayClass
+    name: gatewayclass_v1
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    filename: gateway.networking.k8s.io/httproute_v1beta1.json
+    kind: HTTPRoute
+    name: httproute_v1beta1
+  - apiVersion: gateway.networking.k8s.io/v1alpha2
+    filename: gateway.networking.k8s.io/udproute_v1alpha2.json
+    kind: UDPRoute
+    name: udproute_v1alpha2
+  - apiVersion: gateway.networking.k8s.io/v1
+    filename: gateway.networking.k8s.io/httproute_v1.json
+    kind: HTTPRoute
+    name: httproute_v1
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    filename: gateway.networking.k8s.io/gateway_v1beta1.json
+    kind: Gateway
+    name: gateway_v1beta1
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    filename: gateway.networking.k8s.io/referencegrant_v1beta1.json
+    kind: ReferenceGrant
+    name: referencegrant_v1beta1
+  - apiVersion: gateway.networking.k8s.io/v1beta1
+    filename: gateway.networking.k8s.io/gatewayclass_v1beta1.json
+    kind: GatewayClass
+    name: gatewayclass_v1beta1
+  - apiVersion: gateway.networking.k8s.io/v1alpha2
+    filename: gateway.networking.k8s.io/referencegrant_v1alpha2.json
+    kind: ReferenceGrant
+    name: referencegrant_v1alpha2
+  - apiVersion: gateway.networking.k8s.io/v1
+    filename: gateway.networking.k8s.io/grpcroute_v1.json
+    kind: GRPCRoute
+    name: grpcroute_v1
+  - apiVersion: gateway.networking.k8s.io/v1
+    filename: gateway.networking.k8s.io/gateway_v1.json
+    kind: Gateway
+    name: gateway_v1
+  - apiVersion: gateway.networking.k8s.io/v1alpha3
+    filename: gateway.networking.k8s.io/backendtlspolicy_v1alpha3.json
+    kind: BackendTLSPolicy
+    name: backendtlspolicy_v1alpha3
+gateway.solo.io:
+  - apiVersion: gateway.solo.io/v1
+    filename: gateway.solo.io/virtualservice_v1.json
+    kind: virtualservice
+    name: virtualservice_v1
+  - apiVersion: gateway.solo.io/v1
+    filename: gateway.solo.io/routeoption_v1.json
+    kind: routeoption
+    name: routeoption_v1
+  - apiVersion: gateway.solo.io/v1
+    filename: gateway.solo.io/virtualhostoption_v1.json
+    kind: virtualhostoption
+    name: virtualhostoption_v1
+  - apiVersion: gateway.solo.io/v1
+    filename: gateway.solo.io/matchablehttpgateway_v1.json
+    kind: matchablehttpgateway
+    name: matchablehttpgateway_v1
+  - apiVersion: gateway.solo.io/v1
+    filename: gateway.solo.io/routetable_v1.json
+    kind: routetable
+    name: routetable_v1
+  - apiVersion: gateway.solo.io/v1
+    filename: gateway.solo.io/gateway_v1.json
+    kind: gateway
+    name: gateway_v1
+generators.external-secrets.io:
+  - apiVersion: generators.external-secrets.io/v1alpha1
+    filename: generators.external-secrets.io/fake_v1alpha1.json
+    kind: Fake
+    name: fake_v1alpha1
+  - apiVersion: generators.external-secrets.io/v1alpha1
+    filename: generators.external-secrets.io/githubaccesstoken_v1alpha1.json
+    kind: GithubAccessToken
+    name: githubaccesstoken_v1alpha1
+  - apiVersion: generators.external-secrets.io/v1alpha1
+    filename: generators.external-secrets.io/grafana_v1alpha1.json
+    kind: grafana
+    name: grafana_v1alpha1
+  - apiVersion: generators.external-secrets.io/v1alpha1
+    filename: generators.external-secrets.io/quayaccesstoken_v1alpha1.json
+    kind: QuayAccessToken
+    name: quayaccesstoken_v1alpha1
+  - apiVersion: generators.external-secrets.io/v1alpha1
+    filename: generators.external-secrets.io/password_v1alpha1.json
+    kind: Password
+    name: password_v1alpha1
+  - apiVersion: generators.external-secrets.io/v1alpha1
+    filename: generators.external-secrets.io/acraccesstoken_v1alpha1.json
+    kind: ACRAccessToken
+    name: acraccesstoken_v1alpha1
+  - apiVersion: generators.external-secrets.io/v1alpha1
+    filename: generators.external-secrets.io/generatorstate_v1alpha1.json
+    kind: generatorstate
+    name: generatorstate_v1alpha1
+  - apiVersion: generators.external-secrets.io/v1alpha1
+    filename: generators.external-secrets.io/uuid_v1alpha1.json
+    kind: UUID
+    name: uuid_v1alpha1
+  - apiVersion: generators.external-secrets.io/v1alpha1
+    filename: generators.external-secrets.io/clustergenerator_v1alpha1.json
+    kind: ClusterGenerator
+    name: clustergenerator_v1alpha1
+  - apiVersion: generators.external-secrets.io/v1alpha1
+    filename: generators.external-secrets.io/vaultdynamicsecret_v1alpha1.json
+    kind: vaultdynamicsecret
+    name: vaultdynamicsecret_v1alpha1
+  - apiVersion: generators.external-secrets.io/v1alpha1
+    filename: generators.external-secrets.io/ecrauthorizationtoken_v1alpha1.json
+    kind: ECRAuthorizationToken
+    name: ecrauthorizationtoken_v1alpha1
+  - apiVersion: generators.external-secrets.io/v1alpha1
+    filename: generators.external-secrets.io/webhook_v1alpha1.json
+    kind: Webhook
+    name: webhook_v1alpha1
+  - apiVersion: generators.external-secrets.io/v1alpha1
+    filename: generators.external-secrets.io/gcraccesstoken_v1alpha1.json
+    kind: GCRAccessToken
+    name: gcraccesstoken_v1alpha1
+  - apiVersion: generators.external-secrets.io/v1alpha1
+    filename: generators.external-secrets.io/stssessiontoken_v1alpha1.json
+    kind: STSSessionToken
+    name: stssessiontoken_v1alpha1
+getambassador.io:
+  - apiVersion: getambassador.io/v2
+    filename: getambassador.io/host_v2.json
+    kind: Host
+    name: host_v2
+  - apiVersion: getambassador.io/v2
+    filename: getambassador.io/tracingservice_v2.json
+    kind: TracingService
+    name: tracingservice_v2
+  - apiVersion: getambassador.io/v2
+    filename: getambassador.io/authservice_v2.json
+    kind: AuthService
+    name: authservice_v2
+  - apiVersion: getambassador.io/v2
+    filename: getambassador.io/tcpmapping_v2.json
+    kind: TCPMapping
+    name: tcpmapping_v2
+  - apiVersion: getambassador.io/v1
+    filename: getambassador.io/module_v1.json
+    kind: Module
+    name: module_v1
+  - apiVersion: getambassador.io/v3alpha1
+    filename: getambassador.io/module_v3alpha1.json
+    kind: Module
+    name: module_v3alpha1
+  - apiVersion: getambassador.io/v3alpha1
+    filename: getambassador.io/listener_v3alpha1.json
+    kind: Listener
+    name: listener_v3alpha1
+  - apiVersion: getambassador.io/v1
+    filename: getambassador.io/kubernetesserviceresolver_v1.json
+    kind: KubernetesServiceResolver
+    name: kubernetesserviceresolver_v1
+  - apiVersion: getambassador.io/v3alpha1
+    filename: getambassador.io/kubernetesserviceresolver_v3alpha1.json
+    kind: KubernetesServiceResolver
+    name: kubernetesserviceresolver_v3alpha1
+  - apiVersion: getambassador.io/v1beta1
+    filename: getambassador.io/ratelimit_v1beta1.json
+    kind: ratelimit
+    name: ratelimit_v1beta1
+  - apiVersion: getambassador.io/v1
+    filename: getambassador.io/kubernetesendpointresolver_v1.json
+    kind: KubernetesEndpointResolver
+    name: kubernetesendpointresolver_v1
+  - apiVersion: getambassador.io/v2
+    filename: getambassador.io/ratelimitservice_v2.json
+    kind: RateLimitService
+    name: ratelimitservice_v2
+  - apiVersion: getambassador.io/v2
+    filename: getambassador.io/devportal_v2.json
+    kind: DevPortal
+    name: devportal_v2
+  - apiVersion: getambassador.io/v3alpha1
+    filename: getambassador.io/ratelimit_v3alpha1.json
+    kind: ratelimit
+    name: ratelimit_v3alpha1
+  - apiVersion: getambassador.io/v3alpha1
+    filename: getambassador.io/host_v3alpha1.json
+    kind: Host
+    name: host_v3alpha1
+  - apiVersion: getambassador.io/v3alpha1
+    filename: getambassador.io/logservice_v3alpha1.json
+    kind: LogService
+    name: logservice_v3alpha1
+  - apiVersion: getambassador.io/v3alpha1
+    filename: getambassador.io/filterpolicy_v3alpha1.json
+    kind: filterpolicy
+    name: filterpolicy_v3alpha1
+  - apiVersion: getambassador.io/v2
+    filename: getambassador.io/filterpolicy_v2.json
+    kind: filterpolicy
+    name: filterpolicy_v2
+  - apiVersion: getambassador.io/v2
+    filename: getambassador.io/consulresolver_v2.json
+    kind: ConsulResolver
+    name: consulresolver_v2
+  - apiVersion: getambassador.io/v1beta2
+    filename: getambassador.io/filterpolicy_v1beta2.json
+    kind: filterpolicy
+    name: filterpolicy_v1beta2
+  - apiVersion: getambassador.io/v2
+    filename: getambassador.io/tlscontext_v2.json
+    kind: TLSContext
+    name: tlscontext_v2
+  - apiVersion: getambassador.io/v3alpha1
+    filename: getambassador.io/devportal_v3alpha1.json
+    kind: DevPortal
+    name: devportal_v3alpha1
+  - apiVersion: getambassador.io/v1
+    filename: getambassador.io/mapping_v1.json
+    kind: Mapping
+    name: mapping_v1
+  - apiVersion: getambassador.io/v3alpha1
+    filename: getambassador.io/filter_v3alpha1.json
+    kind: filter
+    name: filter_v3alpha1
+  - apiVersion: getambassador.io/v2
+    filename: getambassador.io/ratelimit_v2.json
+    kind: ratelimit
+    name: ratelimit_v2
+  - apiVersion: getambassador.io/v3alpha1
+    filename: getambassador.io/mapping_v3alpha1.json
+    kind: Mapping
+    name: mapping_v3alpha1
+  - apiVersion: getambassador.io/v1
+    filename: getambassador.io/logservice_v1.json
+    kind: LogService
+    name: logservice_v1
+  - apiVersion: getambassador.io/v2
+    filename: getambassador.io/kubernetesserviceresolver_v2.json
+    kind: KubernetesServiceResolver
+    name: kubernetesserviceresolver_v2
+  - apiVersion: getambassador.io/v1beta2
+    filename: getambassador.io/ratelimit_v1beta2.json
+    kind: ratelimit
+    name: ratelimit_v1beta2
+  - apiVersion: getambassador.io/v2
+    filename: getambassador.io/kubernetesendpointresolver_v2.json
+    kind: KubernetesEndpointResolver
+    name: kubernetesendpointresolver_v2
+  - apiVersion: getambassador.io/v3alpha1
+    filename: getambassador.io/tcpmapping_v3alpha1.json
+    kind: TCPMapping
+    name: tcpmapping_v3alpha1
+  - apiVersion: getambassador.io/v1
+    filename: getambassador.io/ratelimitservice_v1.json
+    kind: RateLimitService
+    name: ratelimitservice_v1
+  - apiVersion: getambassador.io/v3alpha1
+    filename: getambassador.io/tracingservice_v3alpha1.json
+    kind: TracingService
+    name: tracingservice_v3alpha1
+  - apiVersion: getambassador.io/v1
+    filename: getambassador.io/devportal_v1.json
+    kind: DevPortal
+    name: devportal_v1
+  - apiVersion: getambassador.io/v3alpha1
+    filename: getambassador.io/ratelimitservice_v3alpha1.json
+    kind: RateLimitService
+    name: ratelimitservice_v3alpha1
+  - apiVersion: getambassador.io/v1
+    filename: getambassador.io/tracingservice_v1.json
+    kind: TracingService
+    name: tracingservice_v1
+  - apiVersion: getambassador.io/v1
+    filename: getambassador.io/authservice_v1.json
+    kind: AuthService
+    name: authservice_v1
+  - apiVersion: getambassador.io/v1
+    filename: getambassador.io/tcpmapping_v1.json
+    kind: TCPMapping
+    name: tcpmapping_v1
+  - apiVersion: getambassador.io/v2
+    filename: getambassador.io/module_v2.json
+    kind: Module
+    name: module_v2
+  - apiVersion: getambassador.io/v1
+    filename: getambassador.io/tlscontext_v1.json
+    kind: TLSContext
+    name: tlscontext_v1
+  - apiVersion: getambassador.io/v2
+    filename: getambassador.io/mapping_v2.json
+    kind: Mapping
+    name: mapping_v2
+  - apiVersion: getambassador.io/v1beta2
+    filename: getambassador.io/filter_v1beta2.json
+    kind: filter
+    name: filter_v1beta2
+  - apiVersion: getambassador.io/v3alpha1
+    filename: getambassador.io/consulresolver_v3alpha1.json
+    kind: ConsulResolver
+    name: consulresolver_v3alpha1
+  - apiVersion: getambassador.io/v2
+    filename: getambassador.io/filter_v2.json
+    kind: filter
+    name: filter_v2
+  - apiVersion: getambassador.io/v2
+    filename: getambassador.io/logservice_v2.json
+    kind: LogService
+    name: logservice_v2
+  - apiVersion: getambassador.io/v3alpha1
+    filename: getambassador.io/kubernetesendpointresolver_v3alpha1.json
+    kind: KubernetesEndpointResolver
+    name: kubernetesendpointresolver_v3alpha1
+  - apiVersion: getambassador.io/v3alpha1
+    filename: getambassador.io/authservice_v3alpha1.json
+    kind: AuthService
+    name: authservice_v3alpha1
+  - apiVersion: getambassador.io/v3alpha1
+    filename: getambassador.io/tlscontext_v3alpha1.json
+    kind: TLSContext
+    name: tlscontext_v3alpha1
+  - apiVersion: getambassador.io/v1
+    filename: getambassador.io/consulresolver_v1.json
+    kind: ConsulResolver
+    name: consulresolver_v1
+gkebackup.cnrm.cloud.google.com:
+  - apiVersion: gkebackup.cnrm.cloud.google.com/v1alpha1
+    filename: gkebackup.cnrm.cloud.google.com/gkebackupbackupplan_v1alpha1.json
+    kind: gkebackupbackupplan
+    name: gkebackupbackupplan_v1alpha1
+gkehub.cnrm.cloud.google.com:
+  - apiVersion: gkehub.cnrm.cloud.google.com/v1beta1
+    filename: gkehub.cnrm.cloud.google.com/gkehubfeature_v1beta1.json
+    kind: gkehubfeature
+    name: gkehubfeature_v1beta1
+  - apiVersion: gkehub.cnrm.cloud.google.com/v1beta1
+    filename: gkehub.cnrm.cloud.google.com/gkehubfeaturemembership_v1beta1.json
+    kind: GKEHubFeatureMembership
+    name: gkehubfeaturemembership_v1beta1
+  - apiVersion: gkehub.cnrm.cloud.google.com/v1beta1
+    filename: gkehub.cnrm.cloud.google.com/gkehubmembership_v1beta1.json
+    kind: gkehubmembership
+    name: gkehubmembership_v1beta1
+gloo.solo.io:
+  - apiVersion: gloo.solo.io/v1
+    filename: gloo.solo.io/upstreamgroup_v1.json
+    kind: upstreamgroup
+    name: upstreamgroup_v1
+  - apiVersion: gloo.solo.io/v1
+    filename: gloo.solo.io/settings_v1.json
+    kind: settings
+    name: settings_v1
+  - apiVersion: gloo.solo.io/v1
+    filename: gloo.solo.io/proxy_v1.json
+    kind: proxy
+    name: proxy_v1
+  - apiVersion: gloo.solo.io/v1
+    filename: gloo.solo.io/upstream_v1.json
+    kind: upstream
+    name: upstream_v1
+grafana.integreatly.org:
+  - apiVersion: grafana.integreatly.org/v1beta1
+    filename: grafana.integreatly.org/grafanafolder_v1beta1.json
+    kind: GrafanaFolder
+    name: grafanafolder_v1beta1
+  - apiVersion: grafana.integreatly.org/v1beta1
+    filename: grafana.integreatly.org/grafanacontactpoint_v1beta1.json
+    kind: GrafanaContactPoint
+    name: grafanacontactpoint_v1beta1
+  - apiVersion: grafana.integreatly.org/v1beta1
+    filename: grafana.integreatly.org/grafananotificationpolicy_v1beta1.json
+    kind: GrafanaNotificationPolicy
+    name: grafananotificationpolicy_v1beta1
+  - apiVersion: grafana.integreatly.org/v1alpha1
+    filename: grafana.integreatly.org/grafana_v1alpha1.json
+    kind: grafana
+    name: grafana_v1alpha1
+  - apiVersion: grafana.integreatly.org/v1beta1
+    filename: grafana.integreatly.org/grafanadatasource_v1beta1.json
+    kind: GrafanaDatasource
+    name: grafanadatasource_v1beta1
+  - apiVersion: grafana.integreatly.org/v1beta1
+    filename: grafana.integreatly.org/grafananotificationtemplate_v1beta1.json
+    kind: GrafanaNotificationTemplate
+    name: grafananotificationtemplate_v1beta1
+  - apiVersion: grafana.integreatly.org/v1beta1
+    filename: grafana.integreatly.org/grafana_v1beta1.json
+    kind: Grafana
+    name: grafana_v1beta1
+  - apiVersion: grafana.integreatly.org/v1beta1
+    filename: grafana.integreatly.org/grafanadashboard_v1beta1.json
+    kind: GrafanaDashboard
+    name: grafanadashboard_v1beta1
+  - apiVersion: grafana.integreatly.org/v1beta1
+    filename: grafana.integreatly.org/grafanaalertrulegroup_v1beta1.json
+    kind: GrafanaAlertRuleGroup
+    name: grafanaalertrulegroup_v1beta1
+graphql.gloo.solo.io:
+  - apiVersion: graphql.gloo.solo.io/v1beta1
+    filename: graphql.gloo.solo.io/graphqlapi_v1beta1.json
+    kind: graphqlapi
+    name: graphqlapi_v1beta1
+groupsnapshot.storage.k8s.io:
+  - apiVersion: groupsnapshot.storage.k8s.io/v1beta1
+    filename: groupsnapshot.storage.k8s.io/volumegroupsnapshot_v1beta1.json
+    kind: VolumeGroupSnapshot
+    name: volumegroupsnapshot_v1beta1
+  - apiVersion: groupsnapshot.storage.k8s.io/v1beta1
+    filename: groupsnapshot.storage.k8s.io/volumegroupsnapshotclass_v1beta1.json
+    kind: VolumeGroupSnapshotClass
+    name: volumegroupsnapshotclass_v1beta1
+  - apiVersion: groupsnapshot.storage.k8s.io/v1beta1
+    filename: groupsnapshot.storage.k8s.io/volumegroupsnapshotcontent_v1beta1.json
+    kind: VolumeGroupSnapshotContent
+    name: volumegroupsnapshotcontent_v1beta1
+healthcare.cnrm.cloud.google.com:
+  - apiVersion: healthcare.cnrm.cloud.google.com/v1alpha1
+    filename: healthcare.cnrm.cloud.google.com/healthcaredataset_v1alpha1.json
+    kind: healthcaredataset
+    name: healthcaredataset_v1alpha1
+  - apiVersion: healthcare.cnrm.cloud.google.com/v1alpha1
+    filename: healthcare.cnrm.cloud.google.com/healthcarehl7v2store_v1alpha1.json
+    kind: healthcarehl7v2store
+    name: healthcarehl7v2store_v1alpha1
+  - apiVersion: healthcare.cnrm.cloud.google.com/v1alpha1
+    filename: healthcare.cnrm.cloud.google.com/healthcarefhirstore_v1alpha1.json
+    kind: healthcarefhirstore
+    name: healthcarefhirstore_v1alpha1
+  - apiVersion: healthcare.cnrm.cloud.google.com/v1alpha1
+    filename: healthcare.cnrm.cloud.google.com/healthcareconsentstore_v1alpha1.json
+    kind: healthcareconsentstore
+    name: healthcareconsentstore_v1alpha1
+  - apiVersion: healthcare.cnrm.cloud.google.com/v1alpha1
+    filename: healthcare.cnrm.cloud.google.com/healthcaredicomstore_v1alpha1.json
+    kind: healthcaredicomstore
+    name: healthcaredicomstore_v1alpha1
+helm.k0sproject.io:
+  - apiVersion: helm.k0sproject.io/v1beta1
+    filename: helm.k0sproject.io/chart_v1beta1.json
+    kind: Chart
+    name: chart_v1beta1
 helm.toolkit.fluxcd.io:
   - apiVersion: helm.toolkit.fluxcd.io/v1
     filename: helm.toolkit.fluxcd.io/helmrelease_v1.json
@@ -139,6 +3542,152 @@ helm.toolkit.fluxcd.io:
     filename: helm.toolkit.fluxcd.io/helmrelease_v2beta1.json
     kind: HelmRelease
     name: helmrelease_v2beta1
+  - apiVersion: helm.toolkit.fluxcd.io/v2
+    filename: helm.toolkit.fluxcd.io/helmrelease_v2.json
+    kind: HelmRelease
+    name: helmrelease_v2
+  - apiVersion: helm.toolkit.fluxcd.io/v2beta2
+    filename: helm.toolkit.fluxcd.io/helmrelease_v2beta2.json
+    kind: HelmRelease
+    name: helmrelease_v2beta2
+hivemq.com:
+  - apiVersion: hivemq.com/v1
+    filename: hivemq.com/hivemqplatform_v1.json
+    kind: hivemqplatform
+    name: hivemqplatform_v1
+iam.cnrm.cloud.google.com:
+  - apiVersion: iam.cnrm.cloud.google.com/v1beta1
+    filename: iam.cnrm.cloud.google.com/iamserviceaccount_v1beta1.json
+    kind: iamserviceaccount
+    name: iamserviceaccount_v1beta1
+  - apiVersion: iam.cnrm.cloud.google.com/v1beta1
+    filename: iam.cnrm.cloud.google.com/iampolicy_v1beta1.json
+    kind: IAMPolicy
+    name: iampolicy_v1beta1
+  - apiVersion: iam.cnrm.cloud.google.com/v1beta1
+    filename: iam.cnrm.cloud.google.com/iamauditconfig_v1beta1.json
+    kind: IAMAuditConfig
+    name: iamauditconfig_v1beta1
+  - apiVersion: iam.cnrm.cloud.google.com/v1beta1
+    filename: iam.cnrm.cloud.google.com/iamserviceaccountkey_v1beta1.json
+    kind: iamserviceaccountkey
+    name: iamserviceaccountkey_v1beta1
+  - apiVersion: iam.cnrm.cloud.google.com/v1beta1
+    filename: iam.cnrm.cloud.google.com/iamworkloadidentitypoolprovider_v1beta1.json
+    kind: iamworkloadidentitypoolprovider
+    name: iamworkloadidentitypoolprovider_v1beta1
+  - apiVersion: iam.cnrm.cloud.google.com/v1beta1
+    filename: iam.cnrm.cloud.google.com/iamworkloadidentitypool_v1beta1.json
+    kind: iamworkloadidentitypool
+    name: iamworkloadidentitypool_v1beta1
+  - apiVersion: iam.cnrm.cloud.google.com/v1beta1
+    filename: iam.cnrm.cloud.google.com/iamworkforcepoolprovider_v1beta1.json
+    kind: iamworkforcepoolprovider
+    name: iamworkforcepoolprovider_v1beta1
+  - apiVersion: iam.cnrm.cloud.google.com/v1beta1
+    filename: iam.cnrm.cloud.google.com/iampolicymember_v1beta1.json
+    kind: IAMPolicyMember
+    name: iampolicymember_v1beta1
+  - apiVersion: iam.cnrm.cloud.google.com/v1beta1
+    filename: iam.cnrm.cloud.google.com/iamaccessboundarypolicy_v1beta1.json
+    kind: iamaccessboundarypolicy
+    name: iamaccessboundarypolicy_v1beta1
+  - apiVersion: iam.cnrm.cloud.google.com/v1beta1
+    filename: iam.cnrm.cloud.google.com/iamcustomrole_v1beta1.json
+    kind: iamcustomrole
+    name: iamcustomrole_v1beta1
+  - apiVersion: iam.cnrm.cloud.google.com/v1beta1
+    filename: iam.cnrm.cloud.google.com/iampartialpolicy_v1beta1.json
+    kind: IAMPartialPolicy
+    name: iampartialpolicy_v1beta1
+  - apiVersion: iam.cnrm.cloud.google.com/v1beta1
+    filename: iam.cnrm.cloud.google.com/iamworkforcepool_v1beta1.json
+    kind: iamworkforcepool
+    name: iamworkforcepool_v1beta1
+iam.services.k8s.aws:
+  - apiVersion: iam.services.k8s.aws/v1alpha1
+    filename: iam.services.k8s.aws/user_v1alpha1.json
+    kind: User
+    name: user_v1alpha1
+  - apiVersion: iam.services.k8s.aws/v1alpha1
+    filename: iam.services.k8s.aws/openidconnectprovider_v1alpha1.json
+    kind: OpenIDConnectProvider
+    name: openidconnectprovider_v1alpha1
+  - apiVersion: iam.services.k8s.aws/v1alpha1
+    filename: iam.services.k8s.aws/policy_v1alpha1.json
+    kind: Policy
+    name: policy_v1alpha1
+  - apiVersion: iam.services.k8s.aws/v1alpha1
+    filename: iam.services.k8s.aws/role_v1alpha1.json
+    kind: Role
+    name: role_v1alpha1
+  - apiVersion: iam.services.k8s.aws/v1alpha1
+    filename: iam.services.k8s.aws/group_v1alpha1.json
+    kind: Group
+    name: group_v1alpha1
+iap.cnrm.cloud.google.com:
+  - apiVersion: iap.cnrm.cloud.google.com/v1beta1
+    filename: iap.cnrm.cloud.google.com/iapbrand_v1beta1.json
+    kind: iapbrand
+    name: iapbrand_v1beta1
+  - apiVersion: iap.cnrm.cloud.google.com/v1beta1
+    filename: iap.cnrm.cloud.google.com/iapidentityawareproxyclient_v1beta1.json
+    kind: iapidentityawareproxyclient
+    name: iapidentityawareproxyclient_v1beta1
+identityplatform.cnrm.cloud.google.com:
+  - apiVersion: identityplatform.cnrm.cloud.google.com/v1beta1
+    filename: identityplatform.cnrm.cloud.google.com/identityplatformoauthidpconfig_v1beta1.json
+    kind: identityplatformoauthidpconfig
+    name: identityplatformoauthidpconfig_v1beta1
+  - apiVersion: identityplatform.cnrm.cloud.google.com/v1alpha1
+    filename: identityplatform.cnrm.cloud.google.com/identityplatformtenantinboundsamlconfig_v1alpha1.json
+    kind: identityplatformtenantinboundsamlconfig
+    name: identityplatformtenantinboundsamlconfig_v1alpha1
+  - apiVersion: identityplatform.cnrm.cloud.google.com/v1alpha1
+    filename: identityplatform.cnrm.cloud.google.com/identityplatforminboundsamlconfig_v1alpha1.json
+    kind: identityplatforminboundsamlconfig
+    name: identityplatforminboundsamlconfig_v1alpha1
+  - apiVersion: identityplatform.cnrm.cloud.google.com/v1beta1
+    filename: identityplatform.cnrm.cloud.google.com/identityplatformconfig_v1beta1.json
+    kind: identityplatformconfig
+    name: identityplatformconfig_v1beta1
+  - apiVersion: identityplatform.cnrm.cloud.google.com/v1alpha1
+    filename: identityplatform.cnrm.cloud.google.com/identityplatformtenantdefaultsupportedidpconfig_v1alpha1.json
+    kind: identityplatformtenantdefaultsupportedidpconfig
+    name: identityplatformtenantdefaultsupportedidpconfig_v1alpha1
+  - apiVersion: identityplatform.cnrm.cloud.google.com/v1alpha1
+    filename: identityplatform.cnrm.cloud.google.com/identityplatformprojectdefaultconfig_v1alpha1.json
+    kind: identityplatformprojectdefaultconfig
+    name: identityplatformprojectdefaultconfig_v1alpha1
+  - apiVersion: identityplatform.cnrm.cloud.google.com/v1alpha1
+    filename: identityplatform.cnrm.cloud.google.com/identityplatformdefaultsupportedidpconfig_v1alpha1.json
+    kind: identityplatformdefaultsupportedidpconfig
+    name: identityplatformdefaultsupportedidpconfig_v1alpha1
+  - apiVersion: identityplatform.cnrm.cloud.google.com/v1beta1
+    filename: identityplatform.cnrm.cloud.google.com/identityplatformtenantoauthidpconfig_v1beta1.json
+    kind: identityplatformtenantoauthidpconfig
+    name: identityplatformtenantoauthidpconfig_v1beta1
+  - apiVersion: identityplatform.cnrm.cloud.google.com/v1beta1
+    filename: identityplatform.cnrm.cloud.google.com/identityplatformtenant_v1beta1.json
+    kind: identityplatformtenant
+    name: identityplatformtenant_v1beta1
+idp.supervisor.pinniped.dev:
+  - apiVersion: idp.supervisor.pinniped.dev/v1alpha1
+    filename: idp.supervisor.pinniped.dev/activedirectoryidentityprovider_v1alpha1.json
+    kind: ActiveDirectoryIdentityProvider
+    name: activedirectoryidentityprovider_v1alpha1
+  - apiVersion: idp.supervisor.pinniped.dev/v1alpha1
+    filename: idp.supervisor.pinniped.dev/oidcidentityprovider_v1alpha1.json
+    kind: OIDCIdentityProvider
+    name: oidcidentityprovider_v1alpha1
+  - apiVersion: idp.supervisor.pinniped.dev/v1alpha1
+    filename: idp.supervisor.pinniped.dev/ldapidentityprovider_v1alpha1.json
+    kind: LDAPIdentityProvider
+    name: ldapidentityprovider_v1alpha1
+  - apiVersion: idp.supervisor.pinniped.dev/v1alpha1
+    filename: idp.supervisor.pinniped.dev/githubidentityprovider_v1alpha1.json
+    kind: GitHubIdentityProvider
+    name: githubidentityprovider_v1alpha1
 image.toolkit.fluxcd.io:
   - apiVersion: image.toolkit.fluxcd.io/v1alpha1
     filename: image.toolkit.fluxcd.io/imageupdateautomation_v1alpha1.json
@@ -176,11 +3725,852 @@ image.toolkit.fluxcd.io:
     filename: image.toolkit.fluxcd.io/imagerepository_v1beta1.json
     kind: ImageRepository
     name: imagerepository_v1beta1
+  - apiVersion: image.toolkit.fluxcd.io/v1beta2
+    filename: image.toolkit.fluxcd.io/imagepolicy_v1beta2.json
+    kind: ImagePolicy
+    name: imagepolicy_v1beta2
+  - apiVersion: image.toolkit.fluxcd.io/v1beta2
+    filename: image.toolkit.fluxcd.io/imagerepository_v1beta2.json
+    kind: ImageRepository
+    name: imagerepository_v1beta2
+  - apiVersion: image.toolkit.fluxcd.io/v1beta2
+    filename: image.toolkit.fluxcd.io/imageupdateautomation_v1beta2.json
+    kind: ImageUpdateAutomation
+    name: imageupdateautomation_v1beta2
+infrastructure.cluster.x-k8s.io:
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    filename: infrastructure.cluster.x-k8s.io/awsclusterroleidentity_v1beta2.json
+    kind: AWSClusterRoleIdentity
+    name: awsclusterroleidentity_v1beta2
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    filename: infrastructure.cluster.x-k8s.io/awsmachine_v1beta2.json
+    kind: AWSMachine
+    name: awsmachine_v1beta2
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    filename: infrastructure.cluster.x-k8s.io/gcpmachinetemplate_v1beta1.json
+    kind: GCPMachineTemplate
+    name: gcpmachinetemplate_v1beta1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+    filename: infrastructure.cluster.x-k8s.io/azuremanagedmachinepool_v1alpha4.json
+    kind: AzureManagedMachinePool
+    name: azuremanagedmachinepool_v1alpha4
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    filename: infrastructure.cluster.x-k8s.io/awscluster_v1beta1.json
+    kind: AWSCluster
+    name: awscluster_v1beta1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    filename: infrastructure.cluster.x-k8s.io/awsclustertemplate_v1beta2.json
+    kind: AWSClusterTemplate
+    name: awsclustertemplate_v1beta2
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+    filename: infrastructure.cluster.x-k8s.io/azuremachinetemplate_v1alpha2.json
+    kind: AzureMachineTemplate
+    name: azuremachinetemplate_v1alpha2
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    filename: infrastructure.cluster.x-k8s.io/byocluster_v1beta1.json
+    kind: ByoCluster
+    name: byocluster_v1beta1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+    filename: infrastructure.cluster.x-k8s.io/awsfargateprofile_v1alpha3.json
+    kind: AWSFargateProfile
+    name: awsfargateprofile_v1alpha3
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+    filename: infrastructure.cluster.x-k8s.io/azuremanagedcontrolplane_v1alpha3.json
+    kind: AzureManagedControlPlane
+    name: azuremanagedcontrolplane_v1alpha3
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+    filename: infrastructure.cluster.x-k8s.io/azuremachinepool_v1alpha4.json
+    kind: AzureMachinePool
+    name: azuremachinepool_v1alpha4
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    filename: infrastructure.cluster.x-k8s.io/awsmachinetemplate_v1beta1.json
+    kind: AWSMachineTemplate
+    name: awsmachinetemplate_v1beta1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    filename: infrastructure.cluster.x-k8s.io/ocivirtualmachinepool_v1beta2.json
+    kind: OCIVirtualMachinePool
+    name: ocivirtualmachinepool_v1beta2
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+    filename: infrastructure.cluster.x-k8s.io/awsmachinepool_v1alpha3.json
+    kind: AWSMachinePool
+    name: awsmachinepool_v1alpha3
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    filename: infrastructure.cluster.x-k8s.io/azuremanagedmachinepooltemplate_v1beta1.json
+    kind: AzureManagedMachinePoolTemplate
+    name: azuremanagedmachinepooltemplate_v1beta1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    filename: infrastructure.cluster.x-k8s.io/ocimanagedmachinepooltemplate_v1beta2.json
+    kind: OCIManagedMachinePoolTemplate
+    name: ocimanagedmachinepooltemplate_v1beta2
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+    filename: infrastructure.cluster.x-k8s.io/azurecluster_v1alpha2.json
+    kind: AzureCluster
+    name: azurecluster_v1alpha2
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    filename: infrastructure.cluster.x-k8s.io/azuremachine_v1beta1.json
+    kind: AzureMachine
+    name: azuremachine_v1beta1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    filename: infrastructure.cluster.x-k8s.io/ociclusteridentity_v1beta2.json
+    kind: OCIClusterIdentity
+    name: ociclusteridentity_v1beta2
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    filename: infrastructure.cluster.x-k8s.io/ocimachinepoolmachine_v1beta1.json
+    kind: ocimachinepoolmachine
+    name: ocimachinepoolmachine_v1beta1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    filename: infrastructure.cluster.x-k8s.io/ocimanagedcluster_v1beta2.json
+    kind: OCIManagedCluster
+    name: ocimanagedcluster_v1beta2
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+    filename: infrastructure.cluster.x-k8s.io/gcpcluster_v1alpha2.json
+    kind: GCPCluster
+    name: gcpcluster_v1alpha2
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    filename: infrastructure.cluster.x-k8s.io/azuremanagedcluster_v1beta1.json
+    kind: AzureManagedCluster
+    name: azuremanagedcluster_v1beta1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+    filename: infrastructure.cluster.x-k8s.io/azureasomanagedmachinepool_v1alpha1.json
+    kind: AzureASOManagedMachinePool
+    name: azureasomanagedmachinepool_v1alpha1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+    filename: infrastructure.cluster.x-k8s.io/awscluster_v1alpha3.json
+    kind: AWSCluster
+    name: awscluster_v1alpha3
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    filename: infrastructure.cluster.x-k8s.io/awsmachinepool_v1beta2.json
+    kind: AWSMachinePool
+    name: awsmachinepool_v1beta2
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    filename: infrastructure.cluster.x-k8s.io/ocicluster_v1beta2.json
+    kind: OCICluster
+    name: ocicluster_v1beta2
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+    filename: infrastructure.cluster.x-k8s.io/azureasomanagedcontrolplanetemplate_v1alpha1.json
+    kind: AzureASOManagedControlPlaneTemplate
+    name: azureasomanagedcontrolplanetemplate_v1alpha1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+    filename: infrastructure.cluster.x-k8s.io/awsclustercontrolleridentity_v1alpha4.json
+    kind: AWSClusterControllerIdentity
+    name: awsclustercontrolleridentity_v1alpha4
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    filename: infrastructure.cluster.x-k8s.io/awsfargateprofile_v1beta2.json
+    kind: AWSFargateProfile
+    name: awsfargateprofile_v1beta2
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    filename: infrastructure.cluster.x-k8s.io/ocimachine_v1beta1.json
+    kind: OCIMachine
+    name: ocimachine_v1beta1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+    filename: infrastructure.cluster.x-k8s.io/azuremanagedcluster_v1alpha3.json
+    kind: AzureManagedCluster
+    name: azuremanagedcluster_v1alpha3
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+    filename: infrastructure.cluster.x-k8s.io/gcpmachinetemplate_v1alpha3.json
+    kind: GCPMachineTemplate
+    name: gcpmachinetemplate_v1alpha3
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+    filename: infrastructure.cluster.x-k8s.io/dockermachine_v1alpha3.json
+    kind: DockerMachine
+    name: dockermachine_v1alpha3
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+    filename: infrastructure.cluster.x-k8s.io/dockercluster_v1alpha3.json
+    kind: DockerCluster
+    name: dockercluster_v1alpha3
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+    filename: infrastructure.cluster.x-k8s.io/gcpmachine_v1alpha2.json
+    kind: GCPMachine
+    name: gcpmachine_v1alpha2
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+    filename: infrastructure.cluster.x-k8s.io/awsmachine_v1alpha3.json
+    kind: AWSMachine
+    name: awsmachine_v1alpha3
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    filename: infrastructure.cluster.x-k8s.io/azuremanagedclustertemplate_v1beta1.json
+    kind: AzureManagedClusterTemplate
+    name: azuremanagedclustertemplate_v1beta1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    filename: infrastructure.cluster.x-k8s.io/ocimachinepool_v1beta1.json
+    kind: ocimachinepool
+    name: ocimachinepool_v1beta1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    filename: infrastructure.cluster.x-k8s.io/k8sinstallerconfigtemplate_v1beta1.json
+    kind: K8sInstallerConfigTemplate
+    name: k8sinstallerconfigtemplate_v1beta1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+    filename: infrastructure.cluster.x-k8s.io/azuremachine_v1alpha2.json
+    kind: AzureMachine
+    name: azuremachine_v1alpha2
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+    filename: infrastructure.cluster.x-k8s.io/azureclusteridentity_v1alpha3.json
+    kind: AzureClusterIdentity
+    name: azureclusteridentity_v1alpha3
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    filename: infrastructure.cluster.x-k8s.io/tinkerbellmachinetemplate_v1beta1.json
+    kind: TinkerbellMachineTemplate
+    name: tinkerbellmachinetemplate_v1beta1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+    filename: infrastructure.cluster.x-k8s.io/azurecluster_v1alpha3.json
+    kind: AzureCluster
+    name: azurecluster_v1alpha3
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    filename: infrastructure.cluster.x-k8s.io/byoclustertemplate_v1beta1.json
+    kind: ByoClusterTemplate
+    name: byoclustertemplate_v1beta1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    filename: infrastructure.cluster.x-k8s.io/rosamachinepool_v1beta2.json
+    kind: ROSAMachinePool
+    name: rosamachinepool_v1beta2
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+    filename: infrastructure.cluster.x-k8s.io/awscluster_v1alpha2.json
+    kind: AWSCluster
+    name: awscluster_v1alpha2
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    filename: infrastructure.cluster.x-k8s.io/awsmanagedmachinepool_v1beta2.json
+    kind: AWSManagedMachinePool
+    name: awsmanagedmachinepool_v1beta2
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+    filename: infrastructure.cluster.x-k8s.io/gcpcluster_v1alpha3.json
+    kind: GCPCluster
+    name: gcpcluster_v1alpha3
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    filename: infrastructure.cluster.x-k8s.io/azuremachinepool_v1beta1.json
+    kind: AzureMachinePool
+    name: azuremachinepool_v1beta1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    filename: infrastructure.cluster.x-k8s.io/azuremachinepoolmachine_v1beta1.json
+    kind: AzureMachinePoolMachine
+    name: azuremachinepoolmachine_v1beta1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+    filename: infrastructure.cluster.x-k8s.io/awsmanagedcluster_v1alpha3.json
+    kind: AWSManagedCluster
+    name: awsmanagedcluster_v1alpha3
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+    filename: infrastructure.cluster.x-k8s.io/dockermachine_v1alpha2.json
+    kind: DockerMachine
+    name: dockermachine_v1alpha2
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+    filename: infrastructure.cluster.x-k8s.io/gcpmachinetemplate_v1alpha2.json
+    kind: GCPMachineTemplate
+    name: gcpmachinetemplate_v1alpha2
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+    filename: infrastructure.cluster.x-k8s.io/awsclusterstaticidentity_v1alpha4.json
+    kind: AWSClusterStaticIdentity
+    name: awsclusterstaticidentity_v1alpha4
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    filename: infrastructure.cluster.x-k8s.io/dockermachinepool_v1beta1.json
+    kind: DockerMachinePool
+    name: dockermachinepool_v1beta1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+    filename: infrastructure.cluster.x-k8s.io/dockercluster_v1alpha2.json
+    kind: DockerCluster
+    name: dockercluster_v1alpha2
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    filename: infrastructure.cluster.x-k8s.io/awsmanagedcluster_v1beta2.json
+    kind: AWSManagedCluster
+    name: awsmanagedcluster_v1beta2
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    filename: infrastructure.cluster.x-k8s.io/tinkerbellcluster_v1beta1.json
+    kind: TinkerbellCluster
+    name: tinkerbellcluster_v1beta1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    filename: infrastructure.cluster.x-k8s.io/bootstrapkubeconfig_v1beta1.json
+    kind: BootstrapKubeconfig
+    name: bootstrapkubeconfig_v1beta1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    filename: infrastructure.cluster.x-k8s.io/ociclustertemplate_v1beta2.json
+    kind: OCIClusterTemplate
+    name: ociclustertemplate_v1beta2
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+    filename: infrastructure.cluster.x-k8s.io/awsmachine_v1alpha2.json
+    kind: AWSMachine
+    name: awsmachine_v1alpha2
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+    filename: infrastructure.cluster.x-k8s.io/gcpmachine_v1alpha3.json
+    kind: GCPMachine
+    name: gcpmachine_v1alpha3
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+    filename: infrastructure.cluster.x-k8s.io/awsmanagedmachinepool_v1alpha3.json
+    kind: AWSManagedMachinePool
+    name: awsmanagedmachinepool_v1alpha3
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+    filename: infrastructure.cluster.x-k8s.io/dockerclustertemplate_v1alpha4.json
+    kind: DockerClusterTemplate
+    name: dockerclustertemplate_v1alpha4
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    filename: infrastructure.cluster.x-k8s.io/ocimachinetemplate_v1beta1.json
+    kind: OCIMachineTemplate
+    name: ocimachinetemplate_v1beta1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    filename: infrastructure.cluster.x-k8s.io/gcpmanagedcontrolplane_v1beta1.json
+    kind: GCPManagedControlPlane
+    name: gcpmanagedcontrolplane_v1beta1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+    filename: infrastructure.cluster.x-k8s.io/awsclusterroleidentity_v1alpha3.json
+    kind: AWSClusterRoleIdentity
+    name: awsclusterroleidentity_v1alpha3
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+    filename: infrastructure.cluster.x-k8s.io/awsclustertemplate_v1alpha4.json
+    kind: AWSClusterTemplate
+    name: awsclustertemplate_v1alpha4
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    filename: infrastructure.cluster.x-k8s.io/awsclusterstaticidentity_v1beta1.json
+    kind: AWSClusterStaticIdentity
+    name: awsclusterstaticidentity_v1beta1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    filename: infrastructure.cluster.x-k8s.io/ocimanagedclustertemplate_v1beta2.json
+    kind: OCIManagedClusterTemplate
+    name: ocimanagedclustertemplate_v1beta2
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+    filename: infrastructure.cluster.x-k8s.io/azuremachine_v1alpha3.json
+    kind: AzureMachine
+    name: azuremachine_v1alpha3
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    filename: infrastructure.cluster.x-k8s.io/rosacluster_v1beta2.json
+    kind: ROSACluster
+    name: rosacluster_v1beta2
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+    filename: infrastructure.cluster.x-k8s.io/azuremachinetemplate_v1alpha3.json
+    kind: AzureMachineTemplate
+    name: azuremachinetemplate_v1alpha3
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+    filename: infrastructure.cluster.x-k8s.io/azureasomanagedmachinepooltemplate_v1alpha1.json
+    kind: AzureASOManagedMachinePoolTemplate
+    name: azureasomanagedmachinepooltemplate_v1alpha1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+    filename: infrastructure.cluster.x-k8s.io/awsmachinetemplate_v1alpha4.json
+    kind: AWSMachineTemplate
+    name: awsmachinetemplate_v1alpha4
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    filename: infrastructure.cluster.x-k8s.io/ocimanagedcontrolplane_v1beta1.json
+    kind: OCIManagedControlPlane
+    name: ocimanagedcontrolplane_v1beta1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    filename: infrastructure.cluster.x-k8s.io/azuremachinetemplate_v1beta1.json
+    kind: AzureMachineTemplate
+    name: azuremachinetemplate_v1beta1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    filename: infrastructure.cluster.x-k8s.io/ocimanagedcontrolplanetemplate_v1beta2.json
+    kind: OCIManagedControlPlaneTemplate
+    name: ocimanagedcontrolplanetemplate_v1beta2
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    filename: infrastructure.cluster.x-k8s.io/dockermachinetemplate_v1beta1.json
+    kind: DockerMachineTemplate
+    name: dockermachinetemplate_v1beta1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+    filename: infrastructure.cluster.x-k8s.io/azureasomanagedcluster_v1alpha1.json
+    kind: AzureASOManagedCluster
+    name: azureasomanagedcluster_v1alpha1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+    filename: infrastructure.cluster.x-k8s.io/dockermachinepool_v1alpha3.json
+    kind: DockerMachinePool
+    name: dockermachinepool_v1alpha3
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    filename: infrastructure.cluster.x-k8s.io/gcpmanagedcluster_v1beta1.json
+    kind: GCPManagedCluster
+    name: gcpmanagedcluster_v1beta1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    filename: infrastructure.cluster.x-k8s.io/awsclustercontrolleridentity_v1beta2.json
+    kind: AWSClusterControllerIdentity
+    name: awsclustercontrolleridentity_v1beta2
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+    filename: infrastructure.cluster.x-k8s.io/dockermachinetemplate_v1alpha4.json
+    kind: DockerMachineTemplate
+    name: dockermachinetemplate_v1alpha4
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    filename: infrastructure.cluster.x-k8s.io/gcpmachine_v1beta1.json
+    kind: GCPMachine
+    name: gcpmachine_v1beta1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+    filename: infrastructure.cluster.x-k8s.io/azuremachinepoolmachine_v1alpha4.json
+    kind: AzureMachinePoolMachine
+    name: azuremachinepoolmachine_v1alpha4
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    filename: infrastructure.cluster.x-k8s.io/dockercluster_v1beta1.json
+    kind: DockerCluster
+    name: dockercluster_v1beta1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    filename: infrastructure.cluster.x-k8s.io/ocimanagedmachinepool_v1beta2.json
+    kind: OCIManagedMachinePool
+    name: ocimanagedmachinepool_v1beta2
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    filename: infrastructure.cluster.x-k8s.io/azuremanagedcontrolplane_v1beta1.json
+    kind: AzureManagedControlPlane
+    name: azuremanagedcontrolplane_v1beta1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+    filename: infrastructure.cluster.x-k8s.io/awsmachine_v1alpha4.json
+    kind: AWSMachine
+    name: awsmachine_v1alpha4
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    filename: infrastructure.cluster.x-k8s.io/ociclusteridentity_v1beta1.json
+    kind: OCIClusterIdentity
+    name: ociclusteridentity_v1beta1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    filename: infrastructure.cluster.x-k8s.io/ocimanagedcluster_v1beta1.json
+    kind: OCIManagedCluster
+    name: ocimanagedcluster_v1beta1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    filename: infrastructure.cluster.x-k8s.io/ocimachinepoolmachine_v1beta2.json
+    kind: ocimachinepoolmachine
+    name: ocimachinepoolmachine_v1beta2
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    filename: infrastructure.cluster.x-k8s.io/azurecluster_v1beta1.json
+    kind: AzureCluster
+    name: azurecluster_v1beta1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+    filename: infrastructure.cluster.x-k8s.io/dockercluster_v1alpha4.json
+    kind: DockerCluster
+    name: dockercluster_v1alpha4
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+    filename: infrastructure.cluster.x-k8s.io/azureclusteridentity_v1alpha4.json
+    kind: AzureClusterIdentity
+    name: azureclusteridentity_v1alpha4
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    filename: infrastructure.cluster.x-k8s.io/awsmachinepool_v1beta1.json
+    kind: AWSMachinePool
+    name: awsmachinepool_v1beta1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    filename: infrastructure.cluster.x-k8s.io/ocicluster_v1beta1.json
+    kind: OCICluster
+    name: ocicluster_v1beta1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    filename: infrastructure.cluster.x-k8s.io/ocimachine_v1beta2.json
+    kind: OCIMachine
+    name: ocimachine_v1beta2
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    filename: infrastructure.cluster.x-k8s.io/awsfargateprofile_v1beta1.json
+    kind: AWSFargateProfile
+    name: awsfargateprofile_v1beta1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+    filename: infrastructure.cluster.x-k8s.io/nestedcluster_v1alpha4.json
+    kind: NestedCluster
+    name: nestedcluster_v1alpha4
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    filename: infrastructure.cluster.x-k8s.io/ocimachinepool_v1beta2.json
+    kind: ocimachinepool
+    name: ocimachinepool_v1beta2
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+    filename: infrastructure.cluster.x-k8s.io/azuremanagedcluster_v1alpha4.json
+    kind: AzureManagedCluster
+    name: azuremanagedcluster_v1alpha4
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+    filename: infrastructure.cluster.x-k8s.io/gcpmachinetemplate_v1alpha4.json
+    kind: GCPMachineTemplate
+    name: gcpmachinetemplate_v1alpha4
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+    filename: infrastructure.cluster.x-k8s.io/dockermachine_v1alpha4.json
+    kind: DockerMachine
+    name: dockermachine_v1alpha4
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+    filename: infrastructure.cluster.x-k8s.io/awsclustercontrolleridentity_v1alpha3.json
+    kind: AWSClusterControllerIdentity
+    name: awsclustercontrolleridentity_v1alpha3
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+    filename: infrastructure.cluster.x-k8s.io/awscluster_v1alpha4.json
+    kind: AWSCluster
+    name: awscluster_v1alpha4
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    filename: infrastructure.cluster.x-k8s.io/byomachine_v1beta1.json
+    kind: ByoMachine
+    name: byomachine_v1beta1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    filename: infrastructure.cluster.x-k8s.io/awsclusterroleidentity_v1beta1.json
+    kind: AWSClusterRoleIdentity
+    name: awsclusterroleidentity_v1beta1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    filename: infrastructure.cluster.x-k8s.io/awsmachine_v1beta1.json
+    kind: AWSMachine
+    name: awsmachine_v1beta1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    filename: infrastructure.cluster.x-k8s.io/awscluster_v1beta2.json
+    kind: AWSCluster
+    name: awscluster_v1beta2
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    filename: infrastructure.cluster.x-k8s.io/awsclustertemplate_v1beta1.json
+    kind: AWSClusterTemplate
+    name: awsclustertemplate_v1beta1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    filename: infrastructure.cluster.x-k8s.io/awsmachinetemplate_v1beta2.json
+    kind: AWSMachineTemplate
+    name: awsmachinetemplate_v1beta2
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    filename: infrastructure.cluster.x-k8s.io/azuremanagedcontrolplanetemplate_v1beta1.json
+    kind: AzureManagedControlPlaneTemplate
+    name: azuremanagedcontrolplanetemplate_v1beta1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+    filename: infrastructure.cluster.x-k8s.io/gcpclustertemplate_v1alpha4.json
+    kind: GCPClusterTemplate
+    name: gcpclustertemplate_v1alpha4
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    filename: infrastructure.cluster.x-k8s.io/ocivirtualmachinepool_v1beta1.json
+    kind: OCIVirtualMachinePool
+    name: ocivirtualmachinepool_v1beta1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    filename: infrastructure.cluster.x-k8s.io/gcpclustertemplate_v1beta1.json
+    kind: GCPClusterTemplate
+    name: gcpclustertemplate_v1beta1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+    filename: infrastructure.cluster.x-k8s.io/azureasomanagedcontrolplane_v1alpha1.json
+    kind: AzureASOManagedControlPlane
+    name: azureasomanagedcontrolplane_v1alpha1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+    filename: infrastructure.cluster.x-k8s.io/awsfargateprofile_v1alpha4.json
+    kind: AWSFargateProfile
+    name: awsfargateprofile_v1alpha4
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    filename: infrastructure.cluster.x-k8s.io/azureclusteridentity_v1beta1.json
+    kind: AzureClusterIdentity
+    name: azureclusteridentity_v1beta1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    filename: infrastructure.cluster.x-k8s.io/azuremanagedmachinepool_v1beta1.json
+    kind: AzureManagedMachinePool
+    name: azuremanagedmachinepool_v1beta1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    filename: infrastructure.cluster.x-k8s.io/byohost_v1beta1.json
+    kind: ByoHost
+    name: byohost_v1beta1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+    filename: infrastructure.cluster.x-k8s.io/azuremanagedmachinepool_v1alpha3.json
+    kind: AzureManagedMachinePool
+    name: azuremanagedmachinepool_v1alpha3
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    filename: infrastructure.cluster.x-k8s.io/ocimanagedmachinepooltemplate_v1beta1.json
+    kind: OCIManagedMachinePoolTemplate
+    name: ocimanagedmachinepooltemplate_v1beta1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    filename: infrastructure.cluster.x-k8s.io/gcpmanagedmachinepool_v1beta1.json
+    kind: GCPManagedMachinePool
+    name: gcpmanagedmachinepool_v1beta1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+    filename: infrastructure.cluster.x-k8s.io/dockermachinetemplate_v1alpha2.json
+    kind: DockerMachineTemplate
+    name: dockermachinetemplate_v1alpha2
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+    filename: infrastructure.cluster.x-k8s.io/awsmachinepool_v1alpha4.json
+    kind: AWSMachinePool
+    name: awsmachinepool_v1alpha4
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+    filename: infrastructure.cluster.x-k8s.io/awsmachinetemplate_v1alpha2.json
+    kind: AWSMachineTemplate
+    name: awsmachinetemplate_v1alpha2
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+    filename: infrastructure.cluster.x-k8s.io/azuremanagedcontrolplane_v1alpha4.json
+    kind: AzureManagedControlPlane
+    name: azuremanagedcontrolplane_v1alpha4
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+    filename: infrastructure.cluster.x-k8s.io/azuremachinepool_v1alpha3.json
+    kind: AzureMachinePool
+    name: azuremachinepool_v1alpha3
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    filename: infrastructure.cluster.x-k8s.io/k8sinstallerconfig_v1beta1.json
+    kind: K8sInstallerConfig
+    name: k8sinstallerconfig_v1beta1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    filename: infrastructure.cluster.x-k8s.io/dockerclustertemplate_v1beta1.json
+    kind: DockerClusterTemplate
+    name: dockerclustertemplate_v1beta1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    filename: infrastructure.cluster.x-k8s.io/azureclustertemplate_v1beta1.json
+    kind: AzureClusterTemplate
+    name: azureclustertemplate_v1beta1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+    filename: infrastructure.cluster.x-k8s.io/azureasomanagedclustertemplate_v1alpha1.json
+    kind: AzureASOManagedClusterTemplate
+    name: azureasomanagedclustertemplate_v1alpha1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    filename: infrastructure.cluster.x-k8s.io/ocimanagedcontrolplanetemplate_v1beta1.json
+    kind: OCIManagedControlPlaneTemplate
+    name: ocimanagedcontrolplanetemplate_v1beta1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    filename: infrastructure.cluster.x-k8s.io/ocimanagedcontrolplane_v1beta2.json
+    kind: OCIManagedControlPlane
+    name: ocimanagedcontrolplane_v1beta2
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    filename: infrastructure.cluster.x-k8s.io/awsclustercontrolleridentity_v1beta1.json
+    kind: AWSClusterControllerIdentity
+    name: awsclustercontrolleridentity_v1beta1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+    filename: infrastructure.cluster.x-k8s.io/azuremachinetemplate_v1alpha4.json
+    kind: AzureMachineTemplate
+    name: azuremachinetemplate_v1alpha4
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    filename: infrastructure.cluster.x-k8s.io/dockermachine_v1beta1.json
+    kind: DockerMachine
+    name: dockermachine_v1beta1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    filename: infrastructure.cluster.x-k8s.io/gcpcluster_v1beta1.json
+    kind: GCPCluster
+    name: gcpcluster_v1beta1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+    filename: infrastructure.cluster.x-k8s.io/dockermachinetemplate_v1alpha3.json
+    kind: DockerMachineTemplate
+    name: dockermachinetemplate_v1alpha3
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+    filename: infrastructure.cluster.x-k8s.io/dockermachinepool_v1alpha4.json
+    kind: DockerMachinePool
+    name: dockermachinepool_v1alpha4
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    filename: infrastructure.cluster.x-k8s.io/ocimanagedmachinepool_v1beta1.json
+    kind: OCIManagedMachinePool
+    name: ocimanagedmachinepool_v1beta1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+    filename: infrastructure.cluster.x-k8s.io/awsmachinetemplate_v1alpha3.json
+    kind: AWSMachineTemplate
+    name: awsmachinetemplate_v1alpha3
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+    filename: infrastructure.cluster.x-k8s.io/gcpmachine_v1alpha4.json
+    kind: GCPMachine
+    name: gcpmachine_v1alpha4
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+    filename: infrastructure.cluster.x-k8s.io/azuremachine_v1alpha4.json
+    kind: AzureMachine
+    name: azuremachine_v1alpha4
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    filename: infrastructure.cluster.x-k8s.io/awsmanagedmachinepool_v1beta1.json
+    kind: AWSManagedMachinePool
+    name: awsmanagedmachinepool_v1beta1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    filename: infrastructure.cluster.x-k8s.io/byomachinetemplate_v1beta1.json
+    kind: ByoMachineTemplate
+    name: byomachinetemplate_v1beta1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+    filename: infrastructure.cluster.x-k8s.io/awsclusterroleidentity_v1alpha4.json
+    kind: AWSClusterRoleIdentity
+    name: awsclusterroleidentity_v1alpha4
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+    filename: infrastructure.cluster.x-k8s.io/awsmanagedmachinepool_v1alpha4.json
+    kind: AWSManagedMachinePool
+    name: awsmanagedmachinepool_v1alpha4
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    filename: infrastructure.cluster.x-k8s.io/ociclustertemplate_v1beta1.json
+    kind: OCIClusterTemplate
+    name: ociclustertemplate_v1beta1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    filename: infrastructure.cluster.x-k8s.io/tinkerbellmachine_v1beta1.json
+    kind: TinkerbellMachine
+    name: tinkerbellmachine_v1beta1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+    filename: infrastructure.cluster.x-k8s.io/azurecluster_v1alpha4.json
+    kind: AzureCluster
+    name: azurecluster_v1alpha4
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    filename: infrastructure.cluster.x-k8s.io/ocimachinetemplate_v1beta2.json
+    kind: OCIMachineTemplate
+    name: ocimachinetemplate_v1beta2
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+    filename: infrastructure.cluster.x-k8s.io/awsclusterstaticidentity_v1alpha3.json
+    kind: AWSClusterStaticIdentity
+    name: awsclusterstaticidentity_v1alpha3
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    filename: infrastructure.cluster.x-k8s.io/ocimanagedclustertemplate_v1beta1.json
+    kind: OCIManagedClusterTemplate
+    name: ocimanagedclustertemplate_v1beta1
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    filename: infrastructure.cluster.x-k8s.io/awsclusterstaticidentity_v1beta2.json
+    kind: AWSClusterStaticIdentity
+    name: awsclusterstaticidentity_v1beta2
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+    filename: infrastructure.cluster.x-k8s.io/gcpcluster_v1alpha4.json
+    kind: GCPCluster
+    name: gcpcluster_v1alpha4
+ingress.oraclecloud.com:
+  - apiVersion: ingress.oraclecloud.com/v1beta1
+    filename: ingress.oraclecloud.com/ingressclassparameters_v1beta1.json
+    kind: IngressClassParameters
+    name: ingressclassparameters_v1beta1
+ipam.cluster.x-k8s.io:
+  - apiVersion: ipam.cluster.x-k8s.io/v1alpha1
+    filename: ipam.cluster.x-k8s.io/ipaddressclaim_v1alpha1.json
+    kind: IPAddressClaim
+    name: ipaddressclaim_v1alpha1
+  - apiVersion: ipam.cluster.x-k8s.io/v1alpha1
+    filename: ipam.cluster.x-k8s.io/ipaddress_v1alpha1.json
+    kind: IPAddress
+    name: ipaddress_v1alpha1
+isindir.github.com:
+  - apiVersion: isindir.github.com/v1alpha3
+    filename: isindir.github.com/sopssecret_v1alpha3.json
+    kind: SopsSecret
+    name: sopssecret_v1alpha3
+  - apiVersion: isindir.github.com/v1alpha2
+    filename: isindir.github.com/sopssecret_v1alpha2.json
+    kind: SopsSecret
+    name: sopssecret_v1alpha2
+  - apiVersion: isindir.github.com/v1alpha1
+    filename: isindir.github.com/sopssecret_v1alpha1.json
+    kind: SopsSecret
+    name: sopssecret_v1alpha1
 jaegertracing.io:
   - apiVersion: jaegertracing.io/v1
     filename: jaegertracing.io/jaeger_v1.json
     kind: Jaeger
     name: jaeger_v1
+jetstream.nats.io:
+  - apiVersion: jetstream.nats.io/v1beta1
+    filename: jetstream.nats.io/streamtemplate_v1beta1.json
+    kind: streamtemplate
+    name: streamtemplate_v1beta1
+  - apiVersion: jetstream.nats.io/v1beta2
+    filename: jetstream.nats.io/stream_v1beta2.json
+    kind: stream
+    name: stream_v1beta2
+  - apiVersion: jetstream.nats.io/v1beta2
+    filename: jetstream.nats.io/consumer_v1beta2.json
+    kind: consumer
+    name: consumer_v1beta2
+  - apiVersion: jetstream.nats.io/v1beta1
+    filename: jetstream.nats.io/stream_v1beta1.json
+    kind: stream
+    name: stream_v1beta1
+  - apiVersion: jetstream.nats.io/v1beta2
+    filename: jetstream.nats.io/account_v1beta2.json
+    kind: account
+    name: account_v1beta2
+  - apiVersion: jetstream.nats.io/v1beta1
+    filename: jetstream.nats.io/consumer_v1beta1.json
+    kind: consumer
+    name: consumer_v1beta1
+job.min.io:
+  - apiVersion: job.min.io/v1alpha1
+    filename: job.min.io/miniojob_v1alpha1.json
+    kind: miniojob
+    name: miniojob_v1alpha1
+k6.io:
+  - apiVersion: k6.io/v1alpha1
+    filename: k6.io/k6_v1alpha1.json
+    kind: k6
+    name: k6_v1alpha1
+  - apiVersion: k6.io/v1alpha1
+    filename: k6.io/testrun_v1alpha1.json
+    kind: testrun
+    name: testrun_v1alpha1
+k8s.cni.cncf.io:
+  - apiVersion: k8s.cni.cncf.io/v1
+    filename: k8s.cni.cncf.io/networkattachmentdefinition_v1.json
+    kind: NetworkAttachmentDefinition
+    name: networkattachmentdefinition_v1
+k8s.keycloak.org:
+  - apiVersion: k8s.keycloak.org/v2alpha1
+    filename: k8s.keycloak.org/keycloak_v2alpha1.json
+    kind: keycloak
+    name: keycloak_v2alpha1
+  - apiVersion: k8s.keycloak.org/v2alpha1
+    filename: k8s.keycloak.org/keycloakrealmimport_v2alpha1.json
+    kind: keycloakrealmimport
+    name: keycloakrealmimport_v2alpha1
+k8s.mariadb.com:
+  - apiVersion: k8s.mariadb.com/v1alpha1
+    filename: k8s.mariadb.com/grant_v1alpha1.json
+    kind: Grant
+    name: grant_v1alpha1
+  - apiVersion: k8s.mariadb.com/v1alpha1
+    filename: k8s.mariadb.com/maxscale_v1alpha1.json
+    kind: MaxScale
+    name: maxscale_v1alpha1
+  - apiVersion: k8s.mariadb.com/v1alpha1
+    filename: k8s.mariadb.com/restore_v1alpha1.json
+    kind: Restore
+    name: restore_v1alpha1
+  - apiVersion: k8s.mariadb.com/v1alpha1
+    filename: k8s.mariadb.com/backup_v1alpha1.json
+    kind: Backup
+    name: backup_v1alpha1
+  - apiVersion: k8s.mariadb.com/v1alpha1
+    filename: k8s.mariadb.com/mariadb_v1alpha1.json
+    kind: MariaDB
+    name: mariadb_v1alpha1
+  - apiVersion: k8s.mariadb.com/v1alpha1
+    filename: k8s.mariadb.com/user_v1alpha1.json
+    kind: User
+    name: user_v1alpha1
+  - apiVersion: k8s.mariadb.com/v1alpha1
+    filename: k8s.mariadb.com/sqljob_v1alpha1.json
+    kind: SqlJob
+    name: sqljob_v1alpha1
+  - apiVersion: k8s.mariadb.com/v1alpha1
+    filename: k8s.mariadb.com/database_v1alpha1.json
+    kind: Database
+    name: database_v1alpha1
+  - apiVersion: k8s.mariadb.com/v1alpha1
+    filename: k8s.mariadb.com/connection_v1alpha1.json
+    kind: Connection
+    name: connection_v1alpha1
+k8s.nginx.org:
+  - apiVersion: k8s.nginx.org/v1alpha1
+    filename: k8s.nginx.org/globalconfiguration_v1alpha1.json
+    kind: GlobalConfiguration
+    name: globalconfiguration_v1alpha1
+  - apiVersion: k8s.nginx.org/v1
+    filename: k8s.nginx.org/transportserver_v1.json
+    kind: TransportServer
+    name: transportserver_v1
+  - apiVersion: k8s.nginx.org/v1
+    filename: k8s.nginx.org/policy_v1.json
+    kind: Policy
+    name: policy_v1
+  - apiVersion: k8s.nginx.org/v1alpha1
+    filename: k8s.nginx.org/policy_v1alpha1.json
+    kind: Policy
+    name: policy_v1alpha1
+  - apiVersion: k8s.nginx.org/v1
+    filename: k8s.nginx.org/virtualserverroute_v1.json
+    kind: VirtualServerRoute
+    name: virtualserverroute_v1
+  - apiVersion: k8s.nginx.org/v1alpha1
+    filename: k8s.nginx.org/transportserver_v1alpha1.json
+    kind: TransportServer
+    name: transportserver_v1alpha1
+  - apiVersion: k8s.nginx.org/v1
+    filename: k8s.nginx.org/virtualserver_v1.json
+    kind: VirtualServer
+    name: virtualserver_v1
+  - apiVersion: k8s.nginx.org/v1
+    filename: k8s.nginx.org/globalconfiguration_v1.json
+    kind: GlobalConfiguration
+    name: globalconfiguration_v1
+k8up.io:
+  - apiVersion: k8up.io/v1
+    filename: k8up.io/podconfig_v1.json
+    kind: PodConfig
+    name: podconfig_v1
+  - apiVersion: k8up.io/v1
+    filename: k8up.io/check_v1.json
+    kind: Check
+    name: check_v1
+  - apiVersion: k8up.io/v1
+    filename: k8up.io/prebackuppod_v1.json
+    kind: PreBackupPod
+    name: prebackuppod_v1
+  - apiVersion: k8up.io/v1
+    filename: k8up.io/schedule_v1.json
+    kind: Schedule
+    name: schedule_v1
+  - apiVersion: k8up.io/v1
+    filename: k8up.io/backup_v1.json
+    kind: Backup
+    name: backup_v1
+  - apiVersion: k8up.io/v1
+    filename: k8up.io/archive_v1.json
+    kind: Archive
+    name: archive_v1
+  - apiVersion: k8up.io/v1
+    filename: k8up.io/snapshot_v1.json
+    kind: Snapshot
+    name: snapshot_v1
+  - apiVersion: k8up.io/v1
+    filename: k8up.io/restore_v1.json
+    kind: Restore
+    name: restore_v1
+  - apiVersion: k8up.io/v1
+    filename: k8up.io/prune_v1.json
+    kind: Prune
+    name: prune_v1
+kafka.services.k8s.aws:
+  - apiVersion: kafka.services.k8s.aws/v1alpha1
+    filename: kafka.services.k8s.aws/cluster_v1alpha1.json
+    kind: Cluster
+    name: cluster_v1alpha1
 kafka.strimzi.io:
   - apiVersion: kafka.strimzi.io/v1beta2
     filename: kafka.strimzi.io/kafka_v1beta2.json
@@ -238,6 +4628,56 @@ kafka.strimzi.io:
     filename: kafka.strimzi.io/strimzipodset_v1beta2.json
     kind: StrimziPodSet
     name: strimzipodset_v1beta2
+  - apiVersion: kafka.strimzi.io/v1alpha1
+    filename: kafka.strimzi.io/kafkatopiccontrolacls_v1alpha1.json
+    kind: kafkatopiccontrolacls
+    name: kafkatopiccontrolacls_v1alpha1
+  - apiVersion: kafka.strimzi.io/v1beta1
+    filename: kafka.strimzi.io/kafkatopiccontrolacls_v1beta1.json
+    kind: kafkatopiccontrolacls
+    name: kafkatopiccontrolacls_v1beta1
+  - apiVersion: kafka.strimzi.io/v1beta2
+    filename: kafka.strimzi.io/kafkanodepool_v1beta2.json
+    kind: kafkanodepool
+    name: kafkanodepool_v1beta2
+karpenter.k8s.aws:
+  - apiVersion: karpenter.k8s.aws/v1alpha1
+    filename: karpenter.k8s.aws/awsnodetemplate_v1alpha1.json
+    kind: AWSNodeTemplate
+    name: awsnodetemplate_v1alpha1
+  - apiVersion: karpenter.k8s.aws/v1beta1
+    filename: karpenter.k8s.aws/ec2nodeclass_v1beta1.json
+    kind: EC2NodeClass
+    name: ec2nodeclass_v1beta1
+  - apiVersion: karpenter.k8s.aws/v1
+    filename: karpenter.k8s.aws/ec2nodeclass_v1.json
+    kind: EC2NodeClass
+    name: ec2nodeclass_v1
+karpenter.sh:
+  - apiVersion: karpenter.sh/v1
+    filename: karpenter.sh/nodepool_v1.json
+    kind: NodePool
+    name: nodepool_v1
+  - apiVersion: karpenter.sh/v1alpha5
+    filename: karpenter.sh/provisioner_v1alpha5.json
+    kind: Provisioner
+    name: provisioner_v1alpha5
+  - apiVersion: karpenter.sh/v1beta1
+    filename: karpenter.sh/nodeclaim_v1beta1.json
+    kind: NodeClaim
+    name: nodeclaim_v1beta1
+  - apiVersion: karpenter.sh/v1beta1
+    filename: karpenter.sh/nodepool_v1beta1.json
+    kind: NodePool
+    name: nodepool_v1beta1
+  - apiVersion: karpenter.sh/v1
+    filename: karpenter.sh/nodeclaim_v1.json
+    kind: NodeClaim
+    name: nodeclaim_v1
+  - apiVersion: karpenter.sh/v1alpha5
+    filename: karpenter.sh/machine_v1alpha5.json
+    kind: Machine
+    name: machine_v1alpha5
 keda.sh:
   - apiVersion: keda.sh/v1alpha1
     filename: keda.sh/clustertriggerauthentication_v1alpha1.json
@@ -255,6 +4695,10 @@ keda.sh:
     filename: keda.sh/triggerauthentication_v1alpha1.json
     kind: TriggerAuthentication
     name: triggerauthentication_v1alpha1
+  - apiVersion: keda.sh/v1alpha1
+    filename: keda.sh/cloudeventsource_v1alpha1.json
+    kind: CloudEventSource
+    name: cloudeventsource_v1alpha1
 kibana.k8s.elastic.co:
   - apiVersion: kibana.k8s.elastic.co/v1alpha1
     filename: kibana.k8s.elastic.co/kibana_v1alpha1.json
@@ -268,6 +4712,53 @@ kibana.k8s.elastic.co:
     filename: kibana.k8s.elastic.co/kibana_v1.json
     kind: Kibana
     name: kibana_v1
+kinesis.services.k8s.aws:
+  - apiVersion: kinesis.services.k8s.aws/v1alpha1
+    filename: kinesis.services.k8s.aws/stream_v1alpha1.json
+    kind: Stream
+    name: stream_v1alpha1
+kms.cnrm.cloud.google.com:
+  - apiVersion: kms.cnrm.cloud.google.com/v1alpha1
+    filename: kms.cnrm.cloud.google.com/kmscryptokeyversion_v1alpha1.json
+    kind: kmscryptokeyversion
+    name: kmscryptokeyversion_v1alpha1
+  - apiVersion: kms.cnrm.cloud.google.com/v1beta1
+    filename: kms.cnrm.cloud.google.com/kmskeyring_v1beta1.json
+    kind: KMSKeyRing
+    name: kmskeyring_v1beta1
+  - apiVersion: kms.cnrm.cloud.google.com/v1alpha1
+    filename: kms.cnrm.cloud.google.com/kmssecretciphertext_v1alpha1.json
+    kind: kmssecretciphertext
+    name: kmssecretciphertext_v1alpha1
+  - apiVersion: kms.cnrm.cloud.google.com/v1alpha1
+    filename: kms.cnrm.cloud.google.com/kmskeyringimportjob_v1alpha1.json
+    kind: kmskeyringimportjob
+    name: kmskeyringimportjob_v1alpha1
+  - apiVersion: kms.cnrm.cloud.google.com/v1beta1
+    filename: kms.cnrm.cloud.google.com/kmscryptokey_v1beta1.json
+    kind: kmscryptokey
+    name: kmscryptokey_v1beta1
+  - apiVersion: kms.cnrm.cloud.google.com/v1alpha1
+    filename: kms.cnrm.cloud.google.com/kmskeyhandle_v1alpha1.json
+    kind: KMSKeyHandle
+    name: kmskeyhandle_v1alpha1
+  - apiVersion: kms.cnrm.cloud.google.com/v1alpha1
+    filename: kms.cnrm.cloud.google.com/kmsautokeyconfig_v1alpha1.json
+    kind: KMSAutokeyConfig
+    name: kmsautokeyconfig_v1alpha1
+kms.services.k8s.aws:
+  - apiVersion: kms.services.k8s.aws/v1alpha1
+    filename: kms.services.k8s.aws/grant_v1alpha1.json
+    kind: Grant
+    name: grant_v1alpha1
+  - apiVersion: kms.services.k8s.aws/v1alpha1
+    filename: kms.services.k8s.aws/key_v1alpha1.json
+    kind: Key
+    name: key_v1alpha1
+  - apiVersion: kms.services.k8s.aws/v1alpha1
+    filename: kms.services.k8s.aws/alias_v1alpha1.json
+    kind: Alias
+    name: alias_v1alpha1
 kubeflow.org:
   - apiVersion: kubeflow.org/v1
     filename: kubeflow.org/profile_v1.json
@@ -293,6 +4784,51 @@ kubeflow.org:
     filename: kubeflow.org/poddefault_v1alpha1.json
     kind: PodDefault
     name: poddefault_v1alpha1
+kueue.x-k8s.io:
+  - apiVersion: kueue.x-k8s.io/v1beta1
+    filename: kueue.x-k8s.io/resourceflavor_v1beta1.json
+    kind: ResourceFlavor
+    name: resourceflavor_v1beta1
+  - apiVersion: kueue.x-k8s.io/v1beta1
+    filename: kueue.x-k8s.io/localqueue_v1beta1.json
+    kind: LocalQueue
+    name: localqueue_v1beta1
+  - apiVersion: kueue.x-k8s.io/v1beta1
+    filename: kueue.x-k8s.io/multikueueconfig_v1beta1.json
+    kind: MultiKueueConfig
+    name: multikueueconfig_v1beta1
+  - apiVersion: kueue.x-k8s.io/v1alpha1
+    filename: kueue.x-k8s.io/cohort_v1alpha1.json
+    kind: Cohort
+    name: cohort_v1alpha1
+  - apiVersion: kueue.x-k8s.io/v1beta1
+    filename: kueue.x-k8s.io/admissioncheck_v1beta1.json
+    kind: AdmissionCheck
+    name: admissioncheck_v1beta1
+  - apiVersion: kueue.x-k8s.io/v1beta1
+    filename: kueue.x-k8s.io/workload_v1beta1.json
+    kind: Workload
+    name: workload_v1beta1
+  - apiVersion: kueue.x-k8s.io/v1beta1
+    filename: kueue.x-k8s.io/clusterqueue_v1beta1.json
+    kind: ClusterQueue
+    name: clusterqueue_v1beta1
+  - apiVersion: kueue.x-k8s.io/v1beta1
+    filename: kueue.x-k8s.io/provisioningrequestconfig_v1beta1.json
+    kind: ProvisioningRequestConfig
+    name: provisioningrequestconfig_v1beta1
+  - apiVersion: kueue.x-k8s.io/v1alpha1
+    filename: kueue.x-k8s.io/topology_v1alpha1.json
+    kind: Topology
+    name: topology_v1alpha1
+  - apiVersion: kueue.x-k8s.io/v1beta1
+    filename: kueue.x-k8s.io/multikueuecluster_v1beta1.json
+    kind: MultiKueueCluster
+    name: multikueuecluster_v1beta1
+  - apiVersion: kueue.x-k8s.io/v1beta1
+    filename: kueue.x-k8s.io/workloadpriorityclass_v1beta1.json
+    kind: WorkloadPriorityClass
+    name: workloadpriorityclass_v1beta1
 kustomize.toolkit.fluxcd.io:
   - apiVersion: kustomize.toolkit.fluxcd.io/v1beta1
     filename: kustomize.toolkit.fluxcd.io/kustomization_v1beta1.json
@@ -302,11 +4838,555 @@ kustomize.toolkit.fluxcd.io:
     filename: kustomize.toolkit.fluxcd.io/kustomization_v1beta2.json
     kind: Kustomization
     name: kustomization_v1beta2
+  - apiVersion: kustomize.toolkit.fluxcd.io/v1
+    filename: kustomize.toolkit.fluxcd.io/kustomization_v1.json
+    kind: Kustomization
+    name: kustomization_v1
+kyverno.io:
+  - apiVersion: kyverno.io/v2alpha1
+    filename: kyverno.io/policyexception_v2alpha1.json
+    kind: PolicyException
+    name: policyexception_v2alpha1
+  - apiVersion: kyverno.io/v2
+    filename: kyverno.io/policyexception_v2.json
+    kind: PolicyException
+    name: policyexception_v2
+  - apiVersion: kyverno.io/v1alpha2
+    filename: kyverno.io/backgroundscanreport_v1alpha2.json
+    kind: BackgroundScanReport
+    name: backgroundscanreport_v1alpha2
+  - apiVersion: kyverno.io/v2beta1
+    filename: kyverno.io/policy_v2beta1.json
+    kind: Policy
+    name: policy_v2beta1
+  - apiVersion: kyverno.io/v1alpha2
+    filename: kyverno.io/policyreport_v1alpha2.json
+    kind: PolicyReport
+    name: policyreport_v1alpha2
+  - apiVersion: kyverno.io/v1
+    filename: kyverno.io/clusterpolicy_v1.json
+    kind: ClusterPolicy
+    name: clusterpolicy_v1
+  - apiVersion: kyverno.io/v1beta1
+    filename: kyverno.io/updaterequest_v1beta1.json
+    kind: UpdateRequest
+    name: updaterequest_v1beta1
+  - apiVersion: kyverno.io/v2
+    filename: kyverno.io/clusterbackgroundscanreport_v2.json
+    kind: ClusterBackgroundScanReport
+    name: clusterbackgroundscanreport_v2
+  - apiVersion: kyverno.io/v2beta1
+    filename: kyverno.io/policyexception_v2beta1.json
+    kind: PolicyException
+    name: policyexception_v2beta1
+  - apiVersion: kyverno.io/v2beta1
+    filename: kyverno.io/clustercleanuppolicy_v2beta1.json
+    kind: ClusterCleanupPolicy
+    name: clustercleanuppolicy_v2beta1
+  - apiVersion: kyverno.io/v1
+    filename: kyverno.io/clusterephemeralreport_v1.json
+    kind: ClusterEphemeralReport
+    name: clusterephemeralreport_v1
+  - apiVersion: kyverno.io/v1
+    filename: kyverno.io/generaterequest_v1.json
+    kind: GenerateRequest
+    name: generaterequest_v1
+  - apiVersion: kyverno.io/v1alpha2
+    filename: kyverno.io/clusterbackgroundscanreport_v1alpha2.json
+    kind: ClusterBackgroundScanReport
+    name: clusterbackgroundscanreport_v1alpha2
+  - apiVersion: kyverno.io/v2alpha1
+    filename: kyverno.io/clustercleanuppolicy_v2alpha1.json
+    kind: ClusterCleanupPolicy
+    name: clustercleanuppolicy_v2alpha1
+  - apiVersion: kyverno.io/v1
+    filename: kyverno.io/policy_v1.json
+    kind: Policy
+    name: policy_v1
+  - apiVersion: kyverno.io/v1alpha2
+    filename: kyverno.io/clusterreportchangerequest_v1alpha2.json
+    kind: ClusterReportChangeRequest
+    name: clusterreportchangerequest_v1alpha2
+  - apiVersion: kyverno.io/v1
+    filename: kyverno.io/ephemeralreport_v1.json
+    kind: EphemeralReport
+    name: ephemeralreport_v1
+  - apiVersion: kyverno.io/v1alpha2
+    filename: kyverno.io/reportchangerequest_v1alpha2.json
+    kind: ReportChangeRequest
+    name: reportchangerequest_v1alpha2
+  - apiVersion: kyverno.io/v2
+    filename: kyverno.io/backgroundscanreport_v2.json
+    kind: BackgroundScanReport
+    name: backgroundscanreport_v2
+  - apiVersion: kyverno.io/v2beta1
+    filename: kyverno.io/cleanuppolicy_v2beta1.json
+    kind: CleanupPolicy
+    name: cleanuppolicy_v2beta1
+  - apiVersion: kyverno.io/v1alpha2
+    filename: kyverno.io/admissionreport_v1alpha2.json
+    kind: AdmissionReport
+    name: admissionreport_v1alpha2
+  - apiVersion: kyverno.io/v1alpha2
+    filename: kyverno.io/clusteradmissionreport_v1alpha2.json
+    kind: ClusterAdmissionReport
+    name: clusteradmissionreport_v1alpha2
+  - apiVersion: kyverno.io/v2alpha1
+    filename: kyverno.io/cleanuppolicy_v2alpha1.json
+    kind: CleanupPolicy
+    name: cleanuppolicy_v2alpha1
+  - apiVersion: kyverno.io/v2
+    filename: kyverno.io/cleanuppolicy_v2.json
+    kind: CleanupPolicy
+    name: cleanuppolicy_v2
+  - apiVersion: kyverno.io/v2
+    filename: kyverno.io/updaterequest_v2.json
+    kind: UpdateRequest
+    name: updaterequest_v2
+  - apiVersion: kyverno.io/v2alpha1
+    filename: kyverno.io/globalcontextentry_v2alpha1.json
+    kind: GlobalContextEntry
+    name: globalcontextentry_v2alpha1
+  - apiVersion: kyverno.io/v2
+    filename: kyverno.io/clustercleanuppolicy_v2.json
+    kind: ClusterCleanupPolicy
+    name: clustercleanuppolicy_v2
+  - apiVersion: kyverno.io/v1alpha2
+    filename: kyverno.io/clusterpolicyreport_v1alpha2.json
+    kind: ClusterPolicyReport
+    name: clusterpolicyreport_v1alpha2
+  - apiVersion: kyverno.io/v2
+    filename: kyverno.io/admissionreport_v2.json
+    kind: AdmissionReport
+    name: admissionreport_v2
+  - apiVersion: kyverno.io/v2beta1
+    filename: kyverno.io/clusterpolicy_v2beta1.json
+    kind: ClusterPolicy
+    name: clusterpolicy_v2beta1
+  - apiVersion: kyverno.io/v2
+    filename: kyverno.io/clusteradmissionreport_v2.json
+    kind: ClusterAdmissionReport
+    name: clusteradmissionreport_v2
+lambda.services.k8s.aws:
+  - apiVersion: lambda.services.k8s.aws/v1alpha1
+    filename: lambda.services.k8s.aws/function_v1alpha1.json
+    kind: Function
+    name: function_v1alpha1
+  - apiVersion: lambda.services.k8s.aws/v1alpha1
+    filename: lambda.services.k8s.aws/functionurlconfig_v1alpha1.json
+    kind: FunctionURLConfig
+    name: functionurlconfig_v1alpha1
+  - apiVersion: lambda.services.k8s.aws/v1alpha1
+    filename: lambda.services.k8s.aws/eventsourcemapping_v1alpha1.json
+    kind: EventSourceMapping
+    name: eventsourcemapping_v1alpha1
+  - apiVersion: lambda.services.k8s.aws/v1alpha1
+    filename: lambda.services.k8s.aws/codesigningconfig_v1alpha1.json
+    kind: CodeSigningConfig
+    name: codesigningconfig_v1alpha1
+  - apiVersion: lambda.services.k8s.aws/v1alpha1
+    filename: lambda.services.k8s.aws/alias_v1alpha1.json
+    kind: Alias
+    name: alias_v1alpha1
+  - apiVersion: lambda.services.k8s.aws/v1alpha1
+    filename: lambda.services.k8s.aws/layerversion_v1alpha1.json
+    kind: LayerVersion
+    name: layerversion_v1alpha1
+linkerd.io:
+  - apiVersion: linkerd.io/v1alpha1
+    filename: linkerd.io/serviceprofile_v1alpha1.json
+    kind: serviceprofile
+    name: serviceprofile_v1alpha1
+  - apiVersion: linkerd.io/v1alpha2
+    filename: linkerd.io/serviceprofile_v1alpha2.json
+    kind: serviceprofile
+    name: serviceprofile_v1alpha2
+logging-extensions.banzaicloud.io:
+  - apiVersion: logging-extensions.banzaicloud.io/v1alpha1
+    filename: logging-extensions.banzaicloud.io/hosttailer_v1alpha1.json
+    kind: hosttailer
+    name: hosttailer_v1alpha1
+  - apiVersion: logging-extensions.banzaicloud.io/v1alpha1
+    filename: logging-extensions.banzaicloud.io/eventtailer_v1alpha1.json
+    kind: eventtailer
+    name: eventtailer_v1alpha1
+logging.banzaicloud.io:
+  - apiVersion: logging.banzaicloud.io/v1alpha1
+    filename: logging.banzaicloud.io/output_v1alpha1.json
+    kind: output
+    name: output_v1alpha1
+  - apiVersion: logging.banzaicloud.io/v1beta1
+    filename: logging.banzaicloud.io/syslogngclusterflow_v1beta1.json
+    kind: syslogngclusterflow
+    name: syslogngclusterflow_v1beta1
+  - apiVersion: logging.banzaicloud.io/v1beta1
+    filename: logging.banzaicloud.io/logging_v1beta1.json
+    kind: logging
+    name: logging_v1beta1
+  - apiVersion: logging.banzaicloud.io/v1beta1
+    filename: logging.banzaicloud.io/syslogngoutput_v1beta1.json
+    kind: syslogngoutput
+    name: syslogngoutput_v1beta1
+  - apiVersion: logging.banzaicloud.io/v1beta1
+    filename: logging.banzaicloud.io/syslogngflow_v1beta1.json
+    kind: syslogngflow
+    name: syslogngflow_v1beta1
+  - apiVersion: logging.banzaicloud.io/v1alpha1
+    filename: logging.banzaicloud.io/clusteroutput_v1alpha1.json
+    kind: clusteroutput
+    name: clusteroutput_v1alpha1
+  - apiVersion: logging.banzaicloud.io/v1alpha1
+    filename: logging.banzaicloud.io/logging_v1alpha1.json
+    kind: logging
+    name: logging_v1alpha1
+  - apiVersion: logging.banzaicloud.io/v1beta1
+    filename: logging.banzaicloud.io/syslogngclusteroutput_v1beta1.json
+    kind: syslogngclusteroutput
+    name: syslogngclusteroutput_v1beta1
+  - apiVersion: logging.banzaicloud.io/v1alpha1
+    filename: logging.banzaicloud.io/clusterflow_v1alpha1.json
+    kind: clusterflow
+    name: clusterflow_v1alpha1
+  - apiVersion: logging.banzaicloud.io/v1beta1
+    filename: logging.banzaicloud.io/clusteroutput_v1beta1.json
+    kind: clusteroutput
+    name: clusteroutput_v1beta1
+  - apiVersion: logging.banzaicloud.io/v1beta1
+    filename: logging.banzaicloud.io/nodeagent_v1beta1.json
+    kind: nodeagent
+    name: nodeagent_v1beta1
+  - apiVersion: logging.banzaicloud.io/v1beta1
+    filename: logging.banzaicloud.io/flow_v1beta1.json
+    kind: flow
+    name: flow_v1beta1
+  - apiVersion: logging.banzaicloud.io/v1beta1
+    filename: logging.banzaicloud.io/fluentdconfig_v1beta1.json
+    kind: fluentdconfig
+    name: fluentdconfig_v1beta1
+  - apiVersion: logging.banzaicloud.io/v1beta1
+    filename: logging.banzaicloud.io/syslogngconfig_v1beta1.json
+    kind: syslogngconfig
+    name: syslogngconfig_v1beta1
+  - apiVersion: logging.banzaicloud.io/v1beta1
+    filename: logging.banzaicloud.io/fluentbitagent_v1beta1.json
+    kind: fluentbitagent
+    name: fluentbitagent_v1beta1
+  - apiVersion: logging.banzaicloud.io/v1beta1
+    filename: logging.banzaicloud.io/clusterflow_v1beta1.json
+    kind: clusterflow
+    name: clusterflow_v1beta1
+  - apiVersion: logging.banzaicloud.io/v1alpha1
+    filename: logging.banzaicloud.io/flow_v1alpha1.json
+    kind: flow
+    name: flow_v1alpha1
+  - apiVersion: logging.banzaicloud.io/v1beta1
+    filename: logging.banzaicloud.io/loggingroute_v1beta1.json
+    kind: loggingroute
+    name: loggingroute_v1beta1
+  - apiVersion: logging.banzaicloud.io/v1beta1
+    filename: logging.banzaicloud.io/output_v1beta1.json
+    kind: output
+    name: output_v1beta1
+logging.cnrm.cloud.google.com:
+  - apiVersion: logging.cnrm.cloud.google.com/v1beta1
+    filename: logging.cnrm.cloud.google.com/logginglogbucket_v1beta1.json
+    kind: logginglogbucket
+    name: logginglogbucket_v1beta1
+  - apiVersion: logging.cnrm.cloud.google.com/v1beta1
+    filename: logging.cnrm.cloud.google.com/logginglogexclusion_v1beta1.json
+    kind: logginglogexclusion
+    name: logginglogexclusion_v1beta1
+  - apiVersion: logging.cnrm.cloud.google.com/v1beta1
+    filename: logging.cnrm.cloud.google.com/logginglogview_v1beta1.json
+    kind: logginglogview
+    name: logginglogview_v1beta1
+  - apiVersion: logging.cnrm.cloud.google.com/v1beta1
+    filename: logging.cnrm.cloud.google.com/logginglogmetric_v1beta1.json
+    kind: LoggingLogMetric
+    name: logginglogmetric_v1beta1
+  - apiVersion: logging.cnrm.cloud.google.com/v1beta1
+    filename: logging.cnrm.cloud.google.com/logginglogsink_v1beta1.json
+    kind: logginglogsink
+    name: logginglogsink_v1beta1
+logging.openshift.io:
+  - apiVersion: logging.openshift.io/v1
+    filename: logging.openshift.io/clusterlogging_v1.json
+    kind: ClusterLogging
+    name: clusterlogging_v1
+  - apiVersion: logging.openshift.io/v1
+    filename: logging.openshift.io/clusterlogforwarder_v1.json
+    kind: ClusterLogForwarder
+    name: clusterlogforwarder_v1
+logstash.k8s.elastic.co:
+  - apiVersion: logstash.k8s.elastic.co/v1alpha1
+    filename: logstash.k8s.elastic.co/logstash_v1alpha1.json
+    kind: Logstash
+    name: logstash_v1alpha1
+longhorn.io:
+  - apiVersion: longhorn.io/v1beta2
+    filename: longhorn.io/backingimagedatasource_v1beta2.json
+    kind: BackingImageDataSource
+    name: backingimagedatasource_v1beta2
+  - apiVersion: longhorn.io/v1beta1
+    filename: longhorn.io/backuptarget_v1beta1.json
+    kind: BackupTarget
+    name: backuptarget_v1beta1
+  - apiVersion: longhorn.io/v1beta2
+    filename: longhorn.io/replica_v1beta2.json
+    kind: Replica
+    name: replica_v1beta2
+  - apiVersion: longhorn.io/v1beta2
+    filename: longhorn.io/orphan_v1beta2.json
+    kind: Orphan
+    name: orphan_v1beta2
+  - apiVersion: longhorn.io/v1beta2
+    filename: longhorn.io/instancemanager_v1beta2.json
+    kind: InstanceManager
+    name: instancemanager_v1beta2
+  - apiVersion: longhorn.io/v1beta2
+    filename: longhorn.io/backupbackingimage_v1beta2.json
+    kind: BackupBackingImage
+    name: backupbackingimage_v1beta2
+  - apiVersion: longhorn.io/v1beta1
+    filename: longhorn.io/sharemanager_v1beta1.json
+    kind: ShareManager
+    name: sharemanager_v1beta1
+  - apiVersion: longhorn.io/v1beta2
+    filename: longhorn.io/backingimage_v1beta2.json
+    kind: BackingImage
+    name: backingimage_v1beta2
+  - apiVersion: longhorn.io/v1beta2
+    filename: longhorn.io/backingimagemanager_v1beta2.json
+    kind: BackingImageManager
+    name: backingimagemanager_v1beta2
+  - apiVersion: longhorn.io/v1beta2
+    filename: longhorn.io/setting_v1beta2.json
+    kind: Setting
+    name: setting_v1beta2
+  - apiVersion: longhorn.io/v1beta2
+    filename: longhorn.io/supportbundle_v1beta2.json
+    kind: SupportBundle
+    name: supportbundle_v1beta2
+  - apiVersion: longhorn.io/v1beta2
+    filename: longhorn.io/node_v1beta2.json
+    kind: Node
+    name: node_v1beta2
+  - apiVersion: longhorn.io/v1beta2
+    filename: longhorn.io/engine_v1beta2.json
+    kind: Engine
+    name: engine_v1beta2
+  - apiVersion: longhorn.io/v1beta1
+    filename: longhorn.io/recurringjob_v1beta1.json
+    kind: RecurringJob
+    name: recurringjob_v1beta1
+  - apiVersion: longhorn.io/v1beta2
+    filename: longhorn.io/engineimage_v1beta2.json
+    kind: EngineImage
+    name: engineimage_v1beta2
+  - apiVersion: longhorn.io/v1beta2
+    filename: longhorn.io/backupvolume_v1beta2.json
+    kind: BackupVolume
+    name: backupvolume_v1beta2
+  - apiVersion: longhorn.io/v1beta1
+    filename: longhorn.io/volume_v1beta1.json
+    kind: Volume
+    name: volume_v1beta1
+  - apiVersion: longhorn.io/v1beta2
+    filename: longhorn.io/volumeattachment_v1beta2.json
+    kind: VolumeAttachment
+    name: volumeattachment_v1beta2
+  - apiVersion: longhorn.io/v1beta1
+    filename: longhorn.io/instancemanager_v1beta1.json
+    kind: InstanceManager
+    name: instancemanager_v1beta1
+  - apiVersion: longhorn.io/v1beta2
+    filename: longhorn.io/systemrestore_v1beta2.json
+    kind: SystemRestore
+    name: systemrestore_v1beta2
+  - apiVersion: longhorn.io/v1beta2
+    filename: longhorn.io/sharemanager_v1beta2.json
+    kind: ShareManager
+    name: sharemanager_v1beta2
+  - apiVersion: longhorn.io/v1beta1
+    filename: longhorn.io/backingimage_v1beta1.json
+    kind: BackingImage
+    name: backingimage_v1beta1
+  - apiVersion: longhorn.io/v1beta1
+    filename: longhorn.io/backingimagedatasource_v1beta1.json
+    kind: BackingImageDataSource
+    name: backingimagedatasource_v1beta1
+  - apiVersion: longhorn.io/v1beta2
+    filename: longhorn.io/backuptarget_v1beta2.json
+    kind: BackupTarget
+    name: backuptarget_v1beta2
+  - apiVersion: longhorn.io/v1beta1
+    filename: longhorn.io/replica_v1beta1.json
+    kind: Replica
+    name: replica_v1beta1
+  - apiVersion: longhorn.io/v1beta2
+    filename: longhorn.io/systembackup_v1beta2.json
+    kind: SystemBackup
+    name: systembackup_v1beta2
+  - apiVersion: longhorn.io/v1beta2
+    filename: longhorn.io/recurringjob_v1beta2.json
+    kind: RecurringJob
+    name: recurringjob_v1beta2
+  - apiVersion: longhorn.io/v1beta1
+    filename: longhorn.io/engine_v1beta1.json
+    kind: Engine
+    name: engine_v1beta1
+  - apiVersion: longhorn.io/v1beta1
+    filename: longhorn.io/engineimage_v1beta1.json
+    kind: EngineImage
+    name: engineimage_v1beta1
+  - apiVersion: longhorn.io/v1beta1
+    filename: longhorn.io/backupvolume_v1beta1.json
+    kind: BackupVolume
+    name: backupvolume_v1beta1
+  - apiVersion: longhorn.io/v1beta2
+    filename: longhorn.io/volume_v1beta2.json
+    kind: Volume
+    name: volume_v1beta2
+  - apiVersion: longhorn.io/v1beta1
+    filename: longhorn.io/backingimagemanager_v1beta1.json
+    kind: BackingImageManager
+    name: backingimagemanager_v1beta1
+  - apiVersion: longhorn.io/v1beta1
+    filename: longhorn.io/setting_v1beta1.json
+    kind: Setting
+    name: setting_v1beta1
+  - apiVersion: longhorn.io/v1beta2
+    filename: longhorn.io/snapshot_v1beta2.json
+    kind: Snapshot
+    name: snapshot_v1beta2
+  - apiVersion: longhorn.io/v1beta1
+    filename: longhorn.io/node_v1beta1.json
+    kind: Node
+    name: node_v1beta1
 maps.k8s.elastic.co:
   - apiVersion: maps.k8s.elastic.co/v1alpha1
-    filename: ''
+    filename: maps.k8s.elastic.co/elasticmapsserver_v1alpha1.json
     kind: ElasticMapsServer
-    name: elasticsearch_v1alpha1
+    name: elasticmapsserver_v1alpha1
+memcache.cnrm.cloud.google.com:
+  - apiVersion: memcache.cnrm.cloud.google.com/v1beta1
+    filename: memcache.cnrm.cloud.google.com/memcacheinstance_v1beta1.json
+    kind: memcacheinstance
+    name: memcacheinstance_v1beta1
+memorydb.services.k8s.aws:
+  - apiVersion: memorydb.services.k8s.aws/v1alpha1
+    filename: memorydb.services.k8s.aws/subnetgroup_v1alpha1.json
+    kind: SubnetGroup
+    name: subnetgroup_v1alpha1
+  - apiVersion: memorydb.services.k8s.aws/v1alpha1
+    filename: memorydb.services.k8s.aws/parametergroup_v1alpha1.json
+    kind: ParameterGroup
+    name: parametergroup_v1alpha1
+  - apiVersion: memorydb.services.k8s.aws/v1alpha1
+    filename: memorydb.services.k8s.aws/cluster_v1alpha1.json
+    kind: Cluster
+    name: cluster_v1alpha1
+  - apiVersion: memorydb.services.k8s.aws/v1alpha1
+    filename: memorydb.services.k8s.aws/acl_v1alpha1.json
+    kind: ACL
+    name: acl_v1alpha1
+  - apiVersion: memorydb.services.k8s.aws/v1alpha1
+    filename: memorydb.services.k8s.aws/snapshot_v1alpha1.json
+    kind: Snapshot
+    name: snapshot_v1alpha1
+  - apiVersion: memorydb.services.k8s.aws/v1alpha1
+    filename: memorydb.services.k8s.aws/user_v1alpha1.json
+    kind: User
+    name: user_v1alpha1
+metallb.io:
+  - apiVersion: metallb.io/v1beta1
+    filename: metallb.io/ipaddresspool_v1beta1.json
+    kind: IPAddressPool
+    name: ipaddresspool_v1beta1
+  - apiVersion: metallb.io/v1beta1
+    filename: metallb.io/bgppeer_v1beta1.json
+    kind: BGPPeer
+    name: bgppeer_v1beta1
+  - apiVersion: metallb.io/v1beta1
+    filename: metallb.io/l2advertisement_v1beta1.json
+    kind: L2Advertisement
+    name: l2advertisement_v1beta1
+  - apiVersion: metallb.io/v1beta1
+    filename: metallb.io/bfdprofile_v1beta1.json
+    kind: BFDProfile
+    name: bfdprofile_v1beta1
+  - apiVersion: metallb.io/v1beta1
+    filename: metallb.io/community_v1beta1.json
+    kind: Community
+    name: community_v1beta1
+  - apiVersion: metallb.io/v1beta1
+    filename: metallb.io/bgpadvertisement_v1beta1.json
+    kind: BGPAdvertisement
+    name: bgpadvertisement_v1beta1
+  - apiVersion: metallb.io/v1alpha1
+    filename: metallb.io/addresspool_v1alpha1.json
+    kind: AddressPool
+    name: addresspool_v1alpha1
+  - apiVersion: metallb.io/v1beta1
+    filename: metallb.io/addresspool_v1beta1.json
+    kind: AddressPool
+    name: addresspool_v1beta1
+  - apiVersion: metallb.io/v1beta2
+    filename: metallb.io/bgppeer_v1beta2.json
+    kind: BGPPeer
+    name: bgppeer_v1beta2
+minio.min.io:
+  - apiVersion: minio.min.io/v2
+    filename: minio.min.io/tenant_v2.json
+    kind: tenant
+    name: tenant_v2
+mlengine.cnrm.cloud.google.com:
+  - apiVersion: mlengine.cnrm.cloud.google.com/v1alpha1
+    filename: mlengine.cnrm.cloud.google.com/mlenginemodel_v1alpha1.json
+    kind: mlenginemodel
+    name: mlenginemodel_v1alpha1
+mongodbcommunity.mongodb.com:
+  - apiVersion: mongodbcommunity.mongodb.com/v1
+    filename: mongodbcommunity.mongodb.com/mongodbcommunity_v1.json
+    kind: MongoDBCommunity
+    name: mongodbcommunity_v1
+monitoring.cnrm.cloud.google.com:
+  - apiVersion: monitoring.cnrm.cloud.google.com/v1beta1
+    filename: monitoring.cnrm.cloud.google.com/monitoringuptimecheckconfig_v1beta1.json
+    kind: monitoringuptimecheckconfig
+    name: monitoringuptimecheckconfig_v1beta1
+  - apiVersion: monitoring.cnrm.cloud.google.com/v1beta1
+    filename: monitoring.cnrm.cloud.google.com/monitoringservicelevelobjective_v1beta1.json
+    kind: monitoringservicelevelobjective
+    name: monitoringservicelevelobjective_v1beta1
+  - apiVersion: monitoring.cnrm.cloud.google.com/v1beta1
+    filename: monitoring.cnrm.cloud.google.com/monitoringgroup_v1beta1.json
+    kind: monitoringgroup
+    name: monitoringgroup_v1beta1
+  - apiVersion: monitoring.cnrm.cloud.google.com/v1beta1
+    filename: monitoring.cnrm.cloud.google.com/monitoringnotificationchannel_v1beta1.json
+    kind: monitoringnotificationchannel
+    name: monitoringnotificationchannel_v1beta1
+  - apiVersion: monitoring.cnrm.cloud.google.com/v1beta1
+    filename: monitoring.cnrm.cloud.google.com/monitoringdashboard_v1beta1.json
+    kind: MonitoringDashboard
+    name: monitoringdashboard_v1beta1
+  - apiVersion: monitoring.cnrm.cloud.google.com/v1beta1
+    filename: monitoring.cnrm.cloud.google.com/monitoringmonitoredproject_v1beta1.json
+    kind: monitoringmonitoredproject
+    name: monitoringmonitoredproject_v1beta1
+  - apiVersion: monitoring.cnrm.cloud.google.com/v1beta1
+    filename: monitoring.cnrm.cloud.google.com/monitoringalertpolicy_v1beta1.json
+    kind: monitoringalertpolicy
+    name: monitoringalertpolicy_v1beta1
+  - apiVersion: monitoring.cnrm.cloud.google.com/v1beta1
+    filename: monitoring.cnrm.cloud.google.com/monitoringmetricdescriptor_v1beta1.json
+    kind: monitoringmetricdescriptor
+    name: monitoringmetricdescriptor_v1beta1
+  - apiVersion: monitoring.cnrm.cloud.google.com/v1beta1
+    filename: monitoring.cnrm.cloud.google.com/monitoringservice_v1beta1.json
+    kind: monitoringservice
+    name: monitoringservice_v1beta1
 monitoring.coreos.com:
   - apiVersion: monitoring.coreos.com/v1
     filename: monitoring.coreos.com/alertmanager_v1.json
@@ -340,6 +5420,137 @@ monitoring.coreos.com:
     filename: monitoring.coreos.com/thanosruler_v1.json
     kind: ThanosRuler
     name: thanosruler_v1
+  - apiVersion: monitoring.coreos.com/v1alpha1
+    filename: monitoring.coreos.com/scrapeconfig_v1alpha1.json
+    kind: ScrapeConfig
+    name: scrapeconfig_v1alpha1
+  - apiVersion: monitoring.coreos.com/v1alpha1
+    filename: monitoring.coreos.com/prometheusagent_v1alpha1.json
+    kind: PrometheusAgent
+    name: prometheusagent_v1alpha1
+monitoring.grafana.com:
+  - apiVersion: monitoring.grafana.com/v1alpha1
+    filename: monitoring.grafana.com/logsinstance_v1alpha1.json
+    kind: LogsInstance
+    name: logsinstance_v1alpha1
+  - apiVersion: monitoring.grafana.com/v1alpha1
+    filename: monitoring.grafana.com/metricsinstance_v1alpha1.json
+    kind: MetricsInstance
+    name: metricsinstance_v1alpha1
+  - apiVersion: monitoring.grafana.com/v1alpha1
+    filename: monitoring.grafana.com/integration_v1alpha1.json
+    kind: Integration
+    name: integration_v1alpha1
+  - apiVersion: monitoring.grafana.com/v1alpha1
+    filename: monitoring.grafana.com/podlogs_v1alpha1.json
+    kind: PodLogs
+    name: podlogs_v1alpha1
+  - apiVersion: monitoring.grafana.com/v1alpha1
+    filename: monitoring.grafana.com/grafanaagent_v1alpha1.json
+    kind: GrafanaAgent
+    name: grafanaagent_v1alpha1
+mq.services.k8s.aws:
+  - apiVersion: mq.services.k8s.aws/v1alpha1
+    filename: mq.services.k8s.aws/broker_v1alpha1.json
+    kind: Broker
+    name: broker_v1alpha1
+mutations.gatekeeper.sh:
+  - apiVersion: mutations.gatekeeper.sh/v1
+    filename: mutations.gatekeeper.sh/assignmetadata_v1.json
+    kind: AssignMetadata
+    name: assignmetadata_v1
+  - apiVersion: mutations.gatekeeper.sh/v1alpha1
+    filename: mutations.gatekeeper.sh/assignmetadata_v1alpha1.json
+    kind: AssignMetadata
+    name: assignmetadata_v1alpha1
+  - apiVersion: mutations.gatekeeper.sh/v1beta1
+    filename: mutations.gatekeeper.sh/modifyset_v1beta1.json
+    kind: ModifySet
+    name: modifyset_v1beta1
+  - apiVersion: mutations.gatekeeper.sh/v1
+    filename: mutations.gatekeeper.sh/modifyset_v1.json
+    kind: ModifySet
+    name: modifyset_v1
+  - apiVersion: mutations.gatekeeper.sh/v1alpha1
+    filename: mutations.gatekeeper.sh/modifyset_v1alpha1.json
+    kind: ModifySet
+    name: modifyset_v1alpha1
+  - apiVersion: mutations.gatekeeper.sh/v1alpha1
+    filename: mutations.gatekeeper.sh/assign_v1alpha1.json
+    kind: Assign
+    name: assign_v1alpha1
+  - apiVersion: mutations.gatekeeper.sh/v1beta1
+    filename: mutations.gatekeeper.sh/assign_v1beta1.json
+    kind: Assign
+    name: assign_v1beta1
+  - apiVersion: mutations.gatekeeper.sh/v1alpha1
+    filename: mutations.gatekeeper.sh/assignimage_v1alpha1.json
+    kind: AssignImage
+    name: assignimage_v1alpha1
+  - apiVersion: mutations.gatekeeper.sh/v1
+    filename: mutations.gatekeeper.sh/assign_v1.json
+    kind: Assign
+    name: assign_v1
+  - apiVersion: mutations.gatekeeper.sh/v1beta1
+    filename: mutations.gatekeeper.sh/assignmetadata_v1beta1.json
+    kind: AssignMetadata
+    name: assignmetadata_v1beta1
+mysql.oracle.com:
+  - apiVersion: mysql.oracle.com/v2
+    filename: mysql.oracle.com/innodbcluster_v2.json
+    kind: innodbcluster
+    name: innodbcluster_v2
+  - apiVersion: mysql.oracle.com/v2
+    filename: mysql.oracle.com/mysqlbackup_v2.json
+    kind: mysqlbackup
+    name: mysqlbackup_v2
+mysql.presslabs.org:
+  - apiVersion: mysql.presslabs.org/v1alpha1
+    filename: mysql.presslabs.org/mysqlcluster_v1alpha1.json
+    kind: MysqlCluster
+    name: mysqlcluster_v1alpha1
+  - apiVersion: mysql.presslabs.org/v1alpha1
+    filename: mysql.presslabs.org/mysqluser_v1alpha1.json
+    kind: MysqlUser
+    name: mysqluser_v1alpha1
+  - apiVersion: mysql.presslabs.org/v1alpha1
+    filename: mysql.presslabs.org/mysqldatabase_v1alpha1.json
+    kind: MysqlDatabase
+    name: mysqldatabase_v1alpha1
+  - apiVersion: mysql.presslabs.org/v1alpha1
+    filename: mysql.presslabs.org/mysqlbackup_v1alpha1.json
+    kind: MysqlBackup
+    name: mysqlbackup_v1alpha1
+  - apiVersion: mysql.presslabs.org/v2
+    filename: mysql.presslabs.org/mysqlbackup_v2.json
+    kind: mysqlbackup
+    name: mysqlbackup_v2
+networkconnectivity.cnrm.cloud.google.com:
+  - apiVersion: networkconnectivity.cnrm.cloud.google.com/v1alpha1
+    filename: networkconnectivity.cnrm.cloud.google.com/networkconnectivityserviceconnectionpolicy_v1alpha1.json
+    kind: NetworkConnectivityServiceConnectionPolicy
+    name: networkconnectivityserviceconnectionpolicy_v1alpha1
+  - apiVersion: networkconnectivity.cnrm.cloud.google.com/v1beta1
+    filename: networkconnectivity.cnrm.cloud.google.com/networkconnectivityspoke_v1beta1.json
+    kind: networkconnectivityspoke
+    name: networkconnectivityspoke_v1beta1
+  - apiVersion: networkconnectivity.cnrm.cloud.google.com/v1beta1
+    filename: networkconnectivity.cnrm.cloud.google.com/networkconnectivityhub_v1beta1.json
+    kind: networkconnectivityhub
+    name: networkconnectivityhub_v1beta1
+networkfirewall.services.k8s.aws:
+  - apiVersion: networkfirewall.services.k8s.aws/v1alpha1
+    filename: networkfirewall.services.k8s.aws/firewall_v1alpha1.json
+    kind: Firewall
+    name: firewall_v1alpha1
+  - apiVersion: networkfirewall.services.k8s.aws/v1alpha1
+    filename: networkfirewall.services.k8s.aws/rulegroup_v1alpha1.json
+    kind: RuleGroup
+    name: rulegroup_v1alpha1
+  - apiVersion: networkfirewall.services.k8s.aws/v1alpha1
+    filename: networkfirewall.services.k8s.aws/firewallpolicy_v1alpha1.json
+    kind: FirewallPolicy
+    name: firewallpolicy_v1alpha1
 networking.gke.io:
   - apiVersion: networking.gke.io/v1
     filename: networking.gke.io/managedcertificate_v1.json
@@ -353,6 +5564,212 @@ networking.gke.io:
     filename: networking.gke.io/managedcertificate_v1beta2.json
     kind: ManagedCertificate
     name: managedcertificate_v1beta2
+  - apiVersion: networking.gke.io/v1
+    filename: networking.gke.io/gcpbackendpolicy_v1.json
+    kind: GCPBackendPolicy
+    name: gcpbackendpolicy_v1
+  - apiVersion: networking.gke.io/v1
+    filename: networking.gke.io/network_v1.json
+    kind: Network
+    name: network_v1
+  - apiVersion: networking.gke.io/v1
+    filename: networking.gke.io/healthcheckpolicy_v1.json
+    kind: HealthCheckPolicy
+    name: healthcheckpolicy_v1
+  - apiVersion: networking.gke.io/v1
+    filename: networking.gke.io/gcpgatewaypolicy_v1.json
+    kind: GCPGatewayPolicy
+    name: gcpgatewaypolicy_v1
+  - apiVersion: networking.gke.io/v1
+    filename: networking.gke.io/serviceattachment_v1.json
+    kind: ServiceAttachment
+    name: serviceattachment_v1
+  - apiVersion: networking.gke.io/v1
+    filename: networking.gke.io/lbpolicy_v1.json
+    kind: LBPolicy
+    name: lbpolicy_v1
+  - apiVersion: networking.gke.io/v1
+    filename: networking.gke.io/gkenetworkparamset_v1.json
+    kind: GKENetworkParamSet
+    name: gkenetworkparamset_v1
+  - apiVersion: networking.gke.io/v1beta1
+    filename: networking.gke.io/serviceattachment_v1beta1.json
+    kind: ServiceAttachment
+    name: serviceattachment_v1beta1
+  - apiVersion: networking.gke.io/v1beta1
+    filename: networking.gke.io/frontendconfig_v1beta1.json
+    kind: frontendconfig
+    name: frontendconfig_v1beta1
+  - apiVersion: networking.gke.io/v1beta1
+    filename: networking.gke.io/servicenetworkendpointgroup_v1beta1.json
+    kind: servicenetworkendpointgroup
+    name: servicenetworkendpointgroup_v1beta1
+  - apiVersion: networking.gke.io/v1alpha1
+    filename: networking.gke.io/networklogging_v1alpha1.json
+    kind: NetworkLogging
+    name: networklogging_v1alpha1
+networking.istio.io:
+  - apiVersion: networking.istio.io/v1
+    filename: networking.istio.io/workloadgroup_v1.json
+    kind: workloadgroup
+    name: workloadgroup_v1
+  - apiVersion: networking.istio.io/v1beta1
+    filename: networking.istio.io/sidecar_v1beta1.json
+    kind: sidecar
+    name: sidecar_v1beta1
+  - apiVersion: networking.istio.io/v1beta1
+    filename: networking.istio.io/proxyconfig_v1beta1.json
+    kind: proxyconfig
+    name: proxyconfig_v1beta1
+  - apiVersion: networking.istio.io/v1
+    filename: networking.istio.io/sidecar_v1.json
+    kind: sidecar
+    name: sidecar_v1
+  - apiVersion: networking.istio.io/v1beta1
+    filename: networking.istio.io/destinationrule_v1beta1.json
+    kind: destinationrule
+    name: destinationrule_v1beta1
+  - apiVersion: networking.istio.io/v1
+    filename: networking.istio.io/workloadentry_v1.json
+    kind: workloadentry
+    name: workloadentry_v1
+  - apiVersion: networking.istio.io/v1beta1
+    filename: networking.istio.io/serviceentry_v1beta1.json
+    kind: serviceentry
+    name: serviceentry_v1beta1
+  - apiVersion: networking.istio.io/v1alpha3
+    filename: networking.istio.io/workloadentry_v1alpha3.json
+    kind: workloadentry
+    name: workloadentry_v1alpha3
+  - apiVersion: networking.istio.io/v1alpha3
+    filename: networking.istio.io/serviceentry_v1alpha3.json
+    kind: serviceentry
+    name: serviceentry_v1alpha3
+  - apiVersion: networking.istio.io/v1alpha3
+    filename: networking.istio.io/envoyfilter_v1alpha3.json
+    kind: envoyfilter
+    name: envoyfilter_v1alpha3
+  - apiVersion: networking.istio.io/v1
+    filename: networking.istio.io/serviceentry_v1.json
+    kind: serviceentry
+    name: serviceentry_v1
+  - apiVersion: networking.istio.io/v1alpha3
+    filename: networking.istio.io/workloadgroup_v1alpha3.json
+    kind: workloadgroup
+    name: workloadgroup_v1alpha3
+  - apiVersion: networking.istio.io/v1alpha3
+    filename: networking.istio.io/destinationrule_v1alpha3.json
+    kind: destinationrule
+    name: destinationrule_v1alpha3
+  - apiVersion: networking.istio.io/v1beta1
+    filename: networking.istio.io/workloadgroup_v1beta1.json
+    kind: workloadgroup
+    name: workloadgroup_v1beta1
+  - apiVersion: networking.istio.io/v1
+    filename: networking.istio.io/destinationrule_v1.json
+    kind: destinationrule
+    name: destinationrule_v1
+  - apiVersion: networking.istio.io/v1
+    filename: networking.istio.io/gateway_v1.json
+    kind: gateway
+    name: gateway_v1
+  - apiVersion: networking.istio.io/v1alpha3
+    filename: networking.istio.io/sidecar_v1alpha3.json
+    kind: sidecar
+    name: sidecar_v1alpha3
+  - apiVersion: networking.istio.io/v1beta1
+    filename: networking.istio.io/gateway_v1beta1.json
+    kind: gateway
+    name: gateway_v1beta1
+  - apiVersion: networking.istio.io/v1beta1
+    filename: networking.istio.io/virtualservice_v1beta1.json
+    kind: virtualservice
+    name: virtualservice_v1beta1
+  - apiVersion: networking.istio.io/v1alpha3
+    filename: networking.istio.io/virtualservice_v1alpha3.json
+    kind: virtualservice
+    name: virtualservice_v1alpha3
+  - apiVersion: networking.istio.io/v1beta1
+    filename: networking.istio.io/workloadentry_v1beta1.json
+    kind: workloadentry
+    name: workloadentry_v1beta1
+  - apiVersion: networking.istio.io/v1alpha3
+    filename: networking.istio.io/gateway_v1alpha3.json
+    kind: gateway
+    name: gateway_v1alpha3
+  - apiVersion: networking.istio.io/v1
+    filename: networking.istio.io/virtualservice_v1.json
+    kind: virtualservice
+    name: virtualservice_v1
+networking.k8s.aws:
+  - apiVersion: networking.k8s.aws/v1alpha1
+    filename: networking.k8s.aws/policyendpoint_v1alpha1.json
+    kind: PolicyEndpoint
+    name: policyendpoint_v1alpha1
+networkmanagement.cnrm.cloud.google.com:
+  - apiVersion: networkmanagement.cnrm.cloud.google.com/v1alpha1
+    filename: networkmanagement.cnrm.cloud.google.com/networkmanagementconnectivitytest_v1alpha1.json
+    kind: networkmanagementconnectivitytest
+    name: networkmanagementconnectivitytest_v1alpha1
+networksecurity.cnrm.cloud.google.com:
+  - apiVersion: networksecurity.cnrm.cloud.google.com/v1beta1
+    filename: networksecurity.cnrm.cloud.google.com/networksecurityauthorizationpolicy_v1beta1.json
+    kind: networksecurityauthorizationpolicy
+    name: networksecurityauthorizationpolicy_v1beta1
+  - apiVersion: networksecurity.cnrm.cloud.google.com/v1beta1
+    filename: networksecurity.cnrm.cloud.google.com/networksecurityclienttlspolicy_v1beta1.json
+    kind: networksecurityclienttlspolicy
+    name: networksecurityclienttlspolicy_v1beta1
+  - apiVersion: networksecurity.cnrm.cloud.google.com/v1beta1
+    filename: networksecurity.cnrm.cloud.google.com/networksecurityservertlspolicy_v1beta1.json
+    kind: networksecurityservertlspolicy
+    name: networksecurityservertlspolicy_v1beta1
+networkservices.cnrm.cloud.google.com:
+  - apiVersion: networkservices.cnrm.cloud.google.com/v1beta1
+    filename: networkservices.cnrm.cloud.google.com/networkservicesgateway_v1beta1.json
+    kind: networkservicesgateway
+    name: networkservicesgateway_v1beta1
+  - apiVersion: networkservices.cnrm.cloud.google.com/v1beta1
+    filename: networkservices.cnrm.cloud.google.com/networkservicesmesh_v1beta1.json
+    kind: networkservicesmesh
+    name: networkservicesmesh_v1beta1
+  - apiVersion: networkservices.cnrm.cloud.google.com/v1beta1
+    filename: networkservices.cnrm.cloud.google.com/networkservicesgrpcroute_v1beta1.json
+    kind: networkservicesgrpcroute
+    name: networkservicesgrpcroute_v1beta1
+  - apiVersion: networkservices.cnrm.cloud.google.com/v1beta1
+    filename: networkservices.cnrm.cloud.google.com/networkservicesendpointpolicy_v1beta1.json
+    kind: networkservicesendpointpolicy
+    name: networkservicesendpointpolicy_v1beta1
+  - apiVersion: networkservices.cnrm.cloud.google.com/v1alpha1
+    filename: networkservices.cnrm.cloud.google.com/networkservicesedgecachekeyset_v1alpha1.json
+    kind: networkservicesedgecachekeyset
+    name: networkservicesedgecachekeyset_v1alpha1
+  - apiVersion: networkservices.cnrm.cloud.google.com/v1alpha1
+    filename: networkservices.cnrm.cloud.google.com/networkservicesedgecacheservice_v1alpha1.json
+    kind: networkservicesedgecacheservice
+    name: networkservicesedgecacheservice_v1alpha1
+  - apiVersion: networkservices.cnrm.cloud.google.com/v1alpha1
+    filename: networkservices.cnrm.cloud.google.com/networkservicesedgecacheorigin_v1alpha1.json
+    kind: networkservicesedgecacheorigin
+    name: networkservicesedgecacheorigin_v1alpha1
+  - apiVersion: networkservices.cnrm.cloud.google.com/v1beta1
+    filename: networkservices.cnrm.cloud.google.com/networkservicestlsroute_v1beta1.json
+    kind: networkservicestlsroute
+    name: networkservicestlsroute_v1beta1
+  - apiVersion: networkservices.cnrm.cloud.google.com/v1beta1
+    filename: networkservices.cnrm.cloud.google.com/networkservicestcproute_v1beta1.json
+    kind: networkservicestcproute
+    name: networkservicestcproute_v1beta1
+  - apiVersion: networkservices.cnrm.cloud.google.com/v1beta1
+    filename: networkservices.cnrm.cloud.google.com/networkserviceshttproute_v1beta1.json
+    kind: networkserviceshttproute
+    name: networkserviceshttproute_v1beta1
+notebooks.cnrm.cloud.google.com:
+  - apiVersion: notebooks.cnrm.cloud.google.com/v1alpha1
+    filename: notebooks.cnrm.cloud.google.com/notebooksenvironment_v1alpha1.json
+    kind: notebooksenvironment
+    name: notebooksenvironment_v1alpha1
 notification.toolkit.fluxcd.io:
   - apiVersion: notification.toolkit.fluxcd.io/v1beta1
     filename: notification.toolkit.fluxcd.io/alert_v1beta1.json
@@ -366,15 +5783,1281 @@ notification.toolkit.fluxcd.io:
     filename: notification.toolkit.fluxcd.io/receiver_v1beta1.json
     kind: Receiver
     name: receiver_v1beta1
+  - apiVersion: notification.toolkit.fluxcd.io/v1
+    filename: notification.toolkit.fluxcd.io/receiver_v1.json
+    kind: Receiver
+    name: receiver_v1
+  - apiVersion: notification.toolkit.fluxcd.io/v1beta2
+    filename: notification.toolkit.fluxcd.io/receiver_v1beta2.json
+    kind: Receiver
+    name: receiver_v1beta2
+  - apiVersion: notification.toolkit.fluxcd.io/v1beta3
+    filename: notification.toolkit.fluxcd.io/alert_v1beta3.json
+    kind: Alert
+    name: alert_v1beta3
+  - apiVersion: notification.toolkit.fluxcd.io/v1beta2
+    filename: notification.toolkit.fluxcd.io/provider_v1beta2.json
+    kind: Provider
+    name: provider_v1beta2
+  - apiVersion: notification.toolkit.fluxcd.io/v1beta3
+    filename: notification.toolkit.fluxcd.io/provider_v1beta3.json
+    kind: Provider
+    name: provider_v1beta3
+  - apiVersion: notification.toolkit.fluxcd.io/v1beta2
+    filename: notification.toolkit.fluxcd.io/alert_v1beta2.json
+    kind: Alert
+    name: alert_v1beta2
+objectbucket.io:
+  - apiVersion: objectbucket.io/v1alpha1
+    filename: objectbucket.io/objectbucketclaim_v1alpha1.json
+    kind: objectbucketclaim
+    name: objectbucketclaim_v1alpha1
+  - apiVersion: objectbucket.io/v1alpha1
+    filename: objectbucket.io/objectbucket_v1alpha1.json
+    kind: objectbucket
+    name: objectbucket_v1alpha1
+onepassword.com:
+  - apiVersion: onepassword.com/v1
+    filename: onepassword.com/onepassworditem_v1.json
+    kind: OnePasswordItem
+    name: onepassworditem_v1
+openebs.io:
+  - apiVersion: openebs.io/v1beta1
+    filename: openebs.io/diskpool_v1beta1.json
+    kind: DiskPool
+    name: diskpool_v1beta1
+  - apiVersion: openebs.io/v1alpha1
+    filename: openebs.io/blockdeviceclaim_v1alpha1.json
+    kind: BlockDeviceClaim
+    name: blockdeviceclaim_v1alpha1
+  - apiVersion: openebs.io/v1alpha1
+    filename: openebs.io/blockdevice_v1alpha1.json
+    kind: BlockDevice
+    name: blockdevice_v1alpha1
+  - apiVersion: openebs.io/v1beta2
+    filename: openebs.io/diskpool_v1beta2.json
+    kind: DiskPool
+    name: diskpool_v1beta2
+opensearchservice.services.k8s.aws:
+  - apiVersion: opensearchservice.services.k8s.aws/v1alpha1
+    filename: opensearchservice.services.k8s.aws/domain_v1alpha1.json
+    kind: Domain
+    name: domain_v1alpha1
+opentelemetry.io:
+  - apiVersion: opentelemetry.io/v1alpha1
+    filename: opentelemetry.io/opampbridge_v1alpha1.json
+    kind: opampbridge
+    name: opampbridge_v1alpha1
+  - apiVersion: opentelemetry.io/v1alpha1
+    filename: opentelemetry.io/instrumentation_v1alpha1.json
+    kind: instrumentation
+    name: instrumentation_v1alpha1
+  - apiVersion: opentelemetry.io/v1alpha1
+    filename: opentelemetry.io/opentelemetrycollector_v1alpha1.json
+    kind: opentelemetrycollector
+    name: opentelemetrycollector_v1alpha1
+  - apiVersion: opentelemetry.io/v1beta1
+    filename: opentelemetry.io/opentelemetrycollector_v1beta1.json
+    kind: opentelemetrycollector
+    name: opentelemetrycollector_v1beta1
+operator.cluster.x-k8s.io:
+  - apiVersion: operator.cluster.x-k8s.io/v1alpha2
+    filename: operator.cluster.x-k8s.io/addonprovider_v1alpha2.json
+    kind: AddonProvider
+    name: addonprovider_v1alpha2
+  - apiVersion: operator.cluster.x-k8s.io/v1alpha1
+    filename: operator.cluster.x-k8s.io/controlplaneprovider_v1alpha1.json
+    kind: ControlPlaneProvider
+    name: controlplaneprovider_v1alpha1
+  - apiVersion: operator.cluster.x-k8s.io/v1alpha1
+    filename: operator.cluster.x-k8s.io/bootstrapprovider_v1alpha1.json
+    kind: BootstrapProvider
+    name: bootstrapprovider_v1alpha1
+  - apiVersion: operator.cluster.x-k8s.io/v1alpha1
+    filename: operator.cluster.x-k8s.io/coreprovider_v1alpha1.json
+    kind: CoreProvider
+    name: coreprovider_v1alpha1
+  - apiVersion: operator.cluster.x-k8s.io/v1alpha1
+    filename: operator.cluster.x-k8s.io/infrastructureprovider_v1alpha1.json
+    kind: InfrastructureProvider
+    name: infrastructureprovider_v1alpha1
+  - apiVersion: operator.cluster.x-k8s.io/v1alpha2
+    filename: operator.cluster.x-k8s.io/controlplaneprovider_v1alpha2.json
+    kind: ControlPlaneProvider
+    name: controlplaneprovider_v1alpha2
+  - apiVersion: operator.cluster.x-k8s.io/v1alpha2
+    filename: operator.cluster.x-k8s.io/bootstrapprovider_v1alpha2.json
+    kind: BootstrapProvider
+    name: bootstrapprovider_v1alpha2
+  - apiVersion: operator.cluster.x-k8s.io/v1alpha2
+    filename: operator.cluster.x-k8s.io/coreprovider_v1alpha2.json
+    kind: CoreProvider
+    name: coreprovider_v1alpha2
+  - apiVersion: operator.cluster.x-k8s.io/v1alpha2
+    filename: operator.cluster.x-k8s.io/ipamprovider_v1alpha2.json
+    kind: IPAMProvider
+    name: ipamprovider_v1alpha2
+  - apiVersion: operator.cluster.x-k8s.io/v1alpha2
+    filename: operator.cluster.x-k8s.io/infrastructureprovider_v1alpha2.json
+    kind: InfrastructureProvider
+    name: infrastructureprovider_v1alpha2
+operator.tigera.io:
+  - apiVersion: operator.tigera.io/v1
+    filename: operator.tigera.io/tigerastatus_v1.json
+    kind: TigeraStatus
+    name: tigerastatus_v1
+  - apiVersion: operator.tigera.io/v1
+    filename: operator.tigera.io/imageset_v1.json
+    kind: ImageSet
+    name: imageset_v1
+  - apiVersion: operator.tigera.io/v1
+    filename: operator.tigera.io/installation_v1.json
+    kind: Installation
+    name: installation_v1
+  - apiVersion: operator.tigera.io/v1
+    filename: operator.tigera.io/apiserver_v1.json
+    kind: APIServer
+    name: apiserver_v1
+operator.victoriametrics.com:
+  - apiVersion: operator.victoriametrics.com/v1beta1
+    filename: operator.victoriametrics.com/vmcluster_v1beta1.json
+    kind: VMCluster
+    name: vmcluster_v1beta1
+  - apiVersion: operator.victoriametrics.com/v1beta1
+    filename: operator.victoriametrics.com/vmalertmanager_v1beta1.json
+    kind: VMAlertmanager
+    name: vmalertmanager_v1beta1
+  - apiVersion: operator.victoriametrics.com/v1beta1
+    filename: operator.victoriametrics.com/vmalert_v1beta1.json
+    kind: VMAlert
+    name: vmalert_v1beta1
+  - apiVersion: operator.victoriametrics.com/v1beta1
+    filename: operator.victoriametrics.com/vmprobe_v1beta1.json
+    kind: VMProbe
+    name: vmprobe_v1beta1
+  - apiVersion: operator.victoriametrics.com/v1beta1
+    filename: operator.victoriametrics.com/vmpodscrape_v1beta1.json
+    kind: VMPodScrape
+    name: vmpodscrape_v1beta1
+  - apiVersion: operator.victoriametrics.com/v1beta1
+    filename: operator.victoriametrics.com/vmauth_v1beta1.json
+    kind: VMAuth
+    name: vmauth_v1beta1
+  - apiVersion: operator.victoriametrics.com/v1beta1
+    filename: operator.victoriametrics.com/vmscrapeconfig_v1beta1.json
+    kind: VMScrapeConfig
+    name: vmscrapeconfig_v1beta1
+  - apiVersion: operator.victoriametrics.com/v1beta1
+    filename: operator.victoriametrics.com/vmagent_v1beta1.json
+    kind: VMAgent
+    name: vmagent_v1beta1
+  - apiVersion: operator.victoriametrics.com/v1beta1
+    filename: operator.victoriametrics.com/vmalertmanagerconfig_v1beta1.json
+    kind: VMAlertmanagerConfig
+    name: vmalertmanagerconfig_v1beta1
+  - apiVersion: operator.victoriametrics.com/v1beta1
+    filename: operator.victoriametrics.com/vmsingle_v1beta1.json
+    kind: VMSingle
+    name: vmsingle_v1beta1
+  - apiVersion: operator.victoriametrics.com/v1beta1
+    filename: operator.victoriametrics.com/vmuser_v1beta1.json
+    kind: VMUser
+    name: vmuser_v1beta1
+  - apiVersion: operator.victoriametrics.com/v1beta1
+    filename: operator.victoriametrics.com/vmnodescrape_v1beta1.json
+    kind: VMNodeScrape
+    name: vmnodescrape_v1beta1
+  - apiVersion: operator.victoriametrics.com/v1beta1
+    filename: operator.victoriametrics.com/vmrule_v1beta1.json
+    kind: VMRule
+    name: vmrule_v1beta1
+  - apiVersion: operator.victoriametrics.com/v1beta1
+    filename: operator.victoriametrics.com/vmservicescrape_v1beta1.json
+    kind: VMServiceScrape
+    name: vmservicescrape_v1beta1
+  - apiVersion: operator.victoriametrics.com/v1beta1
+    filename: operator.victoriametrics.com/vlogs_v1beta1.json
+    kind: VLogs
+    name: vlogs_v1beta1
+  - apiVersion: operator.victoriametrics.com/v1beta1
+    filename: operator.victoriametrics.com/vmstaticscrape_v1beta1.json
+    kind: VMStaticScrape
+    name: vmstaticscrape_v1beta1
+operators.coreos.com:
+  - apiVersion: operators.coreos.com/v2
+    filename: operators.coreos.com/operatorcondition_v2.json
+    kind: OperatorCondition
+    name: operatorcondition_v2
+  - apiVersion: operators.coreos.com/v1alpha1
+    filename: operators.coreos.com/subscription_v1alpha1.json
+    kind: Subscription
+    name: subscription_v1alpha1
+  - apiVersion: operators.coreos.com/v1alpha1
+    filename: operators.coreos.com/installplan_v1alpha1.json
+    kind: InstallPlan
+    name: installplan_v1alpha1
+  - apiVersion: operators.coreos.com/v1alpha1
+    filename: operators.coreos.com/catalogsource_v1alpha1.json
+    kind: CatalogSource
+    name: catalogsource_v1alpha1
+  - apiVersion: operators.coreos.com/v1
+    filename: operators.coreos.com/olmconfig_v1.json
+    kind: OLMConfig
+    name: olmconfig_v1
+  - apiVersion: operators.coreos.com/v1alpha2
+    filename: operators.coreos.com/operatorgroup_v1alpha2.json
+    kind: OperatorGroup
+    name: operatorgroup_v1alpha2
+  - apiVersion: operators.coreos.com/v1alpha1
+    filename: operators.coreos.com/clusterserviceversion_v1alpha1.json
+    kind: ClusterServiceVersion
+    name: clusterserviceversion_v1alpha1
+  - apiVersion: operators.coreos.com/v1
+    filename: operators.coreos.com/operatorcondition_v1.json
+    kind: OperatorCondition
+    name: operatorcondition_v1
+  - apiVersion: operators.coreos.com/v1
+    filename: operators.coreos.com/operatorgroup_v1.json
+    kind: OperatorGroup
+    name: operatorgroup_v1
+  - apiVersion: operators.coreos.com/v1
+    filename: operators.coreos.com/operator_v1.json
+    kind: Operator
+    name: operator_v1
+organizations.services.k8s.aws:
+  - apiVersion: organizations.services.k8s.aws/v1alpha1
+    filename: organizations.services.k8s.aws/organizationalunit_v1alpha1.json
+    kind: OrganizationalUnit
+    name: organizationalunit_v1alpha1
+orgpolicy.cnrm.cloud.google.com:
+  - apiVersion: orgpolicy.cnrm.cloud.google.com/v1alpha1
+    filename: orgpolicy.cnrm.cloud.google.com/orgpolicycustomconstraint_v1alpha1.json
+    kind: orgpolicycustomconstraint
+    name: orgpolicycustomconstraint_v1alpha1
+osconfig.cnrm.cloud.google.com:
+  - apiVersion: osconfig.cnrm.cloud.google.com/v1alpha1
+    filename: osconfig.cnrm.cloud.google.com/osconfigpatchdeployment_v1alpha1.json
+    kind: osconfigpatchdeployment
+    name: osconfigpatchdeployment_v1alpha1
+  - apiVersion: osconfig.cnrm.cloud.google.com/v1beta1
+    filename: osconfig.cnrm.cloud.google.com/osconfigospolicyassignment_v1beta1.json
+    kind: osconfigospolicyassignment
+    name: osconfigospolicyassignment_v1beta1
+  - apiVersion: osconfig.cnrm.cloud.google.com/v1beta1
+    filename: osconfig.cnrm.cloud.google.com/osconfigguestpolicy_v1beta1.json
+    kind: osconfigguestpolicy
+    name: osconfigguestpolicy_v1beta1
+oslogin.cnrm.cloud.google.com:
+  - apiVersion: oslogin.cnrm.cloud.google.com/v1alpha1
+    filename: oslogin.cnrm.cloud.google.com/osloginsshpublickey_v1alpha1.json
+    kind: osloginsshpublickey
+    name: osloginsshpublickey_v1alpha1
+packages.eks.amazonaws.com:
+  - apiVersion: packages.eks.amazonaws.com/v1alpha1
+    filename: packages.eks.amazonaws.com/packagebundlecontroller_v1alpha1.json
+    kind: PackageBundleController
+    name: packagebundlecontroller_v1alpha1
+  - apiVersion: packages.eks.amazonaws.com/v1alpha1
+    filename: packages.eks.amazonaws.com/packagebundle_v1alpha1.json
+    kind: PackageBundle
+    name: packagebundle_v1alpha1
+  - apiVersion: packages.eks.amazonaws.com/v1alpha1
+    filename: packages.eks.amazonaws.com/package_v1alpha1.json
+    kind: Package
+    name: package_v1alpha1
+pg.percona.com:
+  - apiVersion: pg.percona.com/v1
+    filename: pg.percona.com/perconapgcluster_v1.json
+    kind: perconapgcluster
+    name: perconapgcluster_v1
+  - apiVersion: pg.percona.com/v1beta1
+    filename: pg.percona.com/postgrescluster_v1beta1.json
+    kind: PostgresCluster
+    name: postgrescluster_v1beta1
+  - apiVersion: pg.percona.com/v2beta1
+    filename: pg.percona.com/perconapgcluster_v2beta1.json
+    kind: PerconaPGCluster
+    name: perconapgcluster_v2beta1
+  - apiVersion: pg.percona.com/v2beta1
+    filename: pg.percona.com/perconapgrestore_v2beta1.json
+    kind: PerconaPGRestore
+    name: perconapgrestore_v2beta1
+  - apiVersion: pg.percona.com/v2beta1
+    filename: pg.percona.com/perconapgbackup_v2beta1.json
+    kind: PerconaPGBackup
+    name: perconapgbackup_v2beta1
+pingcap.com:
+  - apiVersion: pingcap.com/v1alpha1
+    filename: pingcap.com/tidbcluster_v1alpha1.json
+    kind: tidbcluster
+    name: tidbcluster_v1alpha1
+  - apiVersion: pingcap.com/v1alpha1
+    filename: pingcap.com/tidbdashboard_v1alpha1.json
+    kind: tidbdashboard
+    name: tidbdashboard_v1alpha1
+  - apiVersion: pingcap.com/v1alpha1
+    filename: pingcap.com/tidbngmonitoring_v1alpha1.json
+    kind: tidbngmonitoring
+    name: tidbngmonitoring_v1alpha1
+  - apiVersion: pingcap.com/v1alpha1
+    filename: pingcap.com/restore_v1alpha1.json
+    kind: restore
+    name: restore_v1alpha1
+  - apiVersion: pingcap.com/v1alpha1
+    filename: pingcap.com/dmcluster_v1alpha1.json
+    kind: dmcluster
+    name: dmcluster_v1alpha1
+  - apiVersion: pingcap.com/v1alpha1
+    filename: pingcap.com/tidbclusterautoscaler_v1alpha1.json
+    kind: tidbclusterautoscaler
+    name: tidbclusterautoscaler_v1alpha1
+  - apiVersion: pingcap.com/v1alpha1
+    filename: pingcap.com/tidbmonitor_v1alpha1.json
+    kind: tidbmonitor
+    name: tidbmonitor_v1alpha1
+  - apiVersion: pingcap.com/v1alpha1
+    filename: pingcap.com/backup_v1alpha1.json
+    kind: backup
+    name: backup_v1alpha1
+  - apiVersion: pingcap.com/v1alpha1
+    filename: pingcap.com/backupschedule_v1alpha1.json
+    kind: backupschedule
+    name: backupschedule_v1alpha1
+  - apiVersion: pingcap.com/v1alpha1
+    filename: pingcap.com/tidbinitializer_v1alpha1.json
+    kind: tidbinitializer
+    name: tidbinitializer_v1alpha1
+pipes.services.k8s.aws:
+  - apiVersion: pipes.services.k8s.aws/v1alpha1
+    filename: pipes.services.k8s.aws/pipe_v1alpha1.json
+    kind: Pipe
+    name: pipe_v1alpha1
+pkg.crossplane.io:
+  - apiVersion: pkg.crossplane.io/v1
+    filename: pkg.crossplane.io/configuration_v1.json
+    kind: Configuration
+    name: configuration_v1
+  - apiVersion: pkg.crossplane.io/v1alpha1
+    filename: pkg.crossplane.io/controllerconfig_v1alpha1.json
+    kind: ControllerConfig
+    name: controllerconfig_v1alpha1
+  - apiVersion: pkg.crossplane.io/v1beta1
+    filename: pkg.crossplane.io/lock_v1beta1.json
+    kind: Lock
+    name: lock_v1beta1
+  - apiVersion: pkg.crossplane.io/v1
+    filename: pkg.crossplane.io/configurationrevision_v1.json
+    kind: ConfigurationRevision
+    name: configurationrevision_v1
+  - apiVersion: pkg.crossplane.io/v1beta1
+    filename: pkg.crossplane.io/imageconfig_v1beta1.json
+    kind: ImageConfig
+    name: imageconfig_v1beta1
+  - apiVersion: pkg.crossplane.io/v1beta1
+    filename: pkg.crossplane.io/function_v1beta1.json
+    kind: Function
+    name: function_v1beta1
+  - apiVersion: pkg.crossplane.io/v1
+    filename: pkg.crossplane.io/providerrevision_v1.json
+    kind: ProviderRevision
+    name: providerrevision_v1
+  - apiVersion: pkg.crossplane.io/v1
+    filename: pkg.crossplane.io/functionrevision_v1.json
+    kind: FunctionRevision
+    name: functionrevision_v1
+  - apiVersion: pkg.crossplane.io/v1
+    filename: pkg.crossplane.io/provider_v1.json
+    kind: Provider
+    name: provider_v1
+  - apiVersion: pkg.crossplane.io/v1beta1
+    filename: pkg.crossplane.io/deploymentruntimeconfig_v1beta1.json
+    kind: DeploymentRuntimeConfig
+    name: deploymentruntimeconfig_v1beta1
+  - apiVersion: pkg.crossplane.io/v1alpha1
+    filename: pkg.crossplane.io/lock_v1alpha1.json
+    kind: Lock
+    name: lock_v1alpha1
+  - apiVersion: pkg.crossplane.io/v1
+    filename: pkg.crossplane.io/function_v1.json
+    kind: Function
+    name: function_v1
+  - apiVersion: pkg.crossplane.io/v1beta1
+    filename: pkg.crossplane.io/functionrevision_v1beta1.json
+    kind: FunctionRevision
+    name: functionrevision_v1beta1
+platform.confluent.io:
+  - apiVersion: platform.confluent.io/v1beta1
+    filename: platform.confluent.io/schemaexporter_v1beta1.json
+    kind: SchemaExporter
+    name: schemaexporter_v1beta1
+  - apiVersion: platform.confluent.io/v1beta1
+    filename: platform.confluent.io/schemaregistry_v1beta1.json
+    kind: SchemaRegistry
+    name: schemaregistry_v1beta1
+  - apiVersion: platform.confluent.io/v1beta1
+    filename: platform.confluent.io/kafkarestclass_v1beta1.json
+    kind: KafkaRestClass
+    name: kafkarestclass_v1beta1
+  - apiVersion: platform.confluent.io/v1beta1
+    filename: platform.confluent.io/kafkarestproxy_v1beta1.json
+    kind: KafkaRestProxy
+    name: kafkarestproxy_v1beta1
+  - apiVersion: platform.confluent.io/v1beta1
+    filename: platform.confluent.io/connector_v1beta1.json
+    kind: Connector
+    name: connector_v1beta1
+  - apiVersion: platform.confluent.io/v1beta1
+    filename: platform.confluent.io/kafka_v1beta1.json
+    kind: Kafka
+    name: kafka_v1beta1
+  - apiVersion: platform.confluent.io/v1beta1
+    filename: platform.confluent.io/connect_v1beta1.json
+    kind: Connect
+    name: connect_v1beta1
+  - apiVersion: platform.confluent.io/v1beta1
+    filename: platform.confluent.io/kraftcontroller_v1beta1.json
+    kind: KRaftController
+    name: kraftcontroller_v1beta1
+  - apiVersion: platform.confluent.io/v1beta1
+    filename: platform.confluent.io/confluentrolebinding_v1beta1.json
+    kind: ConfluentRolebinding
+    name: confluentrolebinding_v1beta1
+  - apiVersion: platform.confluent.io/v1beta1
+    filename: platform.confluent.io/kafkatopic_v1beta1.json
+    kind: KafkaTopic
+    name: kafkatopic_v1beta1
+  - apiVersion: platform.confluent.io/v1beta1
+    filename: platform.confluent.io/clusterlink_v1beta1.json
+    kind: ClusterLink
+    name: clusterlink_v1beta1
+  - apiVersion: platform.confluent.io/v1beta1
+    filename: platform.confluent.io/schema_v1beta1.json
+    kind: schema
+    name: schema_v1beta1
+  - apiVersion: platform.confluent.io/v1beta1
+    filename: platform.confluent.io/ksqldb_v1beta1.json
+    kind: KsqlDB
+    name: ksqldb_v1beta1
+  - apiVersion: platform.confluent.io/v1beta1
+    filename: platform.confluent.io/zookeeper_v1beta1.json
+    kind: Zookeeper
+    name: zookeeper_v1beta1
+  - apiVersion: platform.confluent.io/v1beta1
+    filename: platform.confluent.io/controlcenter_v1beta1.json
+    kind: ControlCenter
+    name: controlcenter_v1beta1
+policy.cert-manager.io:
+  - apiVersion: policy.cert-manager.io/v1alpha1
+    filename: policy.cert-manager.io/certificaterequestpolicy_v1alpha1.json
+    kind: CertificateRequestPolicy
+    name: certificaterequestpolicy_v1alpha1
+policy.linkerd.io:
+  - apiVersion: policy.linkerd.io/v1alpha1
+    filename: policy.linkerd.io/serverauthorization_v1alpha1.json
+    kind: serverauthorization
+    name: serverauthorization_v1alpha1
+  - apiVersion: policy.linkerd.io/v1
+    filename: policy.linkerd.io/httproute_v1.json
+    kind: HTTPRoute
+    name: httproute_v1
+  - apiVersion: policy.linkerd.io/v1beta1
+    filename: policy.linkerd.io/httproute_v1beta1.json
+    kind: HTTPRoute
+    name: httproute_v1beta1
+  - apiVersion: policy.linkerd.io/v1alpha1
+    filename: policy.linkerd.io/networkauthentication_v1alpha1.json
+    kind: networkauthentication
+    name: networkauthentication_v1alpha1
+  - apiVersion: policy.linkerd.io/v1beta1
+    filename: policy.linkerd.io/serverauthorization_v1beta1.json
+    kind: serverauthorization
+    name: serverauthorization_v1beta1
+  - apiVersion: policy.linkerd.io/v1alpha1
+    filename: policy.linkerd.io/meshtlsauthentication_v1alpha1.json
+    kind: meshtlsauthentication
+    name: meshtlsauthentication_v1alpha1
+  - apiVersion: policy.linkerd.io/v1beta2
+    filename: policy.linkerd.io/httproute_v1beta2.json
+    kind: HTTPRoute
+    name: httproute_v1beta2
+  - apiVersion: policy.linkerd.io/v1beta1
+    filename: policy.linkerd.io/server_v1beta1.json
+    kind: server
+    name: server_v1beta1
+  - apiVersion: policy.linkerd.io/v1alpha1
+    filename: policy.linkerd.io/server_v1alpha1.json
+    kind: server
+    name: server_v1alpha1
+  - apiVersion: policy.linkerd.io/v1beta3
+    filename: policy.linkerd.io/httproute_v1beta3.json
+    kind: HTTPRoute
+    name: httproute_v1beta3
+  - apiVersion: policy.linkerd.io/v1alpha1
+    filename: policy.linkerd.io/httproute_v1alpha1.json
+    kind: HTTPRoute
+    name: httproute_v1alpha1
+  - apiVersion: policy.linkerd.io/v1alpha1
+    filename: policy.linkerd.io/authorizationpolicy_v1alpha1.json
+    kind: authorizationpolicy
+    name: authorizationpolicy_v1alpha1
+policy.sigstore.dev:
+  - apiVersion: policy.sigstore.dev/v1alpha1
+    filename: policy.sigstore.dev/clusterimagepolicy_v1alpha1.json
+    kind: clusterimagepolicy
+    name: clusterimagepolicy_v1alpha1
+  - apiVersion: policy.sigstore.dev/v1beta1
+    filename: policy.sigstore.dev/clusterimagepolicy_v1beta1.json
+    kind: clusterimagepolicy
+    name: clusterimagepolicy_v1beta1
+  - apiVersion: policy.sigstore.dev/v1alpha1
+    filename: policy.sigstore.dev/trustroot_v1alpha1.json
+    kind: trustroot
+    name: trustroot_v1alpha1
+postgres-operator.crunchydata.com:
+  - apiVersion: postgres-operator.crunchydata.com/v1beta1
+    filename: postgres-operator.crunchydata.com/postgrescluster_v1beta1.json
+    kind: PostgresCluster
+    name: postgrescluster_v1beta1
+  - apiVersion: postgres-operator.crunchydata.com/v1beta1
+    filename: postgres-operator.crunchydata.com/pgupgrade_v1beta1.json
+    kind: PGUpgrade
+    name: pgupgrade_v1beta1
+  - apiVersion: postgres-operator.crunchydata.com/v1beta1
+    filename: postgres-operator.crunchydata.com/pgadmin_v1beta1.json
+    kind: PGAdmin
+    name: pgadmin_v1beta1
+postgresql.cnpg.io:
+  - apiVersion: postgresql.cnpg.io/v1
+    filename: postgresql.cnpg.io/backup_v1.json
+    kind: Backup
+    name: backup_v1
+  - apiVersion: postgresql.cnpg.io/v3
+    filename: postgresql.cnpg.io/cluster_v3.json
+    kind: cluster
+    name: cluster_v3
+  - apiVersion: postgresql.cnpg.io/v1
+    filename: postgresql.cnpg.io/pooler_v1.json
+    kind: Pooler
+    name: pooler_v1
+  - apiVersion: postgresql.cnpg.io/v1
+    filename: postgresql.cnpg.io/scheduledbackup_v1.json
+    kind: ScheduledBackup
+    name: scheduledbackup_v1
+  - apiVersion: postgresql.cnpg.io/v1
+    filename: postgresql.cnpg.io/clusterimagecatalog_v1.json
+    kind: ClusterImageCatalog
+    name: clusterimagecatalog_v1
+  - apiVersion: postgresql.cnpg.io/v1
+    filename: postgresql.cnpg.io/imagecatalog_v1.json
+    kind: ImageCatalog
+    name: imagecatalog_v1
+  - apiVersion: postgresql.cnpg.io/v1
+    filename: postgresql.cnpg.io/publication_v1.json
+    kind: Publication
+    name: publication_v1
+  - apiVersion: postgresql.cnpg.io/v1
+    filename: postgresql.cnpg.io/database_v1.json
+    kind: Database
+    name: database_v1
+  - apiVersion: postgresql.cnpg.io/v1
+    filename: postgresql.cnpg.io/subscription_v1.json
+    kind: Subscription
+    name: subscription_v1
+  - apiVersion: postgresql.cnpg.io/v1
+    filename: postgresql.cnpg.io/cluster_v1.json
+    kind: Cluster
+    name: cluster_v1
+privateca.cnrm.cloud.google.com:
+  - apiVersion: privateca.cnrm.cloud.google.com/v1beta1
+    filename: privateca.cnrm.cloud.google.com/privatecacertificate_v1beta1.json
+    kind: privatecacertificate
+    name: privatecacertificate_v1beta1
+  - apiVersion: privateca.cnrm.cloud.google.com/v1beta1
+    filename: privateca.cnrm.cloud.google.com/privatecacertificateauthority_v1beta1.json
+    kind: privatecacertificateauthority
+    name: privatecacertificateauthority_v1beta1
+  - apiVersion: privateca.cnrm.cloud.google.com/v1beta1
+    filename: privateca.cnrm.cloud.google.com/privatecacapool_v1beta1.json
+    kind: privatecacapool
+    name: privatecacapool_v1beta1
+  - apiVersion: privateca.cnrm.cloud.google.com/v1beta1
+    filename: privateca.cnrm.cloud.google.com/privatecacertificatetemplate_v1beta1.json
+    kind: privatecacertificatetemplate
+    name: privatecacertificatetemplate_v1beta1
+privilegedaccessmanager.cnrm.cloud.google.com:
+  - apiVersion: privilegedaccessmanager.cnrm.cloud.google.com/v1alpha1
+    filename: privilegedaccessmanager.cnrm.cloud.google.com/privilegedaccessmanagerentitlement_v1alpha1.json
+    kind: PrivilegedAccessManagerEntitlement
+    name: privilegedaccessmanagerentitlement_v1alpha1
+  - apiVersion: privilegedaccessmanager.cnrm.cloud.google.com/v1beta1
+    filename: privilegedaccessmanager.cnrm.cloud.google.com/privilegedaccessmanagerentitlement_v1beta1.json
+    kind: PrivilegedAccessManagerEntitlement
+    name: privilegedaccessmanagerentitlement_v1beta1
+projectcontour.io:
+  - apiVersion: projectcontour.io/v1alpha1
+    filename: projectcontour.io/extensionservice_v1alpha1.json
+    kind: ExtensionService
+    name: extensionservice_v1alpha1
+  - apiVersion: projectcontour.io/v1alpha1
+    filename: projectcontour.io/contourconfiguration_v1alpha1.json
+    kind: ContourConfiguration
+    name: contourconfiguration_v1alpha1
+  - apiVersion: projectcontour.io/v1
+    filename: projectcontour.io/tlscertificatedelegation_v1.json
+    kind: TLSCertificateDelegation
+    name: tlscertificatedelegation_v1
+  - apiVersion: projectcontour.io/v1alpha1
+    filename: projectcontour.io/contourdeployment_v1alpha1.json
+    kind: ContourDeployment
+    name: contourdeployment_v1alpha1
+  - apiVersion: projectcontour.io/v1
+    filename: projectcontour.io/httpproxy_v1.json
+    kind: HTTPProxy
+    name: httpproxy_v1
+prometheusservice.services.k8s.aws:
+  - apiVersion: prometheusservice.services.k8s.aws/v1alpha1
+    filename: prometheusservice.services.k8s.aws/workspace_v1alpha1.json
+    kind: Workspace
+    name: workspace_v1alpha1
+  - apiVersion: prometheusservice.services.k8s.aws/v1alpha1
+    filename: prometheusservice.services.k8s.aws/alertmanagerdefinition_v1alpha1.json
+    kind: AlertManagerDefinition
+    name: alertmanagerdefinition_v1alpha1
+  - apiVersion: prometheusservice.services.k8s.aws/v1alpha1
+    filename: prometheusservice.services.k8s.aws/loggingconfiguration_v1alpha1.json
+    kind: LoggingConfiguration
+    name: loggingconfiguration_v1alpha1
+  - apiVersion: prometheusservice.services.k8s.aws/v1alpha1
+    filename: prometheusservice.services.k8s.aws/rulegroupsnamespace_v1alpha1.json
+    kind: RuleGroupsNamespace
+    name: rulegroupsnamespace_v1alpha1
+ps.percona.com:
+  - apiVersion: ps.percona.com/v1alpha1
+    filename: ps.percona.com/perconaservermysqlbackup_v1alpha1.json
+    kind: perconaservermysqlbackup
+    name: perconaservermysqlbackup_v1alpha1
+  - apiVersion: ps.percona.com/v1alpha1
+    filename: ps.percona.com/perconaservermysqlrestore_v1alpha1.json
+    kind: perconaservermysqlrestore
+    name: perconaservermysqlrestore_v1alpha1
+  - apiVersion: ps.percona.com/v1alpha1
+    filename: ps.percona.com/perconaservermysql_v1alpha1.json
+    kind: perconaservermysql
+    name: perconaservermysql_v1alpha1
+psmdb.percona.com:
+  - apiVersion: psmdb.percona.com/v1
+    filename: psmdb.percona.com/perconaservermongodbrestore_v1.json
+    kind: perconaservermongodbrestore
+    name: perconaservermongodbrestore_v1
+  - apiVersion: psmdb.percona.com/v1
+    filename: psmdb.percona.com/perconaservermongodb_v1.json
+    kind: perconaservermongodb
+    name: perconaservermongodb_v1
+  - apiVersion: psmdb.percona.com/v1
+    filename: psmdb.percona.com/perconaservermongodbbackup_v1.json
+    kind: perconaservermongodbbackup
+    name: perconaservermongodbbackup_v1
+pubsub.cnrm.cloud.google.com:
+  - apiVersion: pubsub.cnrm.cloud.google.com/v1beta1
+    filename: pubsub.cnrm.cloud.google.com/pubsubsubscription_v1beta1.json
+    kind: pubsubsubscription
+    name: pubsubsubscription_v1beta1
+  - apiVersion: pubsub.cnrm.cloud.google.com/v1beta1
+    filename: pubsub.cnrm.cloud.google.com/pubsubschema_v1beta1.json
+    kind: pubsubschema
+    name: pubsubschema_v1beta1
+  - apiVersion: pubsub.cnrm.cloud.google.com/v1beta1
+    filename: pubsub.cnrm.cloud.google.com/pubsubtopic_v1beta1.json
+    kind: pubsubtopic
+    name: pubsubtopic_v1beta1
+pubsublite.cnrm.cloud.google.com:
+  - apiVersion: pubsublite.cnrm.cloud.google.com/v1alpha1
+    filename: pubsublite.cnrm.cloud.google.com/pubsublitetopic_v1alpha1.json
+    kind: pubsublitetopic
+    name: pubsublitetopic_v1alpha1
+  - apiVersion: pubsublite.cnrm.cloud.google.com/v1alpha1
+    filename: pubsublite.cnrm.cloud.google.com/pubsublitesubscription_v1alpha1.json
+    kind: pubsublitesubscription
+    name: pubsublitesubscription_v1alpha1
+  - apiVersion: pubsublite.cnrm.cloud.google.com/v1beta1
+    filename: pubsublite.cnrm.cloud.google.com/pubsublitereservation_v1beta1.json
+    kind: pubsublitereservation
+    name: pubsublitereservation_v1beta1
+pxc.percona.com:
+  - apiVersion: pxc.percona.com/v1
+    filename: pxc.percona.com/perconaxtradbcluster_v1.json
+    kind: perconaxtradbcluster
+    name: perconaxtradbcluster_v1
+  - apiVersion: pxc.percona.com/v1
+    filename: pxc.percona.com/perconaxtradbclusterbackup_v1.json
+    kind: perconaxtradbclusterbackup
+    name: perconaxtradbclusterbackup_v1
+  - apiVersion: pxc.percona.com/v1
+    filename: pxc.percona.com/perconaxtradbclusterrestore_v1.json
+    kind: perconaxtradbclusterrestore
+    name: perconaxtradbclusterrestore_v1
+pyrra.dev:
+  - apiVersion: pyrra.dev/v1alpha1
+    filename: pyrra.dev/servicelevelobjective_v1alpha1.json
+    kind: ServiceLevelObjective
+    name: servicelevelobjective_v1alpha1
+rabbitmq.com:
+  - apiVersion: rabbitmq.com/v1beta1
+    filename: rabbitmq.com/topicpermission_v1beta1.json
+    kind: TopicPermission
+    name: topicpermission_v1beta1
+  - apiVersion: rabbitmq.com/v1beta1
+    filename: rabbitmq.com/rabbitmqcluster_v1beta1.json
+    kind: RabbitmqCluster
+    name: rabbitmqcluster_v1beta1
+  - apiVersion: rabbitmq.com/v1beta1
+    filename: rabbitmq.com/permission_v1beta1.json
+    kind: Permission
+    name: permission_v1beta1
+  - apiVersion: rabbitmq.com/v1beta1
+    filename: rabbitmq.com/binding_v1beta1.json
+    kind: Binding
+    name: binding_v1beta1
+  - apiVersion: rabbitmq.com/v1beta1
+    filename: rabbitmq.com/federation_v1beta1.json
+    kind: Federation
+    name: federation_v1beta1
+  - apiVersion: rabbitmq.com/v1beta1
+    filename: rabbitmq.com/queue_v1beta1.json
+    kind: Queue
+    name: queue_v1beta1
+  - apiVersion: rabbitmq.com/v1beta1
+    filename: rabbitmq.com/shovel_v1beta1.json
+    kind: Shovel
+    name: shovel_v1beta1
+  - apiVersion: rabbitmq.com/v1alpha1
+    filename: rabbitmq.com/superstream_v1alpha1.json
+    kind: SuperStream
+    name: superstream_v1alpha1
+  - apiVersion: rabbitmq.com/v1beta1
+    filename: rabbitmq.com/policy_v1beta1.json
+    kind: Policy
+    name: policy_v1beta1
+  - apiVersion: rabbitmq.com/v1beta1
+    filename: rabbitmq.com/vhost_v1beta1.json
+    kind: Vhost
+    name: vhost_v1beta1
+  - apiVersion: rabbitmq.com/v1beta1
+    filename: rabbitmq.com/exchange_v1beta1.json
+    kind: Exchange
+    name: exchange_v1beta1
+  - apiVersion: rabbitmq.com/v1beta1
+    filename: rabbitmq.com/schemareplication_v1beta1.json
+    kind: SchemaReplication
+    name: schemareplication_v1beta1
+  - apiVersion: rabbitmq.com/v1beta1
+    filename: rabbitmq.com/user_v1beta1.json
+    kind: User
+    name: user_v1beta1
+ratelimit.solo.io:
+  - apiVersion: ratelimit.solo.io/v1alpha1
+    filename: ratelimit.solo.io/ratelimitconfig_v1alpha1.json
+    kind: ratelimitconfig
+    name: ratelimitconfig_v1alpha1
+rbacmanager.reactiveops.io:
+  - apiVersion: rbacmanager.reactiveops.io/v1beta1
+    filename: rbacmanager.reactiveops.io/rbacdefinition_v1beta1.json
+    kind: rbacdefinition
+    name: rbacdefinition_v1beta1
+  - apiVersion: rbacmanager.reactiveops.io/v1alpha1
+    filename: rbacmanager.reactiveops.io/rbacdefinitions_v1alpha1.json
+    kind: rbacdefinitions
+    name: rbacdefinitions_v1alpha1
+rds.services.k8s.aws:
+  - apiVersion: rds.services.k8s.aws/v1alpha1
+    filename: rds.services.k8s.aws/dbparametergroup_v1alpha1.json
+    kind: DBParameterGroup
+    name: dbparametergroup_v1alpha1
+  - apiVersion: rds.services.k8s.aws/v1alpha1
+    filename: rds.services.k8s.aws/dbproxy_v1alpha1.json
+    kind: DBProxy
+    name: dbproxy_v1alpha1
+  - apiVersion: rds.services.k8s.aws/v1alpha1
+    filename: rds.services.k8s.aws/globalcluster_v1alpha1.json
+    kind: GlobalCluster
+    name: globalcluster_v1alpha1
+  - apiVersion: rds.services.k8s.aws/v1alpha1
+    filename: rds.services.k8s.aws/dbclusterparametergroup_v1alpha1.json
+    kind: DBClusterParameterGroup
+    name: dbclusterparametergroup_v1alpha1
+  - apiVersion: rds.services.k8s.aws/v1alpha1
+    filename: rds.services.k8s.aws/dbcluster_v1alpha1.json
+    kind: DBCluster
+    name: dbcluster_v1alpha1
+  - apiVersion: rds.services.k8s.aws/v1alpha1
+    filename: rds.services.k8s.aws/dbsubnetgroup_v1alpha1.json
+    kind: DBSubnetGroup
+    name: dbsubnetgroup_v1alpha1
+  - apiVersion: rds.services.k8s.aws/v1alpha1
+    filename: rds.services.k8s.aws/dbinstance_v1alpha1.json
+    kind: DBInstance
+    name: dbinstance_v1alpha1
+recaptchaenterprise.cnrm.cloud.google.com:
+  - apiVersion: recaptchaenterprise.cnrm.cloud.google.com/v1beta1
+    filename: recaptchaenterprise.cnrm.cloud.google.com/recaptchaenterprisekey_v1beta1.json
+    kind: recaptchaenterprisekey
+    name: recaptchaenterprisekey_v1beta1
+redis.cnrm.cloud.google.com:
+  - apiVersion: redis.cnrm.cloud.google.com/v1beta1
+    filename: redis.cnrm.cloud.google.com/redisinstance_v1beta1.json
+    kind: redisinstance
+    name: redisinstance_v1beta1
+  - apiVersion: redis.cnrm.cloud.google.com/v1beta1
+    filename: redis.cnrm.cloud.google.com/rediscluster_v1beta1.json
+    kind: RedisCluster
+    name: rediscluster_v1beta1
+  - apiVersion: redis.cnrm.cloud.google.com/v1alpha1
+    filename: redis.cnrm.cloud.google.com/rediscluster_v1alpha1.json
+    kind: RedisCluster
+    name: rediscluster_v1alpha1
+resourcemanager.cnrm.cloud.google.com:
+  - apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    filename: resourcemanager.cnrm.cloud.google.com/resourcemanagerlien_v1beta1.json
+    kind: resourcemanagerlien
+    name: resourcemanagerlien_v1beta1
+  - apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    filename: resourcemanager.cnrm.cloud.google.com/folder_v1beta1.json
+    kind: folder
+    name: folder_v1beta1
+  - apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    filename: resourcemanager.cnrm.cloud.google.com/project_v1beta1.json
+    kind: project
+    name: project_v1beta1
+  - apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    filename: resourcemanager.cnrm.cloud.google.com/resourcemanagerpolicy_v1beta1.json
+    kind: resourcemanagerpolicy
+    name: resourcemanagerpolicy_v1beta1
+resources.teleport.dev:
+  - apiVersion: resources.teleport.dev/v1
+    filename: resources.teleport.dev/teleportloginrule_v1.json
+    kind: teleportloginrule
+    name: teleportloginrule_v1
+  - apiVersion: resources.teleport.dev/v5
+    filename: resources.teleport.dev/teleportrole_v5.json
+    kind: teleportrole
+    name: teleportrole_v5
+  - apiVersion: resources.teleport.dev/v3
+    filename: resources.teleport.dev/teleportgithubconnector_v3.json
+    kind: teleportgithubconnector
+    name: teleportgithubconnector_v3
+  - apiVersion: resources.teleport.dev/v3
+    filename: resources.teleport.dev/teleportoidcconnector_v3.json
+    kind: teleportoidcconnector
+    name: teleportoidcconnector_v3
+  - apiVersion: resources.teleport.dev/v1
+    filename: resources.teleport.dev/teleportaccesslist_v1.json
+    kind: teleportaccesslist
+    name: teleportaccesslist_v1
+  - apiVersion: resources.teleport.dev/v1
+    filename: resources.teleport.dev/teleportoktaimportrule_v1.json
+    kind: teleportoktaimportrule
+    name: teleportoktaimportrule_v1
+  - apiVersion: resources.teleport.dev/v1
+    filename: resources.teleport.dev/teleportrolev6_v1.json
+    kind: teleportrolev6
+    name: teleportrolev6_v1
+  - apiVersion: resources.teleport.dev/v1
+    filename: resources.teleport.dev/teleportopenssheiceserverv2_v1.json
+    kind: teleportopenssheiceserverv2
+    name: teleportopenssheiceserverv2_v1
+  - apiVersion: resources.teleport.dev/v2
+    filename: resources.teleport.dev/teleportsamlconnector_v2.json
+    kind: teleportsamlconnector
+    name: teleportsamlconnector_v2
+  - apiVersion: resources.teleport.dev/v2
+    filename: resources.teleport.dev/teleportuser_v2.json
+    kind: teleportuser
+    name: teleportuser_v2
+  - apiVersion: resources.teleport.dev/v6
+    filename: resources.teleport.dev/teleportrole_v6.json
+    kind: teleportrole
+    name: teleportrole_v6
+  - apiVersion: resources.teleport.dev/v2
+    filename: resources.teleport.dev/teleportprovisiontoken_v2.json
+    kind: teleportprovisiontoken
+    name: teleportprovisiontoken_v2
+  - apiVersion: resources.teleport.dev/v1
+    filename: resources.teleport.dev/teleportrolev7_v1.json
+    kind: teleportrolev7
+    name: teleportrolev7_v1
+  - apiVersion: resources.teleport.dev/v1
+    filename: resources.teleport.dev/teleportopensshserverv2_v1.json
+    kind: teleportopensshserverv2
+    name: teleportopensshserverv2_v1
+route53.services.k8s.aws:
+  - apiVersion: route53.services.k8s.aws/v1alpha1
+    filename: route53.services.k8s.aws/hostedzone_v1alpha1.json
+    kind: HostedZone
+    name: hostedzone_v1alpha1
+run.cnrm.cloud.google.com:
+  - apiVersion: run.cnrm.cloud.google.com/v1beta1
+    filename: run.cnrm.cloud.google.com/runjob_v1beta1.json
+    kind: runjob
+    name: runjob_v1beta1
+  - apiVersion: run.cnrm.cloud.google.com/v1beta1
+    filename: run.cnrm.cloud.google.com/runservice_v1beta1.json
+    kind: runservice
+    name: runservice_v1beta1
+runtime.cluster.x-k8s.io:
+  - apiVersion: runtime.cluster.x-k8s.io/v1alpha1
+    filename: runtime.cluster.x-k8s.io/extensionconfig_v1alpha1.json
+    kind: ExtensionConfig
+    name: extensionconfig_v1alpha1
+s3.services.k8s.aws:
+  - apiVersion: s3.services.k8s.aws/v1alpha1
+    filename: s3.services.k8s.aws/bucket_v1alpha1.json
+    kind: Bucket
+    name: bucket_v1alpha1
+sagemaker.services.k8s.aws:
+  - apiVersion: sagemaker.services.k8s.aws/v1alpha1
+    filename: sagemaker.services.k8s.aws/userprofile_v1alpha1.json
+    kind: UserProfile
+    name: userprofile_v1alpha1
+  - apiVersion: sagemaker.services.k8s.aws/v1alpha1
+    filename: sagemaker.services.k8s.aws/endpointconfig_v1alpha1.json
+    kind: EndpointConfig
+    name: endpointconfig_v1alpha1
+  - apiVersion: sagemaker.services.k8s.aws/v1alpha1
+    filename: sagemaker.services.k8s.aws/hyperparametertuningjob_v1alpha1.json
+    kind: HyperParameterTuningJob
+    name: hyperparametertuningjob_v1alpha1
+  - apiVersion: sagemaker.services.k8s.aws/v1alpha1
+    filename: sagemaker.services.k8s.aws/modelpackage_v1alpha1.json
+    kind: ModelPackage
+    name: modelpackage_v1alpha1
+  - apiVersion: sagemaker.services.k8s.aws/v1alpha1
+    filename: sagemaker.services.k8s.aws/dataqualityjobdefinition_v1alpha1.json
+    kind: DataQualityJobDefinition
+    name: dataqualityjobdefinition_v1alpha1
+  - apiVersion: sagemaker.services.k8s.aws/v1alpha1
+    filename: sagemaker.services.k8s.aws/domain_v1alpha1.json
+    kind: Domain
+    name: domain_v1alpha1
+  - apiVersion: sagemaker.services.k8s.aws/v1alpha1
+    filename: sagemaker.services.k8s.aws/notebookinstancelifecycleconfig_v1alpha1.json
+    kind: NotebookInstanceLifecycleConfig
+    name: notebookinstancelifecycleconfig_v1alpha1
+  - apiVersion: sagemaker.services.k8s.aws/v1alpha1
+    filename: sagemaker.services.k8s.aws/modelqualityjobdefinition_v1alpha1.json
+    kind: ModelQualityJobDefinition
+    name: modelqualityjobdefinition_v1alpha1
+  - apiVersion: sagemaker.services.k8s.aws/v1alpha1
+    filename: sagemaker.services.k8s.aws/featuregroup_v1alpha1.json
+    kind: FeatureGroup
+    name: featuregroup_v1alpha1
+  - apiVersion: sagemaker.services.k8s.aws/v1alpha1
+    filename: sagemaker.services.k8s.aws/modelexplainabilityjobdefinition_v1alpha1.json
+    kind: ModelExplainabilityJobDefinition
+    name: modelexplainabilityjobdefinition_v1alpha1
+  - apiVersion: sagemaker.services.k8s.aws/v1alpha1
+    filename: sagemaker.services.k8s.aws/transformjob_v1alpha1.json
+    kind: TransformJob
+    name: transformjob_v1alpha1
+  - apiVersion: sagemaker.services.k8s.aws/v1alpha1
+    filename: sagemaker.services.k8s.aws/modelpackagegroup_v1alpha1.json
+    kind: ModelPackageGroup
+    name: modelpackagegroup_v1alpha1
+  - apiVersion: sagemaker.services.k8s.aws/v1alpha1
+    filename: sagemaker.services.k8s.aws/app_v1alpha1.json
+    kind: App
+    name: app_v1alpha1
+  - apiVersion: sagemaker.services.k8s.aws/v1alpha1
+    filename: sagemaker.services.k8s.aws/pipelineexecution_v1alpha1.json
+    kind: PipelineExecution
+    name: pipelineexecution_v1alpha1
+  - apiVersion: sagemaker.services.k8s.aws/v1alpha1
+    filename: sagemaker.services.k8s.aws/trainingjob_v1alpha1.json
+    kind: TrainingJob
+    name: trainingjob_v1alpha1
+  - apiVersion: sagemaker.services.k8s.aws/v1alpha1
+    filename: sagemaker.services.k8s.aws/monitoringschedule_v1alpha1.json
+    kind: MonitoringSchedule
+    name: monitoringschedule_v1alpha1
+  - apiVersion: sagemaker.services.k8s.aws/v1alpha1
+    filename: sagemaker.services.k8s.aws/model_v1alpha1.json
+    kind: Model
+    name: model_v1alpha1
+  - apiVersion: sagemaker.services.k8s.aws/v1alpha1
+    filename: sagemaker.services.k8s.aws/pipeline_v1alpha1.json
+    kind: Pipeline
+    name: pipeline_v1alpha1
+  - apiVersion: sagemaker.services.k8s.aws/v1alpha1
+    filename: sagemaker.services.k8s.aws/processingjob_v1alpha1.json
+    kind: ProcessingJob
+    name: processingjob_v1alpha1
+  - apiVersion: sagemaker.services.k8s.aws/v1alpha1
+    filename: sagemaker.services.k8s.aws/notebookinstance_v1alpha1.json
+    kind: NotebookInstance
+    name: notebookinstance_v1alpha1
+  - apiVersion: sagemaker.services.k8s.aws/v1alpha1
+    filename: sagemaker.services.k8s.aws/modelbiasjobdefinition_v1alpha1.json
+    kind: ModelBiasJobDefinition
+    name: modelbiasjobdefinition_v1alpha1
+  - apiVersion: sagemaker.services.k8s.aws/v1alpha1
+    filename: sagemaker.services.k8s.aws/endpoint_v1alpha1.json
+    kind: Endpoint
+    name: endpoint_v1alpha1
+scylla.scylladb.com:
+  - apiVersion: scylla.scylladb.com/v1alpha1
+    filename: scylla.scylladb.com/scyllaoperatorconfig_v1alpha1.json
+    kind: scyllaoperatorconfig
+    name: scyllaoperatorconfig_v1alpha1
+  - apiVersion: scylla.scylladb.com/v1alpha1
+    filename: scylla.scylladb.com/scylladbmonitoring_v1alpha1.json
+    kind: ScyllaDBMonitoring
+    name: scylladbmonitoring_v1alpha1
+  - apiVersion: scylla.scylladb.com/v1alpha1
+    filename: scylla.scylladb.com/nodeconfig_v1alpha1.json
+    kind: nodeconfig
+    name: nodeconfig_v1alpha1
+  - apiVersion: scylla.scylladb.com/v1
+    filename: scylla.scylladb.com/scyllacluster_v1.json
+    kind: ScyllaCluster
+    name: scyllacluster_v1
+secretmanager.cnrm.cloud.google.com:
+  - apiVersion: secretmanager.cnrm.cloud.google.com/v1beta1
+    filename: secretmanager.cnrm.cloud.google.com/secretmanagersecret_v1beta1.json
+    kind: SecretManagerSecret
+    name: secretmanagersecret_v1beta1
+  - apiVersion: secretmanager.cnrm.cloud.google.com/v1beta1
+    filename: secretmanager.cnrm.cloud.google.com/secretmanagersecretversion_v1beta1.json
+    kind: secretmanagersecretversion
+    name: secretmanagersecretversion_v1beta1
+secrets-store.csi.x-k8s.io:
+  - apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
+    filename: secrets-store.csi.x-k8s.io/secretproviderclasspodstatus_v1alpha1.json
+    kind: SecretProviderClassPodStatus
+    name: secretproviderclasspodstatus_v1alpha1
+  - apiVersion: secrets-store.csi.x-k8s.io/v1
+    filename: secrets-store.csi.x-k8s.io/secretproviderclasspodstatus_v1.json
+    kind: SecretProviderClassPodStatus
+    name: secretproviderclasspodstatus_v1
+  - apiVersion: secrets-store.csi.x-k8s.io/v1
+    filename: secrets-store.csi.x-k8s.io/secretproviderclass_v1.json
+    kind: SecretProviderClass
+    name: secretproviderclass_v1
+  - apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
+    filename: secrets-store.csi.x-k8s.io/secretproviderclass_v1alpha1.json
+    kind: SecretProviderClass
+    name: secretproviderclass_v1alpha1
+secrets.crossplane.io:
+  - apiVersion: secrets.crossplane.io/v1alpha1
+    filename: secrets.crossplane.io/storeconfig_v1alpha1.json
+    kind: StoreConfig
+    name: storeconfig_v1alpha1
+secrets.doppler.com:
+  - apiVersion: secrets.doppler.com/v1alpha1
+    filename: secrets.doppler.com/dopplersecret_v1alpha1.json
+    kind: DopplerSecret
+    name: dopplersecret_v1alpha1
+secrets.hashicorp.com:
+  - apiVersion: secrets.hashicorp.com/v1beta1
+    filename: secrets.hashicorp.com/vaultpkisecret_v1beta1.json
+    kind: VaultPKISecret
+    name: vaultpkisecret_v1beta1
+  - apiVersion: secrets.hashicorp.com/v1beta1
+    filename: secrets.hashicorp.com/vaultstaticsecret_v1beta1.json
+    kind: VaultStaticSecret
+    name: vaultstaticsecret_v1beta1
+  - apiVersion: secrets.hashicorp.com/v1beta1
+    filename: secrets.hashicorp.com/vaultauth_v1beta1.json
+    kind: VaultAuth
+    name: vaultauth_v1beta1
+  - apiVersion: secrets.hashicorp.com/v1beta1
+    filename: secrets.hashicorp.com/hcpauth_v1beta1.json
+    kind: HCPAuth
+    name: hcpauth_v1beta1
+  - apiVersion: secrets.hashicorp.com/v1beta1
+    filename: secrets.hashicorp.com/secrettransformation_v1beta1.json
+    kind: SecretTransformation
+    name: secrettransformation_v1beta1
+  - apiVersion: secrets.hashicorp.com/v1beta1
+    filename: secrets.hashicorp.com/hcpvaultsecretsapp_v1beta1.json
+    kind: HCPVaultSecretsApp
+    name: hcpvaultsecretsapp_v1beta1
+  - apiVersion: secrets.hashicorp.com/v1beta1
+    filename: secrets.hashicorp.com/vaultdynamicsecret_v1beta1.json
+    kind: VaultDynamicSecret
+    name: vaultdynamicsecret_v1beta1
+  - apiVersion: secrets.hashicorp.com/v1beta1
+    filename: secrets.hashicorp.com/vaultconnection_v1beta1.json
+    kind: VaultConnection
+    name: vaultconnection_v1beta1
+securesourcemanager.cnrm.cloud.google.com:
+  - apiVersion: securesourcemanager.cnrm.cloud.google.com/v1alpha1
+    filename: securesourcemanager.cnrm.cloud.google.com/securesourcemanagerinstance_v1alpha1.json
+    kind: SecureSourceManagerInstance
+    name: securesourcemanagerinstance_v1alpha1
+  - apiVersion: securesourcemanager.cnrm.cloud.google.com/v1alpha1
+    filename: securesourcemanager.cnrm.cloud.google.com/securesourcemanagerrepository_v1alpha1.json
+    kind: SecureSourceManagerRepository
+    name: securesourcemanagerrepository_v1alpha1
+security.istio.io:
+  - apiVersion: security.istio.io/v1beta1
+    filename: security.istio.io/peerauthentication_v1beta1.json
+    kind: peerauthentication
+    name: peerauthentication_v1beta1
+  - apiVersion: security.istio.io/v1
+    filename: security.istio.io/authorizationpolicy_v1.json
+    kind: authorizationpolicy
+    name: authorizationpolicy_v1
+  - apiVersion: security.istio.io/v1
+    filename: security.istio.io/requestauthentication_v1.json
+    kind: requestauthentication
+    name: requestauthentication_v1
+  - apiVersion: security.istio.io/v1
+    filename: security.istio.io/peerauthentication_v1.json
+    kind: peerauthentication
+    name: peerauthentication_v1
+  - apiVersion: security.istio.io/v1beta1
+    filename: security.istio.io/requestauthentication_v1beta1.json
+    kind: requestauthentication
+    name: requestauthentication_v1beta1
+  - apiVersion: security.istio.io/v1beta1
+    filename: security.istio.io/authorizationpolicy_v1beta1.json
+    kind: authorizationpolicy
+    name: authorizationpolicy_v1beta1
+securitycenter.cnrm.cloud.google.com:
+  - apiVersion: securitycenter.cnrm.cloud.google.com/v1alpha1
+    filename: securitycenter.cnrm.cloud.google.com/securitycenternotificationconfig_v1alpha1.json
+    kind: securitycenternotificationconfig
+    name: securitycenternotificationconfig_v1alpha1
+  - apiVersion: securitycenter.cnrm.cloud.google.com/v1alpha1
+    filename: securitycenter.cnrm.cloud.google.com/securitycentersource_v1alpha1.json
+    kind: securitycentersource
+    name: securitycentersource_v1alpha1
+servicedirectory.cnrm.cloud.google.com:
+  - apiVersion: servicedirectory.cnrm.cloud.google.com/v1beta1
+    filename: servicedirectory.cnrm.cloud.google.com/servicedirectoryservice_v1beta1.json
+    kind: servicedirectoryservice
+    name: servicedirectoryservice_v1beta1
+  - apiVersion: servicedirectory.cnrm.cloud.google.com/v1beta1
+    filename: servicedirectory.cnrm.cloud.google.com/servicedirectoryendpoint_v1beta1.json
+    kind: servicedirectoryendpoint
+    name: servicedirectoryendpoint_v1beta1
+  - apiVersion: servicedirectory.cnrm.cloud.google.com/v1beta1
+    filename: servicedirectory.cnrm.cloud.google.com/servicedirectorynamespace_v1beta1.json
+    kind: servicedirectorynamespace
+    name: servicedirectorynamespace_v1beta1
+servicenetworking.cnrm.cloud.google.com:
+  - apiVersion: servicenetworking.cnrm.cloud.google.com/v1beta1
+    filename: servicenetworking.cnrm.cloud.google.com/servicenetworkingconnection_v1beta1.json
+    kind: servicenetworkingconnection
+    name: servicenetworkingconnection_v1beta1
+services.k8s.aws:
+  - apiVersion: services.k8s.aws/v1alpha1
+    filename: services.k8s.aws/fieldexport_v1alpha1.json
+    kind: FieldExport
+    name: fieldexport_v1alpha1
+  - apiVersion: services.k8s.aws/v1alpha1
+    filename: services.k8s.aws/adoptedresource_v1alpha1.json
+    kind: AdoptedResource
+    name: adoptedresource_v1alpha1
+serviceusage.cnrm.cloud.google.com:
+  - apiVersion: serviceusage.cnrm.cloud.google.com/v1beta1
+    filename: serviceusage.cnrm.cloud.google.com/service_v1beta1.json
+    kind: service
+    name: service_v1beta1
+  - apiVersion: serviceusage.cnrm.cloud.google.com/v1alpha1
+    filename: serviceusage.cnrm.cloud.google.com/serviceusageconsumerquotaoverride_v1alpha1.json
+    kind: serviceusageconsumerquotaoverride
+    name: serviceusageconsumerquotaoverride_v1alpha1
+  - apiVersion: serviceusage.cnrm.cloud.google.com/v1beta1
+    filename: serviceusage.cnrm.cloud.google.com/serviceidentity_v1beta1.json
+    kind: serviceidentity
+    name: serviceidentity_v1beta1
+serving.kserve.io:
+  - apiVersion: serving.kserve.io/v1alpha1
+    filename: serving.kserve.io/inferencegraph_v1alpha1.json
+    kind: inferencegraph
+    name: inferencegraph_v1alpha1
+  - apiVersion: serving.kserve.io/v1alpha1
+    filename: serving.kserve.io/servingruntime_v1alpha1.json
+    kind: servingruntime
+    name: servingruntime_v1alpha1
+  - apiVersion: serving.kserve.io/v1alpha1
+    filename: serving.kserve.io/trainedmodel_v1alpha1.json
+    kind: trainedmodel
+    name: trainedmodel_v1alpha1
+  - apiVersion: serving.kserve.io/v1beta1
+    filename: serving.kserve.io/inferenceservice_v1beta1.json
+    kind: inferenceservice
+    name: inferenceservice_v1beta1
+  - apiVersion: serving.kserve.io/v1alpha1
+    filename: serving.kserve.io/clusterservingruntime_v1alpha1.json
+    kind: clusterservingruntime
+    name: clusterservingruntime_v1alpha1
+sfn.services.k8s.aws:
+  - apiVersion: sfn.services.k8s.aws/v1alpha1
+    filename: sfn.services.k8s.aws/activity_v1alpha1.json
+    kind: Activity
+    name: activity_v1alpha1
+  - apiVersion: sfn.services.k8s.aws/v1alpha1
+    filename: sfn.services.k8s.aws/statemachine_v1alpha1.json
+    kind: StateMachine
+    name: statemachine_v1alpha1
+sloth.slok.dev:
+  - apiVersion: sloth.slok.dev/v1
+    filename: sloth.slok.dev/prometheusservicelevel_v1.json
+    kind: PrometheusServiceLevel
+    name: prometheusservicelevel_v1
+snapscheduler.backube:
+  - apiVersion: snapscheduler.backube/v1
+    filename: snapscheduler.backube/snapshotschedule_v1.json
+    kind: SnapshotSchedule
+    name: snapshotschedule_v1
+snapshot.storage.k8s.io:
+  - apiVersion: snapshot.storage.k8s.io/v1
+    filename: snapshot.storage.k8s.io/volumesnapshotcontent_v1.json
+    kind: VolumeSnapshotContent
+    name: volumesnapshotcontent_v1
+  - apiVersion: snapshot.storage.k8s.io/v1beta1
+    filename: snapshot.storage.k8s.io/volumesnapshot_v1beta1.json
+    kind: VolumeSnapshot
+    name: volumesnapshot_v1beta1
+  - apiVersion: snapshot.storage.k8s.io/v1beta1
+    filename: snapshot.storage.k8s.io/volumesnapshotcontent_v1beta1.json
+    kind: VolumeSnapshotContent
+    name: volumesnapshotcontent_v1beta1
+  - apiVersion: snapshot.storage.k8s.io/v1
+    filename: snapshot.storage.k8s.io/volumesnapshotclass_v1.json
+    kind: VolumeSnapshotClass
+    name: volumesnapshotclass_v1
+  - apiVersion: snapshot.storage.k8s.io/v1
+    filename: snapshot.storage.k8s.io/volumesnapshot_v1.json
+    kind: VolumeSnapshot
+    name: volumesnapshot_v1
+  - apiVersion: snapshot.storage.k8s.io/v1beta1
+    filename: snapshot.storage.k8s.io/volumesnapshotclass_v1beta1.json
+    kind: VolumeSnapshotClass
+    name: volumesnapshotclass_v1beta1
+sns.services.k8s.aws:
+  - apiVersion: sns.services.k8s.aws/v1alpha1
+    filename: sns.services.k8s.aws/platformapplication_v1alpha1.json
+    kind: PlatformApplication
+    name: platformapplication_v1alpha1
+  - apiVersion: sns.services.k8s.aws/v1alpha1
+    filename: sns.services.k8s.aws/platformendpoint_v1alpha1.json
+    kind: PlatformEndpoint
+    name: platformendpoint_v1alpha1
+  - apiVersion: sns.services.k8s.aws/v1alpha1
+    filename: sns.services.k8s.aws/topic_v1alpha1.json
+    kind: Topic
+    name: topic_v1alpha1
+  - apiVersion: sns.services.k8s.aws/v1alpha1
+    filename: sns.services.k8s.aws/subscription_v1alpha1.json
+    kind: Subscription
+    name: subscription_v1alpha1
 source.toolkit.fluxcd.io:
   - apiVersion: source.toolkit.fluxcd.io/v1beta1
     filename: source.toolkit.fluxcd.io/bucket_v1beta1.json
     kind: Bucket
     name: bucket_v1beta1
-  - apiVersion: source.toolkit.fluxcd.io/v1beta2
-    filename: ''
-    kind: Bucket
-    name: buckcket_v1beta2
   - apiVersion: source.toolkit.fluxcd.io/v1beta1
     filename: source.toolkit.fluxcd.io/gitrepository_v1beta1.json
     kind: GitRepository
@@ -399,6 +7082,269 @@ source.toolkit.fluxcd.io:
     filename: source.toolkit.fluxcd.io/helmrepository_v1beta2.json
     kind: HelmRepository
     name: helmrepository_v1beta2
+  - apiVersion: source.toolkit.fluxcd.io/v1
+    filename: source.toolkit.fluxcd.io/gitrepository_v1.json
+    kind: GitRepository
+    name: gitrepository_v1
+  - apiVersion: source.toolkit.fluxcd.io/v1
+    filename: source.toolkit.fluxcd.io/helmrepository_v1.json
+    kind: HelmRepository
+    name: helmrepository_v1
+  - apiVersion: source.toolkit.fluxcd.io/v1
+    filename: source.toolkit.fluxcd.io/helmchart_v1.json
+    kind: HelmChart
+    name: helmchart_v1
+  - apiVersion: source.toolkit.fluxcd.io/v1beta2
+    filename: source.toolkit.fluxcd.io/ocirepository_v1beta2.json
+    kind: OCIRepository
+    name: ocirepository_v1beta2
+  - apiVersion: source.toolkit.fluxcd.io/v1beta2
+    filename: source.toolkit.fluxcd.io/bucket_v1beta2.json
+    kind: Bucket
+    name: bucket_v1beta2
+  - apiVersion: source.toolkit.fluxcd.io/v1
+    filename: source.toolkit.fluxcd.io/bucket_v1.json
+    kind: Bucket
+    name: bucket_v1
+sourcerepo.cnrm.cloud.google.com:
+  - apiVersion: sourcerepo.cnrm.cloud.google.com/v1beta1
+    filename: sourcerepo.cnrm.cloud.google.com/sourcereporepository_v1beta1.json
+    kind: sourcereporepository
+    name: sourcereporepository_v1beta1
+spanner.cnrm.cloud.google.com:
+  - apiVersion: spanner.cnrm.cloud.google.com/v1beta1
+    filename: spanner.cnrm.cloud.google.com/spannerdatabase_v1beta1.json
+    kind: spannerdatabase
+    name: spannerdatabase_v1beta1
+  - apiVersion: spanner.cnrm.cloud.google.com/v1beta1
+    filename: spanner.cnrm.cloud.google.com/spannerinstance_v1beta1.json
+    kind: SpannerInstance
+    name: spannerinstance_v1beta1
+sparkoperator.k8s.io:
+  - apiVersion: sparkoperator.k8s.io/v1beta2
+    filename: sparkoperator.k8s.io/sparkapplication_v1beta2.json
+    kind: sparkapplication
+    name: sparkapplication_v1beta2
+  - apiVersion: sparkoperator.k8s.io/v1beta2
+    filename: sparkoperator.k8s.io/scheduledsparkapplication_v1beta2.json
+    kind: scheduledsparkapplication
+    name: scheduledsparkapplication_v1beta2
+spv.no:
+  - apiVersion: spv.no/v2beta1
+    filename: spv.no/azurekeyvaultsecret_v2beta1.json
+    kind: AzureKeyVaultSecret
+    name: azurekeyvaultsecret_v2beta1
+  - apiVersion: spv.no/v2alpha1
+    filename: spv.no/azurekeyvaultsecret_v2alpha1.json
+    kind: AzureKeyVaultSecret
+    name: azurekeyvaultsecret_v2alpha1
+  - apiVersion: spv.no/v1alpha1
+    filename: spv.no/azurekeyvaultsecret_v1alpha1.json
+    kind: AzureKeyVaultSecret
+    name: azurekeyvaultsecret_v1alpha1
+  - apiVersion: spv.no/v1
+    filename: spv.no/azurekeyvaultsecret_v1.json
+    kind: AzureKeyVaultSecret
+    name: azurekeyvaultsecret_v1
+sql.cnrm.cloud.google.com:
+  - apiVersion: sql.cnrm.cloud.google.com/v1beta1
+    filename: sql.cnrm.cloud.google.com/sqlsslcert_v1beta1.json
+    kind: sqlsslcert
+    name: sqlsslcert_v1beta1
+  - apiVersion: sql.cnrm.cloud.google.com/v1beta1
+    filename: sql.cnrm.cloud.google.com/sqlinstance_v1beta1.json
+    kind: SQLInstance
+    name: sqlinstance_v1beta1
+  - apiVersion: sql.cnrm.cloud.google.com/v1beta1
+    filename: sql.cnrm.cloud.google.com/sqldatabase_v1beta1.json
+    kind: sqldatabase
+    name: sqldatabase_v1beta1
+  - apiVersion: sql.cnrm.cloud.google.com/v1beta1
+    filename: sql.cnrm.cloud.google.com/sqluser_v1beta1.json
+    kind: sqluser
+    name: sqluser_v1beta1
+sqs.services.k8s.aws:
+  - apiVersion: sqs.services.k8s.aws/v1alpha1
+    filename: sqs.services.k8s.aws/queue_v1alpha1.json
+    kind: Queue
+    name: queue_v1alpha1
+stackconfigpolicy.k8s.elastic.co:
+  - apiVersion: stackconfigpolicy.k8s.elastic.co/v1alpha1
+    filename: stackconfigpolicy.k8s.elastic.co/stackconfigpolicy_v1alpha1.json
+    kind: StackConfigPolicy
+    name: stackconfigpolicy_v1alpha1
+status.gatekeeper.sh:
+  - apiVersion: status.gatekeeper.sh/v1beta1
+    filename: status.gatekeeper.sh/constrainttemplatepodstatus_v1beta1.json
+    kind: ConstraintTemplatePodStatus
+    name: constrainttemplatepodstatus_v1beta1
+  - apiVersion: status.gatekeeper.sh/v1beta1
+    filename: status.gatekeeper.sh/expansiontemplatepodstatus_v1beta1.json
+    kind: ExpansionTemplatePodStatus
+    name: expansiontemplatepodstatus_v1beta1
+  - apiVersion: status.gatekeeper.sh/v1beta1
+    filename: status.gatekeeper.sh/constraintpodstatus_v1beta1.json
+    kind: ConstraintPodStatus
+    name: constraintpodstatus_v1beta1
+  - apiVersion: status.gatekeeper.sh/v1beta1
+    filename: status.gatekeeper.sh/mutatorpodstatus_v1beta1.json
+    kind: MutatorPodStatus
+    name: mutatorpodstatus_v1beta1
+storage.cnrm.cloud.google.com:
+  - apiVersion: storage.cnrm.cloud.google.com/v1beta1
+    filename: storage.cnrm.cloud.google.com/storagebucket_v1beta1.json
+    kind: storagebucket
+    name: storagebucket_v1beta1
+  - apiVersion: storage.cnrm.cloud.google.com/v1alpha1
+    filename: storage.cnrm.cloud.google.com/storagehmackey_v1alpha1.json
+    kind: storagehmackey
+    name: storagehmackey_v1alpha1
+  - apiVersion: storage.cnrm.cloud.google.com/v1beta1
+    filename: storage.cnrm.cloud.google.com/storagenotification_v1beta1.json
+    kind: storagenotification
+    name: storagenotification_v1beta1
+  - apiVersion: storage.cnrm.cloud.google.com/v1beta1
+    filename: storage.cnrm.cloud.google.com/storagedefaultobjectaccesscontrol_v1beta1.json
+    kind: storagedefaultobjectaccesscontrol
+    name: storagedefaultobjectaccesscontrol_v1beta1
+  - apiVersion: storage.cnrm.cloud.google.com/v1beta1
+    filename: storage.cnrm.cloud.google.com/storagebucketaccesscontrol_v1beta1.json
+    kind: storagebucketaccesscontrol
+    name: storagebucketaccesscontrol_v1beta1
+storagetransfer.cnrm.cloud.google.com:
+  - apiVersion: storagetransfer.cnrm.cloud.google.com/v1beta1
+    filename: storagetransfer.cnrm.cloud.google.com/storagetransferjob_v1beta1.json
+    kind: storagetransferjob
+    name: storagetransferjob_v1beta1
+  - apiVersion: storagetransfer.cnrm.cloud.google.com/v1alpha1
+    filename: storagetransfer.cnrm.cloud.google.com/storagetransferagentpool_v1alpha1.json
+    kind: storagetransferagentpool
+    name: storagetransferagentpool_v1alpha1
+sts.min.io:
+  - apiVersion: sts.min.io/v1beta1
+    filename: sts.min.io/policybinding_v1beta1.json
+    kind: policybinding
+    name: policybinding_v1beta1
+  - apiVersion: sts.min.io/v1alpha1
+    filename: sts.min.io/policybinding_v1alpha1.json
+    kind: policybinding
+    name: policybinding_v1alpha1
+syncset.gatekeeper.sh:
+  - apiVersion: syncset.gatekeeper.sh/v1alpha1
+    filename: syncset.gatekeeper.sh/syncset_v1alpha1.json
+    kind: SyncSet
+    name: syncset_v1alpha1
+tags.cnrm.cloud.google.com:
+  - apiVersion: tags.cnrm.cloud.google.com/v1beta1
+    filename: tags.cnrm.cloud.google.com/tagstagbinding_v1beta1.json
+    kind: tagstagbinding
+    name: tagstagbinding_v1beta1
+  - apiVersion: tags.cnrm.cloud.google.com/v1alpha1
+    filename: tags.cnrm.cloud.google.com/tagslocationtagbinding_v1alpha1.json
+    kind: tagslocationtagbinding
+    name: tagslocationtagbinding_v1alpha1
+  - apiVersion: tags.cnrm.cloud.google.com/v1beta1
+    filename: tags.cnrm.cloud.google.com/tagstagvalue_v1beta1.json
+    kind: tagstagvalue
+    name: tagstagvalue_v1beta1
+  - apiVersion: tags.cnrm.cloud.google.com/v1beta1
+    filename: tags.cnrm.cloud.google.com/tagstagkey_v1beta1.json
+    kind: tagstagkey
+    name: tagstagkey_v1beta1
+telemetry.istio.io:
+  - apiVersion: telemetry.istio.io/v1
+    filename: telemetry.istio.io/telemetry_v1.json
+    kind: telemetry
+    name: telemetry_v1
+  - apiVersion: telemetry.istio.io/v1alpha1
+    filename: telemetry.istio.io/telemetry_v1alpha1.json
+    kind: telemetry
+    name: telemetry_v1alpha1
+templates.gatekeeper.sh:
+  - apiVersion: templates.gatekeeper.sh/v1
+    filename: templates.gatekeeper.sh/constrainttemplate_v1.json
+    kind: ConstraintTemplate
+    name: constrainttemplate_v1
+  - apiVersion: templates.gatekeeper.sh/v1beta1
+    filename: templates.gatekeeper.sh/constrainttemplate_v1beta1.json
+    kind: ConstraintTemplate
+    name: constrainttemplate_v1beta1
+  - apiVersion: templates.gatekeeper.sh/v1alpha1
+    filename: templates.gatekeeper.sh/constrainttemplate_v1alpha1.json
+    kind: ConstraintTemplate
+    name: constrainttemplate_v1alpha1
+templates.kluctl.io:
+  - apiVersion: templates.kluctl.io/v1alpha1
+    filename: templates.kluctl.io/objecthandler_v1alpha1.json
+    kind: ObjectHandler
+    name: objecthandler_v1alpha1
+  - apiVersion: templates.kluctl.io/v1alpha1
+    filename: templates.kluctl.io/gitlabcomment_v1alpha1.json
+    kind: GitlabComment
+    name: gitlabcomment_v1alpha1
+  - apiVersion: templates.kluctl.io/v1alpha1
+    filename: templates.kluctl.io/objecttemplate_v1alpha1.json
+    kind: ObjectTemplate
+    name: objecttemplate_v1alpha1
+  - apiVersion: templates.kluctl.io/v1alpha1
+    filename: templates.kluctl.io/listgithubpullrequests_v1alpha1.json
+    kind: ListGithubPullRequests
+    name: listgithubpullrequests_v1alpha1
+  - apiVersion: templates.kluctl.io/v1alpha1
+    filename: templates.kluctl.io/listgitlabmergerequests_v1alpha1.json
+    kind: ListGitlabMergeRequests
+    name: listgitlabmergerequests_v1alpha1
+  - apiVersion: templates.kluctl.io/v1alpha1
+    filename: templates.kluctl.io/gitprojector_v1alpha1.json
+    kind: GitProjector
+    name: gitprojector_v1alpha1
+  - apiVersion: templates.kluctl.io/v1alpha1
+    filename: templates.kluctl.io/texttemplate_v1alpha1.json
+    kind: TextTemplate
+    name: texttemplate_v1alpha1
+  - apiVersion: templates.kluctl.io/v1alpha1
+    filename: templates.kluctl.io/githubcomment_v1alpha1.json
+    kind: GithubComment
+    name: githubcomment_v1alpha1
+temporal.io:
+  - apiVersion: temporal.io/v1beta1
+    filename: temporal.io/temporalclusterclient_v1beta1.json
+    kind: TemporalClusterClient
+    name: temporalclusterclient_v1beta1
+  - apiVersion: temporal.io/v1beta1
+    filename: temporal.io/temporalschedule_v1beta1.json
+    kind: TemporalSchedule
+    name: temporalschedule_v1beta1
+  - apiVersion: temporal.io/v1beta1
+    filename: temporal.io/temporalcluster_v1beta1.json
+    kind: TemporalCluster
+    name: temporalcluster_v1beta1
+  - apiVersion: temporal.io/v1beta1
+    filename: temporal.io/temporalworkerprocess_v1beta1.json
+    kind: TemporalWorkerProcess
+    name: temporalworkerprocess_v1beta1
+  - apiVersion: temporal.io/v1beta1
+    filename: temporal.io/temporalnamespace_v1beta1.json
+    kind: TemporalNamespace
+    name: temporalnamespace_v1beta1
+tinkerbell.org:
+  - apiVersion: tinkerbell.org/v1alpha1
+    filename: tinkerbell.org/workflow_v1alpha1.json
+    kind: Workflow
+    name: workflow_v1alpha1
+  - apiVersion: tinkerbell.org/v1alpha1
+    filename: tinkerbell.org/hardware_v1alpha1.json
+    kind: Hardware
+    name: hardware_v1alpha1
+  - apiVersion: tinkerbell.org/v1alpha1
+    filename: tinkerbell.org/template_v1alpha1.json
+    kind: Template
+    name: template_v1alpha1
+tpu.cnrm.cloud.google.com:
+  - apiVersion: tpu.cnrm.cloud.google.com/v1alpha1
+    filename: tpu.cnrm.cloud.google.com/tpunode_v1alpha1.json
+    kind: tpunode
+    name: tpunode_v1alpha1
 traefik.containo.us:
   - apiVersion: traefik.containo.us/v1alpha1
     filename: traefik.containo.us/ingressroute_v1alpha1.json
@@ -436,3 +7382,259 @@ traefik.containo.us:
     filename: traefik.containo.us/traefikservice_v1alpha1.json
     kind: TraefikService
     name: traefikservice_v1alpha1
+traefik.io:
+  - apiVersion: traefik.io/v1alpha1
+    filename: traefik.io/serverstransport_v1alpha1.json
+    kind: ServersTransport
+    name: serverstransport_v1alpha1
+  - apiVersion: traefik.io/v1alpha1
+    filename: traefik.io/traefikservice_v1alpha1.json
+    kind: TraefikService
+    name: traefikservice_v1alpha1
+  - apiVersion: traefik.io/v1alpha1
+    filename: traefik.io/serverstransporttcp_v1alpha1.json
+    kind: ServersTransportTCP
+    name: serverstransporttcp_v1alpha1
+  - apiVersion: traefik.io/v1alpha1
+    filename: traefik.io/tlsstore_v1alpha1.json
+    kind: TLSStore
+    name: tlsstore_v1alpha1
+  - apiVersion: traefik.io/v1alpha1
+    filename: traefik.io/tlsoption_v1alpha1.json
+    kind: TLSOption
+    name: tlsoption_v1alpha1
+  - apiVersion: traefik.io/v1alpha1
+    filename: traefik.io/ingressroutetcp_v1alpha1.json
+    kind: IngressRouteTCP
+    name: ingressroutetcp_v1alpha1
+  - apiVersion: traefik.io/v1alpha1
+    filename: traefik.io/ingressrouteudp_v1alpha1.json
+    kind: IngressRouteUDP
+    name: ingressrouteudp_v1alpha1
+  - apiVersion: traefik.io/v1alpha1
+    filename: traefik.io/middlewaretcp_v1alpha1.json
+    kind: MiddlewareTCP
+    name: middlewaretcp_v1alpha1
+  - apiVersion: traefik.io/v1alpha1
+    filename: traefik.io/ingressroute_v1alpha1.json
+    kind: IngressRoute
+    name: ingressroute_v1alpha1
+  - apiVersion: traefik.io/v1alpha1
+    filename: traefik.io/middleware_v1alpha1.json
+    kind: Middleware
+    name: middleware_v1alpha1
+trust.cert-manager.io:
+  - apiVersion: trust.cert-manager.io/v1alpha1
+    filename: trust.cert-manager.io/bundle_v1alpha1.json
+    kind: bundle
+    name: bundle_v1alpha1
+upgrade.cattle.io:
+  - apiVersion: upgrade.cattle.io/v1
+    filename: upgrade.cattle.io/plan_v1.json
+    kind: plan
+    name: plan_v1
+vault.banzaicloud.com:
+  - apiVersion: vault.banzaicloud.com/v1alpha1
+    filename: vault.banzaicloud.com/vault_v1alpha1.json
+    kind: vault
+    name: vault_v1alpha1
+velero.io:
+  - apiVersion: velero.io/v1
+    filename: velero.io/deletebackuprequest_v1.json
+    kind: DeleteBackupRequest
+    name: deletebackuprequest_v1
+  - apiVersion: velero.io/v2alpha1
+    filename: velero.io/dataupload_v2alpha1.json
+    kind: DataUpload
+    name: dataupload_v2alpha1
+  - apiVersion: velero.io/v1
+    filename: velero.io/restore_v1.json
+    kind: Restore
+    name: restore_v1
+  - apiVersion: velero.io/v1
+    filename: velero.io/podvolumebackup_v1.json
+    kind: podvolumebackup
+    name: podvolumebackup_v1
+  - apiVersion: velero.io/v1
+    filename: velero.io/podvolumerestore_v1.json
+    kind: podvolumerestore
+    name: podvolumerestore_v1
+  - apiVersion: velero.io/v1
+    filename: velero.io/backuprepository_v1.json
+    kind: backuprepository
+    name: backuprepository_v1
+  - apiVersion: velero.io/v1
+    filename: velero.io/serverstatusrequest_v1.json
+    kind: ServerStatusRequest
+    name: serverstatusrequest_v1
+  - apiVersion: velero.io/v1
+    filename: velero.io/volumesnapshotlocation_v1.json
+    kind: VolumeSnapshotLocation
+    name: volumesnapshotlocation_v1
+  - apiVersion: velero.io/v2alpha1
+    filename: velero.io/datadownload_v2alpha1.json
+    kind: DataDownload
+    name: datadownload_v2alpha1
+  - apiVersion: velero.io/v1
+    filename: velero.io/backup_v1.json
+    kind: Backup
+    name: backup_v1
+  - apiVersion: velero.io/v1
+    filename: velero.io/backupstoragelocation_v1.json
+    kind: BackupStorageLocation
+    name: backupstoragelocation_v1
+  - apiVersion: velero.io/v1
+    filename: velero.io/downloadrequest_v1.json
+    kind: DownloadRequest
+    name: downloadrequest_v1
+  - apiVersion: velero.io/v1
+    filename: velero.io/schedule_v1.json
+    kind: Schedule
+    name: schedule_v1
+vertexai.cnrm.cloud.google.com:
+  - apiVersion: vertexai.cnrm.cloud.google.com/v1alpha1
+    filename: vertexai.cnrm.cloud.google.com/vertexaitensorboard_v1alpha1.json
+    kind: vertexaitensorboard
+    name: vertexaitensorboard_v1alpha1
+  - apiVersion: vertexai.cnrm.cloud.google.com/v1alpha1
+    filename: vertexai.cnrm.cloud.google.com/vertexaifeaturestore_v1alpha1.json
+    kind: vertexaifeaturestore
+    name: vertexaifeaturestore_v1alpha1
+  - apiVersion: vertexai.cnrm.cloud.google.com/v1beta1
+    filename: vertexai.cnrm.cloud.google.com/vertexaidataset_v1beta1.json
+    kind: vertexaidataset
+    name: vertexaidataset_v1beta1
+  - apiVersion: vertexai.cnrm.cloud.google.com/v1alpha1
+    filename: vertexai.cnrm.cloud.google.com/vertexaimetadatastore_v1alpha1.json
+    kind: vertexaimetadatastore
+    name: vertexaimetadatastore_v1alpha1
+  - apiVersion: vertexai.cnrm.cloud.google.com/v1alpha1
+    filename: vertexai.cnrm.cloud.google.com/vertexaiindex_v1alpha1.json
+    kind: vertexaiindex
+    name: vertexaiindex_v1alpha1
+  - apiVersion: vertexai.cnrm.cloud.google.com/v1beta1
+    filename: vertexai.cnrm.cloud.google.com/vertexaiendpoint_v1beta1.json
+    kind: vertexaiendpoint
+    name: vertexaiendpoint_v1beta1
+  - apiVersion: vertexai.cnrm.cloud.google.com/v1alpha1
+    filename: vertexai.cnrm.cloud.google.com/vertexaiendpoint_v1alpha1.json
+    kind: vertexaiendpoint
+    name: vertexaiendpoint_v1alpha1
+  - apiVersion: vertexai.cnrm.cloud.google.com/v1alpha1
+    filename: vertexai.cnrm.cloud.google.com/vertexaifeaturestoreentitytype_v1alpha1.json
+    kind: vertexaifeaturestoreentitytype
+    name: vertexaifeaturestoreentitytype_v1alpha1
+  - apiVersion: vertexai.cnrm.cloud.google.com/v1alpha1
+    filename: vertexai.cnrm.cloud.google.com/vertexaiindexendpoint_v1alpha1.json
+    kind: vertexaiindexendpoint
+    name: vertexaiindexendpoint_v1alpha1
+  - apiVersion: vertexai.cnrm.cloud.google.com/v1beta1
+    filename: vertexai.cnrm.cloud.google.com/vertexaiindex_v1beta1.json
+    kind: vertexaiindex
+    name: vertexaiindex_v1beta1
+  - apiVersion: vertexai.cnrm.cloud.google.com/v1alpha1
+    filename: vertexai.cnrm.cloud.google.com/vertexaifeaturestoreentitytypefeature_v1alpha1.json
+    kind: vertexaifeaturestoreentitytypefeature
+    name: vertexaifeaturestoreentitytypefeature_v1alpha1
+  - apiVersion: vertexai.cnrm.cloud.google.com/v1alpha1
+    filename: vertexai.cnrm.cloud.google.com/vertexaidataset_v1alpha1.json
+    kind: vertexaidataset
+    name: vertexaidataset_v1alpha1
+volsync.backube:
+  - apiVersion: volsync.backube/v1alpha1
+    filename: volsync.backube/replicationsource_v1alpha1.json
+    kind: ReplicationSource
+    name: replicationsource_v1alpha1
+  - apiVersion: volsync.backube/v1alpha1
+    filename: volsync.backube/replicationdestination_v1alpha1.json
+    kind: ReplicationDestination
+    name: replicationdestination_v1alpha1
+vpcaccess.cnrm.cloud.google.com:
+  - apiVersion: vpcaccess.cnrm.cloud.google.com/v1beta1
+    filename: vpcaccess.cnrm.cloud.google.com/vpcaccessconnector_v1beta1.json
+    kind: vpcaccessconnector
+    name: vpcaccessconnector_v1beta1
+vpcresources.k8s.aws:
+  - apiVersion: vpcresources.k8s.aws/v1alpha1
+    filename: vpcresources.k8s.aws/cninode_v1alpha1.json
+    kind: cninode
+    name: cninode_v1alpha1
+  - apiVersion: vpcresources.k8s.aws/v1beta1
+    filename: vpcresources.k8s.aws/securitygrouppolicy_v1beta1.json
+    kind: securitygrouppolicy
+    name: securitygrouppolicy_v1beta1
+vshn.appcat.vshn.io:
+  - apiVersion: vshn.appcat.vshn.io/v1
+    filename: vshn.appcat.vshn.io/xvshnredis_v1.json
+    kind: XVSHNRedis
+    name: xvshnredis_v1
+  - apiVersion: vshn.appcat.vshn.io/v1
+    filename: vshn.appcat.vshn.io/vshnkeycloak_v1.json
+    kind: VSHNKeycloak
+    name: vshnkeycloak_v1
+  - apiVersion: vshn.appcat.vshn.io/v1
+    filename: vshn.appcat.vshn.io/vshnmariadb_v1.json
+    kind: VSHNMariaDB
+    name: vshnmariadb_v1
+  - apiVersion: vshn.appcat.vshn.io/v1
+    filename: vshn.appcat.vshn.io/xvshnkeycloak_v1.json
+    kind: XVSHNKeycloak
+    name: xvshnkeycloak_v1
+  - apiVersion: vshn.appcat.vshn.io/v1
+    filename: vshn.appcat.vshn.io/vshnpostgresql_v1.json
+    kind: VSHNPostgreSQL
+    name: vshnpostgresql_v1
+  - apiVersion: vshn.appcat.vshn.io/v1
+    filename: vshn.appcat.vshn.io/vshnminio_v1.json
+    kind: VSHNMinio
+    name: vshnminio_v1
+  - apiVersion: vshn.appcat.vshn.io/v1
+    filename: vshn.appcat.vshn.io/xvshnmariadb_v1.json
+    kind: XVSHNMariaDB
+    name: xvshnmariadb_v1
+  - apiVersion: vshn.appcat.vshn.io/v1
+    filename: vshn.appcat.vshn.io/compositemariadbinstance_v1.json
+    kind: compositemariadbinstance
+    name: compositemariadbinstance_v1
+  - apiVersion: vshn.appcat.vshn.io/v1
+    filename: vshn.appcat.vshn.io/xvshnnextcloud_v1.json
+    kind: XVSHNNextcloud
+    name: xvshnnextcloud_v1
+  - apiVersion: vshn.appcat.vshn.io/v1
+    filename: vshn.appcat.vshn.io/xvshnpostgresql_v1.json
+    kind: XVSHNPostgreSQL
+    name: xvshnpostgresql_v1
+  - apiVersion: vshn.appcat.vshn.io/v1
+    filename: vshn.appcat.vshn.io/compositeredisinstance_v1.json
+    kind: compositeredisinstance
+    name: compositeredisinstance_v1
+  - apiVersion: vshn.appcat.vshn.io/v1
+    filename: vshn.appcat.vshn.io/vshnredis_v1.json
+    kind: VSHNRedis
+    name: vshnredis_v1
+  - apiVersion: vshn.appcat.vshn.io/v1
+    filename: vshn.appcat.vshn.io/vshnnextcloud_v1.json
+    kind: VSHNNextcloud
+    name: vshnnextcloud_v1
+  - apiVersion: vshn.appcat.vshn.io/v1
+    filename: vshn.appcat.vshn.io/xvshnminio_v1.json
+    kind: XVSHNMinio
+    name: xvshnminio_v1
+workflows.cnrm.cloud.google.com:
+  - apiVersion: workflows.cnrm.cloud.google.com/v1alpha1
+    filename: workflows.cnrm.cloud.google.com/workflowsworkflow_v1alpha1.json
+    kind: workflowsworkflow
+    name: workflowsworkflow_v1alpha1
+workstations.cnrm.cloud.google.com:
+  - apiVersion: workstations.cnrm.cloud.google.com/v1alpha1
+    filename: workstations.cnrm.cloud.google.com/workstationcluster_v1alpha1.json
+    kind: WorkstationCluster
+    name: workstationcluster_v1alpha1
+  - apiVersion: workstations.cnrm.cloud.google.com/v1alpha1
+    filename: workstations.cnrm.cloud.google.com/workstationsworkstationcluster_v1alpha1.json
+    kind: workstationsworkstationcluster
+    name: workstationsworkstationcluster_v1alpha1
+  - apiVersion: workstations.cnrm.cloud.google.com/v1beta1
+    filename: workstations.cnrm.cloud.google.com/workstationcluster_v1beta1.json
+    kind: WorkstationCluster
+    name: workstationcluster_v1beta1


### PR DESCRIPTION
@eyarz I have tried to make an auto-updater script.

I also have also reworked the structure of the index file a bit:
 - The collection is still grouped by organisation (e.g. `aadpodidentity.k8s.io`)
 - Within that grouping, I removed `org` and `githubOrg`.
 - Within each organisation group, there was another grouping, which I flattened.
 - I kept the fields `apiVersion`, `kind`, `filename`, and `name`. The rest I removed.
 - I don't think I need the `name`, but I thought maybe you needed it? It corresponds to the key of the grouping that I flattened.

In general, the reason for removing the data I removed above is:
 - I could not deduct the missing data from the files.
 - I failed to see the value of the data – but perhaps you have a need for this?
   - I kind of doubt it since the `index.yaml` was wildly out of date

The update-script will ignore any existing entries for existing files. So if there is data out-of-date, it will not get updated. We may want a different strategy for this in the future.

The script removes entries for files that is no longer present.


If this gets merged, next steps may be to consider whether it should be a github action to run this. If yes; should it auto-commit changes? Should it fail the PR (forcing the author(s) to run the script?
