### PR TITLE
Update spark operator CRDs

### DIFF
--- a/sparkoperator.k8s.io/scheduledsparkapplication_v1beta2.json
+++ b/sparkoperator.k8s.io/scheduledsparkapplication_v1beta2.json
@@ -1,50 +1,65 @@
 {
+  "description": "ScheduledSparkApplication is the Schema for the scheduledsparkapplications API.",
   "properties": {
     "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
       "type": "string"
     },
     "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
       "type": "string"
     },
     "metadata": {
       "type": "object"
     },
     "spec": {
+      "description": "ScheduledSparkApplicationSpec defines the desired state of ScheduledSparkApplication.",
       "properties": {
         "concurrencyPolicy": {
+          "description": "ConcurrencyPolicy is the policy governing concurrent SparkApplication runs.",
           "type": "string"
         },
         "failedRunHistoryLimit": {
+          "description": "FailedRunHistoryLimit is the number of past failed runs of the application to keep.\nDefaults to 1.",
           "format": "int32",
           "type": "integer"
         },
         "schedule": {
+          "description": "Schedule is a cron schedule on which the application should run.",
           "type": "string"
         },
         "successfulRunHistoryLimit": {
+          "description": "SuccessfulRunHistoryLimit is the number of past successful runs of the application to keep.\nDefaults to 1.",
           "format": "int32",
           "type": "integer"
         },
         "suspend": {
+          "description": "Suspend is a flag telling the controller to suspend subsequent runs of the application if set to true.\nDefaults to false.",
           "type": "boolean"
         },
         "template": {
+          "description": "Template is a template from which SparkApplication instances can be created.",
           "properties": {
             "arguments": {
+              "description": "Arguments is a list of arguments to be passed to the application.",
               "items": {
                 "type": "string"
               },
               "type": "array"
             },
             "batchScheduler": {
+              "description": "BatchScheduler configures which batch scheduler will be used for scheduling",
               "type": "string"
             },
             "batchSchedulerOptions": {
+              "description": "BatchSchedulerOptions provides fine-grained control on how to batch scheduling.",
               "properties": {
                 "priorityClassName": {
+                  "description": "PriorityClassName stands for the name of k8s PriorityClass resource, it's being used in Volcano batch scheduler.",
                   "type": "string"
                 },
                 "queue": {
+                  "description": "Queue stands for the resource queue which the application belongs to, it's being used in Volcano batch scheduler.",
                   "type": "string"
                 },
                 "resources": {
@@ -60,6 +75,7 @@
                     "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                     "x-kubernetes-int-or-string": true
                   },
+                  "description": "Resources stands for the resource list custom request for. Usually it is used to define the lower-bound limit.\nIf specified, volcano scheduler will consider it as the resources requested.",
                   "type": "object"
                 }
               },
@@ -67,38 +83,52 @@
               "additionalProperties": false
             },
             "deps": {
+              "description": "Deps captures all possible types of dependencies of a Spark application.",
               "properties": {
+                "archives": {
+                  "description": "Archives is a list of archives to be extracted into the working directory of each executor.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
                 "excludePackages": {
+                  "description": "ExcludePackages is a list of \"groupId:artifactId\", to exclude while resolving the\ndependencies provided in Packages to avoid dependency conflicts.",
                   "items": {
                     "type": "string"
                   },
                   "type": "array"
                 },
                 "files": {
+                  "description": "Files is a list of files the Spark application depends on.",
                   "items": {
                     "type": "string"
                   },
                   "type": "array"
                 },
                 "jars": {
+                  "description": "Jars is a list of JAR files the Spark application depends on.",
                   "items": {
                     "type": "string"
                   },
                   "type": "array"
                 },
                 "packages": {
+                  "description": "Packages is a list of maven coordinates of jars to include on the driver and executor\nclasspaths. This will search the local maven repo, then maven central and any additional\nremote repositories given by the \"repositories\" option.\nEach package should be of the form \"groupId:artifactId:version\".",
                   "items": {
                     "type": "string"
                   },
                   "type": "array"
                 },
                 "pyFiles": {
+                  "description": "PyFiles is a list of Python files the Spark application depends on.",
                   "items": {
                     "type": "string"
                   },
                   "type": "array"
                 },
                 "repositories": {
+                  "description": "Repositories is a list of additional remote repositories to search for the maven coordinate\ngiven with the \"packages\" option.",
                   "items": {
                     "type": "string"
                   },
@@ -109,30 +139,42 @@
               "additionalProperties": false
             },
             "driver": {
+              "description": "Driver is the driver specification.",
               "properties": {
                 "affinity": {
+                  "description": "Affinity specifies the affinity/anti-affinity settings for the pod.",
                   "properties": {
                     "nodeAffinity": {
+                      "description": "Describes node affinity scheduling rules for the pod.",
                       "properties": {
                         "preferredDuringSchedulingIgnoredDuringExecution": {
+                          "description": "The scheduler will prefer to schedule pods to nodes that satisfy\nthe affinity expressions specified by this field, but it may choose\na node that violates one or more of the expressions. The node that is\nmost preferred is the one with the greatest sum of weights, i.e.\nfor each node that meets all of the scheduling requirements (resource\nrequest, requiredDuringScheduling affinity expressions, etc.),\ncompute a sum by iterating through the elements of this field and adding\n\"weight\" to the sum if the node matches the corresponding matchExpressions; the\nnode(s) with the highest sum are the most preferred.",
                           "items": {
+                            "description": "An empty preferred scheduling term matches all objects with implicit weight 0\n(i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).",
                             "properties": {
                               "preference": {
+                                "description": "A node selector term, associated with the corresponding weight.",
                                 "properties": {
                                   "matchExpressions": {
+                                    "description": "A list of node selector requirements by node's labels.",
                                     "items": {
+                                      "description": "A node selector requirement is a selector that contains values, a key, and an operator\nthat relates the key and values.",
                                       "properties": {
                                         "key": {
+                                          "description": "The label key that the selector applies to.",
                                           "type": "string"
                                         },
                                         "operator": {
+                                          "description": "Represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
                                           "type": "string"
                                         },
                                         "values": {
+                                          "description": "An array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. If the operator is Gt or Lt, the values\narray must have a single element, which will be interpreted as an integer.\nThis array is replaced during a strategic merge patch.",
                                           "items": {
                                             "type": "string"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       },
                                       "required": [
@@ -142,22 +184,29 @@
                                       "type": "object",
                                       "additionalProperties": false
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "matchFields": {
+                                    "description": "A list of node selector requirements by node's fields.",
                                     "items": {
+                                      "description": "A node selector requirement is a selector that contains values, a key, and an operator\nthat relates the key and values.",
                                       "properties": {
                                         "key": {
+                                          "description": "The label key that the selector applies to.",
                                           "type": "string"
                                         },
                                         "operator": {
+                                          "description": "Represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
                                           "type": "string"
                                         },
                                         "values": {
+                                          "description": "An array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. If the operator is Gt or Lt, the values\narray must have a single element, which will be interpreted as an integer.\nThis array is replaced during a strategic merge patch.",
                                           "items": {
                                             "type": "string"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       },
                                       "required": [
@@ -167,13 +216,16 @@
                                       "type": "object",
                                       "additionalProperties": false
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   }
                                 },
                                 "type": "object",
+                                "x-kubernetes-map-type": "atomic",
                                 "additionalProperties": false
                               },
                               "weight": {
+                                "description": "Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.",
                                 "format": "int32",
                                 "type": "integer"
                               }
@@ -185,27 +237,37 @@
                             "type": "object",
                             "additionalProperties": false
                           },
-                          "type": "array"
+                          "type": "array",
+                          "x-kubernetes-list-type": "atomic"
                         },
                         "requiredDuringSchedulingIgnoredDuringExecution": {
+                          "description": "If the affinity requirements specified by this field are not met at\nscheduling time, the pod will not be scheduled onto the node.\nIf the affinity requirements specified by this field cease to be met\nat some point during pod execution (e.g. due to an update), the system\nmay or may not try to eventually evict the pod from its node.",
                           "properties": {
                             "nodeSelectorTerms": {
+                              "description": "Required. A list of node selector terms. The terms are ORed.",
                               "items": {
+                                "description": "A null or empty node selector term matches no objects. The requirements of\nthem are ANDed.\nThe TopologySelectorTerm type implements a subset of the NodeSelectorTerm.",
                                 "properties": {
                                   "matchExpressions": {
+                                    "description": "A list of node selector requirements by node's labels.",
                                     "items": {
+                                      "description": "A node selector requirement is a selector that contains values, a key, and an operator\nthat relates the key and values.",
                                       "properties": {
                                         "key": {
+                                          "description": "The label key that the selector applies to.",
                                           "type": "string"
                                         },
                                         "operator": {
+                                          "description": "Represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
                                           "type": "string"
                                         },
                                         "values": {
+                                          "description": "An array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. If the operator is Gt or Lt, the values\narray must have a single element, which will be interpreted as an integer.\nThis array is replaced during a strategic merge patch.",
                                           "items": {
                                             "type": "string"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       },
                                       "required": [
@@ -215,22 +277,29 @@
                                       "type": "object",
                                       "additionalProperties": false
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "matchFields": {
+                                    "description": "A list of node selector requirements by node's fields.",
                                     "items": {
+                                      "description": "A node selector requirement is a selector that contains values, a key, and an operator\nthat relates the key and values.",
                                       "properties": {
                                         "key": {
+                                          "description": "The label key that the selector applies to.",
                                           "type": "string"
                                         },
                                         "operator": {
+                                          "description": "Represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
                                           "type": "string"
                                         },
                                         "values": {
+                                          "description": "An array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. If the operator is Gt or Lt, the values\narray must have a single element, which will be interpreted as an integer.\nThis array is replaced during a strategic merge patch.",
                                           "items": {
                                             "type": "string"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       },
                                       "required": [
@@ -240,19 +309,23 @@
                                       "type": "object",
                                       "additionalProperties": false
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   }
                                 },
                                 "type": "object",
+                                "x-kubernetes-map-type": "atomic",
                                 "additionalProperties": false
                               },
-                              "type": "array"
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
                             }
                           },
                           "required": [
                             "nodeSelectorTerms"
                           ],
                           "type": "object",
+                          "x-kubernetes-map-type": "atomic",
                           "additionalProperties": false
                         }
                       },
@@ -260,28 +333,39 @@
                       "additionalProperties": false
                     },
                     "podAffinity": {
+                      "description": "Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).",
                       "properties": {
                         "preferredDuringSchedulingIgnoredDuringExecution": {
+                          "description": "The scheduler will prefer to schedule pods to nodes that satisfy\nthe affinity expressions specified by this field, but it may choose\na node that violates one or more of the expressions. The node that is\nmost preferred is the one with the greatest sum of weights, i.e.\nfor each node that meets all of the scheduling requirements (resource\nrequest, requiredDuringScheduling affinity expressions, etc.),\ncompute a sum by iterating through the elements of this field and adding\n\"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the\nnode(s) with the highest sum are the most preferred.",
                           "items": {
+                            "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
                             "properties": {
                               "podAffinityTerm": {
+                                "description": "Required. A pod affinity term, associated with the corresponding weight.",
                                 "properties": {
                                   "labelSelector": {
+                                    "description": "A label query over a set of resources, in this case pods.\nIf it's null, this PodAffinityTerm matches with no Pods.",
                                     "properties": {
                                       "matchExpressions": {
+                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
                                         "items": {
+                                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
                                           "properties": {
                                             "key": {
+                                              "description": "key is the label key that the selector applies to.",
                                               "type": "string"
                                             },
                                             "operator": {
+                                              "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
                                               "type": "string"
                                             },
                                             "values": {
+                                              "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
                                               "items": {
                                                 "type": "string"
                                               },
-                                              "type": "array"
+                                              "type": "array",
+                                              "x-kubernetes-list-type": "atomic"
                                             }
                                           },
                                           "required": [
@@ -291,25 +375,94 @@
                                           "type": "object",
                                           "additionalProperties": false
                                         },
-                                        "type": "array"
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
                                       },
                                       "matchLabels": {
                                         "additionalProperties": {
                                           "type": "string"
                                         },
+                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                                         "type": "object"
                                       }
                                     },
                                     "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
                                     "additionalProperties": false
                                   },
-                                  "namespaces": {
+                                  "matchLabelKeys": {
+                                    "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both matchLabelKeys and labelSelector.\nAlso, matchLabelKeys cannot be set when labelSelector isn't set.\nThis is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).",
                                     "items": {
                                       "type": "string"
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "mismatchLabelKeys": {
+                                    "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both mismatchLabelKeys and labelSelector.\nAlso, mismatchLabelKeys cannot be set when labelSelector isn't set.\nThis is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "namespaceSelector": {
+                                    "description": "A label query over the set of namespaces that the term applies to.\nThe term is applied to the union of the namespaces selected by this field\nand the ones listed in the namespaces field.\nnull selector and null or empty namespaces list means \"this pod's namespace\".\nAn empty selector ({}) matches all namespaces.",
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                        "items": {
+                                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                          "properties": {
+                                            "key": {
+                                              "description": "key is the label key that the selector applies to.",
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array",
+                                              "x-kubernetes-list-type": "atomic"
+                                            }
+                                          },
+                                          "required": [
+                                            "key",
+                                            "operator"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "matchLabels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  },
+                                  "namespaces": {
+                                    "description": "namespaces specifies a static list of namespace names that the term applies to.\nThe term is applied to the union of the namespaces listed in this field\nand the ones selected by namespaceSelector.\nnull or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "topologyKey": {
+                                    "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
                                     "type": "string"
                                   }
                                 },
@@ -320,6 +473,7 @@
                                 "additionalProperties": false
                               },
                               "weight": {
+                                "description": "weight associated with matching the corresponding podAffinityTerm,\nin the range 1-100.",
                                 "format": "int32",
                                 "type": "integer"
                               }
@@ -331,27 +485,37 @@
                             "type": "object",
                             "additionalProperties": false
                           },
-                          "type": "array"
+                          "type": "array",
+                          "x-kubernetes-list-type": "atomic"
                         },
                         "requiredDuringSchedulingIgnoredDuringExecution": {
+                          "description": "If the affinity requirements specified by this field are not met at\nscheduling time, the pod will not be scheduled onto the node.\nIf the affinity requirements specified by this field cease to be met\nat some point during pod execution (e.g. due to a pod label update), the\nsystem may or may not try to eventually evict the pod from its node.\nWhen there are multiple elements, the lists of nodes corresponding to each\npodAffinityTerm are intersected, i.e. all terms must be satisfied.",
                           "items": {
+                            "description": "Defines a set of pods (namely those matching the labelSelector\nrelative to the given namespace(s)) that this pod should be\nco-located (affinity) or not co-located (anti-affinity) with,\nwhere co-located is defined as running on a node whose value of\nthe label with key <topologyKey> matches that of any node on which\na pod of the set of pods is running",
                             "properties": {
                               "labelSelector": {
+                                "description": "A label query over a set of resources, in this case pods.\nIf it's null, this PodAffinityTerm matches with no Pods.",
                                 "properties": {
                                   "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
                                     "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
                                       "properties": {
                                         "key": {
+                                          "description": "key is the label key that the selector applies to.",
                                           "type": "string"
                                         },
                                         "operator": {
+                                          "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
                                           "type": "string"
                                         },
                                         "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
                                           "items": {
                                             "type": "string"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       },
                                       "required": [
@@ -361,25 +525,94 @@
                                       "type": "object",
                                       "additionalProperties": false
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "matchLabels": {
                                     "additionalProperties": {
                                       "type": "string"
                                     },
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                                     "type": "object"
                                   }
                                 },
                                 "type": "object",
+                                "x-kubernetes-map-type": "atomic",
                                 "additionalProperties": false
                               },
-                              "namespaces": {
+                              "matchLabelKeys": {
+                                "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both matchLabelKeys and labelSelector.\nAlso, matchLabelKeys cannot be set when labelSelector isn't set.\nThis is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).",
                                 "items": {
                                   "type": "string"
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "mismatchLabelKeys": {
+                                "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both mismatchLabelKeys and labelSelector.\nAlso, mismatchLabelKeys cannot be set when labelSelector isn't set.\nThis is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "namespaceSelector": {
+                                "description": "A label query over the set of namespaces that the term applies to.\nThe term is applied to the union of the namespaces selected by this field\nand the ones listed in the namespaces field.\nnull selector and null or empty namespaces list means \"this pod's namespace\".\nAn empty selector ({}) matches all namespaces.",
+                                "properties": {
+                                  "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                    "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                      "properties": {
+                                        "key": {
+                                          "description": "key is the label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "namespaces": {
+                                "description": "namespaces specifies a static list of namespace names that the term applies to.\nThe term is applied to the union of the namespaces listed in this field\nand the ones selected by namespaceSelector.\nnull or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "topologyKey": {
+                                "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
                                 "type": "string"
                               }
                             },
@@ -389,35 +622,47 @@
                             "type": "object",
                             "additionalProperties": false
                           },
-                          "type": "array"
+                          "type": "array",
+                          "x-kubernetes-list-type": "atomic"
                         }
                       },
                       "type": "object",
                       "additionalProperties": false
                     },
                     "podAntiAffinity": {
+                      "description": "Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).",
                       "properties": {
                         "preferredDuringSchedulingIgnoredDuringExecution": {
+                          "description": "The scheduler will prefer to schedule pods to nodes that satisfy\nthe anti-affinity expressions specified by this field, but it may choose\na node that violates one or more of the expressions. The node that is\nmost preferred is the one with the greatest sum of weights, i.e.\nfor each node that meets all of the scheduling requirements (resource\nrequest, requiredDuringScheduling anti-affinity expressions, etc.),\ncompute a sum by iterating through the elements of this field and adding\n\"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the\nnode(s) with the highest sum are the most preferred.",
                           "items": {
+                            "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
                             "properties": {
                               "podAffinityTerm": {
+                                "description": "Required. A pod affinity term, associated with the corresponding weight.",
                                 "properties": {
                                   "labelSelector": {
+                                    "description": "A label query over a set of resources, in this case pods.\nIf it's null, this PodAffinityTerm matches with no Pods.",
                                     "properties": {
                                       "matchExpressions": {
+                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
                                         "items": {
+                                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
                                           "properties": {
                                             "key": {
+                                              "description": "key is the label key that the selector applies to.",
                                               "type": "string"
                                             },
                                             "operator": {
+                                              "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
                                               "type": "string"
                                             },
                                             "values": {
+                                              "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
                                               "items": {
                                                 "type": "string"
                                               },
-                                              "type": "array"
+                                              "type": "array",
+                                              "x-kubernetes-list-type": "atomic"
                                             }
                                           },
                                           "required": [
@@ -427,25 +672,94 @@
                                           "type": "object",
                                           "additionalProperties": false
                                         },
-                                        "type": "array"
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
                                       },
                                       "matchLabels": {
                                         "additionalProperties": {
                                           "type": "string"
                                         },
+                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                                         "type": "object"
                                       }
                                     },
                                     "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
                                     "additionalProperties": false
                                   },
-                                  "namespaces": {
+                                  "matchLabelKeys": {
+                                    "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both matchLabelKeys and labelSelector.\nAlso, matchLabelKeys cannot be set when labelSelector isn't set.\nThis is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).",
                                     "items": {
                                       "type": "string"
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "mismatchLabelKeys": {
+                                    "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both mismatchLabelKeys and labelSelector.\nAlso, mismatchLabelKeys cannot be set when labelSelector isn't set.\nThis is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "namespaceSelector": {
+                                    "description": "A label query over the set of namespaces that the term applies to.\nThe term is applied to the union of the namespaces selected by this field\nand the ones listed in the namespaces field.\nnull selector and null or empty namespaces list means \"this pod's namespace\".\nAn empty selector ({}) matches all namespaces.",
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                        "items": {
+                                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                          "properties": {
+                                            "key": {
+                                              "description": "key is the label key that the selector applies to.",
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array",
+                                              "x-kubernetes-list-type": "atomic"
+                                            }
+                                          },
+                                          "required": [
+                                            "key",
+                                            "operator"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "matchLabels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  },
+                                  "namespaces": {
+                                    "description": "namespaces specifies a static list of namespace names that the term applies to.\nThe term is applied to the union of the namespaces listed in this field\nand the ones selected by namespaceSelector.\nnull or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "topologyKey": {
+                                    "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
                                     "type": "string"
                                   }
                                 },
@@ -456,6 +770,7 @@
                                 "additionalProperties": false
                               },
                               "weight": {
+                                "description": "weight associated with matching the corresponding podAffinityTerm,\nin the range 1-100.",
                                 "format": "int32",
                                 "type": "integer"
                               }
@@ -467,27 +782,37 @@
                             "type": "object",
                             "additionalProperties": false
                           },
-                          "type": "array"
+                          "type": "array",
+                          "x-kubernetes-list-type": "atomic"
                         },
                         "requiredDuringSchedulingIgnoredDuringExecution": {
+                          "description": "If the anti-affinity requirements specified by this field are not met at\nscheduling time, the pod will not be scheduled onto the node.\nIf the anti-affinity requirements specified by this field cease to be met\nat some point during pod execution (e.g. due to a pod label update), the\nsystem may or may not try to eventually evict the pod from its node.\nWhen there are multiple elements, the lists of nodes corresponding to each\npodAffinityTerm are intersected, i.e. all terms must be satisfied.",
                           "items": {
+                            "description": "Defines a set of pods (namely those matching the labelSelector\nrelative to the given namespace(s)) that this pod should be\nco-located (affinity) or not co-located (anti-affinity) with,\nwhere co-located is defined as running on a node whose value of\nthe label with key <topologyKey> matches that of any node on which\na pod of the set of pods is running",
                             "properties": {
                               "labelSelector": {
+                                "description": "A label query over a set of resources, in this case pods.\nIf it's null, this PodAffinityTerm matches with no Pods.",
                                 "properties": {
                                   "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
                                     "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
                                       "properties": {
                                         "key": {
+                                          "description": "key is the label key that the selector applies to.",
                                           "type": "string"
                                         },
                                         "operator": {
+                                          "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
                                           "type": "string"
                                         },
                                         "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
                                           "items": {
                                             "type": "string"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       },
                                       "required": [
@@ -497,25 +822,94 @@
                                       "type": "object",
                                       "additionalProperties": false
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "matchLabels": {
                                     "additionalProperties": {
                                       "type": "string"
                                     },
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                                     "type": "object"
                                   }
                                 },
                                 "type": "object",
+                                "x-kubernetes-map-type": "atomic",
                                 "additionalProperties": false
                               },
-                              "namespaces": {
+                              "matchLabelKeys": {
+                                "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both matchLabelKeys and labelSelector.\nAlso, matchLabelKeys cannot be set when labelSelector isn't set.\nThis is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).",
                                 "items": {
                                   "type": "string"
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "mismatchLabelKeys": {
+                                "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both mismatchLabelKeys and labelSelector.\nAlso, mismatchLabelKeys cannot be set when labelSelector isn't set.\nThis is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "namespaceSelector": {
+                                "description": "A label query over the set of namespaces that the term applies to.\nThe term is applied to the union of the namespaces selected by this field\nand the ones listed in the namespaces field.\nnull selector and null or empty namespaces list means \"this pod's namespace\".\nAn empty selector ({}) matches all namespaces.",
+                                "properties": {
+                                  "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                    "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                      "properties": {
+                                        "key": {
+                                          "description": "key is the label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "namespaces": {
+                                "description": "namespaces specifies a static list of namespace names that the term applies to.\nThe term is applied to the union of the namespaces listed in this field\nand the ones selected by namespaceSelector.\nnull or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "topologyKey": {
+                                "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
                                 "type": "string"
                               }
                             },
@@ -525,7 +919,8 @@
                             "type": "object",
                             "additionalProperties": false
                           },
-                          "type": "array"
+                          "type": "array",
+                          "x-kubernetes-list-type": "atomic"
                         }
                       },
                       "type": "object",
@@ -539,10 +934,13 @@
                   "additionalProperties": {
                     "type": "string"
                   },
+                  "description": "Annotations are the Kubernetes annotations to be added to the pod.",
                   "type": "object"
                 },
                 "configMaps": {
+                  "description": "ConfigMaps carries information of other ConfigMaps to add to the pod.",
                   "items": {
+                    "description": "NamePath is a pair of a name and a path to which the named objects should be mounted to.",
                     "properties": {
                       "name": {
                         "type": "string"
@@ -561,69 +959,92 @@
                   "type": "array"
                 },
                 "coreLimit": {
+                  "description": "CoreLimit specifies a hard limit on CPU cores for the pod.\nOptional",
                   "type": "string"
                 },
                 "coreRequest": {
+                  "description": "CoreRequest is the physical CPU core request for the driver.\nMaps to `spark.kubernetes.driver.request.cores` that is available since Spark 3.0.",
                   "type": "string"
                 },
                 "cores": {
+                  "description": "Cores maps to `spark.driver.cores` or `spark.executor.cores` for the driver and executors, respectively.",
                   "format": "int32",
                   "minimum": 1,
                   "type": "integer"
                 },
                 "dnsConfig": {
+                  "description": "DnsConfig dns settings for the pod, following the Kubernetes specifications.",
                   "properties": {
                     "nameservers": {
+                      "description": "A list of DNS name server IP addresses.\nThis will be appended to the base nameservers generated from DNSPolicy.\nDuplicated nameservers will be removed.",
                       "items": {
                         "type": "string"
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     },
                     "options": {
+                      "description": "A list of DNS resolver options.\nThis will be merged with the base options generated from DNSPolicy.\nDuplicated entries will be removed. Resolution options given in Options\nwill override those that appear in the base DNSPolicy.",
                       "items": {
+                        "description": "PodDNSConfigOption defines DNS resolver options of a pod.",
                         "properties": {
                           "name": {
+                            "description": "Name is this DNS resolver option's name.\nRequired.",
                             "type": "string"
                           },
                           "value": {
+                            "description": "Value is this DNS resolver option's value.",
                             "type": "string"
                           }
                         },
                         "type": "object",
                         "additionalProperties": false
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     },
                     "searches": {
+                      "description": "A list of DNS search domains for host-name lookup.\nThis will be appended to the base search paths generated from DNSPolicy.\nDuplicated search paths will be removed.",
                       "items": {
                         "type": "string"
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     }
                   },
                   "type": "object",
                   "additionalProperties": false
                 },
                 "env": {
+                  "description": "Env carries the environment variables to add to the pod.",
                   "items": {
+                    "description": "EnvVar represents an environment variable present in a Container.",
                     "properties": {
                       "name": {
+                        "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
                         "type": "string"
                       },
                       "value": {
+                        "description": "Variable references $(VAR_NAME) are expanded\nusing the previously defined environment variables in the container and\nany service environment variables. If a variable cannot be resolved,\nthe reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.\n\"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\".\nEscaped references will never be expanded, regardless of whether the variable\nexists or not.\nDefaults to \"\".",
                         "type": "string"
                       },
                       "valueFrom": {
+                        "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
                         "properties": {
                           "configMapKeyRef": {
+                            "description": "Selects a key of a ConfigMap.",
                             "properties": {
                               "key": {
+                                "description": "The key to select.",
                                 "type": "string"
                               },
                               "name": {
+                                "default": "",
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                 "type": "string"
                               },
                               "optional": {
+                                "description": "Specify whether the ConfigMap or its key must be defined",
                                 "type": "boolean"
                               }
                             },
@@ -631,14 +1052,18 @@
                               "key"
                             ],
                             "type": "object",
+                            "x-kubernetes-map-type": "atomic",
                             "additionalProperties": false
                           },
                           "fieldRef": {
+                            "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,\nspec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
                             "properties": {
                               "apiVersion": {
+                                "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
                                 "type": "string"
                               },
                               "fieldPath": {
+                                "description": "Path of the field to select in the specified API version.",
                                 "type": "string"
                               }
                             },
@@ -646,11 +1071,14 @@
                               "fieldPath"
                             ],
                             "type": "object",
+                            "x-kubernetes-map-type": "atomic",
                             "additionalProperties": false
                           },
                           "resourceFieldRef": {
+                            "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
                             "properties": {
                               "containerName": {
+                                "description": "Container name: required for volumes, optional for env vars",
                                 "type": "string"
                               },
                               "divisor": {
@@ -662,10 +1090,12 @@
                                     "type": "string"
                                   }
                                 ],
+                                "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
                                 "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                                 "x-kubernetes-int-or-string": true
                               },
                               "resource": {
+                                "description": "Required: resource to select",
                                 "type": "string"
                               }
                             },
@@ -673,17 +1103,23 @@
                               "resource"
                             ],
                             "type": "object",
+                            "x-kubernetes-map-type": "atomic",
                             "additionalProperties": false
                           },
                           "secretKeyRef": {
+                            "description": "Selects a key of a secret in the pod's namespace",
                             "properties": {
                               "key": {
+                                "description": "The key of the secret to select from.  Must be a valid secret key.",
                                 "type": "string"
                               },
                               "name": {
+                                "default": "",
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                 "type": "string"
                               },
                               "optional": {
+                                "description": "Specify whether the Secret or its key must be defined",
                                 "type": "boolean"
                               }
                             },
@@ -691,6 +1127,7 @@
                               "key"
                             ],
                             "type": "object",
+                            "x-kubernetes-map-type": "atomic",
                             "additionalProperties": false
                           }
                         },
@@ -707,33 +1144,46 @@
                   "type": "array"
                 },
                 "envFrom": {
+                  "description": "EnvFrom is a list of sources to populate environment variables in the container.",
                   "items": {
+                    "description": "EnvFromSource represents the source of a set of ConfigMaps",
                     "properties": {
                       "configMapRef": {
+                        "description": "The ConfigMap to select from",
                         "properties": {
                           "name": {
+                            "default": "",
+                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                             "type": "string"
                           },
                           "optional": {
+                            "description": "Specify whether the ConfigMap must be defined",
                             "type": "boolean"
                           }
                         },
                         "type": "object",
+                        "x-kubernetes-map-type": "atomic",
                         "additionalProperties": false
                       },
                       "prefix": {
+                        "description": "An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.",
                         "type": "string"
                       },
                       "secretRef": {
+                        "description": "The Secret to select from",
                         "properties": {
                           "name": {
+                            "default": "",
+                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                             "type": "string"
                           },
                           "optional": {
+                            "description": "Specify whether the Secret must be defined",
                             "type": "boolean"
                           }
                         },
                         "type": "object",
+                        "x-kubernetes-map-type": "atomic",
                         "additionalProperties": false
                       }
                     },
@@ -744,6 +1194,7 @@
                 },
                 "envSecretKeyRefs": {
                   "additionalProperties": {
+                    "description": "NameKey represents the name and key of a SecretKeyRef.",
                     "properties": {
                       "key": {
                         "type": "string"
@@ -759,20 +1210,25 @@
                     "type": "object",
                     "additionalProperties": false
                   },
+                  "description": "EnvSecretKeyRefs holds a mapping from environment variable names to SecretKeyRefs.\nDeprecated. Consider using `env` instead.",
                   "type": "object"
                 },
                 "envVars": {
                   "additionalProperties": {
                     "type": "string"
                   },
+                  "description": "EnvVars carries the environment variables to add to the pod.\nDeprecated. Consider using `env` instead.",
                   "type": "object"
                 },
                 "gpu": {
+                  "description": "GPU specifies GPU requirement for the pod.",
                   "properties": {
                     "name": {
+                      "description": "Name is GPU resource name, such as: nvidia.com/gpu or amd.com/gpu",
                       "type": "string"
                     },
                     "quantity": {
+                      "description": "Quantity is the number of GPUs to request for driver or executor.",
                       "format": "int64",
                       "type": "integer"
                     }
@@ -785,64 +1241,90 @@
                   "additionalProperties": false
                 },
                 "hostAliases": {
+                  "description": "HostAliases settings for the pod, following the Kubernetes specifications.",
                   "items": {
+                    "description": "HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the\npod's hosts file.",
                     "properties": {
                       "hostnames": {
+                        "description": "Hostnames for the above IP address.",
                         "items": {
                           "type": "string"
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "ip": {
+                        "description": "IP address of the host file entry.",
                         "type": "string"
                       }
                     },
+                    "required": [
+                      "ip"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
                   "type": "array"
                 },
                 "hostNetwork": {
+                  "description": "HostNetwork indicates whether to request host networking for the pod or not.",
                   "type": "boolean"
                 },
                 "image": {
+                  "description": "Image is the container image to use. Overrides Spec.Image if set.",
                   "type": "string"
                 },
                 "initContainers": {
+                  "description": "InitContainers is a list of init-containers that run to completion before the main Spark container.",
                   "items": {
+                    "description": "A single application container that you want to run within a pod.",
                     "properties": {
                       "args": {
+                        "description": "Arguments to the entrypoint.\nThe container image's CMD is used if this is not provided.\nVariable references $(VAR_NAME) are expanded using the container's environment. If a variable\ncannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will\nproduce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless\nof whether the variable exists or not. Cannot be updated.\nMore info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
                         "items": {
                           "type": "string"
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "command": {
+                        "description": "Entrypoint array. Not executed within a shell.\nThe container image's ENTRYPOINT is used if this is not provided.\nVariable references $(VAR_NAME) are expanded using the container's environment. If a variable\ncannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will\nproduce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless\nof whether the variable exists or not. Cannot be updated.\nMore info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
                         "items": {
                           "type": "string"
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "env": {
+                        "description": "List of environment variables to set in the container.\nCannot be updated.",
                         "items": {
+                          "description": "EnvVar represents an environment variable present in a Container.",
                           "properties": {
                             "name": {
+                              "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
                               "type": "string"
                             },
                             "value": {
+                              "description": "Variable references $(VAR_NAME) are expanded\nusing the previously defined environment variables in the container and\nany service environment variables. If a variable cannot be resolved,\nthe reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.\n\"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\".\nEscaped references will never be expanded, regardless of whether the variable\nexists or not.\nDefaults to \"\".",
                               "type": "string"
                             },
                             "valueFrom": {
+                              "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
                               "properties": {
                                 "configMapKeyRef": {
+                                  "description": "Selects a key of a ConfigMap.",
                                   "properties": {
                                     "key": {
+                                      "description": "The key to select.",
                                       "type": "string"
                                     },
                                     "name": {
+                                      "default": "",
+                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                       "type": "string"
                                     },
                                     "optional": {
+                                      "description": "Specify whether the ConfigMap or its key must be defined",
                                       "type": "boolean"
                                     }
                                   },
@@ -850,14 +1332,18 @@
                                     "key"
                                   ],
                                   "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
                                   "additionalProperties": false
                                 },
                                 "fieldRef": {
+                                  "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,\nspec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
                                   "properties": {
                                     "apiVersion": {
+                                      "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
                                       "type": "string"
                                     },
                                     "fieldPath": {
+                                      "description": "Path of the field to select in the specified API version.",
                                       "type": "string"
                                     }
                                   },
@@ -865,11 +1351,14 @@
                                     "fieldPath"
                                   ],
                                   "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
                                   "additionalProperties": false
                                 },
                                 "resourceFieldRef": {
+                                  "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
                                   "properties": {
                                     "containerName": {
+                                      "description": "Container name: required for volumes, optional for env vars",
                                       "type": "string"
                                     },
                                     "divisor": {
@@ -881,10 +1370,12 @@
                                           "type": "string"
                                         }
                                       ],
+                                      "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
                                       "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                                       "x-kubernetes-int-or-string": true
                                     },
                                     "resource": {
+                                      "description": "Required: resource to select",
                                       "type": "string"
                                     }
                                   },
@@ -892,17 +1383,23 @@
                                     "resource"
                                   ],
                                   "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
                                   "additionalProperties": false
                                 },
                                 "secretKeyRef": {
+                                  "description": "Selects a key of a secret in the pod's namespace",
                                   "properties": {
                                     "key": {
+                                      "description": "The key of the secret to select from.  Must be a valid secret key.",
                                       "type": "string"
                                     },
                                     "name": {
+                                      "default": "",
+                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                       "type": "string"
                                     },
                                     "optional": {
+                                      "description": "Specify whether the Secret or its key must be defined",
                                       "type": "boolean"
                                     }
                                   },
@@ -910,6 +1407,7 @@
                                     "key"
                                   ],
                                   "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
                                   "additionalProperties": false
                                 }
                               },
@@ -923,78 +1421,109 @@
                           "type": "object",
                           "additionalProperties": false
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-map-keys": [
+                          "name"
+                        ],
+                        "x-kubernetes-list-type": "map"
                       },
                       "envFrom": {
+                        "description": "List of sources to populate environment variables in the container.\nThe keys defined within a source must be a C_IDENTIFIER. All invalid keys\nwill be reported as an event when the container is starting. When a key exists in multiple\nsources, the value associated with the last source will take precedence.\nValues defined by an Env with a duplicate key will take precedence.\nCannot be updated.",
                         "items": {
+                          "description": "EnvFromSource represents the source of a set of ConfigMaps",
                           "properties": {
                             "configMapRef": {
+                              "description": "The ConfigMap to select from",
                               "properties": {
                                 "name": {
+                                  "default": "",
+                                  "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                   "type": "string"
                                 },
                                 "optional": {
+                                  "description": "Specify whether the ConfigMap must be defined",
                                   "type": "boolean"
                                 }
                               },
                               "type": "object",
+                              "x-kubernetes-map-type": "atomic",
                               "additionalProperties": false
                             },
                             "prefix": {
+                              "description": "An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.",
                               "type": "string"
                             },
                             "secretRef": {
+                              "description": "The Secret to select from",
                               "properties": {
                                 "name": {
+                                  "default": "",
+                                  "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                   "type": "string"
                                 },
                                 "optional": {
+                                  "description": "Specify whether the Secret must be defined",
                                   "type": "boolean"
                                 }
                               },
                               "type": "object",
+                              "x-kubernetes-map-type": "atomic",
                               "additionalProperties": false
                             }
                           },
                           "type": "object",
                           "additionalProperties": false
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "image": {
+                        "description": "Container image name.\nMore info: https://kubernetes.io/docs/concepts/containers/images\nThis field is optional to allow higher level config management to default or override\ncontainer images in workload controllers like Deployments and StatefulSets.",
                         "type": "string"
                       },
                       "imagePullPolicy": {
+                        "description": "Image pull policy.\nOne of Always, Never, IfNotPresent.\nDefaults to Always if :latest tag is specified, or IfNotPresent otherwise.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/containers/images#updating-images",
                         "type": "string"
                       },
                       "lifecycle": {
+                        "description": "Actions that the management system should take in response to container lifecycle events.\nCannot be updated.",
                         "properties": {
                           "postStart": {
+                            "description": "PostStart is called immediately after a container is created. If the handler fails,\nthe container is terminated and restarted according to its restart policy.\nOther management of the container blocks until the hook completes.\nMore info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks",
                             "properties": {
                               "exec": {
+                                "description": "Exec specifies a command to execute in the container.",
                                 "properties": {
                                   "command": {
+                                    "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
                                     "items": {
                                       "type": "string"
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   }
                                 },
                                 "type": "object",
                                 "additionalProperties": false
                               },
                               "httpGet": {
+                                "description": "HTTPGet specifies an HTTP GET request to perform.",
                                 "properties": {
                                   "host": {
+                                    "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
                                     "type": "string"
                                   },
                                   "httpHeaders": {
+                                    "description": "Custom headers to set in the request. HTTP allows repeated headers.",
                                     "items": {
+                                      "description": "HTTPHeader describes a custom header to be used in HTTP probes",
                                       "properties": {
                                         "name": {
+                                          "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
                                           "type": "string"
                                         },
                                         "value": {
+                                          "description": "The header field value",
                                           "type": "string"
                                         }
                                       },
@@ -1005,9 +1534,11 @@
                                       "type": "object",
                                       "additionalProperties": false
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "path": {
+                                    "description": "Path to access on the HTTP server.",
                                     "type": "string"
                                   },
                                   "port": {
@@ -1019,9 +1550,11 @@
                                         "type": "string"
                                       }
                                     ],
+                                    "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
                                     "x-kubernetes-int-or-string": true
                                   },
                                   "scheme": {
+                                    "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
                                     "type": "string"
                                   }
                                 },
@@ -1031,9 +1564,26 @@
                                 "type": "object",
                                 "additionalProperties": false
                               },
+                              "sleep": {
+                                "description": "Sleep represents a duration that the container should sleep.",
+                                "properties": {
+                                  "seconds": {
+                                    "description": "Seconds is the number of seconds to sleep.",
+                                    "format": "int64",
+                                    "type": "integer"
+                                  }
+                                },
+                                "required": [
+                                  "seconds"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
                               "tcpSocket": {
+                                "description": "Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept\nfor backward compatibility. There is no validation of this field and\nlifecycle hooks will fail at runtime when it is specified.",
                                 "properties": {
                                   "host": {
+                                    "description": "Optional: Host name to connect to, defaults to the pod IP.",
                                     "type": "string"
                                   },
                                   "port": {
@@ -1045,6 +1595,7 @@
                                         "type": "string"
                                       }
                                     ],
+                                    "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
                                     "x-kubernetes-int-or-string": true
                                   }
                                 },
@@ -1059,31 +1610,41 @@
                             "additionalProperties": false
                           },
                           "preStop": {
+                            "description": "PreStop is called immediately before a container is terminated due to an\nAPI request or management event such as liveness/startup probe failure,\npreemption, resource contention, etc. The handler is not called if the\ncontainer crashes or exits. The Pod's termination grace period countdown begins before the\nPreStop hook is executed. Regardless of the outcome of the handler, the\ncontainer will eventually terminate within the Pod's termination grace\nperiod (unless delayed by finalizers). Other management of the container blocks until the hook completes\nor until the termination grace period is reached.\nMore info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks",
                             "properties": {
                               "exec": {
+                                "description": "Exec specifies a command to execute in the container.",
                                 "properties": {
                                   "command": {
+                                    "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
                                     "items": {
                                       "type": "string"
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   }
                                 },
                                 "type": "object",
                                 "additionalProperties": false
                               },
                               "httpGet": {
+                                "description": "HTTPGet specifies an HTTP GET request to perform.",
                                 "properties": {
                                   "host": {
+                                    "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
                                     "type": "string"
                                   },
                                   "httpHeaders": {
+                                    "description": "Custom headers to set in the request. HTTP allows repeated headers.",
                                     "items": {
+                                      "description": "HTTPHeader describes a custom header to be used in HTTP probes",
                                       "properties": {
                                         "name": {
+                                          "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
                                           "type": "string"
                                         },
                                         "value": {
+                                          "description": "The header field value",
                                           "type": "string"
                                         }
                                       },
@@ -1094,9 +1655,11 @@
                                       "type": "object",
                                       "additionalProperties": false
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "path": {
+                                    "description": "Path to access on the HTTP server.",
                                     "type": "string"
                                   },
                                   "port": {
@@ -1108,9 +1671,11 @@
                                         "type": "string"
                                       }
                                     ],
+                                    "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
                                     "x-kubernetes-int-or-string": true
                                   },
                                   "scheme": {
+                                    "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
                                     "type": "string"
                                   }
                                 },
@@ -1120,9 +1685,26 @@
                                 "type": "object",
                                 "additionalProperties": false
                               },
+                              "sleep": {
+                                "description": "Sleep represents a duration that the container should sleep.",
+                                "properties": {
+                                  "seconds": {
+                                    "description": "Seconds is the number of seconds to sleep.",
+                                    "format": "int64",
+                                    "type": "integer"
+                                  }
+                                },
+                                "required": [
+                                  "seconds"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
                               "tcpSocket": {
+                                "description": "Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept\nfor backward compatibility. There is no validation of this field and\nlifecycle hooks will fail at runtime when it is specified.",
                                 "properties": {
                                   "host": {
+                                    "description": "Optional: Host name to connect to, defaults to the pod IP.",
                                     "type": "string"
                                   },
                                   "port": {
@@ -1134,6 +1716,7 @@
                                         "type": "string"
                                       }
                                     ],
+                                    "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
                                     "x-kubernetes-int-or-string": true
                                   }
                                 },
@@ -1152,35 +1735,66 @@
                         "additionalProperties": false
                       },
                       "livenessProbe": {
+                        "description": "Periodic probe of container liveness.\nContainer will be restarted if the probe fails.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
                         "properties": {
                           "exec": {
+                            "description": "Exec specifies a command to execute in the container.",
                             "properties": {
                               "command": {
+                                "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
                                 "items": {
                                   "type": "string"
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               }
                             },
                             "type": "object",
                             "additionalProperties": false
                           },
                           "failureThreshold": {
+                            "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded.\nDefaults to 3. Minimum value is 1.",
                             "format": "int32",
                             "type": "integer"
                           },
+                          "grpc": {
+                            "description": "GRPC specifies a GRPC HealthCheckRequest.",
+                            "properties": {
+                              "port": {
+                                "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "service": {
+                                "default": "",
+                                "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
                           "httpGet": {
+                            "description": "HTTPGet specifies an HTTP GET request to perform.",
                             "properties": {
                               "host": {
+                                "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
                                 "type": "string"
                               },
                               "httpHeaders": {
+                                "description": "Custom headers to set in the request. HTTP allows repeated headers.",
                                 "items": {
+                                  "description": "HTTPHeader describes a custom header to be used in HTTP probes",
                                   "properties": {
                                     "name": {
+                                      "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
                                       "type": "string"
                                     },
                                     "value": {
+                                      "description": "The header field value",
                                       "type": "string"
                                     }
                                   },
@@ -1191,9 +1805,11 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "path": {
+                                "description": "Path to access on the HTTP server.",
                                 "type": "string"
                               },
                               "port": {
@@ -1205,9 +1821,11 @@
                                     "type": "string"
                                   }
                                 ],
+                                "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
                                 "x-kubernetes-int-or-string": true
                               },
                               "scheme": {
+                                "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
                                 "type": "string"
                               }
                             },
@@ -1218,20 +1836,25 @@
                             "additionalProperties": false
                           },
                           "initialDelaySeconds": {
+                            "description": "Number of seconds after the container has started before liveness probes are initiated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
                             "format": "int32",
                             "type": "integer"
                           },
                           "periodSeconds": {
+                            "description": "How often (in seconds) to perform the probe.\nDefault to 10 seconds. Minimum value is 1.",
                             "format": "int32",
                             "type": "integer"
                           },
                           "successThreshold": {
+                            "description": "Minimum consecutive successes for the probe to be considered successful after having failed.\nDefaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
                             "format": "int32",
                             "type": "integer"
                           },
                           "tcpSocket": {
+                            "description": "TCPSocket specifies a connection to a TCP port.",
                             "properties": {
                               "host": {
+                                "description": "Optional: Host name to connect to, defaults to the pod IP.",
                                 "type": "string"
                               },
                               "port": {
@@ -1243,6 +1866,7 @@
                                     "type": "string"
                                   }
                                 ],
+                                "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
                                 "x-kubernetes-int-or-string": true
                               }
                             },
@@ -1252,7 +1876,13 @@
                             "type": "object",
                             "additionalProperties": false
                           },
+                          "terminationGracePeriodSeconds": {
+                            "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure.\nThe grace period is the duration in seconds after the processes running in the pod are sent\na termination signal and the time when the processes are forcibly halted with a kill signal.\nSet this value longer than the expected cleanup time for your process.\nIf this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this\nvalue overrides the value provided by the pod spec.\nValue must be non-negative integer. The value zero indicates stop immediately via\nthe kill signal (no opportunity to shut down).\nThis is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.\nMinimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+                            "format": "int64",
+                            "type": "integer"
+                          },
                           "timeoutSeconds": {
+                            "description": "Number of seconds after which the probe times out.\nDefaults to 1 second. Minimum value is 1.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
                             "format": "int32",
                             "type": "integer"
                           }
@@ -1261,32 +1891,40 @@
                         "additionalProperties": false
                       },
                       "name": {
+                        "description": "Name of the container specified as a DNS_LABEL.\nEach container in a pod must have a unique name (DNS_LABEL).\nCannot be updated.",
                         "type": "string"
                       },
                       "ports": {
+                        "description": "List of ports to expose from the container. Not specifying a port here\nDOES NOT prevent that port from being exposed. Any port which is\nlistening on the default \"0.0.0.0\" address inside a container will be\naccessible from the network.\nModifying this array with strategic merge patch may corrupt the data.\nFor more information See https://github.com/kubernetes/kubernetes/issues/108255.\nCannot be updated.",
                         "items": {
+                          "description": "ContainerPort represents a network port in a single container.",
                           "properties": {
                             "containerPort": {
+                              "description": "Number of port to expose on the pod's IP address.\nThis must be a valid port number, 0 < x < 65536.",
                               "format": "int32",
                               "type": "integer"
                             },
                             "hostIP": {
+                              "description": "What host IP to bind the external port to.",
                               "type": "string"
                             },
                             "hostPort": {
+                              "description": "Number of port to expose on the host.\nIf specified, this must be a valid port number, 0 < x < 65536.\nIf HostNetwork is specified, this must match ContainerPort.\nMost containers do not need this.",
                               "format": "int32",
                               "type": "integer"
                             },
                             "name": {
+                              "description": "If specified, this must be an IANA_SVC_NAME and unique within the pod. Each\nnamed port in a pod must have a unique name. Name for the port that can be\nreferred to by services.",
                               "type": "string"
                             },
                             "protocol": {
+                              "default": "TCP",
+                              "description": "Protocol for port. Must be UDP, TCP, or SCTP.\nDefaults to \"TCP\".",
                               "type": "string"
                             }
                           },
                           "required": [
-                            "containerPort",
-                            "protocol"
+                            "containerPort"
                           ],
                           "type": "object",
                           "additionalProperties": false
@@ -1299,35 +1937,66 @@
                         "x-kubernetes-list-type": "map"
                       },
                       "readinessProbe": {
+                        "description": "Periodic probe of container service readiness.\nContainer will be removed from service endpoints if the probe fails.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
                         "properties": {
                           "exec": {
+                            "description": "Exec specifies a command to execute in the container.",
                             "properties": {
                               "command": {
+                                "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
                                 "items": {
                                   "type": "string"
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               }
                             },
                             "type": "object",
                             "additionalProperties": false
                           },
                           "failureThreshold": {
+                            "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded.\nDefaults to 3. Minimum value is 1.",
                             "format": "int32",
                             "type": "integer"
                           },
+                          "grpc": {
+                            "description": "GRPC specifies a GRPC HealthCheckRequest.",
+                            "properties": {
+                              "port": {
+                                "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "service": {
+                                "default": "",
+                                "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
                           "httpGet": {
+                            "description": "HTTPGet specifies an HTTP GET request to perform.",
                             "properties": {
                               "host": {
+                                "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
                                 "type": "string"
                               },
                               "httpHeaders": {
+                                "description": "Custom headers to set in the request. HTTP allows repeated headers.",
                                 "items": {
+                                  "description": "HTTPHeader describes a custom header to be used in HTTP probes",
                                   "properties": {
                                     "name": {
+                                      "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
                                       "type": "string"
                                     },
                                     "value": {
+                                      "description": "The header field value",
                                       "type": "string"
                                     }
                                   },
@@ -1338,9 +2007,11 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "path": {
+                                "description": "Path to access on the HTTP server.",
                                 "type": "string"
                               },
                               "port": {
@@ -1352,9 +2023,11 @@
                                     "type": "string"
                                   }
                                 ],
+                                "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
                                 "x-kubernetes-int-or-string": true
                               },
                               "scheme": {
+                                "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
                                 "type": "string"
                               }
                             },
@@ -1365,20 +2038,25 @@
                             "additionalProperties": false
                           },
                           "initialDelaySeconds": {
+                            "description": "Number of seconds after the container has started before liveness probes are initiated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
                             "format": "int32",
                             "type": "integer"
                           },
                           "periodSeconds": {
+                            "description": "How often (in seconds) to perform the probe.\nDefault to 10 seconds. Minimum value is 1.",
                             "format": "int32",
                             "type": "integer"
                           },
                           "successThreshold": {
+                            "description": "Minimum consecutive successes for the probe to be considered successful after having failed.\nDefaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
                             "format": "int32",
                             "type": "integer"
                           },
                           "tcpSocket": {
+                            "description": "TCPSocket specifies a connection to a TCP port.",
                             "properties": {
                               "host": {
+                                "description": "Optional: Host name to connect to, defaults to the pod IP.",
                                 "type": "string"
                               },
                               "port": {
@@ -1390,6 +2068,7 @@
                                     "type": "string"
                                   }
                                 ],
+                                "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
                                 "x-kubernetes-int-or-string": true
                               }
                             },
@@ -1399,7 +2078,13 @@
                             "type": "object",
                             "additionalProperties": false
                           },
+                          "terminationGracePeriodSeconds": {
+                            "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure.\nThe grace period is the duration in seconds after the processes running in the pod are sent\na termination signal and the time when the processes are forcibly halted with a kill signal.\nSet this value longer than the expected cleanup time for your process.\nIf this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this\nvalue overrides the value provided by the pod spec.\nValue must be non-negative integer. The value zero indicates stop immediately via\nthe kill signal (no opportunity to shut down).\nThis is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.\nMinimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+                            "format": "int64",
+                            "type": "integer"
+                          },
                           "timeoutSeconds": {
+                            "description": "Number of seconds after which the probe times out.\nDefaults to 1 second. Minimum value is 1.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
                             "format": "int32",
                             "type": "integer"
                           }
@@ -1407,8 +2092,59 @@
                         "type": "object",
                         "additionalProperties": false
                       },
+                      "resizePolicy": {
+                        "description": "Resources resize policy for the container.",
+                        "items": {
+                          "description": "ContainerResizePolicy represents resource resize policy for the container.",
+                          "properties": {
+                            "resourceName": {
+                              "description": "Name of the resource to which this resource resize policy applies.\nSupported values: cpu, memory.",
+                              "type": "string"
+                            },
+                            "restartPolicy": {
+                              "description": "Restart policy to apply when specified resource is resized.\nIf not specified, it defaults to NotRequired.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "resourceName",
+                            "restartPolicy"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
+                      },
                       "resources": {
+                        "description": "Compute Resources required by this container.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
                         "properties": {
+                          "claims": {
+                            "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
+                            "items": {
+                              "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                              "properties": {
+                                "name": {
+                                  "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
+                                  "type": "string"
+                                },
+                                "request": {
+                                  "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-map-keys": [
+                              "name"
+                            ],
+                            "x-kubernetes-list-type": "map"
+                          },
                           "limits": {
                             "additionalProperties": {
                               "anyOf": [
@@ -1422,6 +2158,7 @@
                               "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                               "x-kubernetes-int-or-string": true
                             },
+                            "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
                             "type": "object"
                           },
                           "requests": {
@@ -1437,82 +2174,151 @@
                               "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                               "x-kubernetes-int-or-string": true
                             },
+                            "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
                             "type": "object"
                           }
                         },
                         "type": "object",
                         "additionalProperties": false
                       },
+                      "restartPolicy": {
+                        "description": "RestartPolicy defines the restart behavior of individual containers in a pod.\nThis field may only be set for init containers, and the only allowed value is \"Always\".\nFor non-init containers or when this field is not specified,\nthe restart behavior is defined by the Pod's restart policy and the container type.\nSetting the RestartPolicy as \"Always\" for the init container will have the following effect:\nthis init container will be continually restarted on\nexit until all regular containers have terminated. Once all regular\ncontainers have completed, all init containers with restartPolicy \"Always\"\nwill be shut down. This lifecycle differs from normal init containers and\nis often referred to as a \"sidecar\" container. Although this init\ncontainer still starts in the init container sequence, it does not wait\nfor the container to complete before proceeding to the next init\ncontainer. Instead, the next init container starts immediately after this\ninit container is started, or after any startupProbe has successfully\ncompleted.",
+                        "type": "string"
+                      },
                       "securityContext": {
+                        "description": "SecurityContext defines the security options the container should be run with.\nIf set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.\nMore info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/",
                         "properties": {
                           "allowPrivilegeEscalation": {
+                            "description": "AllowPrivilegeEscalation controls whether a process can gain more\nprivileges than its parent process. This bool directly controls if\nthe no_new_privs flag will be set on the container process.\nAllowPrivilegeEscalation is true always when the container is:\n1) run as Privileged\n2) has CAP_SYS_ADMIN\nNote that this field cannot be set when spec.os.name is windows.",
                             "type": "boolean"
                           },
+                          "appArmorProfile": {
+                            "description": "appArmorProfile is the AppArmor options to use by this container. If set, this profile\noverrides the pod's appArmorProfile.\nNote that this field cannot be set when spec.os.name is windows.",
+                            "properties": {
+                              "localhostProfile": {
+                                "description": "localhostProfile indicates a profile loaded on the node that should be used.\nThe profile must be preconfigured on the node to work.\nMust match the loaded name of the profile.\nMust be set if and only if type is \"Localhost\".",
+                                "type": "string"
+                              },
+                              "type": {
+                                "description": "type indicates which kind of AppArmor profile will be applied.\nValid options are:\n  Localhost - a profile pre-loaded on the node.\n  RuntimeDefault - the container runtime's default profile.\n  Unconfined - no AppArmor enforcement.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "type"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
                           "capabilities": {
+                            "description": "The capabilities to add/drop when running containers.\nDefaults to the default set of capabilities granted by the container runtime.\nNote that this field cannot be set when spec.os.name is windows.",
                             "properties": {
                               "add": {
+                                "description": "Added capabilities",
                                 "items": {
+                                  "description": "Capability represent POSIX capabilities type",
                                   "type": "string"
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "drop": {
+                                "description": "Removed capabilities",
                                 "items": {
+                                  "description": "Capability represent POSIX capabilities type",
                                   "type": "string"
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               }
                             },
                             "type": "object",
                             "additionalProperties": false
                           },
                           "privileged": {
+                            "description": "Run container in privileged mode.\nProcesses in privileged containers are essentially equivalent to root on the host.\nDefaults to false.\nNote that this field cannot be set when spec.os.name is windows.",
                             "type": "boolean"
                           },
                           "procMount": {
+                            "description": "procMount denotes the type of proc mount to use for the containers.\nThe default value is Default which uses the container runtime defaults for\nreadonly paths and masked paths.\nThis requires the ProcMountType feature flag to be enabled.\nNote that this field cannot be set when spec.os.name is windows.",
                             "type": "string"
                           },
                           "readOnlyRootFilesystem": {
+                            "description": "Whether this container has a read-only root filesystem.\nDefault is false.\nNote that this field cannot be set when spec.os.name is windows.",
                             "type": "boolean"
                           },
                           "runAsGroup": {
+                            "description": "The GID to run the entrypoint of the container process.\nUses runtime default if unset.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
                             "format": "int64",
                             "type": "integer"
                           },
                           "runAsNonRoot": {
+                            "description": "Indicates that the container must run as a non-root user.\nIf true, the Kubelet will validate the image at runtime to ensure that it\ndoes not run as UID 0 (root) and fail to start the container if it does.\nIf unset or false, no such validation will be performed.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
                             "type": "boolean"
                           },
                           "runAsUser": {
+                            "description": "The UID to run the entrypoint of the container process.\nDefaults to user specified in image metadata if unspecified.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
                             "format": "int64",
                             "type": "integer"
                           },
                           "seLinuxOptions": {
+                            "description": "The SELinux context to be applied to the container.\nIf unspecified, the container runtime will allocate a random SELinux context for each\ncontainer.  May also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
                             "properties": {
                               "level": {
+                                "description": "Level is SELinux level label that applies to the container.",
                                 "type": "string"
                               },
                               "role": {
+                                "description": "Role is a SELinux role label that applies to the container.",
                                 "type": "string"
                               },
                               "type": {
+                                "description": "Type is a SELinux type label that applies to the container.",
                                 "type": "string"
                               },
                               "user": {
+                                "description": "User is a SELinux user label that applies to the container.",
                                 "type": "string"
                               }
                             },
                             "type": "object",
                             "additionalProperties": false
                           },
+                          "seccompProfile": {
+                            "description": "The seccomp options to use by this container. If seccomp options are\nprovided at both the pod & container level, the container options\noverride the pod options.\nNote that this field cannot be set when spec.os.name is windows.",
+                            "properties": {
+                              "localhostProfile": {
+                                "description": "localhostProfile indicates a profile defined in a file on the node should be used.\nThe profile must be preconfigured on the node to work.\nMust be a descending path, relative to the kubelet's configured seccomp profile location.\nMust be set if type is \"Localhost\". Must NOT be set for any other type.",
+                                "type": "string"
+                              },
+                              "type": {
+                                "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "type"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
                           "windowsOptions": {
+                            "description": "The Windows specific settings applied to all containers.\nIf unspecified, the options from the PodSecurityContext will be used.\nIf set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is linux.",
                             "properties": {
                               "gmsaCredentialSpec": {
+                                "description": "GMSACredentialSpec is where the GMSA admission webhook\n(https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the\nGMSA credential spec named by the GMSACredentialSpecName field.",
                                 "type": "string"
                               },
                               "gmsaCredentialSpecName": {
+                                "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
                                 "type": "string"
                               },
+                              "hostProcess": {
+                                "description": "HostProcess determines if a container should be run as a 'Host Process' container.\nAll of a Pod's containers must have the same effective HostProcess value\n(it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).\nIn addition, if HostProcess is true then HostNetwork must also be set to true.",
+                                "type": "boolean"
+                              },
                               "runAsUserName": {
+                                "description": "The UserName in Windows to run the entrypoint of the container process.\nDefaults to the user specified in image metadata if unspecified.\nMay also be set in PodSecurityContext. If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
                                 "type": "string"
                               }
                             },
@@ -1524,35 +2330,66 @@
                         "additionalProperties": false
                       },
                       "startupProbe": {
+                        "description": "StartupProbe indicates that the Pod has successfully initialized.\nIf specified, no other probes are executed until this completes successfully.\nIf this probe fails, the Pod will be restarted, just as if the livenessProbe failed.\nThis can be used to provide different probe parameters at the beginning of a Pod's lifecycle,\nwhen it might take a long time to load data or warm a cache, than during steady-state operation.\nThis cannot be updated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
                         "properties": {
                           "exec": {
+                            "description": "Exec specifies a command to execute in the container.",
                             "properties": {
                               "command": {
+                                "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
                                 "items": {
                                   "type": "string"
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               }
                             },
                             "type": "object",
                             "additionalProperties": false
                           },
                           "failureThreshold": {
+                            "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded.\nDefaults to 3. Minimum value is 1.",
                             "format": "int32",
                             "type": "integer"
                           },
+                          "grpc": {
+                            "description": "GRPC specifies a GRPC HealthCheckRequest.",
+                            "properties": {
+                              "port": {
+                                "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "service": {
+                                "default": "",
+                                "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
                           "httpGet": {
+                            "description": "HTTPGet specifies an HTTP GET request to perform.",
                             "properties": {
                               "host": {
+                                "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
                                 "type": "string"
                               },
                               "httpHeaders": {
+                                "description": "Custom headers to set in the request. HTTP allows repeated headers.",
                                 "items": {
+                                  "description": "HTTPHeader describes a custom header to be used in HTTP probes",
                                   "properties": {
                                     "name": {
+                                      "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
                                       "type": "string"
                                     },
                                     "value": {
+                                      "description": "The header field value",
                                       "type": "string"
                                     }
                                   },
@@ -1563,9 +2400,11 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "path": {
+                                "description": "Path to access on the HTTP server.",
                                 "type": "string"
                               },
                               "port": {
@@ -1577,9 +2416,11 @@
                                     "type": "string"
                                   }
                                 ],
+                                "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
                                 "x-kubernetes-int-or-string": true
                               },
                               "scheme": {
+                                "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
                                 "type": "string"
                               }
                             },
@@ -1590,20 +2431,25 @@
                             "additionalProperties": false
                           },
                           "initialDelaySeconds": {
+                            "description": "Number of seconds after the container has started before liveness probes are initiated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
                             "format": "int32",
                             "type": "integer"
                           },
                           "periodSeconds": {
+                            "description": "How often (in seconds) to perform the probe.\nDefault to 10 seconds. Minimum value is 1.",
                             "format": "int32",
                             "type": "integer"
                           },
                           "successThreshold": {
+                            "description": "Minimum consecutive successes for the probe to be considered successful after having failed.\nDefaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
                             "format": "int32",
                             "type": "integer"
                           },
                           "tcpSocket": {
+                            "description": "TCPSocket specifies a connection to a TCP port.",
                             "properties": {
                               "host": {
+                                "description": "Optional: Host name to connect to, defaults to the pod IP.",
                                 "type": "string"
                               },
                               "port": {
@@ -1615,6 +2461,7 @@
                                     "type": "string"
                                   }
                                 ],
+                                "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
                                 "x-kubernetes-int-or-string": true
                               }
                             },
@@ -1624,7 +2471,13 @@
                             "type": "object",
                             "additionalProperties": false
                           },
+                          "terminationGracePeriodSeconds": {
+                            "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure.\nThe grace period is the duration in seconds after the processes running in the pod are sent\na termination signal and the time when the processes are forcibly halted with a kill signal.\nSet this value longer than the expected cleanup time for your process.\nIf this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this\nvalue overrides the value provided by the pod spec.\nValue must be non-negative integer. The value zero indicates stop immediately via\nthe kill signal (no opportunity to shut down).\nThis is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.\nMinimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+                            "format": "int64",
+                            "type": "integer"
+                          },
                           "timeoutSeconds": {
+                            "description": "Number of seconds after which the probe times out.\nDefaults to 1 second. Minimum value is 1.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
                             "format": "int32",
                             "type": "integer"
                           }
@@ -1633,27 +2486,36 @@
                         "additionalProperties": false
                       },
                       "stdin": {
+                        "description": "Whether this container should allocate a buffer for stdin in the container runtime. If this\nis not set, reads from stdin in the container will always result in EOF.\nDefault is false.",
                         "type": "boolean"
                       },
                       "stdinOnce": {
+                        "description": "Whether the container runtime should close the stdin channel after it has been opened by\na single attach. When stdin is true the stdin stream will remain open across multiple attach\nsessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the\nfirst client attaches to stdin, and then remains open and accepts data until the client disconnects,\nat which time stdin is closed and remains closed until the container is restarted. If this\nflag is false, a container processes that reads from stdin will never receive an EOF.\nDefault is false",
                         "type": "boolean"
                       },
                       "terminationMessagePath": {
+                        "description": "Optional: Path at which the file to which the container's termination message\nwill be written is mounted into the container's filesystem.\nMessage written is intended to be brief final status, such as an assertion failure message.\nWill be truncated by the node if greater than 4096 bytes. The total message length across\nall containers will be limited to 12kb.\nDefaults to /dev/termination-log.\nCannot be updated.",
                         "type": "string"
                       },
                       "terminationMessagePolicy": {
+                        "description": "Indicate how the termination message should be populated. File will use the contents of\nterminationMessagePath to populate the container status message on both success and failure.\nFallbackToLogsOnError will use the last chunk of container log output if the termination\nmessage file is empty and the container exited with an error.\nThe log output is limited to 2048 bytes or 80 lines, whichever is smaller.\nDefaults to File.\nCannot be updated.",
                         "type": "string"
                       },
                       "tty": {
+                        "description": "Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.\nDefault is false.",
                         "type": "boolean"
                       },
                       "volumeDevices": {
+                        "description": "volumeDevices is the list of block devices to be used by the container.",
                         "items": {
+                          "description": "volumeDevice describes a mapping of a raw block device within a container.",
                           "properties": {
                             "devicePath": {
+                              "description": "devicePath is the path inside of the container that the device will be mapped to.",
                               "type": "string"
                             },
                             "name": {
+                              "description": "name must match the name of a persistentVolumeClaim in the pod",
                               "type": "string"
                             }
                           },
@@ -1664,27 +2526,43 @@
                           "type": "object",
                           "additionalProperties": false
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-map-keys": [
+                          "devicePath"
+                        ],
+                        "x-kubernetes-list-type": "map"
                       },
                       "volumeMounts": {
+                        "description": "Pod volumes to mount into the container's filesystem.\nCannot be updated.",
                         "items": {
+                          "description": "VolumeMount describes a mounting of a Volume within a container.",
                           "properties": {
                             "mountPath": {
+                              "description": "Path within the container at which the volume should be mounted.  Must\nnot contain ':'.",
                               "type": "string"
                             },
                             "mountPropagation": {
+                              "description": "mountPropagation determines how mounts are propagated from the host\nto container and the other way around.\nWhen not set, MountPropagationNone is used.\nThis field is beta in 1.10.\nWhen RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified\n(which defaults to None).",
                               "type": "string"
                             },
                             "name": {
+                              "description": "This must match the Name of a Volume.",
                               "type": "string"
                             },
                             "readOnly": {
+                              "description": "Mounted read-only if true, read-write otherwise (false or unspecified).\nDefaults to false.",
                               "type": "boolean"
                             },
+                            "recursiveReadOnly": {
+                              "description": "RecursiveReadOnly specifies whether read-only mounts should be handled\nrecursively.\n\nIf ReadOnly is false, this field has no meaning and must be unspecified.\n\nIf ReadOnly is true, and this field is set to Disabled, the mount is not made\nrecursively read-only.  If this field is set to IfPossible, the mount is made\nrecursively read-only, if it is supported by the container runtime.  If this\nfield is set to Enabled, the mount is made recursively read-only if it is\nsupported by the container runtime, otherwise the pod will not be started and\nan error will be generated to indicate the reason.\n\nIf this field is set to IfPossible or Enabled, MountPropagation must be set to\nNone (or be unspecified, which defaults to None).\n\nIf this field is not specified, it is treated as an equivalent of Disabled.",
+                              "type": "string"
+                            },
                             "subPath": {
+                              "description": "Path within the volume from which the container's volume should be mounted.\nDefaults to \"\" (volume's root).",
                               "type": "string"
                             },
                             "subPathExpr": {
+                              "description": "Expanded path within the volume from which the container's volume should be mounted.\nBehaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.\nDefaults to \"\" (volume's root).\nSubPathExpr and SubPath are mutually exclusive.",
                               "type": "string"
                             }
                           },
@@ -1695,9 +2573,14 @@
                           "type": "object",
                           "additionalProperties": false
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-map-keys": [
+                          "mountPath"
+                        ],
+                        "x-kubernetes-list-type": "map"
                       },
                       "workingDir": {
+                        "description": "Container's working directory.\nIf not specified, the container runtime's default will be used, which\nmight be configured in the container image.\nCannot be updated.",
                         "type": "string"
                       }
                     },
@@ -1710,45 +2593,59 @@
                   "type": "array"
                 },
                 "javaOptions": {
+                  "description": "JavaOptions is a string of extra JVM options to pass to the driver. For instance,\nGC settings or other logging.",
                   "type": "string"
                 },
                 "kubernetesMaster": {
+                  "description": "KubernetesMaster is the URL of the Kubernetes master used by the driver to manage executor pods and\nother Kubernetes resources. Default to https://kubernetes.default.svc.",
                   "type": "string"
                 },
                 "labels": {
                   "additionalProperties": {
                     "type": "string"
                   },
+                  "description": "Labels are the Kubernetes labels to be added to the pod.",
                   "type": "object"
                 },
                 "lifecycle": {
+                  "description": "Lifecycle for running preStop or postStart commands",
                   "properties": {
                     "postStart": {
+                      "description": "PostStart is called immediately after a container is created. If the handler fails,\nthe container is terminated and restarted according to its restart policy.\nOther management of the container blocks until the hook completes.\nMore info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks",
                       "properties": {
                         "exec": {
+                          "description": "Exec specifies a command to execute in the container.",
                           "properties": {
                             "command": {
+                              "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
                               "items": {
                                 "type": "string"
                               },
-                              "type": "array"
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
                             }
                           },
                           "type": "object",
                           "additionalProperties": false
                         },
                         "httpGet": {
+                          "description": "HTTPGet specifies an HTTP GET request to perform.",
                           "properties": {
                             "host": {
+                              "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
                               "type": "string"
                             },
                             "httpHeaders": {
+                              "description": "Custom headers to set in the request. HTTP allows repeated headers.",
                               "items": {
+                                "description": "HTTPHeader describes a custom header to be used in HTTP probes",
                                 "properties": {
                                   "name": {
+                                    "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
                                     "type": "string"
                                   },
                                   "value": {
+                                    "description": "The header field value",
                                     "type": "string"
                                   }
                                 },
@@ -1759,9 +2656,11 @@
                                 "type": "object",
                                 "additionalProperties": false
                               },
-                              "type": "array"
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "path": {
+                              "description": "Path to access on the HTTP server.",
                               "type": "string"
                             },
                             "port": {
@@ -1773,9 +2672,11 @@
                                   "type": "string"
                                 }
                               ],
+                              "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
                               "x-kubernetes-int-or-string": true
                             },
                             "scheme": {
+                              "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
                               "type": "string"
                             }
                           },
@@ -1785,9 +2686,26 @@
                           "type": "object",
                           "additionalProperties": false
                         },
+                        "sleep": {
+                          "description": "Sleep represents a duration that the container should sleep.",
+                          "properties": {
+                            "seconds": {
+                              "description": "Seconds is the number of seconds to sleep.",
+                              "format": "int64",
+                              "type": "integer"
+                            }
+                          },
+                          "required": [
+                            "seconds"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
                         "tcpSocket": {
+                          "description": "Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept\nfor backward compatibility. There is no validation of this field and\nlifecycle hooks will fail at runtime when it is specified.",
                           "properties": {
                             "host": {
+                              "description": "Optional: Host name to connect to, defaults to the pod IP.",
                               "type": "string"
                             },
                             "port": {
@@ -1799,6 +2717,7 @@
                                   "type": "string"
                                 }
                               ],
+                              "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
                               "x-kubernetes-int-or-string": true
                             }
                           },
@@ -1813,31 +2732,41 @@
                       "additionalProperties": false
                     },
                     "preStop": {
+                      "description": "PreStop is called immediately before a container is terminated due to an\nAPI request or management event such as liveness/startup probe failure,\npreemption, resource contention, etc. The handler is not called if the\ncontainer crashes or exits. The Pod's termination grace period countdown begins before the\nPreStop hook is executed. Regardless of the outcome of the handler, the\ncontainer will eventually terminate within the Pod's termination grace\nperiod (unless delayed by finalizers). Other management of the container blocks until the hook completes\nor until the termination grace period is reached.\nMore info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks",
                       "properties": {
                         "exec": {
+                          "description": "Exec specifies a command to execute in the container.",
                           "properties": {
                             "command": {
+                              "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
                               "items": {
                                 "type": "string"
                               },
-                              "type": "array"
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
                             }
                           },
                           "type": "object",
                           "additionalProperties": false
                         },
                         "httpGet": {
+                          "description": "HTTPGet specifies an HTTP GET request to perform.",
                           "properties": {
                             "host": {
+                              "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
                               "type": "string"
                             },
                             "httpHeaders": {
+                              "description": "Custom headers to set in the request. HTTP allows repeated headers.",
                               "items": {
+                                "description": "HTTPHeader describes a custom header to be used in HTTP probes",
                                 "properties": {
                                   "name": {
+                                    "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
                                     "type": "string"
                                   },
                                   "value": {
+                                    "description": "The header field value",
                                     "type": "string"
                                   }
                                 },
@@ -1848,9 +2777,11 @@
                                 "type": "object",
                                 "additionalProperties": false
                               },
-                              "type": "array"
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "path": {
+                              "description": "Path to access on the HTTP server.",
                               "type": "string"
                             },
                             "port": {
@@ -1862,9 +2793,11 @@
                                   "type": "string"
                                 }
                               ],
+                              "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
                               "x-kubernetes-int-or-string": true
                             },
                             "scheme": {
+                              "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
                               "type": "string"
                             }
                           },
@@ -1874,9 +2807,26 @@
                           "type": "object",
                           "additionalProperties": false
                         },
+                        "sleep": {
+                          "description": "Sleep represents a duration that the container should sleep.",
+                          "properties": {
+                            "seconds": {
+                              "description": "Seconds is the number of seconds to sleep.",
+                              "format": "int64",
+                              "type": "integer"
+                            }
+                          },
+                          "required": [
+                            "seconds"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
                         "tcpSocket": {
+                          "description": "Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept\nfor backward compatibility. There is no validation of this field and\nlifecycle hooks will fail at runtime when it is specified.",
                           "properties": {
                             "host": {
+                              "description": "Optional: Host name to connect to, defaults to the pod IP.",
                               "type": "string"
                             },
                             "port": {
@@ -1888,6 +2838,7 @@
                                   "type": "string"
                                 }
                               ],
+                              "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
                               "x-kubernetes-int-or-string": true
                             }
                           },
@@ -1906,70 +2857,138 @@
                   "additionalProperties": false
                 },
                 "memory": {
+                  "description": "Memory is the amount of memory to request for the pod.",
                   "type": "string"
                 },
                 "memoryOverhead": {
+                  "description": "MemoryOverhead is the amount of off-heap memory to allocate in cluster mode, in MiB unless otherwise specified.",
                   "type": "string"
                 },
                 "nodeSelector": {
                   "additionalProperties": {
                     "type": "string"
                   },
+                  "description": "NodeSelector is the Kubernetes node selector to be added to the driver and executor pods.\nThis field is mutually exclusive with nodeSelector at SparkApplication level (which will be deprecated).",
                   "type": "object"
                 },
                 "podName": {
+                  "description": "PodName is the name of the driver pod that the user creates. This is used for the\nin-cluster client mode in which the user creates a client pod where the driver of\nthe user application runs. It's an error to set this field if Mode is not\nin-cluster-client.",
                   "pattern": "[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*",
                   "type": "string"
                 },
                 "podSecurityContext": {
+                  "description": "PodSecurityContext specifies the PodSecurityContext to apply.",
                   "properties": {
+                    "appArmorProfile": {
+                      "description": "appArmorProfile is the AppArmor options to use by the containers in this pod.\nNote that this field cannot be set when spec.os.name is windows.",
+                      "properties": {
+                        "localhostProfile": {
+                          "description": "localhostProfile indicates a profile loaded on the node that should be used.\nThe profile must be preconfigured on the node to work.\nMust match the loaded name of the profile.\nMust be set if and only if type is \"Localhost\".",
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "type indicates which kind of AppArmor profile will be applied.\nValid options are:\n  Localhost - a profile pre-loaded on the node.\n  RuntimeDefault - the container runtime's default profile.\n  Unconfined - no AppArmor enforcement.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "type"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
                     "fsGroup": {
+                      "description": "A special supplemental group that applies to all containers in a pod.\nSome volume types allow the Kubelet to change the ownership of that volume\nto be owned by the pod:\n\n1. The owning GID will be the FSGroup\n2. The setgid bit is set (new files created in the volume will be owned by FSGroup)\n3. The permission bits are OR'd with rw-rw----\n\nIf unset, the Kubelet will not modify the ownership and permissions of any volume.\nNote that this field cannot be set when spec.os.name is windows.",
                       "format": "int64",
                       "type": "integer"
                     },
+                    "fsGroupChangePolicy": {
+                      "description": "fsGroupChangePolicy defines behavior of changing ownership and permission of the volume\nbefore being exposed inside Pod. This field will only apply to\nvolume types which support fsGroup based ownership(and permissions).\nIt will have no effect on ephemeral volume types such as: secret, configmaps\nand emptydir.\nValid values are \"OnRootMismatch\" and \"Always\". If not specified, \"Always\" is used.\nNote that this field cannot be set when spec.os.name is windows.",
+                      "type": "string"
+                    },
                     "runAsGroup": {
+                      "description": "The GID to run the entrypoint of the container process.\nUses runtime default if unset.\nMay also be set in SecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence\nfor that container.\nNote that this field cannot be set when spec.os.name is windows.",
                       "format": "int64",
                       "type": "integer"
                     },
                     "runAsNonRoot": {
+                      "description": "Indicates that the container must run as a non-root user.\nIf true, the Kubelet will validate the image at runtime to ensure that it\ndoes not run as UID 0 (root) and fail to start the container if it does.\nIf unset or false, no such validation will be performed.\nMay also be set in SecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
                       "type": "boolean"
                     },
                     "runAsUser": {
+                      "description": "The UID to run the entrypoint of the container process.\nDefaults to user specified in image metadata if unspecified.\nMay also be set in SecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence\nfor that container.\nNote that this field cannot be set when spec.os.name is windows.",
                       "format": "int64",
                       "type": "integer"
                     },
+                    "seLinuxChangePolicy": {
+                      "description": "seLinuxChangePolicy defines how the container's SELinux label is applied to all volumes used by the Pod.\nIt has no effect on nodes that do not support SELinux or to volumes does not support SELinux.\nValid values are \"MountOption\" and \"Recursive\".\n\n\"Recursive\" means relabeling of all files on all Pod volumes by the container runtime.\nThis may be slow for large volumes, but allows mixing privileged and unprivileged Pods sharing the same volume on the same node.\n\n\"MountOption\" mounts all eligible Pod volumes with `-o context` mount option.\nThis requires all Pods that share the same volume to use the same SELinux label.\nIt is not possible to share the same volume among privileged and unprivileged Pods.\nEligible volumes are in-tree FibreChannel and iSCSI volumes, and all CSI volumes\nwhose CSI driver announces SELinux support by setting spec.seLinuxMount: true in their\nCSIDriver instance. Other volumes are always re-labelled recursively.\n\"MountOption\" value is allowed only when SELinuxMount feature gate is enabled.\n\nIf not specified and SELinuxMount feature gate is enabled, \"MountOption\" is used.\nIf not specified and SELinuxMount feature gate is disabled, \"MountOption\" is used for ReadWriteOncePod volumes\nand \"Recursive\" for all other volumes.\n\nThis field affects only Pods that have SELinux label set, either in PodSecurityContext or in SecurityContext of all containers.\n\nAll Pods that use the same volume should use the same seLinuxChangePolicy, otherwise some pods can get stuck in ContainerCreating state.\nNote that this field cannot be set when spec.os.name is windows.",
+                      "type": "string"
+                    },
                     "seLinuxOptions": {
+                      "description": "The SELinux context to be applied to all containers.\nIf unspecified, the container runtime will allocate a random SELinux context for each\ncontainer.  May also be set in SecurityContext.  If set in\nboth SecurityContext and PodSecurityContext, the value specified in SecurityContext\ntakes precedence for that container.\nNote that this field cannot be set when spec.os.name is windows.",
                       "properties": {
                         "level": {
+                          "description": "Level is SELinux level label that applies to the container.",
                           "type": "string"
                         },
                         "role": {
+                          "description": "Role is a SELinux role label that applies to the container.",
                           "type": "string"
                         },
                         "type": {
+                          "description": "Type is a SELinux type label that applies to the container.",
                           "type": "string"
                         },
                         "user": {
+                          "description": "User is a SELinux user label that applies to the container.",
                           "type": "string"
                         }
                       },
                       "type": "object",
                       "additionalProperties": false
                     },
+                    "seccompProfile": {
+                      "description": "The seccomp options to use by the containers in this pod.\nNote that this field cannot be set when spec.os.name is windows.",
+                      "properties": {
+                        "localhostProfile": {
+                          "description": "localhostProfile indicates a profile defined in a file on the node should be used.\nThe profile must be preconfigured on the node to work.\nMust be a descending path, relative to the kubelet's configured seccomp profile location.\nMust be set if type is \"Localhost\". Must NOT be set for any other type.",
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "type"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
                     "supplementalGroups": {
+                      "description": "A list of groups applied to the first process run in each container, in\naddition to the container's primary GID and fsGroup (if specified).  If\nthe SupplementalGroupsPolicy feature is enabled, the\nsupplementalGroupsPolicy field determines whether these are in addition\nto or instead of any group memberships defined in the container image.\nIf unspecified, no additional groups are added, though group memberships\ndefined in the container image may still be used, depending on the\nsupplementalGroupsPolicy field.\nNote that this field cannot be set when spec.os.name is windows.",
                       "items": {
                         "format": "int64",
                         "type": "integer"
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
+                    },
+                    "supplementalGroupsPolicy": {
+                      "description": "Defines how supplemental groups of the first container processes are calculated.\nValid values are \"Merge\" and \"Strict\". If not specified, \"Merge\" is used.\n(Alpha) Using the field requires the SupplementalGroupsPolicy feature gate to be enabled\nand the container runtime must implement support for this feature.\nNote that this field cannot be set when spec.os.name is windows.",
+                      "type": "string"
                     },
                     "sysctls": {
+                      "description": "Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported\nsysctls (by the container runtime) might fail to launch.\nNote that this field cannot be set when spec.os.name is windows.",
                       "items": {
+                        "description": "Sysctl defines a kernel parameter to be set",
                         "properties": {
                           "name": {
+                            "description": "Name of a property to set",
                             "type": "string"
                           },
                           "value": {
+                            "description": "Value of a property to set",
                             "type": "string"
                           }
                         },
@@ -1980,17 +2999,26 @@
                         "type": "object",
                         "additionalProperties": false
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     },
                     "windowsOptions": {
+                      "description": "The Windows specific settings applied to all containers.\nIf unspecified, the options within a container's SecurityContext will be used.\nIf set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is linux.",
                       "properties": {
                         "gmsaCredentialSpec": {
+                          "description": "GMSACredentialSpec is where the GMSA admission webhook\n(https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the\nGMSA credential spec named by the GMSACredentialSpecName field.",
                           "type": "string"
                         },
                         "gmsaCredentialSpecName": {
+                          "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
                           "type": "string"
                         },
+                        "hostProcess": {
+                          "description": "HostProcess determines if a container should be run as a 'Host Process' container.\nAll of a Pod's containers must have the same effective HostProcess value\n(it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).\nIn addition, if HostProcess is true then HostNetwork must also be set to true.",
+                          "type": "boolean"
+                        },
                         "runAsUserName": {
+                          "description": "The UserName in Windows to run the entrypoint of the container process.\nDefaults to the user specified in image metadata if unspecified.\nMay also be set in PodSecurityContext. If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
                           "type": "string"
                         }
                       },
@@ -2001,11 +3029,44 @@
                   "type": "object",
                   "additionalProperties": false
                 },
+                "ports": {
+                  "description": "Ports settings for the pods, following the Kubernetes specifications.",
+                  "items": {
+                    "description": "Port represents the port definition in the pods objects.",
+                    "properties": {
+                      "containerPort": {
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "protocol": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "containerPort",
+                      "name",
+                      "protocol"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "priorityClassName": {
+                  "description": "PriorityClassName is the name of the PriorityClass for the driver pod.",
+                  "type": "string"
+                },
                 "schedulerName": {
+                  "description": "SchedulerName specifies the scheduler that will be used for scheduling",
                   "type": "string"
                 },
                 "secrets": {
+                  "description": "Secrets carries information of secrets to add to the pod.",
                   "items": {
+                    "description": "SecretInfo captures information of a secret.",
                     "properties": {
                       "name": {
                         "type": "string"
@@ -2014,6 +3075,7 @@
                         "type": "string"
                       },
                       "secretType": {
+                        "description": "SecretType tells the type of a secret.",
                         "type": "string"
                       }
                     },
@@ -2028,75 +3090,139 @@
                   "type": "array"
                 },
                 "securityContext": {
+                  "description": "SecurityContext specifies the container's SecurityContext to apply.",
                   "properties": {
                     "allowPrivilegeEscalation": {
+                      "description": "AllowPrivilegeEscalation controls whether a process can gain more\nprivileges than its parent process. This bool directly controls if\nthe no_new_privs flag will be set on the container process.\nAllowPrivilegeEscalation is true always when the container is:\n1) run as Privileged\n2) has CAP_SYS_ADMIN\nNote that this field cannot be set when spec.os.name is windows.",
                       "type": "boolean"
                     },
+                    "appArmorProfile": {
+                      "description": "appArmorProfile is the AppArmor options to use by this container. If set, this profile\noverrides the pod's appArmorProfile.\nNote that this field cannot be set when spec.os.name is windows.",
+                      "properties": {
+                        "localhostProfile": {
+                          "description": "localhostProfile indicates a profile loaded on the node that should be used.\nThe profile must be preconfigured on the node to work.\nMust match the loaded name of the profile.\nMust be set if and only if type is \"Localhost\".",
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "type indicates which kind of AppArmor profile will be applied.\nValid options are:\n  Localhost - a profile pre-loaded on the node.\n  RuntimeDefault - the container runtime's default profile.\n  Unconfined - no AppArmor enforcement.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "type"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
                     "capabilities": {
+                      "description": "The capabilities to add/drop when running containers.\nDefaults to the default set of capabilities granted by the container runtime.\nNote that this field cannot be set when spec.os.name is windows.",
                       "properties": {
                         "add": {
+                          "description": "Added capabilities",
                           "items": {
+                            "description": "Capability represent POSIX capabilities type",
                             "type": "string"
                           },
-                          "type": "array"
+                          "type": "array",
+                          "x-kubernetes-list-type": "atomic"
                         },
                         "drop": {
+                          "description": "Removed capabilities",
                           "items": {
+                            "description": "Capability represent POSIX capabilities type",
                             "type": "string"
                           },
-                          "type": "array"
+                          "type": "array",
+                          "x-kubernetes-list-type": "atomic"
                         }
                       },
                       "type": "object",
                       "additionalProperties": false
                     },
                     "privileged": {
+                      "description": "Run container in privileged mode.\nProcesses in privileged containers are essentially equivalent to root on the host.\nDefaults to false.\nNote that this field cannot be set when spec.os.name is windows.",
                       "type": "boolean"
                     },
                     "procMount": {
+                      "description": "procMount denotes the type of proc mount to use for the containers.\nThe default value is Default which uses the container runtime defaults for\nreadonly paths and masked paths.\nThis requires the ProcMountType feature flag to be enabled.\nNote that this field cannot be set when spec.os.name is windows.",
                       "type": "string"
                     },
                     "readOnlyRootFilesystem": {
+                      "description": "Whether this container has a read-only root filesystem.\nDefault is false.\nNote that this field cannot be set when spec.os.name is windows.",
                       "type": "boolean"
                     },
                     "runAsGroup": {
+                      "description": "The GID to run the entrypoint of the container process.\nUses runtime default if unset.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
                       "format": "int64",
                       "type": "integer"
                     },
                     "runAsNonRoot": {
+                      "description": "Indicates that the container must run as a non-root user.\nIf true, the Kubelet will validate the image at runtime to ensure that it\ndoes not run as UID 0 (root) and fail to start the container if it does.\nIf unset or false, no such validation will be performed.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
                       "type": "boolean"
                     },
                     "runAsUser": {
+                      "description": "The UID to run the entrypoint of the container process.\nDefaults to user specified in image metadata if unspecified.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
                       "format": "int64",
                       "type": "integer"
                     },
                     "seLinuxOptions": {
+                      "description": "The SELinux context to be applied to the container.\nIf unspecified, the container runtime will allocate a random SELinux context for each\ncontainer.  May also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
                       "properties": {
                         "level": {
+                          "description": "Level is SELinux level label that applies to the container.",
                           "type": "string"
                         },
                         "role": {
+                          "description": "Role is a SELinux role label that applies to the container.",
                           "type": "string"
                         },
                         "type": {
+                          "description": "Type is a SELinux type label that applies to the container.",
                           "type": "string"
                         },
                         "user": {
+                          "description": "User is a SELinux user label that applies to the container.",
                           "type": "string"
                         }
                       },
                       "type": "object",
                       "additionalProperties": false
                     },
+                    "seccompProfile": {
+                      "description": "The seccomp options to use by this container. If seccomp options are\nprovided at both the pod & container level, the container options\noverride the pod options.\nNote that this field cannot be set when spec.os.name is windows.",
+                      "properties": {
+                        "localhostProfile": {
+                          "description": "localhostProfile indicates a profile defined in a file on the node should be used.\nThe profile must be preconfigured on the node to work.\nMust be a descending path, relative to the kubelet's configured seccomp profile location.\nMust be set if type is \"Localhost\". Must NOT be set for any other type.",
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "type"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
                     "windowsOptions": {
+                      "description": "The Windows specific settings applied to all containers.\nIf unspecified, the options from the PodSecurityContext will be used.\nIf set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is linux.",
                       "properties": {
                         "gmsaCredentialSpec": {
+                          "description": "GMSACredentialSpec is where the GMSA admission webhook\n(https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the\nGMSA credential spec named by the GMSACredentialSpecName field.",
                           "type": "string"
                         },
                         "gmsaCredentialSpecName": {
+                          "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
                           "type": "string"
                         },
+                        "hostProcess": {
+                          "description": "HostProcess determines if a container should be run as a 'Host Process' container.\nAll of a Pod's containers must have the same effective HostProcess value\n(it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).\nIn addition, if HostProcess is true then HostNetwork must also be set to true.",
+                          "type": "boolean"
+                        },
                         "runAsUserName": {
+                          "description": "The UserName in Windows to run the entrypoint of the container process.\nDefaults to the user specified in image metadata if unspecified.\nMay also be set in PodSecurityContext. If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
                           "type": "string"
                         }
                       },
@@ -2108,52 +3234,78 @@
                   "additionalProperties": false
                 },
                 "serviceAccount": {
+                  "description": "ServiceAccount is the name of the custom Kubernetes service account used by the pod.",
                   "type": "string"
                 },
                 "serviceAnnotations": {
                   "additionalProperties": {
                     "type": "string"
                   },
+                  "description": "ServiceAnnotations defines the annotations to be added to the Kubernetes headless service used by\nexecutors to connect to the driver.",
+                  "type": "object"
+                },
+                "serviceLabels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "ServiceLabels defines the labels to be added to the Kubernetes headless service used by\nexecutors to connect to the driver.",
                   "type": "object"
                 },
                 "shareProcessNamespace": {
+                  "description": "ShareProcessNamespace settings for the pod, following the Kubernetes specifications.",
                   "type": "boolean"
                 },
                 "sidecars": {
+                  "description": "Sidecars is a list of sidecar containers that run along side the main Spark container.",
                   "items": {
+                    "description": "A single application container that you want to run within a pod.",
                     "properties": {
                       "args": {
+                        "description": "Arguments to the entrypoint.\nThe container image's CMD is used if this is not provided.\nVariable references $(VAR_NAME) are expanded using the container's environment. If a variable\ncannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will\nproduce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless\nof whether the variable exists or not. Cannot be updated.\nMore info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
                         "items": {
                           "type": "string"
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "command": {
+                        "description": "Entrypoint array. Not executed within a shell.\nThe container image's ENTRYPOINT is used if this is not provided.\nVariable references $(VAR_NAME) are expanded using the container's environment. If a variable\ncannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will\nproduce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless\nof whether the variable exists or not. Cannot be updated.\nMore info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
                         "items": {
                           "type": "string"
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "env": {
+                        "description": "List of environment variables to set in the container.\nCannot be updated.",
                         "items": {
+                          "description": "EnvVar represents an environment variable present in a Container.",
                           "properties": {
                             "name": {
+                              "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
                               "type": "string"
                             },
                             "value": {
+                              "description": "Variable references $(VAR_NAME) are expanded\nusing the previously defined environment variables in the container and\nany service environment variables. If a variable cannot be resolved,\nthe reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.\n\"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\".\nEscaped references will never be expanded, regardless of whether the variable\nexists or not.\nDefaults to \"\".",
                               "type": "string"
                             },
                             "valueFrom": {
+                              "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
                               "properties": {
                                 "configMapKeyRef": {
+                                  "description": "Selects a key of a ConfigMap.",
                                   "properties": {
                                     "key": {
+                                      "description": "The key to select.",
                                       "type": "string"
                                     },
                                     "name": {
+                                      "default": "",
+                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                       "type": "string"
                                     },
                                     "optional": {
+                                      "description": "Specify whether the ConfigMap or its key must be defined",
                                       "type": "boolean"
                                     }
                                   },
@@ -2161,14 +3313,18 @@
                                     "key"
                                   ],
                                   "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
                                   "additionalProperties": false
                                 },
                                 "fieldRef": {
+                                  "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,\nspec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
                                   "properties": {
                                     "apiVersion": {
+                                      "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
                                       "type": "string"
                                     },
                                     "fieldPath": {
+                                      "description": "Path of the field to select in the specified API version.",
                                       "type": "string"
                                     }
                                   },
@@ -2176,11 +3332,14 @@
                                     "fieldPath"
                                   ],
                                   "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
                                   "additionalProperties": false
                                 },
                                 "resourceFieldRef": {
+                                  "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
                                   "properties": {
                                     "containerName": {
+                                      "description": "Container name: required for volumes, optional for env vars",
                                       "type": "string"
                                     },
                                     "divisor": {
@@ -2192,10 +3351,12 @@
                                           "type": "string"
                                         }
                                       ],
+                                      "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
                                       "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                                       "x-kubernetes-int-or-string": true
                                     },
                                     "resource": {
+                                      "description": "Required: resource to select",
                                       "type": "string"
                                     }
                                   },
@@ -2203,17 +3364,23 @@
                                     "resource"
                                   ],
                                   "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
                                   "additionalProperties": false
                                 },
                                 "secretKeyRef": {
+                                  "description": "Selects a key of a secret in the pod's namespace",
                                   "properties": {
                                     "key": {
+                                      "description": "The key of the secret to select from.  Must be a valid secret key.",
                                       "type": "string"
                                     },
                                     "name": {
+                                      "default": "",
+                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                       "type": "string"
                                     },
                                     "optional": {
+                                      "description": "Specify whether the Secret or its key must be defined",
                                       "type": "boolean"
                                     }
                                   },
@@ -2221,6 +3388,7 @@
                                     "key"
                                   ],
                                   "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
                                   "additionalProperties": false
                                 }
                               },
@@ -2234,78 +3402,109 @@
                           "type": "object",
                           "additionalProperties": false
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-map-keys": [
+                          "name"
+                        ],
+                        "x-kubernetes-list-type": "map"
                       },
                       "envFrom": {
+                        "description": "List of sources to populate environment variables in the container.\nThe keys defined within a source must be a C_IDENTIFIER. All invalid keys\nwill be reported as an event when the container is starting. When a key exists in multiple\nsources, the value associated with the last source will take precedence.\nValues defined by an Env with a duplicate key will take precedence.\nCannot be updated.",
                         "items": {
+                          "description": "EnvFromSource represents the source of a set of ConfigMaps",
                           "properties": {
                             "configMapRef": {
+                              "description": "The ConfigMap to select from",
                               "properties": {
                                 "name": {
+                                  "default": "",
+                                  "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                   "type": "string"
                                 },
                                 "optional": {
+                                  "description": "Specify whether the ConfigMap must be defined",
                                   "type": "boolean"
                                 }
                               },
                               "type": "object",
+                              "x-kubernetes-map-type": "atomic",
                               "additionalProperties": false
                             },
                             "prefix": {
+                              "description": "An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.",
                               "type": "string"
                             },
                             "secretRef": {
+                              "description": "The Secret to select from",
                               "properties": {
                                 "name": {
+                                  "default": "",
+                                  "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                   "type": "string"
                                 },
                                 "optional": {
+                                  "description": "Specify whether the Secret must be defined",
                                   "type": "boolean"
                                 }
                               },
                               "type": "object",
+                              "x-kubernetes-map-type": "atomic",
                               "additionalProperties": false
                             }
                           },
                           "type": "object",
                           "additionalProperties": false
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "image": {
+                        "description": "Container image name.\nMore info: https://kubernetes.io/docs/concepts/containers/images\nThis field is optional to allow higher level config management to default or override\ncontainer images in workload controllers like Deployments and StatefulSets.",
                         "type": "string"
                       },
                       "imagePullPolicy": {
+                        "description": "Image pull policy.\nOne of Always, Never, IfNotPresent.\nDefaults to Always if :latest tag is specified, or IfNotPresent otherwise.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/containers/images#updating-images",
                         "type": "string"
                       },
                       "lifecycle": {
+                        "description": "Actions that the management system should take in response to container lifecycle events.\nCannot be updated.",
                         "properties": {
                           "postStart": {
+                            "description": "PostStart is called immediately after a container is created. If the handler fails,\nthe container is terminated and restarted according to its restart policy.\nOther management of the container blocks until the hook completes.\nMore info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks",
                             "properties": {
                               "exec": {
+                                "description": "Exec specifies a command to execute in the container.",
                                 "properties": {
                                   "command": {
+                                    "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
                                     "items": {
                                       "type": "string"
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   }
                                 },
                                 "type": "object",
                                 "additionalProperties": false
                               },
                               "httpGet": {
+                                "description": "HTTPGet specifies an HTTP GET request to perform.",
                                 "properties": {
                                   "host": {
+                                    "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
                                     "type": "string"
                                   },
                                   "httpHeaders": {
+                                    "description": "Custom headers to set in the request. HTTP allows repeated headers.",
                                     "items": {
+                                      "description": "HTTPHeader describes a custom header to be used in HTTP probes",
                                       "properties": {
                                         "name": {
+                                          "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
                                           "type": "string"
                                         },
                                         "value": {
+                                          "description": "The header field value",
                                           "type": "string"
                                         }
                                       },
@@ -2316,9 +3515,11 @@
                                       "type": "object",
                                       "additionalProperties": false
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "path": {
+                                    "description": "Path to access on the HTTP server.",
                                     "type": "string"
                                   },
                                   "port": {
@@ -2330,9 +3531,11 @@
                                         "type": "string"
                                       }
                                     ],
+                                    "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
                                     "x-kubernetes-int-or-string": true
                                   },
                                   "scheme": {
+                                    "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
                                     "type": "string"
                                   }
                                 },
@@ -2342,9 +3545,26 @@
                                 "type": "object",
                                 "additionalProperties": false
                               },
+                              "sleep": {
+                                "description": "Sleep represents a duration that the container should sleep.",
+                                "properties": {
+                                  "seconds": {
+                                    "description": "Seconds is the number of seconds to sleep.",
+                                    "format": "int64",
+                                    "type": "integer"
+                                  }
+                                },
+                                "required": [
+                                  "seconds"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
                               "tcpSocket": {
+                                "description": "Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept\nfor backward compatibility. There is no validation of this field and\nlifecycle hooks will fail at runtime when it is specified.",
                                 "properties": {
                                   "host": {
+                                    "description": "Optional: Host name to connect to, defaults to the pod IP.",
                                     "type": "string"
                                   },
                                   "port": {
@@ -2356,6 +3576,7 @@
                                         "type": "string"
                                       }
                                     ],
+                                    "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
                                     "x-kubernetes-int-or-string": true
                                   }
                                 },
@@ -2370,31 +3591,41 @@
                             "additionalProperties": false
                           },
                           "preStop": {
+                            "description": "PreStop is called immediately before a container is terminated due to an\nAPI request or management event such as liveness/startup probe failure,\npreemption, resource contention, etc. The handler is not called if the\ncontainer crashes or exits. The Pod's termination grace period countdown begins before the\nPreStop hook is executed. Regardless of the outcome of the handler, the\ncontainer will eventually terminate within the Pod's termination grace\nperiod (unless delayed by finalizers). Other management of the container blocks until the hook completes\nor until the termination grace period is reached.\nMore info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks",
                             "properties": {
                               "exec": {
+                                "description": "Exec specifies a command to execute in the container.",
                                 "properties": {
                                   "command": {
+                                    "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
                                     "items": {
                                       "type": "string"
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   }
                                 },
                                 "type": "object",
                                 "additionalProperties": false
                               },
                               "httpGet": {
+                                "description": "HTTPGet specifies an HTTP GET request to perform.",
                                 "properties": {
                                   "host": {
+                                    "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
                                     "type": "string"
                                   },
                                   "httpHeaders": {
+                                    "description": "Custom headers to set in the request. HTTP allows repeated headers.",
                                     "items": {
+                                      "description": "HTTPHeader describes a custom header to be used in HTTP probes",
                                       "properties": {
                                         "name": {
+                                          "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
                                           "type": "string"
                                         },
                                         "value": {
+                                          "description": "The header field value",
                                           "type": "string"
                                         }
                                       },
@@ -2405,9 +3636,11 @@
                                       "type": "object",
                                       "additionalProperties": false
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "path": {
+                                    "description": "Path to access on the HTTP server.",
                                     "type": "string"
                                   },
                                   "port": {
@@ -2419,9 +3652,11 @@
                                         "type": "string"
                                       }
                                     ],
+                                    "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
                                     "x-kubernetes-int-or-string": true
                                   },
                                   "scheme": {
+                                    "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
                                     "type": "string"
                                   }
                                 },
@@ -2431,9 +3666,26 @@
                                 "type": "object",
                                 "additionalProperties": false
                               },
+                              "sleep": {
+                                "description": "Sleep represents a duration that the container should sleep.",
+                                "properties": {
+                                  "seconds": {
+                                    "description": "Seconds is the number of seconds to sleep.",
+                                    "format": "int64",
+                                    "type": "integer"
+                                  }
+                                },
+                                "required": [
+                                  "seconds"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
                               "tcpSocket": {
+                                "description": "Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept\nfor backward compatibility. There is no validation of this field and\nlifecycle hooks will fail at runtime when it is specified.",
                                 "properties": {
                                   "host": {
+                                    "description": "Optional: Host name to connect to, defaults to the pod IP.",
                                     "type": "string"
                                   },
                                   "port": {
@@ -2445,6 +3697,7 @@
                                         "type": "string"
                                       }
                                     ],
+                                    "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
                                     "x-kubernetes-int-or-string": true
                                   }
                                 },
@@ -2463,35 +3716,66 @@
                         "additionalProperties": false
                       },
                       "livenessProbe": {
+                        "description": "Periodic probe of container liveness.\nContainer will be restarted if the probe fails.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
                         "properties": {
                           "exec": {
+                            "description": "Exec specifies a command to execute in the container.",
                             "properties": {
                               "command": {
+                                "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
                                 "items": {
                                   "type": "string"
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               }
                             },
                             "type": "object",
                             "additionalProperties": false
                           },
                           "failureThreshold": {
+                            "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded.\nDefaults to 3. Minimum value is 1.",
                             "format": "int32",
                             "type": "integer"
                           },
+                          "grpc": {
+                            "description": "GRPC specifies a GRPC HealthCheckRequest.",
+                            "properties": {
+                              "port": {
+                                "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "service": {
+                                "default": "",
+                                "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
                           "httpGet": {
+                            "description": "HTTPGet specifies an HTTP GET request to perform.",
                             "properties": {
                               "host": {
+                                "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
                                 "type": "string"
                               },
                               "httpHeaders": {
+                                "description": "Custom headers to set in the request. HTTP allows repeated headers.",
                                 "items": {
+                                  "description": "HTTPHeader describes a custom header to be used in HTTP probes",
                                   "properties": {
                                     "name": {
+                                      "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
                                       "type": "string"
                                     },
                                     "value": {
+                                      "description": "The header field value",
                                       "type": "string"
                                     }
                                   },
@@ -2502,9 +3786,11 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "path": {
+                                "description": "Path to access on the HTTP server.",
                                 "type": "string"
                               },
                               "port": {
@@ -2516,9 +3802,11 @@
                                     "type": "string"
                                   }
                                 ],
+                                "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
                                 "x-kubernetes-int-or-string": true
                               },
                               "scheme": {
+                                "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
                                 "type": "string"
                               }
                             },
@@ -2529,20 +3817,25 @@
                             "additionalProperties": false
                           },
                           "initialDelaySeconds": {
+                            "description": "Number of seconds after the container has started before liveness probes are initiated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
                             "format": "int32",
                             "type": "integer"
                           },
                           "periodSeconds": {
+                            "description": "How often (in seconds) to perform the probe.\nDefault to 10 seconds. Minimum value is 1.",
                             "format": "int32",
                             "type": "integer"
                           },
                           "successThreshold": {
+                            "description": "Minimum consecutive successes for the probe to be considered successful after having failed.\nDefaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
                             "format": "int32",
                             "type": "integer"
                           },
                           "tcpSocket": {
+                            "description": "TCPSocket specifies a connection to a TCP port.",
                             "properties": {
                               "host": {
+                                "description": "Optional: Host name to connect to, defaults to the pod IP.",
                                 "type": "string"
                               },
                               "port": {
@@ -2554,6 +3847,7 @@
                                     "type": "string"
                                   }
                                 ],
+                                "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
                                 "x-kubernetes-int-or-string": true
                               }
                             },
@@ -2563,7 +3857,13 @@
                             "type": "object",
                             "additionalProperties": false
                           },
+                          "terminationGracePeriodSeconds": {
+                            "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure.\nThe grace period is the duration in seconds after the processes running in the pod are sent\na termination signal and the time when the processes are forcibly halted with a kill signal.\nSet this value longer than the expected cleanup time for your process.\nIf this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this\nvalue overrides the value provided by the pod spec.\nValue must be non-negative integer. The value zero indicates stop immediately via\nthe kill signal (no opportunity to shut down).\nThis is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.\nMinimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+                            "format": "int64",
+                            "type": "integer"
+                          },
                           "timeoutSeconds": {
+                            "description": "Number of seconds after which the probe times out.\nDefaults to 1 second. Minimum value is 1.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
                             "format": "int32",
                             "type": "integer"
                           }
@@ -2572,32 +3872,40 @@
                         "additionalProperties": false
                       },
                       "name": {
+                        "description": "Name of the container specified as a DNS_LABEL.\nEach container in a pod must have a unique name (DNS_LABEL).\nCannot be updated.",
                         "type": "string"
                       },
                       "ports": {
+                        "description": "List of ports to expose from the container. Not specifying a port here\nDOES NOT prevent that port from being exposed. Any port which is\nlistening on the default \"0.0.0.0\" address inside a container will be\naccessible from the network.\nModifying this array with strategic merge patch may corrupt the data.\nFor more information See https://github.com/kubernetes/kubernetes/issues/108255.\nCannot be updated.",
                         "items": {
+                          "description": "ContainerPort represents a network port in a single container.",
                           "properties": {
                             "containerPort": {
+                              "description": "Number of port to expose on the pod's IP address.\nThis must be a valid port number, 0 < x < 65536.",
                               "format": "int32",
                               "type": "integer"
                             },
                             "hostIP": {
+                              "description": "What host IP to bind the external port to.",
                               "type": "string"
                             },
                             "hostPort": {
+                              "description": "Number of port to expose on the host.\nIf specified, this must be a valid port number, 0 < x < 65536.\nIf HostNetwork is specified, this must match ContainerPort.\nMost containers do not need this.",
                               "format": "int32",
                               "type": "integer"
                             },
                             "name": {
+                              "description": "If specified, this must be an IANA_SVC_NAME and unique within the pod. Each\nnamed port in a pod must have a unique name. Name for the port that can be\nreferred to by services.",
                               "type": "string"
                             },
                             "protocol": {
+                              "default": "TCP",
+                              "description": "Protocol for port. Must be UDP, TCP, or SCTP.\nDefaults to \"TCP\".",
                               "type": "string"
                             }
                           },
                           "required": [
-                            "containerPort",
-                            "protocol"
+                            "containerPort"
                           ],
                           "type": "object",
                           "additionalProperties": false
@@ -2610,35 +3918,66 @@
                         "x-kubernetes-list-type": "map"
                       },
                       "readinessProbe": {
+                        "description": "Periodic probe of container service readiness.\nContainer will be removed from service endpoints if the probe fails.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
                         "properties": {
                           "exec": {
+                            "description": "Exec specifies a command to execute in the container.",
                             "properties": {
                               "command": {
+                                "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
                                 "items": {
                                   "type": "string"
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               }
                             },
                             "type": "object",
                             "additionalProperties": false
                           },
                           "failureThreshold": {
+                            "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded.\nDefaults to 3. Minimum value is 1.",
                             "format": "int32",
                             "type": "integer"
                           },
+                          "grpc": {
+                            "description": "GRPC specifies a GRPC HealthCheckRequest.",
+                            "properties": {
+                              "port": {
+                                "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "service": {
+                                "default": "",
+                                "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
                           "httpGet": {
+                            "description": "HTTPGet specifies an HTTP GET request to perform.",
                             "properties": {
                               "host": {
+                                "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
                                 "type": "string"
                               },
                               "httpHeaders": {
+                                "description": "Custom headers to set in the request. HTTP allows repeated headers.",
                                 "items": {
+                                  "description": "HTTPHeader describes a custom header to be used in HTTP probes",
                                   "properties": {
                                     "name": {
+                                      "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
                                       "type": "string"
                                     },
                                     "value": {
+                                      "description": "The header field value",
                                       "type": "string"
                                     }
                                   },
@@ -2649,9 +3988,11 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "path": {
+                                "description": "Path to access on the HTTP server.",
                                 "type": "string"
                               },
                               "port": {
@@ -2663,9 +4004,11 @@
                                     "type": "string"
                                   }
                                 ],
+                                "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
                                 "x-kubernetes-int-or-string": true
                               },
                               "scheme": {
+                                "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
                                 "type": "string"
                               }
                             },
@@ -2676,20 +4019,25 @@
                             "additionalProperties": false
                           },
                           "initialDelaySeconds": {
+                            "description": "Number of seconds after the container has started before liveness probes are initiated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
                             "format": "int32",
                             "type": "integer"
                           },
                           "periodSeconds": {
+                            "description": "How often (in seconds) to perform the probe.\nDefault to 10 seconds. Minimum value is 1.",
                             "format": "int32",
                             "type": "integer"
                           },
                           "successThreshold": {
+                            "description": "Minimum consecutive successes for the probe to be considered successful after having failed.\nDefaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
                             "format": "int32",
                             "type": "integer"
                           },
                           "tcpSocket": {
+                            "description": "TCPSocket specifies a connection to a TCP port.",
                             "properties": {
                               "host": {
+                                "description": "Optional: Host name to connect to, defaults to the pod IP.",
                                 "type": "string"
                               },
                               "port": {
@@ -2701,6 +4049,7 @@
                                     "type": "string"
                                   }
                                 ],
+                                "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
                                 "x-kubernetes-int-or-string": true
                               }
                             },
@@ -2710,7 +4059,13 @@
                             "type": "object",
                             "additionalProperties": false
                           },
+                          "terminationGracePeriodSeconds": {
+                            "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure.\nThe grace period is the duration in seconds after the processes running in the pod are sent\na termination signal and the time when the processes are forcibly halted with a kill signal.\nSet this value longer than the expected cleanup time for your process.\nIf this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this\nvalue overrides the value provided by the pod spec.\nValue must be non-negative integer. The value zero indicates stop immediately via\nthe kill signal (no opportunity to shut down).\nThis is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.\nMinimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+                            "format": "int64",
+                            "type": "integer"
+                          },
                           "timeoutSeconds": {
+                            "description": "Number of seconds after which the probe times out.\nDefaults to 1 second. Minimum value is 1.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
                             "format": "int32",
                             "type": "integer"
                           }
@@ -2718,8 +4073,59 @@
                         "type": "object",
                         "additionalProperties": false
                       },
+                      "resizePolicy": {
+                        "description": "Resources resize policy for the container.",
+                        "items": {
+                          "description": "ContainerResizePolicy represents resource resize policy for the container.",
+                          "properties": {
+                            "resourceName": {
+                              "description": "Name of the resource to which this resource resize policy applies.\nSupported values: cpu, memory.",
+                              "type": "string"
+                            },
+                            "restartPolicy": {
+                              "description": "Restart policy to apply when specified resource is resized.\nIf not specified, it defaults to NotRequired.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "resourceName",
+                            "restartPolicy"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
+                      },
                       "resources": {
+                        "description": "Compute Resources required by this container.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
                         "properties": {
+                          "claims": {
+                            "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
+                            "items": {
+                              "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                              "properties": {
+                                "name": {
+                                  "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
+                                  "type": "string"
+                                },
+                                "request": {
+                                  "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-map-keys": [
+                              "name"
+                            ],
+                            "x-kubernetes-list-type": "map"
+                          },
                           "limits": {
                             "additionalProperties": {
                               "anyOf": [
@@ -2733,6 +4139,7 @@
                               "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                               "x-kubernetes-int-or-string": true
                             },
+                            "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
                             "type": "object"
                           },
                           "requests": {
@@ -2748,82 +4155,151 @@
                               "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                               "x-kubernetes-int-or-string": true
                             },
+                            "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
                             "type": "object"
                           }
                         },
                         "type": "object",
                         "additionalProperties": false
                       },
+                      "restartPolicy": {
+                        "description": "RestartPolicy defines the restart behavior of individual containers in a pod.\nThis field may only be set for init containers, and the only allowed value is \"Always\".\nFor non-init containers or when this field is not specified,\nthe restart behavior is defined by the Pod's restart policy and the container type.\nSetting the RestartPolicy as \"Always\" for the init container will have the following effect:\nthis init container will be continually restarted on\nexit until all regular containers have terminated. Once all regular\ncontainers have completed, all init containers with restartPolicy \"Always\"\nwill be shut down. This lifecycle differs from normal init containers and\nis often referred to as a \"sidecar\" container. Although this init\ncontainer still starts in the init container sequence, it does not wait\nfor the container to complete before proceeding to the next init\ncontainer. Instead, the next init container starts immediately after this\ninit container is started, or after any startupProbe has successfully\ncompleted.",
+                        "type": "string"
+                      },
                       "securityContext": {
+                        "description": "SecurityContext defines the security options the container should be run with.\nIf set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.\nMore info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/",
                         "properties": {
                           "allowPrivilegeEscalation": {
+                            "description": "AllowPrivilegeEscalation controls whether a process can gain more\nprivileges than its parent process. This bool directly controls if\nthe no_new_privs flag will be set on the container process.\nAllowPrivilegeEscalation is true always when the container is:\n1) run as Privileged\n2) has CAP_SYS_ADMIN\nNote that this field cannot be set when spec.os.name is windows.",
                             "type": "boolean"
                           },
+                          "appArmorProfile": {
+                            "description": "appArmorProfile is the AppArmor options to use by this container. If set, this profile\noverrides the pod's appArmorProfile.\nNote that this field cannot be set when spec.os.name is windows.",
+                            "properties": {
+                              "localhostProfile": {
+                                "description": "localhostProfile indicates a profile loaded on the node that should be used.\nThe profile must be preconfigured on the node to work.\nMust match the loaded name of the profile.\nMust be set if and only if type is \"Localhost\".",
+                                "type": "string"
+                              },
+                              "type": {
+                                "description": "type indicates which kind of AppArmor profile will be applied.\nValid options are:\n  Localhost - a profile pre-loaded on the node.\n  RuntimeDefault - the container runtime's default profile.\n  Unconfined - no AppArmor enforcement.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "type"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
                           "capabilities": {
+                            "description": "The capabilities to add/drop when running containers.\nDefaults to the default set of capabilities granted by the container runtime.\nNote that this field cannot be set when spec.os.name is windows.",
                             "properties": {
                               "add": {
+                                "description": "Added capabilities",
                                 "items": {
+                                  "description": "Capability represent POSIX capabilities type",
                                   "type": "string"
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "drop": {
+                                "description": "Removed capabilities",
                                 "items": {
+                                  "description": "Capability represent POSIX capabilities type",
                                   "type": "string"
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               }
                             },
                             "type": "object",
                             "additionalProperties": false
                           },
                           "privileged": {
+                            "description": "Run container in privileged mode.\nProcesses in privileged containers are essentially equivalent to root on the host.\nDefaults to false.\nNote that this field cannot be set when spec.os.name is windows.",
                             "type": "boolean"
                           },
                           "procMount": {
+                            "description": "procMount denotes the type of proc mount to use for the containers.\nThe default value is Default which uses the container runtime defaults for\nreadonly paths and masked paths.\nThis requires the ProcMountType feature flag to be enabled.\nNote that this field cannot be set when spec.os.name is windows.",
                             "type": "string"
                           },
                           "readOnlyRootFilesystem": {
+                            "description": "Whether this container has a read-only root filesystem.\nDefault is false.\nNote that this field cannot be set when spec.os.name is windows.",
                             "type": "boolean"
                           },
                           "runAsGroup": {
+                            "description": "The GID to run the entrypoint of the container process.\nUses runtime default if unset.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
                             "format": "int64",
                             "type": "integer"
                           },
                           "runAsNonRoot": {
+                            "description": "Indicates that the container must run as a non-root user.\nIf true, the Kubelet will validate the image at runtime to ensure that it\ndoes not run as UID 0 (root) and fail to start the container if it does.\nIf unset or false, no such validation will be performed.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
                             "type": "boolean"
                           },
                           "runAsUser": {
+                            "description": "The UID to run the entrypoint of the container process.\nDefaults to user specified in image metadata if unspecified.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
                             "format": "int64",
                             "type": "integer"
                           },
                           "seLinuxOptions": {
+                            "description": "The SELinux context to be applied to the container.\nIf unspecified, the container runtime will allocate a random SELinux context for each\ncontainer.  May also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
                             "properties": {
                               "level": {
+                                "description": "Level is SELinux level label that applies to the container.",
                                 "type": "string"
                               },
                               "role": {
+                                "description": "Role is a SELinux role label that applies to the container.",
                                 "type": "string"
                               },
                               "type": {
+                                "description": "Type is a SELinux type label that applies to the container.",
                                 "type": "string"
                               },
                               "user": {
+                                "description": "User is a SELinux user label that applies to the container.",
                                 "type": "string"
                               }
                             },
                             "type": "object",
                             "additionalProperties": false
                           },
+                          "seccompProfile": {
+                            "description": "The seccomp options to use by this container. If seccomp options are\nprovided at both the pod & container level, the container options\noverride the pod options.\nNote that this field cannot be set when spec.os.name is windows.",
+                            "properties": {
+                              "localhostProfile": {
+                                "description": "localhostProfile indicates a profile defined in a file on the node should be used.\nThe profile must be preconfigured on the node to work.\nMust be a descending path, relative to the kubelet's configured seccomp profile location.\nMust be set if type is \"Localhost\". Must NOT be set for any other type.",
+                                "type": "string"
+                              },
+                              "type": {
+                                "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "type"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
                           "windowsOptions": {
+                            "description": "The Windows specific settings applied to all containers.\nIf unspecified, the options from the PodSecurityContext will be used.\nIf set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is linux.",
                             "properties": {
                               "gmsaCredentialSpec": {
+                                "description": "GMSACredentialSpec is where the GMSA admission webhook\n(https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the\nGMSA credential spec named by the GMSACredentialSpecName field.",
                                 "type": "string"
                               },
                               "gmsaCredentialSpecName": {
+                                "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
                                 "type": "string"
                               },
+                              "hostProcess": {
+                                "description": "HostProcess determines if a container should be run as a 'Host Process' container.\nAll of a Pod's containers must have the same effective HostProcess value\n(it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).\nIn addition, if HostProcess is true then HostNetwork must also be set to true.",
+                                "type": "boolean"
+                              },
                               "runAsUserName": {
+                                "description": "The UserName in Windows to run the entrypoint of the container process.\nDefaults to the user specified in image metadata if unspecified.\nMay also be set in PodSecurityContext. If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
                                 "type": "string"
                               }
                             },
@@ -2835,35 +4311,66 @@
                         "additionalProperties": false
                       },
                       "startupProbe": {
+                        "description": "StartupProbe indicates that the Pod has successfully initialized.\nIf specified, no other probes are executed until this completes successfully.\nIf this probe fails, the Pod will be restarted, just as if the livenessProbe failed.\nThis can be used to provide different probe parameters at the beginning of a Pod's lifecycle,\nwhen it might take a long time to load data or warm a cache, than during steady-state operation.\nThis cannot be updated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
                         "properties": {
                           "exec": {
+                            "description": "Exec specifies a command to execute in the container.",
                             "properties": {
                               "command": {
+                                "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
                                 "items": {
                                   "type": "string"
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               }
                             },
                             "type": "object",
                             "additionalProperties": false
                           },
                           "failureThreshold": {
+                            "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded.\nDefaults to 3. Minimum value is 1.",
                             "format": "int32",
                             "type": "integer"
                           },
+                          "grpc": {
+                            "description": "GRPC specifies a GRPC HealthCheckRequest.",
+                            "properties": {
+                              "port": {
+                                "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "service": {
+                                "default": "",
+                                "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
                           "httpGet": {
+                            "description": "HTTPGet specifies an HTTP GET request to perform.",
                             "properties": {
                               "host": {
+                                "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
                                 "type": "string"
                               },
                               "httpHeaders": {
+                                "description": "Custom headers to set in the request. HTTP allows repeated headers.",
                                 "items": {
+                                  "description": "HTTPHeader describes a custom header to be used in HTTP probes",
                                   "properties": {
                                     "name": {
+                                      "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
                                       "type": "string"
                                     },
                                     "value": {
+                                      "description": "The header field value",
                                       "type": "string"
                                     }
                                   },
@@ -2874,9 +4381,11 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "path": {
+                                "description": "Path to access on the HTTP server.",
                                 "type": "string"
                               },
                               "port": {
@@ -2888,9 +4397,11 @@
                                     "type": "string"
                                   }
                                 ],
+                                "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
                                 "x-kubernetes-int-or-string": true
                               },
                               "scheme": {
+                                "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
                                 "type": "string"
                               }
                             },
@@ -2901,20 +4412,25 @@
                             "additionalProperties": false
                           },
                           "initialDelaySeconds": {
+                            "description": "Number of seconds after the container has started before liveness probes are initiated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
                             "format": "int32",
                             "type": "integer"
                           },
                           "periodSeconds": {
+                            "description": "How often (in seconds) to perform the probe.\nDefault to 10 seconds. Minimum value is 1.",
                             "format": "int32",
                             "type": "integer"
                           },
                           "successThreshold": {
+                            "description": "Minimum consecutive successes for the probe to be considered successful after having failed.\nDefaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
                             "format": "int32",
                             "type": "integer"
                           },
                           "tcpSocket": {
+                            "description": "TCPSocket specifies a connection to a TCP port.",
                             "properties": {
                               "host": {
+                                "description": "Optional: Host name to connect to, defaults to the pod IP.",
                                 "type": "string"
                               },
                               "port": {
@@ -2926,6 +4442,7 @@
                                     "type": "string"
                                   }
                                 ],
+                                "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
                                 "x-kubernetes-int-or-string": true
                               }
                             },
@@ -2935,7 +4452,13 @@
                             "type": "object",
                             "additionalProperties": false
                           },
+                          "terminationGracePeriodSeconds": {
+                            "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure.\nThe grace period is the duration in seconds after the processes running in the pod are sent\na termination signal and the time when the processes are forcibly halted with a kill signal.\nSet this value longer than the expected cleanup time for your process.\nIf this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this\nvalue overrides the value provided by the pod spec.\nValue must be non-negative integer. The value zero indicates stop immediately via\nthe kill signal (no opportunity to shut down).\nThis is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.\nMinimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+                            "format": "int64",
+                            "type": "integer"
+                          },
                           "timeoutSeconds": {
+                            "description": "Number of seconds after which the probe times out.\nDefaults to 1 second. Minimum value is 1.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
                             "format": "int32",
                             "type": "integer"
                           }
@@ -2944,27 +4467,36 @@
                         "additionalProperties": false
                       },
                       "stdin": {
+                        "description": "Whether this container should allocate a buffer for stdin in the container runtime. If this\nis not set, reads from stdin in the container will always result in EOF.\nDefault is false.",
                         "type": "boolean"
                       },
                       "stdinOnce": {
+                        "description": "Whether the container runtime should close the stdin channel after it has been opened by\na single attach. When stdin is true the stdin stream will remain open across multiple attach\nsessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the\nfirst client attaches to stdin, and then remains open and accepts data until the client disconnects,\nat which time stdin is closed and remains closed until the container is restarted. If this\nflag is false, a container processes that reads from stdin will never receive an EOF.\nDefault is false",
                         "type": "boolean"
                       },
                       "terminationMessagePath": {
+                        "description": "Optional: Path at which the file to which the container's termination message\nwill be written is mounted into the container's filesystem.\nMessage written is intended to be brief final status, such as an assertion failure message.\nWill be truncated by the node if greater than 4096 bytes. The total message length across\nall containers will be limited to 12kb.\nDefaults to /dev/termination-log.\nCannot be updated.",
                         "type": "string"
                       },
                       "terminationMessagePolicy": {
+                        "description": "Indicate how the termination message should be populated. File will use the contents of\nterminationMessagePath to populate the container status message on both success and failure.\nFallbackToLogsOnError will use the last chunk of container log output if the termination\nmessage file is empty and the container exited with an error.\nThe log output is limited to 2048 bytes or 80 lines, whichever is smaller.\nDefaults to File.\nCannot be updated.",
                         "type": "string"
                       },
                       "tty": {
+                        "description": "Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.\nDefault is false.",
                         "type": "boolean"
                       },
                       "volumeDevices": {
+                        "description": "volumeDevices is the list of block devices to be used by the container.",
                         "items": {
+                          "description": "volumeDevice describes a mapping of a raw block device within a container.",
                           "properties": {
                             "devicePath": {
+                              "description": "devicePath is the path inside of the container that the device will be mapped to.",
                               "type": "string"
                             },
                             "name": {
+                              "description": "name must match the name of a persistentVolumeClaim in the pod",
                               "type": "string"
                             }
                           },
@@ -2975,27 +4507,43 @@
                           "type": "object",
                           "additionalProperties": false
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-map-keys": [
+                          "devicePath"
+                        ],
+                        "x-kubernetes-list-type": "map"
                       },
                       "volumeMounts": {
+                        "description": "Pod volumes to mount into the container's filesystem.\nCannot be updated.",
                         "items": {
+                          "description": "VolumeMount describes a mounting of a Volume within a container.",
                           "properties": {
                             "mountPath": {
+                              "description": "Path within the container at which the volume should be mounted.  Must\nnot contain ':'.",
                               "type": "string"
                             },
                             "mountPropagation": {
+                              "description": "mountPropagation determines how mounts are propagated from the host\nto container and the other way around.\nWhen not set, MountPropagationNone is used.\nThis field is beta in 1.10.\nWhen RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified\n(which defaults to None).",
                               "type": "string"
                             },
                             "name": {
+                              "description": "This must match the Name of a Volume.",
                               "type": "string"
                             },
                             "readOnly": {
+                              "description": "Mounted read-only if true, read-write otherwise (false or unspecified).\nDefaults to false.",
                               "type": "boolean"
                             },
+                            "recursiveReadOnly": {
+                              "description": "RecursiveReadOnly specifies whether read-only mounts should be handled\nrecursively.\n\nIf ReadOnly is false, this field has no meaning and must be unspecified.\n\nIf ReadOnly is true, and this field is set to Disabled, the mount is not made\nrecursively read-only.  If this field is set to IfPossible, the mount is made\nrecursively read-only, if it is supported by the container runtime.  If this\nfield is set to Enabled, the mount is made recursively read-only if it is\nsupported by the container runtime, otherwise the pod will not be started and\nan error will be generated to indicate the reason.\n\nIf this field is set to IfPossible or Enabled, MountPropagation must be set to\nNone (or be unspecified, which defaults to None).\n\nIf this field is not specified, it is treated as an equivalent of Disabled.",
+                              "type": "string"
+                            },
                             "subPath": {
+                              "description": "Path within the volume from which the container's volume should be mounted.\nDefaults to \"\" (volume's root).",
                               "type": "string"
                             },
                             "subPathExpr": {
+                              "description": "Expanded path within the volume from which the container's volume should be mounted.\nBehaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.\nDefaults to \"\" (volume's root).\nSubPathExpr and SubPath are mutually exclusive.",
                               "type": "string"
                             }
                           },
@@ -3006,9 +4554,14 @@
                           "type": "object",
                           "additionalProperties": false
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-map-keys": [
+                          "mountPath"
+                        ],
+                        "x-kubernetes-list-type": "map"
                       },
                       "workingDir": {
+                        "description": "Container's working directory.\nIf not specified, the container runtime's default will be used, which\nmight be configured in the container image.\nCannot be updated.",
                         "type": "string"
                       }
                     },
@@ -3020,27 +4573,40 @@
                   },
                   "type": "array"
                 },
+                "template": {
+                  "description": "Template is a pod template that can be used to define the driver or executor pod configurations that Spark configurations do not support.\nSpark version >= 3.0.0 is required.\nRef: https://spark.apache.org/docs/latest/running-on-kubernetes.html#pod-template.",
+                  "type": "object",
+                  "x-kubernetes-preserve-unknown-fields": true
+                },
                 "terminationGracePeriodSeconds": {
+                  "description": "Termination grace period seconds for the pod",
                   "format": "int64",
                   "type": "integer"
                 },
                 "tolerations": {
+                  "description": "Tolerations specifies the tolerations listed in \".spec.tolerations\" to be applied to the pod.",
                   "items": {
+                    "description": "The pod this Toleration is attached to tolerates any taint that matches\nthe triple <key,value,effect> using the matching operator <operator>.",
                     "properties": {
                       "effect": {
+                        "description": "Effect indicates the taint effect to match. Empty means match all taint effects.\nWhen specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
                         "type": "string"
                       },
                       "key": {
+                        "description": "Key is the taint key that the toleration applies to. Empty means match all taint keys.\nIf the key is empty, operator must be Exists; this combination means to match all values and all keys.",
                         "type": "string"
                       },
                       "operator": {
+                        "description": "Operator represents a key's relationship to the value.\nValid operators are Exists and Equal. Defaults to Equal.\nExists is equivalent to wildcard for value, so that a pod can\ntolerate all taints of a particular category.",
                         "type": "string"
                       },
                       "tolerationSeconds": {
+                        "description": "TolerationSeconds represents the period of time the toleration (which must be\nof effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,\nit is not set, which means tolerate the taint forever (do not evict). Zero and\nnegative values will be treated as 0 (evict immediately) by the system.",
                         "format": "int64",
                         "type": "integer"
                       },
                       "value": {
+                        "description": "Value is the taint value the toleration matches to.\nIf the operator is Exists, the value should be empty, otherwise just a regular string.",
                         "type": "string"
                       }
                     },
@@ -3050,24 +4616,36 @@
                   "type": "array"
                 },
                 "volumeMounts": {
+                  "description": "VolumeMounts specifies the volumes listed in \".spec.volumes\" to mount into the main container's filesystem.",
                   "items": {
+                    "description": "VolumeMount describes a mounting of a Volume within a container.",
                     "properties": {
                       "mountPath": {
+                        "description": "Path within the container at which the volume should be mounted.  Must\nnot contain ':'.",
                         "type": "string"
                       },
                       "mountPropagation": {
+                        "description": "mountPropagation determines how mounts are propagated from the host\nto container and the other way around.\nWhen not set, MountPropagationNone is used.\nThis field is beta in 1.10.\nWhen RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified\n(which defaults to None).",
                         "type": "string"
                       },
                       "name": {
+                        "description": "This must match the Name of a Volume.",
                         "type": "string"
                       },
                       "readOnly": {
+                        "description": "Mounted read-only if true, read-write otherwise (false or unspecified).\nDefaults to false.",
                         "type": "boolean"
                       },
+                      "recursiveReadOnly": {
+                        "description": "RecursiveReadOnly specifies whether read-only mounts should be handled\nrecursively.\n\nIf ReadOnly is false, this field has no meaning and must be unspecified.\n\nIf ReadOnly is true, and this field is set to Disabled, the mount is not made\nrecursively read-only.  If this field is set to IfPossible, the mount is made\nrecursively read-only, if it is supported by the container runtime.  If this\nfield is set to Enabled, the mount is made recursively read-only if it is\nsupported by the container runtime, otherwise the pod will not be started and\nan error will be generated to indicate the reason.\n\nIf this field is set to IfPossible or Enabled, MountPropagation must be set to\nNone (or be unspecified, which defaults to None).\n\nIf this field is not specified, it is treated as an equivalent of Disabled.",
+                        "type": "string"
+                      },
                       "subPath": {
+                        "description": "Path within the volume from which the container's volume should be mounted.\nDefaults to \"\" (volume's root).",
                         "type": "string"
                       },
                       "subPathExpr": {
+                        "description": "Expanded path within the volume from which the container's volume should be mounted.\nBehaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.\nDefaults to \"\" (volume's root).\nSubPathExpr and SubPath are mutually exclusive.",
                         "type": "string"
                       }
                     },
@@ -3084,24 +4662,106 @@
               "type": "object",
               "additionalProperties": false
             },
+            "driverIngressOptions": {
+              "description": "DriverIngressOptions allows configuring the Service and the Ingress to expose ports inside Spark Driver",
+              "items": {
+                "description": "DriverIngressConfiguration is for driver ingress specific configuration parameters.",
+                "properties": {
+                  "ingressAnnotations": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "IngressAnnotations is a map of key,value pairs of annotations that might be added to the ingress object. i.e. specify nginx as ingress.class",
+                    "type": "object"
+                  },
+                  "ingressTLS": {
+                    "description": "TlsHosts is useful If we need to declare SSL certificates to the ingress object",
+                    "items": {
+                      "description": "IngressTLS describes the transport layer security associated with an ingress.",
+                      "properties": {
+                        "hosts": {
+                          "description": "hosts is a list of hosts included in the TLS certificate. The values in\nthis list must match the name/s used in the tlsSecret. Defaults to the\nwildcard host setting for the loadbalancer controller fulfilling this\nIngress, if left unspecified.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array",
+                          "x-kubernetes-list-type": "atomic"
+                        },
+                        "secretName": {
+                          "description": "secretName is the name of the secret used to terminate TLS traffic on\nport 443. Field is left optional to allow TLS routing based on SNI\nhostname alone. If the SNI host in a listener conflicts with the \"Host\"\nheader field used by an IngressRule, the SNI host is used for termination\nand value of the \"Host\" header is used for routing.",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
+                  "ingressURLFormat": {
+                    "description": "IngressURLFormat is the URL for the ingress.",
+                    "type": "string"
+                  },
+                  "serviceAnnotations": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "ServiceAnnotations is a map of key,value pairs of annotations that might be added to the service object.",
+                    "type": "object"
+                  },
+                  "serviceLabels": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "ServiceLabels is a map of key,value pairs of labels that might be added to the service object.",
+                    "type": "object"
+                  },
+                  "servicePort": {
+                    "description": "ServicePort allows configuring the port at service level that might be different from the targetPort.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "servicePortName": {
+                    "description": "ServicePortName allows configuring the name of the service port.\nThis may be useful for sidecar proxies like Envoy injected by Istio which require specific ports names to treat traffic as proper HTTP.",
+                    "type": "string"
+                  },
+                  "serviceType": {
+                    "description": "ServiceType allows configuring the type of the service. Defaults to ClusterIP.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "servicePort",
+                  "servicePortName"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
             "dynamicAllocation": {
+              "description": "DynamicAllocation configures dynamic allocation that becomes available for the Kubernetes\nscheduler backend since Spark 3.0.",
               "properties": {
                 "enabled": {
+                  "description": "Enabled controls whether dynamic allocation is enabled or not.",
                   "type": "boolean"
                 },
                 "initialExecutors": {
+                  "description": "InitialExecutors is the initial number of executors to request. If .spec.executor.instances\nis also set, the initial number of executors is set to the bigger of that and this option.",
                   "format": "int32",
                   "type": "integer"
                 },
                 "maxExecutors": {
+                  "description": "MaxExecutors is the upper bound for the number of executors if dynamic allocation is enabled.",
                   "format": "int32",
                   "type": "integer"
                 },
                 "minExecutors": {
+                  "description": "MinExecutors is the lower bound for the number of executors if dynamic allocation is enabled.",
                   "format": "int32",
                   "type": "integer"
                 },
                 "shuffleTrackingTimeout": {
+                  "description": "ShuffleTrackingTimeout controls the timeout in milliseconds for executors that are holding\nshuffle data if shuffle tracking is enabled (true by default if dynamic allocation is enabled).",
                   "format": "int64",
                   "type": "integer"
                 }
@@ -3110,30 +4770,42 @@
               "additionalProperties": false
             },
             "executor": {
+              "description": "Executor is the executor specification.",
               "properties": {
                 "affinity": {
+                  "description": "Affinity specifies the affinity/anti-affinity settings for the pod.",
                   "properties": {
                     "nodeAffinity": {
+                      "description": "Describes node affinity scheduling rules for the pod.",
                       "properties": {
                         "preferredDuringSchedulingIgnoredDuringExecution": {
+                          "description": "The scheduler will prefer to schedule pods to nodes that satisfy\nthe affinity expressions specified by this field, but it may choose\na node that violates one or more of the expressions. The node that is\nmost preferred is the one with the greatest sum of weights, i.e.\nfor each node that meets all of the scheduling requirements (resource\nrequest, requiredDuringScheduling affinity expressions, etc.),\ncompute a sum by iterating through the elements of this field and adding\n\"weight\" to the sum if the node matches the corresponding matchExpressions; the\nnode(s) with the highest sum are the most preferred.",
                           "items": {
+                            "description": "An empty preferred scheduling term matches all objects with implicit weight 0\n(i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).",
                             "properties": {
                               "preference": {
+                                "description": "A node selector term, associated with the corresponding weight.",
                                 "properties": {
                                   "matchExpressions": {
+                                    "description": "A list of node selector requirements by node's labels.",
                                     "items": {
+                                      "description": "A node selector requirement is a selector that contains values, a key, and an operator\nthat relates the key and values.",
                                       "properties": {
                                         "key": {
+                                          "description": "The label key that the selector applies to.",
                                           "type": "string"
                                         },
                                         "operator": {
+                                          "description": "Represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
                                           "type": "string"
                                         },
                                         "values": {
+                                          "description": "An array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. If the operator is Gt or Lt, the values\narray must have a single element, which will be interpreted as an integer.\nThis array is replaced during a strategic merge patch.",
                                           "items": {
                                             "type": "string"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       },
                                       "required": [
@@ -3143,22 +4815,29 @@
                                       "type": "object",
                                       "additionalProperties": false
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "matchFields": {
+                                    "description": "A list of node selector requirements by node's fields.",
                                     "items": {
+                                      "description": "A node selector requirement is a selector that contains values, a key, and an operator\nthat relates the key and values.",
                                       "properties": {
                                         "key": {
+                                          "description": "The label key that the selector applies to.",
                                           "type": "string"
                                         },
                                         "operator": {
+                                          "description": "Represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
                                           "type": "string"
                                         },
                                         "values": {
+                                          "description": "An array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. If the operator is Gt or Lt, the values\narray must have a single element, which will be interpreted as an integer.\nThis array is replaced during a strategic merge patch.",
                                           "items": {
                                             "type": "string"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       },
                                       "required": [
@@ -3168,13 +4847,16 @@
                                       "type": "object",
                                       "additionalProperties": false
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   }
                                 },
                                 "type": "object",
+                                "x-kubernetes-map-type": "atomic",
                                 "additionalProperties": false
                               },
                               "weight": {
+                                "description": "Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.",
                                 "format": "int32",
                                 "type": "integer"
                               }
@@ -3186,27 +4868,37 @@
                             "type": "object",
                             "additionalProperties": false
                           },
-                          "type": "array"
+                          "type": "array",
+                          "x-kubernetes-list-type": "atomic"
                         },
                         "requiredDuringSchedulingIgnoredDuringExecution": {
+                          "description": "If the affinity requirements specified by this field are not met at\nscheduling time, the pod will not be scheduled onto the node.\nIf the affinity requirements specified by this field cease to be met\nat some point during pod execution (e.g. due to an update), the system\nmay or may not try to eventually evict the pod from its node.",
                           "properties": {
                             "nodeSelectorTerms": {
+                              "description": "Required. A list of node selector terms. The terms are ORed.",
                               "items": {
+                                "description": "A null or empty node selector term matches no objects. The requirements of\nthem are ANDed.\nThe TopologySelectorTerm type implements a subset of the NodeSelectorTerm.",
                                 "properties": {
                                   "matchExpressions": {
+                                    "description": "A list of node selector requirements by node's labels.",
                                     "items": {
+                                      "description": "A node selector requirement is a selector that contains values, a key, and an operator\nthat relates the key and values.",
                                       "properties": {
                                         "key": {
+                                          "description": "The label key that the selector applies to.",
                                           "type": "string"
                                         },
                                         "operator": {
+                                          "description": "Represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
                                           "type": "string"
                                         },
                                         "values": {
+                                          "description": "An array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. If the operator is Gt or Lt, the values\narray must have a single element, which will be interpreted as an integer.\nThis array is replaced during a strategic merge patch.",
                                           "items": {
                                             "type": "string"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       },
                                       "required": [
@@ -3216,22 +4908,29 @@
                                       "type": "object",
                                       "additionalProperties": false
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "matchFields": {
+                                    "description": "A list of node selector requirements by node's fields.",
                                     "items": {
+                                      "description": "A node selector requirement is a selector that contains values, a key, and an operator\nthat relates the key and values.",
                                       "properties": {
                                         "key": {
+                                          "description": "The label key that the selector applies to.",
                                           "type": "string"
                                         },
                                         "operator": {
+                                          "description": "Represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
                                           "type": "string"
                                         },
                                         "values": {
+                                          "description": "An array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. If the operator is Gt or Lt, the values\narray must have a single element, which will be interpreted as an integer.\nThis array is replaced during a strategic merge patch.",
                                           "items": {
                                             "type": "string"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       },
                                       "required": [
@@ -3241,19 +4940,23 @@
                                       "type": "object",
                                       "additionalProperties": false
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   }
                                 },
                                 "type": "object",
+                                "x-kubernetes-map-type": "atomic",
                                 "additionalProperties": false
                               },
-                              "type": "array"
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
                             }
                           },
                           "required": [
                             "nodeSelectorTerms"
                           ],
                           "type": "object",
+                          "x-kubernetes-map-type": "atomic",
                           "additionalProperties": false
                         }
                       },
@@ -3261,28 +4964,39 @@
                       "additionalProperties": false
                     },
                     "podAffinity": {
+                      "description": "Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).",
                       "properties": {
                         "preferredDuringSchedulingIgnoredDuringExecution": {
+                          "description": "The scheduler will prefer to schedule pods to nodes that satisfy\nthe affinity expressions specified by this field, but it may choose\na node that violates one or more of the expressions. The node that is\nmost preferred is the one with the greatest sum of weights, i.e.\nfor each node that meets all of the scheduling requirements (resource\nrequest, requiredDuringScheduling affinity expressions, etc.),\ncompute a sum by iterating through the elements of this field and adding\n\"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the\nnode(s) with the highest sum are the most preferred.",
                           "items": {
+                            "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
                             "properties": {
                               "podAffinityTerm": {
+                                "description": "Required. A pod affinity term, associated with the corresponding weight.",
                                 "properties": {
                                   "labelSelector": {
+                                    "description": "A label query over a set of resources, in this case pods.\nIf it's null, this PodAffinityTerm matches with no Pods.",
                                     "properties": {
                                       "matchExpressions": {
+                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
                                         "items": {
+                                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
                                           "properties": {
                                             "key": {
+                                              "description": "key is the label key that the selector applies to.",
                                               "type": "string"
                                             },
                                             "operator": {
+                                              "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
                                               "type": "string"
                                             },
                                             "values": {
+                                              "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
                                               "items": {
                                                 "type": "string"
                                               },
-                                              "type": "array"
+                                              "type": "array",
+                                              "x-kubernetes-list-type": "atomic"
                                             }
                                           },
                                           "required": [
@@ -3292,25 +5006,94 @@
                                           "type": "object",
                                           "additionalProperties": false
                                         },
-                                        "type": "array"
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
                                       },
                                       "matchLabels": {
                                         "additionalProperties": {
                                           "type": "string"
                                         },
+                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                                         "type": "object"
                                       }
                                     },
                                     "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
                                     "additionalProperties": false
                                   },
-                                  "namespaces": {
+                                  "matchLabelKeys": {
+                                    "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both matchLabelKeys and labelSelector.\nAlso, matchLabelKeys cannot be set when labelSelector isn't set.\nThis is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).",
                                     "items": {
                                       "type": "string"
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "mismatchLabelKeys": {
+                                    "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both mismatchLabelKeys and labelSelector.\nAlso, mismatchLabelKeys cannot be set when labelSelector isn't set.\nThis is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "namespaceSelector": {
+                                    "description": "A label query over the set of namespaces that the term applies to.\nThe term is applied to the union of the namespaces selected by this field\nand the ones listed in the namespaces field.\nnull selector and null or empty namespaces list means \"this pod's namespace\".\nAn empty selector ({}) matches all namespaces.",
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                        "items": {
+                                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                          "properties": {
+                                            "key": {
+                                              "description": "key is the label key that the selector applies to.",
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array",
+                                              "x-kubernetes-list-type": "atomic"
+                                            }
+                                          },
+                                          "required": [
+                                            "key",
+                                            "operator"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "matchLabels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  },
+                                  "namespaces": {
+                                    "description": "namespaces specifies a static list of namespace names that the term applies to.\nThe term is applied to the union of the namespaces listed in this field\nand the ones selected by namespaceSelector.\nnull or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "topologyKey": {
+                                    "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
                                     "type": "string"
                                   }
                                 },
@@ -3321,6 +5104,7 @@
                                 "additionalProperties": false
                               },
                               "weight": {
+                                "description": "weight associated with matching the corresponding podAffinityTerm,\nin the range 1-100.",
                                 "format": "int32",
                                 "type": "integer"
                               }
@@ -3332,27 +5116,37 @@
                             "type": "object",
                             "additionalProperties": false
                           },
-                          "type": "array"
+                          "type": "array",
+                          "x-kubernetes-list-type": "atomic"
                         },
                         "requiredDuringSchedulingIgnoredDuringExecution": {
+                          "description": "If the affinity requirements specified by this field are not met at\nscheduling time, the pod will not be scheduled onto the node.\nIf the affinity requirements specified by this field cease to be met\nat some point during pod execution (e.g. due to a pod label update), the\nsystem may or may not try to eventually evict the pod from its node.\nWhen there are multiple elements, the lists of nodes corresponding to each\npodAffinityTerm are intersected, i.e. all terms must be satisfied.",
                           "items": {
+                            "description": "Defines a set of pods (namely those matching the labelSelector\nrelative to the given namespace(s)) that this pod should be\nco-located (affinity) or not co-located (anti-affinity) with,\nwhere co-located is defined as running on a node whose value of\nthe label with key <topologyKey> matches that of any node on which\na pod of the set of pods is running",
                             "properties": {
                               "labelSelector": {
+                                "description": "A label query over a set of resources, in this case pods.\nIf it's null, this PodAffinityTerm matches with no Pods.",
                                 "properties": {
                                   "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
                                     "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
                                       "properties": {
                                         "key": {
+                                          "description": "key is the label key that the selector applies to.",
                                           "type": "string"
                                         },
                                         "operator": {
+                                          "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
                                           "type": "string"
                                         },
                                         "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
                                           "items": {
                                             "type": "string"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       },
                                       "required": [
@@ -3362,25 +5156,94 @@
                                       "type": "object",
                                       "additionalProperties": false
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "matchLabels": {
                                     "additionalProperties": {
                                       "type": "string"
                                     },
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                                     "type": "object"
                                   }
                                 },
                                 "type": "object",
+                                "x-kubernetes-map-type": "atomic",
                                 "additionalProperties": false
                               },
-                              "namespaces": {
+                              "matchLabelKeys": {
+                                "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both matchLabelKeys and labelSelector.\nAlso, matchLabelKeys cannot be set when labelSelector isn't set.\nThis is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).",
                                 "items": {
                                   "type": "string"
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "mismatchLabelKeys": {
+                                "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both mismatchLabelKeys and labelSelector.\nAlso, mismatchLabelKeys cannot be set when labelSelector isn't set.\nThis is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "namespaceSelector": {
+                                "description": "A label query over the set of namespaces that the term applies to.\nThe term is applied to the union of the namespaces selected by this field\nand the ones listed in the namespaces field.\nnull selector and null or empty namespaces list means \"this pod's namespace\".\nAn empty selector ({}) matches all namespaces.",
+                                "properties": {
+                                  "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                    "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                      "properties": {
+                                        "key": {
+                                          "description": "key is the label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "namespaces": {
+                                "description": "namespaces specifies a static list of namespace names that the term applies to.\nThe term is applied to the union of the namespaces listed in this field\nand the ones selected by namespaceSelector.\nnull or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "topologyKey": {
+                                "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
                                 "type": "string"
                               }
                             },
@@ -3390,35 +5253,47 @@
                             "type": "object",
                             "additionalProperties": false
                           },
-                          "type": "array"
+                          "type": "array",
+                          "x-kubernetes-list-type": "atomic"
                         }
                       },
                       "type": "object",
                       "additionalProperties": false
                     },
                     "podAntiAffinity": {
+                      "description": "Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).",
                       "properties": {
                         "preferredDuringSchedulingIgnoredDuringExecution": {
+                          "description": "The scheduler will prefer to schedule pods to nodes that satisfy\nthe anti-affinity expressions specified by this field, but it may choose\na node that violates one or more of the expressions. The node that is\nmost preferred is the one with the greatest sum of weights, i.e.\nfor each node that meets all of the scheduling requirements (resource\nrequest, requiredDuringScheduling anti-affinity expressions, etc.),\ncompute a sum by iterating through the elements of this field and adding\n\"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the\nnode(s) with the highest sum are the most preferred.",
                           "items": {
+                            "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
                             "properties": {
                               "podAffinityTerm": {
+                                "description": "Required. A pod affinity term, associated with the corresponding weight.",
                                 "properties": {
                                   "labelSelector": {
+                                    "description": "A label query over a set of resources, in this case pods.\nIf it's null, this PodAffinityTerm matches with no Pods.",
                                     "properties": {
                                       "matchExpressions": {
+                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
                                         "items": {
+                                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
                                           "properties": {
                                             "key": {
+                                              "description": "key is the label key that the selector applies to.",
                                               "type": "string"
                                             },
                                             "operator": {
+                                              "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
                                               "type": "string"
                                             },
                                             "values": {
+                                              "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
                                               "items": {
                                                 "type": "string"
                                               },
-                                              "type": "array"
+                                              "type": "array",
+                                              "x-kubernetes-list-type": "atomic"
                                             }
                                           },
                                           "required": [
@@ -3428,25 +5303,94 @@
                                           "type": "object",
                                           "additionalProperties": false
                                         },
-                                        "type": "array"
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
                                       },
                                       "matchLabels": {
                                         "additionalProperties": {
                                           "type": "string"
                                         },
+                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                                         "type": "object"
                                       }
                                     },
                                     "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
                                     "additionalProperties": false
                                   },
-                                  "namespaces": {
+                                  "matchLabelKeys": {
+                                    "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both matchLabelKeys and labelSelector.\nAlso, matchLabelKeys cannot be set when labelSelector isn't set.\nThis is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).",
                                     "items": {
                                       "type": "string"
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "mismatchLabelKeys": {
+                                    "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both mismatchLabelKeys and labelSelector.\nAlso, mismatchLabelKeys cannot be set when labelSelector isn't set.\nThis is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "namespaceSelector": {
+                                    "description": "A label query over the set of namespaces that the term applies to.\nThe term is applied to the union of the namespaces selected by this field\nand the ones listed in the namespaces field.\nnull selector and null or empty namespaces list means \"this pod's namespace\".\nAn empty selector ({}) matches all namespaces.",
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                        "items": {
+                                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                          "properties": {
+                                            "key": {
+                                              "description": "key is the label key that the selector applies to.",
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array",
+                                              "x-kubernetes-list-type": "atomic"
+                                            }
+                                          },
+                                          "required": [
+                                            "key",
+                                            "operator"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "matchLabels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  },
+                                  "namespaces": {
+                                    "description": "namespaces specifies a static list of namespace names that the term applies to.\nThe term is applied to the union of the namespaces listed in this field\nand the ones selected by namespaceSelector.\nnull or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "topologyKey": {
+                                    "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
                                     "type": "string"
                                   }
                                 },
@@ -3457,6 +5401,7 @@
                                 "additionalProperties": false
                               },
                               "weight": {
+                                "description": "weight associated with matching the corresponding podAffinityTerm,\nin the range 1-100.",
                                 "format": "int32",
                                 "type": "integer"
                               }
@@ -3468,27 +5413,37 @@
                             "type": "object",
                             "additionalProperties": false
                           },
-                          "type": "array"
+                          "type": "array",
+                          "x-kubernetes-list-type": "atomic"
                         },
                         "requiredDuringSchedulingIgnoredDuringExecution": {
+                          "description": "If the anti-affinity requirements specified by this field are not met at\nscheduling time, the pod will not be scheduled onto the node.\nIf the anti-affinity requirements specified by this field cease to be met\nat some point during pod execution (e.g. due to a pod label update), the\nsystem may or may not try to eventually evict the pod from its node.\nWhen there are multiple elements, the lists of nodes corresponding to each\npodAffinityTerm are intersected, i.e. all terms must be satisfied.",
                           "items": {
+                            "description": "Defines a set of pods (namely those matching the labelSelector\nrelative to the given namespace(s)) that this pod should be\nco-located (affinity) or not co-located (anti-affinity) with,\nwhere co-located is defined as running on a node whose value of\nthe label with key <topologyKey> matches that of any node on which\na pod of the set of pods is running",
                             "properties": {
                               "labelSelector": {
+                                "description": "A label query over a set of resources, in this case pods.\nIf it's null, this PodAffinityTerm matches with no Pods.",
                                 "properties": {
                                   "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
                                     "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
                                       "properties": {
                                         "key": {
+                                          "description": "key is the label key that the selector applies to.",
                                           "type": "string"
                                         },
                                         "operator": {
+                                          "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
                                           "type": "string"
                                         },
                                         "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
                                           "items": {
                                             "type": "string"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       },
                                       "required": [
@@ -3498,25 +5453,94 @@
                                       "type": "object",
                                       "additionalProperties": false
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "matchLabels": {
                                     "additionalProperties": {
                                       "type": "string"
                                     },
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                                     "type": "object"
                                   }
                                 },
                                 "type": "object",
+                                "x-kubernetes-map-type": "atomic",
                                 "additionalProperties": false
                               },
-                              "namespaces": {
+                              "matchLabelKeys": {
+                                "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both matchLabelKeys and labelSelector.\nAlso, matchLabelKeys cannot be set when labelSelector isn't set.\nThis is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).",
                                 "items": {
                                   "type": "string"
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "mismatchLabelKeys": {
+                                "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both mismatchLabelKeys and labelSelector.\nAlso, mismatchLabelKeys cannot be set when labelSelector isn't set.\nThis is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "namespaceSelector": {
+                                "description": "A label query over the set of namespaces that the term applies to.\nThe term is applied to the union of the namespaces selected by this field\nand the ones listed in the namespaces field.\nnull selector and null or empty namespaces list means \"this pod's namespace\".\nAn empty selector ({}) matches all namespaces.",
+                                "properties": {
+                                  "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                    "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                      "properties": {
+                                        "key": {
+                                          "description": "key is the label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "namespaces": {
+                                "description": "namespaces specifies a static list of namespace names that the term applies to.\nThe term is applied to the union of the namespaces listed in this field\nand the ones selected by namespaceSelector.\nnull or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "topologyKey": {
+                                "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
                                 "type": "string"
                               }
                             },
@@ -3526,7 +5550,8 @@
                             "type": "object",
                             "additionalProperties": false
                           },
-                          "type": "array"
+                          "type": "array",
+                          "x-kubernetes-list-type": "atomic"
                         }
                       },
                       "type": "object",
@@ -3540,10 +5565,13 @@
                   "additionalProperties": {
                     "type": "string"
                   },
+                  "description": "Annotations are the Kubernetes annotations to be added to the pod.",
                   "type": "object"
                 },
                 "configMaps": {
+                  "description": "ConfigMaps carries information of other ConfigMaps to add to the pod.",
                   "items": {
+                    "description": "NamePath is a pair of a name and a path to which the named objects should be mounted to.",
                     "properties": {
                       "name": {
                         "type": "string"
@@ -3562,72 +5590,96 @@
                   "type": "array"
                 },
                 "coreLimit": {
+                  "description": "CoreLimit specifies a hard limit on CPU cores for the pod.\nOptional",
                   "type": "string"
                 },
                 "coreRequest": {
+                  "description": "CoreRequest is the physical CPU core request for the executors.\nMaps to `spark.kubernetes.executor.request.cores` that is available since Spark 2.4.",
                   "type": "string"
                 },
                 "cores": {
+                  "description": "Cores maps to `spark.driver.cores` or `spark.executor.cores` for the driver and executors, respectively.",
                   "format": "int32",
                   "minimum": 1,
                   "type": "integer"
                 },
                 "deleteOnTermination": {
+                  "description": "DeleteOnTermination specify whether executor pods should be deleted in case of failure or normal termination.\nMaps to `spark.kubernetes.executor.deleteOnTermination` that is available since Spark 3.0.",
                   "type": "boolean"
                 },
                 "dnsConfig": {
+                  "description": "DnsConfig dns settings for the pod, following the Kubernetes specifications.",
                   "properties": {
                     "nameservers": {
+                      "description": "A list of DNS name server IP addresses.\nThis will be appended to the base nameservers generated from DNSPolicy.\nDuplicated nameservers will be removed.",
                       "items": {
                         "type": "string"
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     },
                     "options": {
+                      "description": "A list of DNS resolver options.\nThis will be merged with the base options generated from DNSPolicy.\nDuplicated entries will be removed. Resolution options given in Options\nwill override those that appear in the base DNSPolicy.",
                       "items": {
+                        "description": "PodDNSConfigOption defines DNS resolver options of a pod.",
                         "properties": {
                           "name": {
+                            "description": "Name is this DNS resolver option's name.\nRequired.",
                             "type": "string"
                           },
                           "value": {
+                            "description": "Value is this DNS resolver option's value.",
                             "type": "string"
                           }
                         },
                         "type": "object",
                         "additionalProperties": false
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     },
                     "searches": {
+                      "description": "A list of DNS search domains for host-name lookup.\nThis will be appended to the base search paths generated from DNSPolicy.\nDuplicated search paths will be removed.",
                       "items": {
                         "type": "string"
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     }
                   },
                   "type": "object",
                   "additionalProperties": false
                 },
                 "env": {
+                  "description": "Env carries the environment variables to add to the pod.",
                   "items": {
+                    "description": "EnvVar represents an environment variable present in a Container.",
                     "properties": {
                       "name": {
+                        "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
                         "type": "string"
                       },
                       "value": {
+                        "description": "Variable references $(VAR_NAME) are expanded\nusing the previously defined environment variables in the container and\nany service environment variables. If a variable cannot be resolved,\nthe reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.\n\"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\".\nEscaped references will never be expanded, regardless of whether the variable\nexists or not.\nDefaults to \"\".",
                         "type": "string"
                       },
                       "valueFrom": {
+                        "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
                         "properties": {
                           "configMapKeyRef": {
+                            "description": "Selects a key of a ConfigMap.",
                             "properties": {
                               "key": {
+                                "description": "The key to select.",
                                 "type": "string"
                               },
                               "name": {
+                                "default": "",
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                 "type": "string"
                               },
                               "optional": {
+                                "description": "Specify whether the ConfigMap or its key must be defined",
                                 "type": "boolean"
                               }
                             },
@@ -3635,14 +5687,18 @@
                               "key"
                             ],
                             "type": "object",
+                            "x-kubernetes-map-type": "atomic",
                             "additionalProperties": false
                           },
                           "fieldRef": {
+                            "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,\nspec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
                             "properties": {
                               "apiVersion": {
+                                "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
                                 "type": "string"
                               },
                               "fieldPath": {
+                                "description": "Path of the field to select in the specified API version.",
                                 "type": "string"
                               }
                             },
@@ -3650,11 +5706,14 @@
                               "fieldPath"
                             ],
                             "type": "object",
+                            "x-kubernetes-map-type": "atomic",
                             "additionalProperties": false
                           },
                           "resourceFieldRef": {
+                            "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
                             "properties": {
                               "containerName": {
+                                "description": "Container name: required for volumes, optional for env vars",
                                 "type": "string"
                               },
                               "divisor": {
@@ -3666,10 +5725,12 @@
                                     "type": "string"
                                   }
                                 ],
+                                "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
                                 "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                                 "x-kubernetes-int-or-string": true
                               },
                               "resource": {
+                                "description": "Required: resource to select",
                                 "type": "string"
                               }
                             },
@@ -3677,17 +5738,23 @@
                               "resource"
                             ],
                             "type": "object",
+                            "x-kubernetes-map-type": "atomic",
                             "additionalProperties": false
                           },
                           "secretKeyRef": {
+                            "description": "Selects a key of a secret in the pod's namespace",
                             "properties": {
                               "key": {
+                                "description": "The key of the secret to select from.  Must be a valid secret key.",
                                 "type": "string"
                               },
                               "name": {
+                                "default": "",
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                 "type": "string"
                               },
                               "optional": {
+                                "description": "Specify whether the Secret or its key must be defined",
                                 "type": "boolean"
                               }
                             },
@@ -3695,6 +5762,7 @@
                               "key"
                             ],
                             "type": "object",
+                            "x-kubernetes-map-type": "atomic",
                             "additionalProperties": false
                           }
                         },
@@ -3711,33 +5779,46 @@
                   "type": "array"
                 },
                 "envFrom": {
+                  "description": "EnvFrom is a list of sources to populate environment variables in the container.",
                   "items": {
+                    "description": "EnvFromSource represents the source of a set of ConfigMaps",
                     "properties": {
                       "configMapRef": {
+                        "description": "The ConfigMap to select from",
                         "properties": {
                           "name": {
+                            "default": "",
+                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                             "type": "string"
                           },
                           "optional": {
+                            "description": "Specify whether the ConfigMap must be defined",
                             "type": "boolean"
                           }
                         },
                         "type": "object",
+                        "x-kubernetes-map-type": "atomic",
                         "additionalProperties": false
                       },
                       "prefix": {
+                        "description": "An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.",
                         "type": "string"
                       },
                       "secretRef": {
+                        "description": "The Secret to select from",
                         "properties": {
                           "name": {
+                            "default": "",
+                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                             "type": "string"
                           },
                           "optional": {
+                            "description": "Specify whether the Secret must be defined",
                             "type": "boolean"
                           }
                         },
                         "type": "object",
+                        "x-kubernetes-map-type": "atomic",
                         "additionalProperties": false
                       }
                     },
@@ -3748,6 +5829,7 @@
                 },
                 "envSecretKeyRefs": {
                   "additionalProperties": {
+                    "description": "NameKey represents the name and key of a SecretKeyRef.",
                     "properties": {
                       "key": {
                         "type": "string"
@@ -3763,20 +5845,25 @@
                     "type": "object",
                     "additionalProperties": false
                   },
+                  "description": "EnvSecretKeyRefs holds a mapping from environment variable names to SecretKeyRefs.\nDeprecated. Consider using `env` instead.",
                   "type": "object"
                 },
                 "envVars": {
                   "additionalProperties": {
                     "type": "string"
                   },
+                  "description": "EnvVars carries the environment variables to add to the pod.\nDeprecated. Consider using `env` instead.",
                   "type": "object"
                 },
                 "gpu": {
+                  "description": "GPU specifies GPU requirement for the pod.",
                   "properties": {
                     "name": {
+                      "description": "Name is GPU resource name, such as: nvidia.com/gpu or amd.com/gpu",
                       "type": "string"
                     },
                     "quantity": {
+                      "description": "Quantity is the number of GPUs to request for driver or executor.",
                       "format": "int64",
                       "type": "integer"
                     }
@@ -3789,64 +5876,90 @@
                   "additionalProperties": false
                 },
                 "hostAliases": {
+                  "description": "HostAliases settings for the pod, following the Kubernetes specifications.",
                   "items": {
+                    "description": "HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the\npod's hosts file.",
                     "properties": {
                       "hostnames": {
+                        "description": "Hostnames for the above IP address.",
                         "items": {
                           "type": "string"
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "ip": {
+                        "description": "IP address of the host file entry.",
                         "type": "string"
                       }
                     },
+                    "required": [
+                      "ip"
+                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
                   "type": "array"
                 },
                 "hostNetwork": {
+                  "description": "HostNetwork indicates whether to request host networking for the pod or not.",
                   "type": "boolean"
                 },
                 "image": {
+                  "description": "Image is the container image to use. Overrides Spec.Image if set.",
                   "type": "string"
                 },
                 "initContainers": {
+                  "description": "InitContainers is a list of init-containers that run to completion before the main Spark container.",
                   "items": {
+                    "description": "A single application container that you want to run within a pod.",
                     "properties": {
                       "args": {
+                        "description": "Arguments to the entrypoint.\nThe container image's CMD is used if this is not provided.\nVariable references $(VAR_NAME) are expanded using the container's environment. If a variable\ncannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will\nproduce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless\nof whether the variable exists or not. Cannot be updated.\nMore info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
                         "items": {
                           "type": "string"
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "command": {
+                        "description": "Entrypoint array. Not executed within a shell.\nThe container image's ENTRYPOINT is used if this is not provided.\nVariable references $(VAR_NAME) are expanded using the container's environment. If a variable\ncannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will\nproduce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless\nof whether the variable exists or not. Cannot be updated.\nMore info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
                         "items": {
                           "type": "string"
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "env": {
+                        "description": "List of environment variables to set in the container.\nCannot be updated.",
                         "items": {
+                          "description": "EnvVar represents an environment variable present in a Container.",
                           "properties": {
                             "name": {
+                              "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
                               "type": "string"
                             },
                             "value": {
+                              "description": "Variable references $(VAR_NAME) are expanded\nusing the previously defined environment variables in the container and\nany service environment variables. If a variable cannot be resolved,\nthe reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.\n\"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\".\nEscaped references will never be expanded, regardless of whether the variable\nexists or not.\nDefaults to \"\".",
                               "type": "string"
                             },
                             "valueFrom": {
+                              "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
                               "properties": {
                                 "configMapKeyRef": {
+                                  "description": "Selects a key of a ConfigMap.",
                                   "properties": {
                                     "key": {
+                                      "description": "The key to select.",
                                       "type": "string"
                                     },
                                     "name": {
+                                      "default": "",
+                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                       "type": "string"
                                     },
                                     "optional": {
+                                      "description": "Specify whether the ConfigMap or its key must be defined",
                                       "type": "boolean"
                                     }
                                   },
@@ -3854,14 +5967,18 @@
                                     "key"
                                   ],
                                   "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
                                   "additionalProperties": false
                                 },
                                 "fieldRef": {
+                                  "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,\nspec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
                                   "properties": {
                                     "apiVersion": {
+                                      "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
                                       "type": "string"
                                     },
                                     "fieldPath": {
+                                      "description": "Path of the field to select in the specified API version.",
                                       "type": "string"
                                     }
                                   },
@@ -3869,11 +5986,14 @@
                                     "fieldPath"
                                   ],
                                   "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
                                   "additionalProperties": false
                                 },
                                 "resourceFieldRef": {
+                                  "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
                                   "properties": {
                                     "containerName": {
+                                      "description": "Container name: required for volumes, optional for env vars",
                                       "type": "string"
                                     },
                                     "divisor": {
@@ -3885,10 +6005,12 @@
                                           "type": "string"
                                         }
                                       ],
+                                      "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
                                       "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                                       "x-kubernetes-int-or-string": true
                                     },
                                     "resource": {
+                                      "description": "Required: resource to select",
                                       "type": "string"
                                     }
                                   },
@@ -3896,17 +6018,23 @@
                                     "resource"
                                   ],
                                   "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
                                   "additionalProperties": false
                                 },
                                 "secretKeyRef": {
+                                  "description": "Selects a key of a secret in the pod's namespace",
                                   "properties": {
                                     "key": {
+                                      "description": "The key of the secret to select from.  Must be a valid secret key.",
                                       "type": "string"
                                     },
                                     "name": {
+                                      "default": "",
+                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                       "type": "string"
                                     },
                                     "optional": {
+                                      "description": "Specify whether the Secret or its key must be defined",
                                       "type": "boolean"
                                     }
                                   },
@@ -3914,6 +6042,7 @@
                                     "key"
                                   ],
                                   "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
                                   "additionalProperties": false
                                 }
                               },
@@ -3927,78 +6056,109 @@
                           "type": "object",
                           "additionalProperties": false
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-map-keys": [
+                          "name"
+                        ],
+                        "x-kubernetes-list-type": "map"
                       },
                       "envFrom": {
+                        "description": "List of sources to populate environment variables in the container.\nThe keys defined within a source must be a C_IDENTIFIER. All invalid keys\nwill be reported as an event when the container is starting. When a key exists in multiple\nsources, the value associated with the last source will take precedence.\nValues defined by an Env with a duplicate key will take precedence.\nCannot be updated.",
                         "items": {
+                          "description": "EnvFromSource represents the source of a set of ConfigMaps",
                           "properties": {
                             "configMapRef": {
+                              "description": "The ConfigMap to select from",
                               "properties": {
                                 "name": {
+                                  "default": "",
+                                  "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                   "type": "string"
                                 },
                                 "optional": {
+                                  "description": "Specify whether the ConfigMap must be defined",
                                   "type": "boolean"
                                 }
                               },
                               "type": "object",
+                              "x-kubernetes-map-type": "atomic",
                               "additionalProperties": false
                             },
                             "prefix": {
+                              "description": "An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.",
                               "type": "string"
                             },
                             "secretRef": {
+                              "description": "The Secret to select from",
                               "properties": {
                                 "name": {
+                                  "default": "",
+                                  "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                   "type": "string"
                                 },
                                 "optional": {
+                                  "description": "Specify whether the Secret must be defined",
                                   "type": "boolean"
                                 }
                               },
                               "type": "object",
+                              "x-kubernetes-map-type": "atomic",
                               "additionalProperties": false
                             }
                           },
                           "type": "object",
                           "additionalProperties": false
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "image": {
+                        "description": "Container image name.\nMore info: https://kubernetes.io/docs/concepts/containers/images\nThis field is optional to allow higher level config management to default or override\ncontainer images in workload controllers like Deployments and StatefulSets.",
                         "type": "string"
                       },
                       "imagePullPolicy": {
+                        "description": "Image pull policy.\nOne of Always, Never, IfNotPresent.\nDefaults to Always if :latest tag is specified, or IfNotPresent otherwise.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/containers/images#updating-images",
                         "type": "string"
                       },
                       "lifecycle": {
+                        "description": "Actions that the management system should take in response to container lifecycle events.\nCannot be updated.",
                         "properties": {
                           "postStart": {
+                            "description": "PostStart is called immediately after a container is created. If the handler fails,\nthe container is terminated and restarted according to its restart policy.\nOther management of the container blocks until the hook completes.\nMore info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks",
                             "properties": {
                               "exec": {
+                                "description": "Exec specifies a command to execute in the container.",
                                 "properties": {
                                   "command": {
+                                    "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
                                     "items": {
                                       "type": "string"
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   }
                                 },
                                 "type": "object",
                                 "additionalProperties": false
                               },
                               "httpGet": {
+                                "description": "HTTPGet specifies an HTTP GET request to perform.",
                                 "properties": {
                                   "host": {
+                                    "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
                                     "type": "string"
                                   },
                                   "httpHeaders": {
+                                    "description": "Custom headers to set in the request. HTTP allows repeated headers.",
                                     "items": {
+                                      "description": "HTTPHeader describes a custom header to be used in HTTP probes",
                                       "properties": {
                                         "name": {
+                                          "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
                                           "type": "string"
                                         },
                                         "value": {
+                                          "description": "The header field value",
                                           "type": "string"
                                         }
                                       },
@@ -4009,9 +6169,11 @@
                                       "type": "object",
                                       "additionalProperties": false
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "path": {
+                                    "description": "Path to access on the HTTP server.",
                                     "type": "string"
                                   },
                                   "port": {
@@ -4023,9 +6185,11 @@
                                         "type": "string"
                                       }
                                     ],
+                                    "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
                                     "x-kubernetes-int-or-string": true
                                   },
                                   "scheme": {
+                                    "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
                                     "type": "string"
                                   }
                                 },
@@ -4035,9 +6199,26 @@
                                 "type": "object",
                                 "additionalProperties": false
                               },
+                              "sleep": {
+                                "description": "Sleep represents a duration that the container should sleep.",
+                                "properties": {
+                                  "seconds": {
+                                    "description": "Seconds is the number of seconds to sleep.",
+                                    "format": "int64",
+                                    "type": "integer"
+                                  }
+                                },
+                                "required": [
+                                  "seconds"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
                               "tcpSocket": {
+                                "description": "Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept\nfor backward compatibility. There is no validation of this field and\nlifecycle hooks will fail at runtime when it is specified.",
                                 "properties": {
                                   "host": {
+                                    "description": "Optional: Host name to connect to, defaults to the pod IP.",
                                     "type": "string"
                                   },
                                   "port": {
@@ -4049,6 +6230,7 @@
                                         "type": "string"
                                       }
                                     ],
+                                    "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
                                     "x-kubernetes-int-or-string": true
                                   }
                                 },
@@ -4063,31 +6245,41 @@
                             "additionalProperties": false
                           },
                           "preStop": {
+                            "description": "PreStop is called immediately before a container is terminated due to an\nAPI request or management event such as liveness/startup probe failure,\npreemption, resource contention, etc. The handler is not called if the\ncontainer crashes or exits. The Pod's termination grace period countdown begins before the\nPreStop hook is executed. Regardless of the outcome of the handler, the\ncontainer will eventually terminate within the Pod's termination grace\nperiod (unless delayed by finalizers). Other management of the container blocks until the hook completes\nor until the termination grace period is reached.\nMore info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks",
                             "properties": {
                               "exec": {
+                                "description": "Exec specifies a command to execute in the container.",
                                 "properties": {
                                   "command": {
+                                    "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
                                     "items": {
                                       "type": "string"
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   }
                                 },
                                 "type": "object",
                                 "additionalProperties": false
                               },
                               "httpGet": {
+                                "description": "HTTPGet specifies an HTTP GET request to perform.",
                                 "properties": {
                                   "host": {
+                                    "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
                                     "type": "string"
                                   },
                                   "httpHeaders": {
+                                    "description": "Custom headers to set in the request. HTTP allows repeated headers.",
                                     "items": {
+                                      "description": "HTTPHeader describes a custom header to be used in HTTP probes",
                                       "properties": {
                                         "name": {
+                                          "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
                                           "type": "string"
                                         },
                                         "value": {
+                                          "description": "The header field value",
                                           "type": "string"
                                         }
                                       },
@@ -4098,9 +6290,11 @@
                                       "type": "object",
                                       "additionalProperties": false
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "path": {
+                                    "description": "Path to access on the HTTP server.",
                                     "type": "string"
                                   },
                                   "port": {
@@ -4112,9 +6306,11 @@
                                         "type": "string"
                                       }
                                     ],
+                                    "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
                                     "x-kubernetes-int-or-string": true
                                   },
                                   "scheme": {
+                                    "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
                                     "type": "string"
                                   }
                                 },
@@ -4124,9 +6320,26 @@
                                 "type": "object",
                                 "additionalProperties": false
                               },
+                              "sleep": {
+                                "description": "Sleep represents a duration that the container should sleep.",
+                                "properties": {
+                                  "seconds": {
+                                    "description": "Seconds is the number of seconds to sleep.",
+                                    "format": "int64",
+                                    "type": "integer"
+                                  }
+                                },
+                                "required": [
+                                  "seconds"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
                               "tcpSocket": {
+                                "description": "Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept\nfor backward compatibility. There is no validation of this field and\nlifecycle hooks will fail at runtime when it is specified.",
                                 "properties": {
                                   "host": {
+                                    "description": "Optional: Host name to connect to, defaults to the pod IP.",
                                     "type": "string"
                                   },
                                   "port": {
@@ -4138,6 +6351,7 @@
                                         "type": "string"
                                       }
                                     ],
+                                    "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
                                     "x-kubernetes-int-or-string": true
                                   }
                                 },
@@ -4156,35 +6370,66 @@
                         "additionalProperties": false
                       },
                       "livenessProbe": {
+                        "description": "Periodic probe of container liveness.\nContainer will be restarted if the probe fails.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
                         "properties": {
                           "exec": {
+                            "description": "Exec specifies a command to execute in the container.",
                             "properties": {
                               "command": {
+                                "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
                                 "items": {
                                   "type": "string"
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               }
                             },
                             "type": "object",
                             "additionalProperties": false
                           },
                           "failureThreshold": {
+                            "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded.\nDefaults to 3. Minimum value is 1.",
                             "format": "int32",
                             "type": "integer"
                           },
+                          "grpc": {
+                            "description": "GRPC specifies a GRPC HealthCheckRequest.",
+                            "properties": {
+                              "port": {
+                                "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "service": {
+                                "default": "",
+                                "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
                           "httpGet": {
+                            "description": "HTTPGet specifies an HTTP GET request to perform.",
                             "properties": {
                               "host": {
+                                "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
                                 "type": "string"
                               },
                               "httpHeaders": {
+                                "description": "Custom headers to set in the request. HTTP allows repeated headers.",
                                 "items": {
+                                  "description": "HTTPHeader describes a custom header to be used in HTTP probes",
                                   "properties": {
                                     "name": {
+                                      "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
                                       "type": "string"
                                     },
                                     "value": {
+                                      "description": "The header field value",
                                       "type": "string"
                                     }
                                   },
@@ -4195,9 +6440,11 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "path": {
+                                "description": "Path to access on the HTTP server.",
                                 "type": "string"
                               },
                               "port": {
@@ -4209,9 +6456,11 @@
                                     "type": "string"
                                   }
                                 ],
+                                "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
                                 "x-kubernetes-int-or-string": true
                               },
                               "scheme": {
+                                "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
                                 "type": "string"
                               }
                             },
@@ -4222,20 +6471,25 @@
                             "additionalProperties": false
                           },
                           "initialDelaySeconds": {
+                            "description": "Number of seconds after the container has started before liveness probes are initiated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
                             "format": "int32",
                             "type": "integer"
                           },
                           "periodSeconds": {
+                            "description": "How often (in seconds) to perform the probe.\nDefault to 10 seconds. Minimum value is 1.",
                             "format": "int32",
                             "type": "integer"
                           },
                           "successThreshold": {
+                            "description": "Minimum consecutive successes for the probe to be considered successful after having failed.\nDefaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
                             "format": "int32",
                             "type": "integer"
                           },
                           "tcpSocket": {
+                            "description": "TCPSocket specifies a connection to a TCP port.",
                             "properties": {
                               "host": {
+                                "description": "Optional: Host name to connect to, defaults to the pod IP.",
                                 "type": "string"
                               },
                               "port": {
@@ -4247,6 +6501,7 @@
                                     "type": "string"
                                   }
                                 ],
+                                "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
                                 "x-kubernetes-int-or-string": true
                               }
                             },
@@ -4256,7 +6511,13 @@
                             "type": "object",
                             "additionalProperties": false
                           },
+                          "terminationGracePeriodSeconds": {
+                            "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure.\nThe grace period is the duration in seconds after the processes running in the pod are sent\na termination signal and the time when the processes are forcibly halted with a kill signal.\nSet this value longer than the expected cleanup time for your process.\nIf this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this\nvalue overrides the value provided by the pod spec.\nValue must be non-negative integer. The value zero indicates stop immediately via\nthe kill signal (no opportunity to shut down).\nThis is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.\nMinimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+                            "format": "int64",
+                            "type": "integer"
+                          },
                           "timeoutSeconds": {
+                            "description": "Number of seconds after which the probe times out.\nDefaults to 1 second. Minimum value is 1.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
                             "format": "int32",
                             "type": "integer"
                           }
@@ -4265,32 +6526,40 @@
                         "additionalProperties": false
                       },
                       "name": {
+                        "description": "Name of the container specified as a DNS_LABEL.\nEach container in a pod must have a unique name (DNS_LABEL).\nCannot be updated.",
                         "type": "string"
                       },
                       "ports": {
+                        "description": "List of ports to expose from the container. Not specifying a port here\nDOES NOT prevent that port from being exposed. Any port which is\nlistening on the default \"0.0.0.0\" address inside a container will be\naccessible from the network.\nModifying this array with strategic merge patch may corrupt the data.\nFor more information See https://github.com/kubernetes/kubernetes/issues/108255.\nCannot be updated.",
                         "items": {
+                          "description": "ContainerPort represents a network port in a single container.",
                           "properties": {
                             "containerPort": {
+                              "description": "Number of port to expose on the pod's IP address.\nThis must be a valid port number, 0 < x < 65536.",
                               "format": "int32",
                               "type": "integer"
                             },
                             "hostIP": {
+                              "description": "What host IP to bind the external port to.",
                               "type": "string"
                             },
                             "hostPort": {
+                              "description": "Number of port to expose on the host.\nIf specified, this must be a valid port number, 0 < x < 65536.\nIf HostNetwork is specified, this must match ContainerPort.\nMost containers do not need this.",
                               "format": "int32",
                               "type": "integer"
                             },
                             "name": {
+                              "description": "If specified, this must be an IANA_SVC_NAME and unique within the pod. Each\nnamed port in a pod must have a unique name. Name for the port that can be\nreferred to by services.",
                               "type": "string"
                             },
                             "protocol": {
+                              "default": "TCP",
+                              "description": "Protocol for port. Must be UDP, TCP, or SCTP.\nDefaults to \"TCP\".",
                               "type": "string"
                             }
                           },
                           "required": [
-                            "containerPort",
-                            "protocol"
+                            "containerPort"
                           ],
                           "type": "object",
                           "additionalProperties": false
@@ -4303,35 +6572,66 @@
                         "x-kubernetes-list-type": "map"
                       },
                       "readinessProbe": {
+                        "description": "Periodic probe of container service readiness.\nContainer will be removed from service endpoints if the probe fails.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
                         "properties": {
                           "exec": {
+                            "description": "Exec specifies a command to execute in the container.",
                             "properties": {
                               "command": {
+                                "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
                                 "items": {
                                   "type": "string"
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               }
                             },
                             "type": "object",
                             "additionalProperties": false
                           },
                           "failureThreshold": {
+                            "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded.\nDefaults to 3. Minimum value is 1.",
                             "format": "int32",
                             "type": "integer"
                           },
+                          "grpc": {
+                            "description": "GRPC specifies a GRPC HealthCheckRequest.",
+                            "properties": {
+                              "port": {
+                                "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "service": {
+                                "default": "",
+                                "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
                           "httpGet": {
+                            "description": "HTTPGet specifies an HTTP GET request to perform.",
                             "properties": {
                               "host": {
+                                "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
                                 "type": "string"
                               },
                               "httpHeaders": {
+                                "description": "Custom headers to set in the request. HTTP allows repeated headers.",
                                 "items": {
+                                  "description": "HTTPHeader describes a custom header to be used in HTTP probes",
                                   "properties": {
                                     "name": {
+                                      "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
                                       "type": "string"
                                     },
                                     "value": {
+                                      "description": "The header field value",
                                       "type": "string"
                                     }
                                   },
@@ -4342,9 +6642,11 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "path": {
+                                "description": "Path to access on the HTTP server.",
                                 "type": "string"
                               },
                               "port": {
@@ -4356,9 +6658,11 @@
                                     "type": "string"
                                   }
                                 ],
+                                "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
                                 "x-kubernetes-int-or-string": true
                               },
                               "scheme": {
+                                "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
                                 "type": "string"
                               }
                             },
@@ -4369,20 +6673,25 @@
                             "additionalProperties": false
                           },
                           "initialDelaySeconds": {
+                            "description": "Number of seconds after the container has started before liveness probes are initiated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
                             "format": "int32",
                             "type": "integer"
                           },
                           "periodSeconds": {
+                            "description": "How often (in seconds) to perform the probe.\nDefault to 10 seconds. Minimum value is 1.",
                             "format": "int32",
                             "type": "integer"
                           },
                           "successThreshold": {
+                            "description": "Minimum consecutive successes for the probe to be considered successful after having failed.\nDefaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
                             "format": "int32",
                             "type": "integer"
                           },
                           "tcpSocket": {
+                            "description": "TCPSocket specifies a connection to a TCP port.",
                             "properties": {
                               "host": {
+                                "description": "Optional: Host name to connect to, defaults to the pod IP.",
                                 "type": "string"
                               },
                               "port": {
@@ -4394,6 +6703,7 @@
                                     "type": "string"
                                   }
                                 ],
+                                "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
                                 "x-kubernetes-int-or-string": true
                               }
                             },
@@ -4403,7 +6713,13 @@
                             "type": "object",
                             "additionalProperties": false
                           },
+                          "terminationGracePeriodSeconds": {
+                            "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure.\nThe grace period is the duration in seconds after the processes running in the pod are sent\na termination signal and the time when the processes are forcibly halted with a kill signal.\nSet this value longer than the expected cleanup time for your process.\nIf this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this\nvalue overrides the value provided by the pod spec.\nValue must be non-negative integer. The value zero indicates stop immediately via\nthe kill signal (no opportunity to shut down).\nThis is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.\nMinimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+                            "format": "int64",
+                            "type": "integer"
+                          },
                           "timeoutSeconds": {
+                            "description": "Number of seconds after which the probe times out.\nDefaults to 1 second. Minimum value is 1.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
                             "format": "int32",
                             "type": "integer"
                           }
@@ -4411,8 +6727,59 @@
                         "type": "object",
                         "additionalProperties": false
                       },
+                      "resizePolicy": {
+                        "description": "Resources resize policy for the container.",
+                        "items": {
+                          "description": "ContainerResizePolicy represents resource resize policy for the container.",
+                          "properties": {
+                            "resourceName": {
+                              "description": "Name of the resource to which this resource resize policy applies.\nSupported values: cpu, memory.",
+                              "type": "string"
+                            },
+                            "restartPolicy": {
+                              "description": "Restart policy to apply when specified resource is resized.\nIf not specified, it defaults to NotRequired.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "resourceName",
+                            "restartPolicy"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
+                      },
                       "resources": {
+                        "description": "Compute Resources required by this container.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
                         "properties": {
+                          "claims": {
+                            "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
+                            "items": {
+                              "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                              "properties": {
+                                "name": {
+                                  "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
+                                  "type": "string"
+                                },
+                                "request": {
+                                  "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-map-keys": [
+                              "name"
+                            ],
+                            "x-kubernetes-list-type": "map"
+                          },
                           "limits": {
                             "additionalProperties": {
                               "anyOf": [
@@ -4426,6 +6793,7 @@
                               "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                               "x-kubernetes-int-or-string": true
                             },
+                            "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
                             "type": "object"
                           },
                           "requests": {
@@ -4441,82 +6809,151 @@
                               "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                               "x-kubernetes-int-or-string": true
                             },
+                            "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
                             "type": "object"
                           }
                         },
                         "type": "object",
                         "additionalProperties": false
                       },
+                      "restartPolicy": {
+                        "description": "RestartPolicy defines the restart behavior of individual containers in a pod.\nThis field may only be set for init containers, and the only allowed value is \"Always\".\nFor non-init containers or when this field is not specified,\nthe restart behavior is defined by the Pod's restart policy and the container type.\nSetting the RestartPolicy as \"Always\" for the init container will have the following effect:\nthis init container will be continually restarted on\nexit until all regular containers have terminated. Once all regular\ncontainers have completed, all init containers with restartPolicy \"Always\"\nwill be shut down. This lifecycle differs from normal init containers and\nis often referred to as a \"sidecar\" container. Although this init\ncontainer still starts in the init container sequence, it does not wait\nfor the container to complete before proceeding to the next init\ncontainer. Instead, the next init container starts immediately after this\ninit container is started, or after any startupProbe has successfully\ncompleted.",
+                        "type": "string"
+                      },
                       "securityContext": {
+                        "description": "SecurityContext defines the security options the container should be run with.\nIf set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.\nMore info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/",
                         "properties": {
                           "allowPrivilegeEscalation": {
+                            "description": "AllowPrivilegeEscalation controls whether a process can gain more\nprivileges than its parent process. This bool directly controls if\nthe no_new_privs flag will be set on the container process.\nAllowPrivilegeEscalation is true always when the container is:\n1) run as Privileged\n2) has CAP_SYS_ADMIN\nNote that this field cannot be set when spec.os.name is windows.",
                             "type": "boolean"
                           },
+                          "appArmorProfile": {
+                            "description": "appArmorProfile is the AppArmor options to use by this container. If set, this profile\noverrides the pod's appArmorProfile.\nNote that this field cannot be set when spec.os.name is windows.",
+                            "properties": {
+                              "localhostProfile": {
+                                "description": "localhostProfile indicates a profile loaded on the node that should be used.\nThe profile must be preconfigured on the node to work.\nMust match the loaded name of the profile.\nMust be set if and only if type is \"Localhost\".",
+                                "type": "string"
+                              },
+                              "type": {
+                                "description": "type indicates which kind of AppArmor profile will be applied.\nValid options are:\n  Localhost - a profile pre-loaded on the node.\n  RuntimeDefault - the container runtime's default profile.\n  Unconfined - no AppArmor enforcement.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "type"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
                           "capabilities": {
+                            "description": "The capabilities to add/drop when running containers.\nDefaults to the default set of capabilities granted by the container runtime.\nNote that this field cannot be set when spec.os.name is windows.",
                             "properties": {
                               "add": {
+                                "description": "Added capabilities",
                                 "items": {
+                                  "description": "Capability represent POSIX capabilities type",
                                   "type": "string"
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "drop": {
+                                "description": "Removed capabilities",
                                 "items": {
+                                  "description": "Capability represent POSIX capabilities type",
                                   "type": "string"
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               }
                             },
                             "type": "object",
                             "additionalProperties": false
                           },
                           "privileged": {
+                            "description": "Run container in privileged mode.\nProcesses in privileged containers are essentially equivalent to root on the host.\nDefaults to false.\nNote that this field cannot be set when spec.os.name is windows.",
                             "type": "boolean"
                           },
                           "procMount": {
+                            "description": "procMount denotes the type of proc mount to use for the containers.\nThe default value is Default which uses the container runtime defaults for\nreadonly paths and masked paths.\nThis requires the ProcMountType feature flag to be enabled.\nNote that this field cannot be set when spec.os.name is windows.",
                             "type": "string"
                           },
                           "readOnlyRootFilesystem": {
+                            "description": "Whether this container has a read-only root filesystem.\nDefault is false.\nNote that this field cannot be set when spec.os.name is windows.",
                             "type": "boolean"
                           },
                           "runAsGroup": {
+                            "description": "The GID to run the entrypoint of the container process.\nUses runtime default if unset.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
                             "format": "int64",
                             "type": "integer"
                           },
                           "runAsNonRoot": {
+                            "description": "Indicates that the container must run as a non-root user.\nIf true, the Kubelet will validate the image at runtime to ensure that it\ndoes not run as UID 0 (root) and fail to start the container if it does.\nIf unset or false, no such validation will be performed.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
                             "type": "boolean"
                           },
                           "runAsUser": {
+                            "description": "The UID to run the entrypoint of the container process.\nDefaults to user specified in image metadata if unspecified.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
                             "format": "int64",
                             "type": "integer"
                           },
                           "seLinuxOptions": {
+                            "description": "The SELinux context to be applied to the container.\nIf unspecified, the container runtime will allocate a random SELinux context for each\ncontainer.  May also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
                             "properties": {
                               "level": {
+                                "description": "Level is SELinux level label that applies to the container.",
                                 "type": "string"
                               },
                               "role": {
+                                "description": "Role is a SELinux role label that applies to the container.",
                                 "type": "string"
                               },
                               "type": {
+                                "description": "Type is a SELinux type label that applies to the container.",
                                 "type": "string"
                               },
                               "user": {
+                                "description": "User is a SELinux user label that applies to the container.",
                                 "type": "string"
                               }
                             },
                             "type": "object",
                             "additionalProperties": false
                           },
+                          "seccompProfile": {
+                            "description": "The seccomp options to use by this container. If seccomp options are\nprovided at both the pod & container level, the container options\noverride the pod options.\nNote that this field cannot be set when spec.os.name is windows.",
+                            "properties": {
+                              "localhostProfile": {
+                                "description": "localhostProfile indicates a profile defined in a file on the node should be used.\nThe profile must be preconfigured on the node to work.\nMust be a descending path, relative to the kubelet's configured seccomp profile location.\nMust be set if type is \"Localhost\". Must NOT be set for any other type.",
+                                "type": "string"
+                              },
+                              "type": {
+                                "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "type"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
                           "windowsOptions": {
+                            "description": "The Windows specific settings applied to all containers.\nIf unspecified, the options from the PodSecurityContext will be used.\nIf set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is linux.",
                             "properties": {
                               "gmsaCredentialSpec": {
+                                "description": "GMSACredentialSpec is where the GMSA admission webhook\n(https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the\nGMSA credential spec named by the GMSACredentialSpecName field.",
                                 "type": "string"
                               },
                               "gmsaCredentialSpecName": {
+                                "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
                                 "type": "string"
                               },
+                              "hostProcess": {
+                                "description": "HostProcess determines if a container should be run as a 'Host Process' container.\nAll of a Pod's containers must have the same effective HostProcess value\n(it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).\nIn addition, if HostProcess is true then HostNetwork must also be set to true.",
+                                "type": "boolean"
+                              },
                               "runAsUserName": {
+                                "description": "The UserName in Windows to run the entrypoint of the container process.\nDefaults to the user specified in image metadata if unspecified.\nMay also be set in PodSecurityContext. If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
                                 "type": "string"
                               }
                             },
@@ -4528,35 +6965,66 @@
                         "additionalProperties": false
                       },
                       "startupProbe": {
+                        "description": "StartupProbe indicates that the Pod has successfully initialized.\nIf specified, no other probes are executed until this completes successfully.\nIf this probe fails, the Pod will be restarted, just as if the livenessProbe failed.\nThis can be used to provide different probe parameters at the beginning of a Pod's lifecycle,\nwhen it might take a long time to load data or warm a cache, than during steady-state operation.\nThis cannot be updated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
                         "properties": {
                           "exec": {
+                            "description": "Exec specifies a command to execute in the container.",
                             "properties": {
                               "command": {
+                                "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
                                 "items": {
                                   "type": "string"
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               }
                             },
                             "type": "object",
                             "additionalProperties": false
                           },
                           "failureThreshold": {
+                            "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded.\nDefaults to 3. Minimum value is 1.",
                             "format": "int32",
                             "type": "integer"
                           },
+                          "grpc": {
+                            "description": "GRPC specifies a GRPC HealthCheckRequest.",
+                            "properties": {
+                              "port": {
+                                "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "service": {
+                                "default": "",
+                                "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
                           "httpGet": {
+                            "description": "HTTPGet specifies an HTTP GET request to perform.",
                             "properties": {
                               "host": {
+                                "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
                                 "type": "string"
                               },
                               "httpHeaders": {
+                                "description": "Custom headers to set in the request. HTTP allows repeated headers.",
                                 "items": {
+                                  "description": "HTTPHeader describes a custom header to be used in HTTP probes",
                                   "properties": {
                                     "name": {
+                                      "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
                                       "type": "string"
                                     },
                                     "value": {
+                                      "description": "The header field value",
                                       "type": "string"
                                     }
                                   },
@@ -4567,9 +7035,11 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "path": {
+                                "description": "Path to access on the HTTP server.",
                                 "type": "string"
                               },
                               "port": {
@@ -4581,9 +7051,11 @@
                                     "type": "string"
                                   }
                                 ],
+                                "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
                                 "x-kubernetes-int-or-string": true
                               },
                               "scheme": {
+                                "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
                                 "type": "string"
                               }
                             },
@@ -4594,20 +7066,25 @@
                             "additionalProperties": false
                           },
                           "initialDelaySeconds": {
+                            "description": "Number of seconds after the container has started before liveness probes are initiated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
                             "format": "int32",
                             "type": "integer"
                           },
                           "periodSeconds": {
+                            "description": "How often (in seconds) to perform the probe.\nDefault to 10 seconds. Minimum value is 1.",
                             "format": "int32",
                             "type": "integer"
                           },
                           "successThreshold": {
+                            "description": "Minimum consecutive successes for the probe to be considered successful after having failed.\nDefaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
                             "format": "int32",
                             "type": "integer"
                           },
                           "tcpSocket": {
+                            "description": "TCPSocket specifies a connection to a TCP port.",
                             "properties": {
                               "host": {
+                                "description": "Optional: Host name to connect to, defaults to the pod IP.",
                                 "type": "string"
                               },
                               "port": {
@@ -4619,6 +7096,7 @@
                                     "type": "string"
                                   }
                                 ],
+                                "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
                                 "x-kubernetes-int-or-string": true
                               }
                             },
@@ -4628,7 +7106,13 @@
                             "type": "object",
                             "additionalProperties": false
                           },
+                          "terminationGracePeriodSeconds": {
+                            "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure.\nThe grace period is the duration in seconds after the processes running in the pod are sent\na termination signal and the time when the processes are forcibly halted with a kill signal.\nSet this value longer than the expected cleanup time for your process.\nIf this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this\nvalue overrides the value provided by the pod spec.\nValue must be non-negative integer. The value zero indicates stop immediately via\nthe kill signal (no opportunity to shut down).\nThis is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.\nMinimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+                            "format": "int64",
+                            "type": "integer"
+                          },
                           "timeoutSeconds": {
+                            "description": "Number of seconds after which the probe times out.\nDefaults to 1 second. Minimum value is 1.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
                             "format": "int32",
                             "type": "integer"
                           }
@@ -4637,27 +7121,36 @@
                         "additionalProperties": false
                       },
                       "stdin": {
+                        "description": "Whether this container should allocate a buffer for stdin in the container runtime. If this\nis not set, reads from stdin in the container will always result in EOF.\nDefault is false.",
                         "type": "boolean"
                       },
                       "stdinOnce": {
+                        "description": "Whether the container runtime should close the stdin channel after it has been opened by\na single attach. When stdin is true the stdin stream will remain open across multiple attach\nsessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the\nfirst client attaches to stdin, and then remains open and accepts data until the client disconnects,\nat which time stdin is closed and remains closed until the container is restarted. If this\nflag is false, a container processes that reads from stdin will never receive an EOF.\nDefault is false",
                         "type": "boolean"
                       },
                       "terminationMessagePath": {
+                        "description": "Optional: Path at which the file to which the container's termination message\nwill be written is mounted into the container's filesystem.\nMessage written is intended to be brief final status, such as an assertion failure message.\nWill be truncated by the node if greater than 4096 bytes. The total message length across\nall containers will be limited to 12kb.\nDefaults to /dev/termination-log.\nCannot be updated.",
                         "type": "string"
                       },
                       "terminationMessagePolicy": {
+                        "description": "Indicate how the termination message should be populated. File will use the contents of\nterminationMessagePath to populate the container status message on both success and failure.\nFallbackToLogsOnError will use the last chunk of container log output if the termination\nmessage file is empty and the container exited with an error.\nThe log output is limited to 2048 bytes or 80 lines, whichever is smaller.\nDefaults to File.\nCannot be updated.",
                         "type": "string"
                       },
                       "tty": {
+                        "description": "Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.\nDefault is false.",
                         "type": "boolean"
                       },
                       "volumeDevices": {
+                        "description": "volumeDevices is the list of block devices to be used by the container.",
                         "items": {
+                          "description": "volumeDevice describes a mapping of a raw block device within a container.",
                           "properties": {
                             "devicePath": {
+                              "description": "devicePath is the path inside of the container that the device will be mapped to.",
                               "type": "string"
                             },
                             "name": {
+                              "description": "name must match the name of a persistentVolumeClaim in the pod",
                               "type": "string"
                             }
                           },
@@ -4668,27 +7161,43 @@
                           "type": "object",
                           "additionalProperties": false
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-map-keys": [
+                          "devicePath"
+                        ],
+                        "x-kubernetes-list-type": "map"
                       },
                       "volumeMounts": {
+                        "description": "Pod volumes to mount into the container's filesystem.\nCannot be updated.",
                         "items": {
+                          "description": "VolumeMount describes a mounting of a Volume within a container.",
                           "properties": {
                             "mountPath": {
+                              "description": "Path within the container at which the volume should be mounted.  Must\nnot contain ':'.",
                               "type": "string"
                             },
                             "mountPropagation": {
+                              "description": "mountPropagation determines how mounts are propagated from the host\nto container and the other way around.\nWhen not set, MountPropagationNone is used.\nThis field is beta in 1.10.\nWhen RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified\n(which defaults to None).",
                               "type": "string"
                             },
                             "name": {
+                              "description": "This must match the Name of a Volume.",
                               "type": "string"
                             },
                             "readOnly": {
+                              "description": "Mounted read-only if true, read-write otherwise (false or unspecified).\nDefaults to false.",
                               "type": "boolean"
                             },
+                            "recursiveReadOnly": {
+                              "description": "RecursiveReadOnly specifies whether read-only mounts should be handled\nrecursively.\n\nIf ReadOnly is false, this field has no meaning and must be unspecified.\n\nIf ReadOnly is true, and this field is set to Disabled, the mount is not made\nrecursively read-only.  If this field is set to IfPossible, the mount is made\nrecursively read-only, if it is supported by the container runtime.  If this\nfield is set to Enabled, the mount is made recursively read-only if it is\nsupported by the container runtime, otherwise the pod will not be started and\nan error will be generated to indicate the reason.\n\nIf this field is set to IfPossible or Enabled, MountPropagation must be set to\nNone (or be unspecified, which defaults to None).\n\nIf this field is not specified, it is treated as an equivalent of Disabled.",
+                              "type": "string"
+                            },
                             "subPath": {
+                              "description": "Path within the volume from which the container's volume should be mounted.\nDefaults to \"\" (volume's root).",
                               "type": "string"
                             },
                             "subPathExpr": {
+                              "description": "Expanded path within the volume from which the container's volume should be mounted.\nBehaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.\nDefaults to \"\" (volume's root).\nSubPathExpr and SubPath are mutually exclusive.",
                               "type": "string"
                             }
                           },
@@ -4699,9 +7208,14 @@
                           "type": "object",
                           "additionalProperties": false
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-map-keys": [
+                          "mountPath"
+                        ],
+                        "x-kubernetes-list-type": "map"
                       },
                       "workingDir": {
+                        "description": "Container's working directory.\nIf not specified, the container runtime's default will be used, which\nmight be configured in the container image.\nCannot be updated.",
                         "type": "string"
                       }
                     },
@@ -4714,80 +7228,399 @@
                   "type": "array"
                 },
                 "instances": {
+                  "description": "Instances is the number of executor instances.",
                   "format": "int32",
                   "minimum": 1,
                   "type": "integer"
                 },
                 "javaOptions": {
+                  "description": "JavaOptions is a string of extra JVM options to pass to the executors. For instance,\nGC settings or other logging.",
                   "type": "string"
                 },
                 "labels": {
                   "additionalProperties": {
                     "type": "string"
                   },
+                  "description": "Labels are the Kubernetes labels to be added to the pod.",
                   "type": "object"
                 },
+                "lifecycle": {
+                  "description": "Lifecycle for running preStop or postStart commands",
+                  "properties": {
+                    "postStart": {
+                      "description": "PostStart is called immediately after a container is created. If the handler fails,\nthe container is terminated and restarted according to its restart policy.\nOther management of the container blocks until the hook completes.\nMore info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks",
+                      "properties": {
+                        "exec": {
+                          "description": "Exec specifies a command to execute in the container.",
+                          "properties": {
+                            "command": {
+                              "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "httpGet": {
+                          "description": "HTTPGet specifies an HTTP GET request to perform.",
+                          "properties": {
+                            "host": {
+                              "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
+                              "type": "string"
+                            },
+                            "httpHeaders": {
+                              "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                              "items": {
+                                "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                "properties": {
+                                  "name": {
+                                    "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "description": "The header field value",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name",
+                                  "value"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
+                            },
+                            "path": {
+                              "description": "Path to access on the HTTP server.",
+                              "type": "string"
+                            },
+                            "port": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "scheme": {
+                              "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "port"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "sleep": {
+                          "description": "Sleep represents a duration that the container should sleep.",
+                          "properties": {
+                            "seconds": {
+                              "description": "Seconds is the number of seconds to sleep.",
+                              "format": "int64",
+                              "type": "integer"
+                            }
+                          },
+                          "required": [
+                            "seconds"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "tcpSocket": {
+                          "description": "Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept\nfor backward compatibility. There is no validation of this field and\nlifecycle hooks will fail at runtime when it is specified.",
+                          "properties": {
+                            "host": {
+                              "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                              "type": "string"
+                            },
+                            "port": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                              "x-kubernetes-int-or-string": true
+                            }
+                          },
+                          "required": [
+                            "port"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "preStop": {
+                      "description": "PreStop is called immediately before a container is terminated due to an\nAPI request or management event such as liveness/startup probe failure,\npreemption, resource contention, etc. The handler is not called if the\ncontainer crashes or exits. The Pod's termination grace period countdown begins before the\nPreStop hook is executed. Regardless of the outcome of the handler, the\ncontainer will eventually terminate within the Pod's termination grace\nperiod (unless delayed by finalizers). Other management of the container blocks until the hook completes\nor until the termination grace period is reached.\nMore info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks",
+                      "properties": {
+                        "exec": {
+                          "description": "Exec specifies a command to execute in the container.",
+                          "properties": {
+                            "command": {
+                              "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "httpGet": {
+                          "description": "HTTPGet specifies an HTTP GET request to perform.",
+                          "properties": {
+                            "host": {
+                              "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
+                              "type": "string"
+                            },
+                            "httpHeaders": {
+                              "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                              "items": {
+                                "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                "properties": {
+                                  "name": {
+                                    "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "description": "The header field value",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name",
+                                  "value"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
+                            },
+                            "path": {
+                              "description": "Path to access on the HTTP server.",
+                              "type": "string"
+                            },
+                            "port": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "scheme": {
+                              "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "port"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "sleep": {
+                          "description": "Sleep represents a duration that the container should sleep.",
+                          "properties": {
+                            "seconds": {
+                              "description": "Seconds is the number of seconds to sleep.",
+                              "format": "int64",
+                              "type": "integer"
+                            }
+                          },
+                          "required": [
+                            "seconds"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "tcpSocket": {
+                          "description": "Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept\nfor backward compatibility. There is no validation of this field and\nlifecycle hooks will fail at runtime when it is specified.",
+                          "properties": {
+                            "host": {
+                              "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                              "type": "string"
+                            },
+                            "port": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                              "x-kubernetes-int-or-string": true
+                            }
+                          },
+                          "required": [
+                            "port"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
                 "memory": {
+                  "description": "Memory is the amount of memory to request for the pod.",
                   "type": "string"
                 },
                 "memoryOverhead": {
+                  "description": "MemoryOverhead is the amount of off-heap memory to allocate in cluster mode, in MiB unless otherwise specified.",
                   "type": "string"
                 },
                 "nodeSelector": {
                   "additionalProperties": {
                     "type": "string"
                   },
+                  "description": "NodeSelector is the Kubernetes node selector to be added to the driver and executor pods.\nThis field is mutually exclusive with nodeSelector at SparkApplication level (which will be deprecated).",
                   "type": "object"
                 },
                 "podSecurityContext": {
+                  "description": "PodSecurityContext specifies the PodSecurityContext to apply.",
                   "properties": {
+                    "appArmorProfile": {
+                      "description": "appArmorProfile is the AppArmor options to use by the containers in this pod.\nNote that this field cannot be set when spec.os.name is windows.",
+                      "properties": {
+                        "localhostProfile": {
+                          "description": "localhostProfile indicates a profile loaded on the node that should be used.\nThe profile must be preconfigured on the node to work.\nMust match the loaded name of the profile.\nMust be set if and only if type is \"Localhost\".",
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "type indicates which kind of AppArmor profile will be applied.\nValid options are:\n  Localhost - a profile pre-loaded on the node.\n  RuntimeDefault - the container runtime's default profile.\n  Unconfined - no AppArmor enforcement.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "type"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
                     "fsGroup": {
+                      "description": "A special supplemental group that applies to all containers in a pod.\nSome volume types allow the Kubelet to change the ownership of that volume\nto be owned by the pod:\n\n1. The owning GID will be the FSGroup\n2. The setgid bit is set (new files created in the volume will be owned by FSGroup)\n3. The permission bits are OR'd with rw-rw----\n\nIf unset, the Kubelet will not modify the ownership and permissions of any volume.\nNote that this field cannot be set when spec.os.name is windows.",
                       "format": "int64",
                       "type": "integer"
                     },
+                    "fsGroupChangePolicy": {
+                      "description": "fsGroupChangePolicy defines behavior of changing ownership and permission of the volume\nbefore being exposed inside Pod. This field will only apply to\nvolume types which support fsGroup based ownership(and permissions).\nIt will have no effect on ephemeral volume types such as: secret, configmaps\nand emptydir.\nValid values are \"OnRootMismatch\" and \"Always\". If not specified, \"Always\" is used.\nNote that this field cannot be set when spec.os.name is windows.",
+                      "type": "string"
+                    },
                     "runAsGroup": {
+                      "description": "The GID to run the entrypoint of the container process.\nUses runtime default if unset.\nMay also be set in SecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence\nfor that container.\nNote that this field cannot be set when spec.os.name is windows.",
                       "format": "int64",
                       "type": "integer"
                     },
                     "runAsNonRoot": {
+                      "description": "Indicates that the container must run as a non-root user.\nIf true, the Kubelet will validate the image at runtime to ensure that it\ndoes not run as UID 0 (root) and fail to start the container if it does.\nIf unset or false, no such validation will be performed.\nMay also be set in SecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
                       "type": "boolean"
                     },
                     "runAsUser": {
+                      "description": "The UID to run the entrypoint of the container process.\nDefaults to user specified in image metadata if unspecified.\nMay also be set in SecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence\nfor that container.\nNote that this field cannot be set when spec.os.name is windows.",
                       "format": "int64",
                       "type": "integer"
                     },
+                    "seLinuxChangePolicy": {
+                      "description": "seLinuxChangePolicy defines how the container's SELinux label is applied to all volumes used by the Pod.\nIt has no effect on nodes that do not support SELinux or to volumes does not support SELinux.\nValid values are \"MountOption\" and \"Recursive\".\n\n\"Recursive\" means relabeling of all files on all Pod volumes by the container runtime.\nThis may be slow for large volumes, but allows mixing privileged and unprivileged Pods sharing the same volume on the same node.\n\n\"MountOption\" mounts all eligible Pod volumes with `-o context` mount option.\nThis requires all Pods that share the same volume to use the same SELinux label.\nIt is not possible to share the same volume among privileged and unprivileged Pods.\nEligible volumes are in-tree FibreChannel and iSCSI volumes, and all CSI volumes\nwhose CSI driver announces SELinux support by setting spec.seLinuxMount: true in their\nCSIDriver instance. Other volumes are always re-labelled recursively.\n\"MountOption\" value is allowed only when SELinuxMount feature gate is enabled.\n\nIf not specified and SELinuxMount feature gate is enabled, \"MountOption\" is used.\nIf not specified and SELinuxMount feature gate is disabled, \"MountOption\" is used for ReadWriteOncePod volumes\nand \"Recursive\" for all other volumes.\n\nThis field affects only Pods that have SELinux label set, either in PodSecurityContext or in SecurityContext of all containers.\n\nAll Pods that use the same volume should use the same seLinuxChangePolicy, otherwise some pods can get stuck in ContainerCreating state.\nNote that this field cannot be set when spec.os.name is windows.",
+                      "type": "string"
+                    },
                     "seLinuxOptions": {
+                      "description": "The SELinux context to be applied to all containers.\nIf unspecified, the container runtime will allocate a random SELinux context for each\ncontainer.  May also be set in SecurityContext.  If set in\nboth SecurityContext and PodSecurityContext, the value specified in SecurityContext\ntakes precedence for that container.\nNote that this field cannot be set when spec.os.name is windows.",
                       "properties": {
                         "level": {
+                          "description": "Level is SELinux level label that applies to the container.",
                           "type": "string"
                         },
                         "role": {
+                          "description": "Role is a SELinux role label that applies to the container.",
                           "type": "string"
                         },
                         "type": {
+                          "description": "Type is a SELinux type label that applies to the container.",
                           "type": "string"
                         },
                         "user": {
+                          "description": "User is a SELinux user label that applies to the container.",
                           "type": "string"
                         }
                       },
                       "type": "object",
                       "additionalProperties": false
                     },
+                    "seccompProfile": {
+                      "description": "The seccomp options to use by the containers in this pod.\nNote that this field cannot be set when spec.os.name is windows.",
+                      "properties": {
+                        "localhostProfile": {
+                          "description": "localhostProfile indicates a profile defined in a file on the node should be used.\nThe profile must be preconfigured on the node to work.\nMust be a descending path, relative to the kubelet's configured seccomp profile location.\nMust be set if type is \"Localhost\". Must NOT be set for any other type.",
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "type"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
                     "supplementalGroups": {
+                      "description": "A list of groups applied to the first process run in each container, in\naddition to the container's primary GID and fsGroup (if specified).  If\nthe SupplementalGroupsPolicy feature is enabled, the\nsupplementalGroupsPolicy field determines whether these are in addition\nto or instead of any group memberships defined in the container image.\nIf unspecified, no additional groups are added, though group memberships\ndefined in the container image may still be used, depending on the\nsupplementalGroupsPolicy field.\nNote that this field cannot be set when spec.os.name is windows.",
                       "items": {
                         "format": "int64",
                         "type": "integer"
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
+                    },
+                    "supplementalGroupsPolicy": {
+                      "description": "Defines how supplemental groups of the first container processes are calculated.\nValid values are \"Merge\" and \"Strict\". If not specified, \"Merge\" is used.\n(Alpha) Using the field requires the SupplementalGroupsPolicy feature gate to be enabled\nand the container runtime must implement support for this feature.\nNote that this field cannot be set when spec.os.name is windows.",
+                      "type": "string"
                     },
                     "sysctls": {
+                      "description": "Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported\nsysctls (by the container runtime) might fail to launch.\nNote that this field cannot be set when spec.os.name is windows.",
                       "items": {
+                        "description": "Sysctl defines a kernel parameter to be set",
                         "properties": {
                           "name": {
+                            "description": "Name of a property to set",
                             "type": "string"
                           },
                           "value": {
+                            "description": "Value of a property to set",
                             "type": "string"
                           }
                         },
@@ -4798,17 +7631,26 @@
                         "type": "object",
                         "additionalProperties": false
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     },
                     "windowsOptions": {
+                      "description": "The Windows specific settings applied to all containers.\nIf unspecified, the options within a container's SecurityContext will be used.\nIf set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is linux.",
                       "properties": {
                         "gmsaCredentialSpec": {
+                          "description": "GMSACredentialSpec is where the GMSA admission webhook\n(https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the\nGMSA credential spec named by the GMSACredentialSpecName field.",
                           "type": "string"
                         },
                         "gmsaCredentialSpecName": {
+                          "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
                           "type": "string"
                         },
+                        "hostProcess": {
+                          "description": "HostProcess determines if a container should be run as a 'Host Process' container.\nAll of a Pod's containers must have the same effective HostProcess value\n(it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).\nIn addition, if HostProcess is true then HostNetwork must also be set to true.",
+                          "type": "boolean"
+                        },
                         "runAsUserName": {
+                          "description": "The UserName in Windows to run the entrypoint of the container process.\nDefaults to the user specified in image metadata if unspecified.\nMay also be set in PodSecurityContext. If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
                           "type": "string"
                         }
                       },
@@ -4819,11 +7661,44 @@
                   "type": "object",
                   "additionalProperties": false
                 },
+                "ports": {
+                  "description": "Ports settings for the pods, following the Kubernetes specifications.",
+                  "items": {
+                    "description": "Port represents the port definition in the pods objects.",
+                    "properties": {
+                      "containerPort": {
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "protocol": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "containerPort",
+                      "name",
+                      "protocol"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "priorityClassName": {
+                  "description": "PriorityClassName is the name of the PriorityClass for the executor pod.",
+                  "type": "string"
+                },
                 "schedulerName": {
+                  "description": "SchedulerName specifies the scheduler that will be used for scheduling",
                   "type": "string"
                 },
                 "secrets": {
+                  "description": "Secrets carries information of secrets to add to the pod.",
                   "items": {
+                    "description": "SecretInfo captures information of a secret.",
                     "properties": {
                       "name": {
                         "type": "string"
@@ -4832,6 +7707,7 @@
                         "type": "string"
                       },
                       "secretType": {
+                        "description": "SecretType tells the type of a secret.",
                         "type": "string"
                       }
                     },
@@ -4846,75 +7722,139 @@
                   "type": "array"
                 },
                 "securityContext": {
+                  "description": "SecurityContext specifies the container's SecurityContext to apply.",
                   "properties": {
                     "allowPrivilegeEscalation": {
+                      "description": "AllowPrivilegeEscalation controls whether a process can gain more\nprivileges than its parent process. This bool directly controls if\nthe no_new_privs flag will be set on the container process.\nAllowPrivilegeEscalation is true always when the container is:\n1) run as Privileged\n2) has CAP_SYS_ADMIN\nNote that this field cannot be set when spec.os.name is windows.",
                       "type": "boolean"
                     },
+                    "appArmorProfile": {
+                      "description": "appArmorProfile is the AppArmor options to use by this container. If set, this profile\noverrides the pod's appArmorProfile.\nNote that this field cannot be set when spec.os.name is windows.",
+                      "properties": {
+                        "localhostProfile": {
+                          "description": "localhostProfile indicates a profile loaded on the node that should be used.\nThe profile must be preconfigured on the node to work.\nMust match the loaded name of the profile.\nMust be set if and only if type is \"Localhost\".",
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "type indicates which kind of AppArmor profile will be applied.\nValid options are:\n  Localhost - a profile pre-loaded on the node.\n  RuntimeDefault - the container runtime's default profile.\n  Unconfined - no AppArmor enforcement.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "type"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
                     "capabilities": {
+                      "description": "The capabilities to add/drop when running containers.\nDefaults to the default set of capabilities granted by the container runtime.\nNote that this field cannot be set when spec.os.name is windows.",
                       "properties": {
                         "add": {
+                          "description": "Added capabilities",
                           "items": {
+                            "description": "Capability represent POSIX capabilities type",
                             "type": "string"
                           },
-                          "type": "array"
+                          "type": "array",
+                          "x-kubernetes-list-type": "atomic"
                         },
                         "drop": {
+                          "description": "Removed capabilities",
                           "items": {
+                            "description": "Capability represent POSIX capabilities type",
                             "type": "string"
                           },
-                          "type": "array"
+                          "type": "array",
+                          "x-kubernetes-list-type": "atomic"
                         }
                       },
                       "type": "object",
                       "additionalProperties": false
                     },
                     "privileged": {
+                      "description": "Run container in privileged mode.\nProcesses in privileged containers are essentially equivalent to root on the host.\nDefaults to false.\nNote that this field cannot be set when spec.os.name is windows.",
                       "type": "boolean"
                     },
                     "procMount": {
+                      "description": "procMount denotes the type of proc mount to use for the containers.\nThe default value is Default which uses the container runtime defaults for\nreadonly paths and masked paths.\nThis requires the ProcMountType feature flag to be enabled.\nNote that this field cannot be set when spec.os.name is windows.",
                       "type": "string"
                     },
                     "readOnlyRootFilesystem": {
+                      "description": "Whether this container has a read-only root filesystem.\nDefault is false.\nNote that this field cannot be set when spec.os.name is windows.",
                       "type": "boolean"
                     },
                     "runAsGroup": {
+                      "description": "The GID to run the entrypoint of the container process.\nUses runtime default if unset.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
                       "format": "int64",
                       "type": "integer"
                     },
                     "runAsNonRoot": {
+                      "description": "Indicates that the container must run as a non-root user.\nIf true, the Kubelet will validate the image at runtime to ensure that it\ndoes not run as UID 0 (root) and fail to start the container if it does.\nIf unset or false, no such validation will be performed.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
                       "type": "boolean"
                     },
                     "runAsUser": {
+                      "description": "The UID to run the entrypoint of the container process.\nDefaults to user specified in image metadata if unspecified.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
                       "format": "int64",
                       "type": "integer"
                     },
                     "seLinuxOptions": {
+                      "description": "The SELinux context to be applied to the container.\nIf unspecified, the container runtime will allocate a random SELinux context for each\ncontainer.  May also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
                       "properties": {
                         "level": {
+                          "description": "Level is SELinux level label that applies to the container.",
                           "type": "string"
                         },
                         "role": {
+                          "description": "Role is a SELinux role label that applies to the container.",
                           "type": "string"
                         },
                         "type": {
+                          "description": "Type is a SELinux type label that applies to the container.",
                           "type": "string"
                         },
                         "user": {
+                          "description": "User is a SELinux user label that applies to the container.",
                           "type": "string"
                         }
                       },
                       "type": "object",
                       "additionalProperties": false
                     },
+                    "seccompProfile": {
+                      "description": "The seccomp options to use by this container. If seccomp options are\nprovided at both the pod & container level, the container options\noverride the pod options.\nNote that this field cannot be set when spec.os.name is windows.",
+                      "properties": {
+                        "localhostProfile": {
+                          "description": "localhostProfile indicates a profile defined in a file on the node should be used.\nThe profile must be preconfigured on the node to work.\nMust be a descending path, relative to the kubelet's configured seccomp profile location.\nMust be set if type is \"Localhost\". Must NOT be set for any other type.",
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "type"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
                     "windowsOptions": {
+                      "description": "The Windows specific settings applied to all containers.\nIf unspecified, the options from the PodSecurityContext will be used.\nIf set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is linux.",
                       "properties": {
                         "gmsaCredentialSpec": {
+                          "description": "GMSACredentialSpec is where the GMSA admission webhook\n(https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the\nGMSA credential spec named by the GMSACredentialSpecName field.",
                           "type": "string"
                         },
                         "gmsaCredentialSpecName": {
+                          "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
                           "type": "string"
                         },
+                        "hostProcess": {
+                          "description": "HostProcess determines if a container should be run as a 'Host Process' container.\nAll of a Pod's containers must have the same effective HostProcess value\n(it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).\nIn addition, if HostProcess is true then HostNetwork must also be set to true.",
+                          "type": "boolean"
+                        },
                         "runAsUserName": {
+                          "description": "The UserName in Windows to run the entrypoint of the container process.\nDefaults to the user specified in image metadata if unspecified.\nMay also be set in PodSecurityContext. If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
                           "type": "string"
                         }
                       },
@@ -4926,46 +7866,64 @@
                   "additionalProperties": false
                 },
                 "serviceAccount": {
+                  "description": "ServiceAccount is the name of the custom Kubernetes service account used by the pod.",
                   "type": "string"
                 },
                 "shareProcessNamespace": {
+                  "description": "ShareProcessNamespace settings for the pod, following the Kubernetes specifications.",
                   "type": "boolean"
                 },
                 "sidecars": {
+                  "description": "Sidecars is a list of sidecar containers that run along side the main Spark container.",
                   "items": {
+                    "description": "A single application container that you want to run within a pod.",
                     "properties": {
                       "args": {
+                        "description": "Arguments to the entrypoint.\nThe container image's CMD is used if this is not provided.\nVariable references $(VAR_NAME) are expanded using the container's environment. If a variable\ncannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will\nproduce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless\nof whether the variable exists or not. Cannot be updated.\nMore info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
                         "items": {
                           "type": "string"
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "command": {
+                        "description": "Entrypoint array. Not executed within a shell.\nThe container image's ENTRYPOINT is used if this is not provided.\nVariable references $(VAR_NAME) are expanded using the container's environment. If a variable\ncannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will\nproduce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless\nof whether the variable exists or not. Cannot be updated.\nMore info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
                         "items": {
                           "type": "string"
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "env": {
+                        "description": "List of environment variables to set in the container.\nCannot be updated.",
                         "items": {
+                          "description": "EnvVar represents an environment variable present in a Container.",
                           "properties": {
                             "name": {
+                              "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
                               "type": "string"
                             },
                             "value": {
+                              "description": "Variable references $(VAR_NAME) are expanded\nusing the previously defined environment variables in the container and\nany service environment variables. If a variable cannot be resolved,\nthe reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.\n\"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\".\nEscaped references will never be expanded, regardless of whether the variable\nexists or not.\nDefaults to \"\".",
                               "type": "string"
                             },
                             "valueFrom": {
+                              "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
                               "properties": {
                                 "configMapKeyRef": {
+                                  "description": "Selects a key of a ConfigMap.",
                                   "properties": {
                                     "key": {
+                                      "description": "The key to select.",
                                       "type": "string"
                                     },
                                     "name": {
+                                      "default": "",
+                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                       "type": "string"
                                     },
                                     "optional": {
+                                      "description": "Specify whether the ConfigMap or its key must be defined",
                                       "type": "boolean"
                                     }
                                   },
@@ -4973,14 +7931,18 @@
                                     "key"
                                   ],
                                   "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
                                   "additionalProperties": false
                                 },
                                 "fieldRef": {
+                                  "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,\nspec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
                                   "properties": {
                                     "apiVersion": {
+                                      "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
                                       "type": "string"
                                     },
                                     "fieldPath": {
+                                      "description": "Path of the field to select in the specified API version.",
                                       "type": "string"
                                     }
                                   },
@@ -4988,11 +7950,14 @@
                                     "fieldPath"
                                   ],
                                   "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
                                   "additionalProperties": false
                                 },
                                 "resourceFieldRef": {
+                                  "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
                                   "properties": {
                                     "containerName": {
+                                      "description": "Container name: required for volumes, optional for env vars",
                                       "type": "string"
                                     },
                                     "divisor": {
@@ -5004,10 +7969,12 @@
                                           "type": "string"
                                         }
                                       ],
+                                      "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
                                       "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                                       "x-kubernetes-int-or-string": true
                                     },
                                     "resource": {
+                                      "description": "Required: resource to select",
                                       "type": "string"
                                     }
                                   },
@@ -5015,17 +7982,23 @@
                                     "resource"
                                   ],
                                   "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
                                   "additionalProperties": false
                                 },
                                 "secretKeyRef": {
+                                  "description": "Selects a key of a secret in the pod's namespace",
                                   "properties": {
                                     "key": {
+                                      "description": "The key of the secret to select from.  Must be a valid secret key.",
                                       "type": "string"
                                     },
                                     "name": {
+                                      "default": "",
+                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                       "type": "string"
                                     },
                                     "optional": {
+                                      "description": "Specify whether the Secret or its key must be defined",
                                       "type": "boolean"
                                     }
                                   },
@@ -5033,6 +8006,7 @@
                                     "key"
                                   ],
                                   "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
                                   "additionalProperties": false
                                 }
                               },
@@ -5046,78 +8020,109 @@
                           "type": "object",
                           "additionalProperties": false
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-map-keys": [
+                          "name"
+                        ],
+                        "x-kubernetes-list-type": "map"
                       },
                       "envFrom": {
+                        "description": "List of sources to populate environment variables in the container.\nThe keys defined within a source must be a C_IDENTIFIER. All invalid keys\nwill be reported as an event when the container is starting. When a key exists in multiple\nsources, the value associated with the last source will take precedence.\nValues defined by an Env with a duplicate key will take precedence.\nCannot be updated.",
                         "items": {
+                          "description": "EnvFromSource represents the source of a set of ConfigMaps",
                           "properties": {
                             "configMapRef": {
+                              "description": "The ConfigMap to select from",
                               "properties": {
                                 "name": {
+                                  "default": "",
+                                  "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                   "type": "string"
                                 },
                                 "optional": {
+                                  "description": "Specify whether the ConfigMap must be defined",
                                   "type": "boolean"
                                 }
                               },
                               "type": "object",
+                              "x-kubernetes-map-type": "atomic",
                               "additionalProperties": false
                             },
                             "prefix": {
+                              "description": "An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.",
                               "type": "string"
                             },
                             "secretRef": {
+                              "description": "The Secret to select from",
                               "properties": {
                                 "name": {
+                                  "default": "",
+                                  "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                   "type": "string"
                                 },
                                 "optional": {
+                                  "description": "Specify whether the Secret must be defined",
                                   "type": "boolean"
                                 }
                               },
                               "type": "object",
+                              "x-kubernetes-map-type": "atomic",
                               "additionalProperties": false
                             }
                           },
                           "type": "object",
                           "additionalProperties": false
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "image": {
+                        "description": "Container image name.\nMore info: https://kubernetes.io/docs/concepts/containers/images\nThis field is optional to allow higher level config management to default or override\ncontainer images in workload controllers like Deployments and StatefulSets.",
                         "type": "string"
                       },
                       "imagePullPolicy": {
+                        "description": "Image pull policy.\nOne of Always, Never, IfNotPresent.\nDefaults to Always if :latest tag is specified, or IfNotPresent otherwise.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/containers/images#updating-images",
                         "type": "string"
                       },
                       "lifecycle": {
+                        "description": "Actions that the management system should take in response to container lifecycle events.\nCannot be updated.",
                         "properties": {
                           "postStart": {
+                            "description": "PostStart is called immediately after a container is created. If the handler fails,\nthe container is terminated and restarted according to its restart policy.\nOther management of the container blocks until the hook completes.\nMore info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks",
                             "properties": {
                               "exec": {
+                                "description": "Exec specifies a command to execute in the container.",
                                 "properties": {
                                   "command": {
+                                    "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
                                     "items": {
                                       "type": "string"
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   }
                                 },
                                 "type": "object",
                                 "additionalProperties": false
                               },
                               "httpGet": {
+                                "description": "HTTPGet specifies an HTTP GET request to perform.",
                                 "properties": {
                                   "host": {
+                                    "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
                                     "type": "string"
                                   },
                                   "httpHeaders": {
+                                    "description": "Custom headers to set in the request. HTTP allows repeated headers.",
                                     "items": {
+                                      "description": "HTTPHeader describes a custom header to be used in HTTP probes",
                                       "properties": {
                                         "name": {
+                                          "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
                                           "type": "string"
                                         },
                                         "value": {
+                                          "description": "The header field value",
                                           "type": "string"
                                         }
                                       },
@@ -5128,9 +8133,11 @@
                                       "type": "object",
                                       "additionalProperties": false
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "path": {
+                                    "description": "Path to access on the HTTP server.",
                                     "type": "string"
                                   },
                                   "port": {
@@ -5142,9 +8149,11 @@
                                         "type": "string"
                                       }
                                     ],
+                                    "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
                                     "x-kubernetes-int-or-string": true
                                   },
                                   "scheme": {
+                                    "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
                                     "type": "string"
                                   }
                                 },
@@ -5154,9 +8163,26 @@
                                 "type": "object",
                                 "additionalProperties": false
                               },
+                              "sleep": {
+                                "description": "Sleep represents a duration that the container should sleep.",
+                                "properties": {
+                                  "seconds": {
+                                    "description": "Seconds is the number of seconds to sleep.",
+                                    "format": "int64",
+                                    "type": "integer"
+                                  }
+                                },
+                                "required": [
+                                  "seconds"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
                               "tcpSocket": {
+                                "description": "Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept\nfor backward compatibility. There is no validation of this field and\nlifecycle hooks will fail at runtime when it is specified.",
                                 "properties": {
                                   "host": {
+                                    "description": "Optional: Host name to connect to, defaults to the pod IP.",
                                     "type": "string"
                                   },
                                   "port": {
@@ -5168,6 +8194,7 @@
                                         "type": "string"
                                       }
                                     ],
+                                    "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
                                     "x-kubernetes-int-or-string": true
                                   }
                                 },
@@ -5182,31 +8209,41 @@
                             "additionalProperties": false
                           },
                           "preStop": {
+                            "description": "PreStop is called immediately before a container is terminated due to an\nAPI request or management event such as liveness/startup probe failure,\npreemption, resource contention, etc. The handler is not called if the\ncontainer crashes or exits. The Pod's termination grace period countdown begins before the\nPreStop hook is executed. Regardless of the outcome of the handler, the\ncontainer will eventually terminate within the Pod's termination grace\nperiod (unless delayed by finalizers). Other management of the container blocks until the hook completes\nor until the termination grace period is reached.\nMore info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks",
                             "properties": {
                               "exec": {
+                                "description": "Exec specifies a command to execute in the container.",
                                 "properties": {
                                   "command": {
+                                    "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
                                     "items": {
                                       "type": "string"
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   }
                                 },
                                 "type": "object",
                                 "additionalProperties": false
                               },
                               "httpGet": {
+                                "description": "HTTPGet specifies an HTTP GET request to perform.",
                                 "properties": {
                                   "host": {
+                                    "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
                                     "type": "string"
                                   },
                                   "httpHeaders": {
+                                    "description": "Custom headers to set in the request. HTTP allows repeated headers.",
                                     "items": {
+                                      "description": "HTTPHeader describes a custom header to be used in HTTP probes",
                                       "properties": {
                                         "name": {
+                                          "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
                                           "type": "string"
                                         },
                                         "value": {
+                                          "description": "The header field value",
                                           "type": "string"
                                         }
                                       },
@@ -5217,9 +8254,11 @@
                                       "type": "object",
                                       "additionalProperties": false
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "path": {
+                                    "description": "Path to access on the HTTP server.",
                                     "type": "string"
                                   },
                                   "port": {
@@ -5231,9 +8270,11 @@
                                         "type": "string"
                                       }
                                     ],
+                                    "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
                                     "x-kubernetes-int-or-string": true
                                   },
                                   "scheme": {
+                                    "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
                                     "type": "string"
                                   }
                                 },
@@ -5243,9 +8284,26 @@
                                 "type": "object",
                                 "additionalProperties": false
                               },
+                              "sleep": {
+                                "description": "Sleep represents a duration that the container should sleep.",
+                                "properties": {
+                                  "seconds": {
+                                    "description": "Seconds is the number of seconds to sleep.",
+                                    "format": "int64",
+                                    "type": "integer"
+                                  }
+                                },
+                                "required": [
+                                  "seconds"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
                               "tcpSocket": {
+                                "description": "Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept\nfor backward compatibility. There is no validation of this field and\nlifecycle hooks will fail at runtime when it is specified.",
                                 "properties": {
                                   "host": {
+                                    "description": "Optional: Host name to connect to, defaults to the pod IP.",
                                     "type": "string"
                                   },
                                   "port": {
@@ -5257,6 +8315,7 @@
                                         "type": "string"
                                       }
                                     ],
+                                    "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
                                     "x-kubernetes-int-or-string": true
                                   }
                                 },
@@ -5275,35 +8334,66 @@
                         "additionalProperties": false
                       },
                       "livenessProbe": {
+                        "description": "Periodic probe of container liveness.\nContainer will be restarted if the probe fails.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
                         "properties": {
                           "exec": {
+                            "description": "Exec specifies a command to execute in the container.",
                             "properties": {
                               "command": {
+                                "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
                                 "items": {
                                   "type": "string"
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               }
                             },
                             "type": "object",
                             "additionalProperties": false
                           },
                           "failureThreshold": {
+                            "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded.\nDefaults to 3. Minimum value is 1.",
                             "format": "int32",
                             "type": "integer"
                           },
+                          "grpc": {
+                            "description": "GRPC specifies a GRPC HealthCheckRequest.",
+                            "properties": {
+                              "port": {
+                                "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "service": {
+                                "default": "",
+                                "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
                           "httpGet": {
+                            "description": "HTTPGet specifies an HTTP GET request to perform.",
                             "properties": {
                               "host": {
+                                "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
                                 "type": "string"
                               },
                               "httpHeaders": {
+                                "description": "Custom headers to set in the request. HTTP allows repeated headers.",
                                 "items": {
+                                  "description": "HTTPHeader describes a custom header to be used in HTTP probes",
                                   "properties": {
                                     "name": {
+                                      "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
                                       "type": "string"
                                     },
                                     "value": {
+                                      "description": "The header field value",
                                       "type": "string"
                                     }
                                   },
@@ -5314,9 +8404,11 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "path": {
+                                "description": "Path to access on the HTTP server.",
                                 "type": "string"
                               },
                               "port": {
@@ -5328,9 +8420,11 @@
                                     "type": "string"
                                   }
                                 ],
+                                "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
                                 "x-kubernetes-int-or-string": true
                               },
                               "scheme": {
+                                "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
                                 "type": "string"
                               }
                             },
@@ -5341,20 +8435,25 @@
                             "additionalProperties": false
                           },
                           "initialDelaySeconds": {
+                            "description": "Number of seconds after the container has started before liveness probes are initiated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
                             "format": "int32",
                             "type": "integer"
                           },
                           "periodSeconds": {
+                            "description": "How often (in seconds) to perform the probe.\nDefault to 10 seconds. Minimum value is 1.",
                             "format": "int32",
                             "type": "integer"
                           },
                           "successThreshold": {
+                            "description": "Minimum consecutive successes for the probe to be considered successful after having failed.\nDefaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
                             "format": "int32",
                             "type": "integer"
                           },
                           "tcpSocket": {
+                            "description": "TCPSocket specifies a connection to a TCP port.",
                             "properties": {
                               "host": {
+                                "description": "Optional: Host name to connect to, defaults to the pod IP.",
                                 "type": "string"
                               },
                               "port": {
@@ -5366,6 +8465,7 @@
                                     "type": "string"
                                   }
                                 ],
+                                "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
                                 "x-kubernetes-int-or-string": true
                               }
                             },
@@ -5375,7 +8475,13 @@
                             "type": "object",
                             "additionalProperties": false
                           },
+                          "terminationGracePeriodSeconds": {
+                            "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure.\nThe grace period is the duration in seconds after the processes running in the pod are sent\na termination signal and the time when the processes are forcibly halted with a kill signal.\nSet this value longer than the expected cleanup time for your process.\nIf this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this\nvalue overrides the value provided by the pod spec.\nValue must be non-negative integer. The value zero indicates stop immediately via\nthe kill signal (no opportunity to shut down).\nThis is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.\nMinimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+                            "format": "int64",
+                            "type": "integer"
+                          },
                           "timeoutSeconds": {
+                            "description": "Number of seconds after which the probe times out.\nDefaults to 1 second. Minimum value is 1.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
                             "format": "int32",
                             "type": "integer"
                           }
@@ -5384,32 +8490,40 @@
                         "additionalProperties": false
                       },
                       "name": {
+                        "description": "Name of the container specified as a DNS_LABEL.\nEach container in a pod must have a unique name (DNS_LABEL).\nCannot be updated.",
                         "type": "string"
                       },
                       "ports": {
+                        "description": "List of ports to expose from the container. Not specifying a port here\nDOES NOT prevent that port from being exposed. Any port which is\nlistening on the default \"0.0.0.0\" address inside a container will be\naccessible from the network.\nModifying this array with strategic merge patch may corrupt the data.\nFor more information See https://github.com/kubernetes/kubernetes/issues/108255.\nCannot be updated.",
                         "items": {
+                          "description": "ContainerPort represents a network port in a single container.",
                           "properties": {
                             "containerPort": {
+                              "description": "Number of port to expose on the pod's IP address.\nThis must be a valid port number, 0 < x < 65536.",
                               "format": "int32",
                               "type": "integer"
                             },
                             "hostIP": {
+                              "description": "What host IP to bind the external port to.",
                               "type": "string"
                             },
                             "hostPort": {
+                              "description": "Number of port to expose on the host.\nIf specified, this must be a valid port number, 0 < x < 65536.\nIf HostNetwork is specified, this must match ContainerPort.\nMost containers do not need this.",
                               "format": "int32",
                               "type": "integer"
                             },
                             "name": {
+                              "description": "If specified, this must be an IANA_SVC_NAME and unique within the pod. Each\nnamed port in a pod must have a unique name. Name for the port that can be\nreferred to by services.",
                               "type": "string"
                             },
                             "protocol": {
+                              "default": "TCP",
+                              "description": "Protocol for port. Must be UDP, TCP, or SCTP.\nDefaults to \"TCP\".",
                               "type": "string"
                             }
                           },
                           "required": [
-                            "containerPort",
-                            "protocol"
+                            "containerPort"
                           ],
                           "type": "object",
                           "additionalProperties": false
@@ -5422,35 +8536,66 @@
                         "x-kubernetes-list-type": "map"
                       },
                       "readinessProbe": {
+                        "description": "Periodic probe of container service readiness.\nContainer will be removed from service endpoints if the probe fails.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
                         "properties": {
                           "exec": {
+                            "description": "Exec specifies a command to execute in the container.",
                             "properties": {
                               "command": {
+                                "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
                                 "items": {
                                   "type": "string"
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               }
                             },
                             "type": "object",
                             "additionalProperties": false
                           },
                           "failureThreshold": {
+                            "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded.\nDefaults to 3. Minimum value is 1.",
                             "format": "int32",
                             "type": "integer"
                           },
+                          "grpc": {
+                            "description": "GRPC specifies a GRPC HealthCheckRequest.",
+                            "properties": {
+                              "port": {
+                                "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "service": {
+                                "default": "",
+                                "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
                           "httpGet": {
+                            "description": "HTTPGet specifies an HTTP GET request to perform.",
                             "properties": {
                               "host": {
+                                "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
                                 "type": "string"
                               },
                               "httpHeaders": {
+                                "description": "Custom headers to set in the request. HTTP allows repeated headers.",
                                 "items": {
+                                  "description": "HTTPHeader describes a custom header to be used in HTTP probes",
                                   "properties": {
                                     "name": {
+                                      "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
                                       "type": "string"
                                     },
                                     "value": {
+                                      "description": "The header field value",
                                       "type": "string"
                                     }
                                   },
@@ -5461,9 +8606,11 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "path": {
+                                "description": "Path to access on the HTTP server.",
                                 "type": "string"
                               },
                               "port": {
@@ -5475,9 +8622,11 @@
                                     "type": "string"
                                   }
                                 ],
+                                "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
                                 "x-kubernetes-int-or-string": true
                               },
                               "scheme": {
+                                "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
                                 "type": "string"
                               }
                             },
@@ -5488,20 +8637,25 @@
                             "additionalProperties": false
                           },
                           "initialDelaySeconds": {
+                            "description": "Number of seconds after the container has started before liveness probes are initiated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
                             "format": "int32",
                             "type": "integer"
                           },
                           "periodSeconds": {
+                            "description": "How often (in seconds) to perform the probe.\nDefault to 10 seconds. Minimum value is 1.",
                             "format": "int32",
                             "type": "integer"
                           },
                           "successThreshold": {
+                            "description": "Minimum consecutive successes for the probe to be considered successful after having failed.\nDefaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
                             "format": "int32",
                             "type": "integer"
                           },
                           "tcpSocket": {
+                            "description": "TCPSocket specifies a connection to a TCP port.",
                             "properties": {
                               "host": {
+                                "description": "Optional: Host name to connect to, defaults to the pod IP.",
                                 "type": "string"
                               },
                               "port": {
@@ -5513,6 +8667,7 @@
                                     "type": "string"
                                   }
                                 ],
+                                "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
                                 "x-kubernetes-int-or-string": true
                               }
                             },
@@ -5522,7 +8677,13 @@
                             "type": "object",
                             "additionalProperties": false
                           },
+                          "terminationGracePeriodSeconds": {
+                            "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure.\nThe grace period is the duration in seconds after the processes running in the pod are sent\na termination signal and the time when the processes are forcibly halted with a kill signal.\nSet this value longer than the expected cleanup time for your process.\nIf this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this\nvalue overrides the value provided by the pod spec.\nValue must be non-negative integer. The value zero indicates stop immediately via\nthe kill signal (no opportunity to shut down).\nThis is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.\nMinimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+                            "format": "int64",
+                            "type": "integer"
+                          },
                           "timeoutSeconds": {
+                            "description": "Number of seconds after which the probe times out.\nDefaults to 1 second. Minimum value is 1.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
                             "format": "int32",
                             "type": "integer"
                           }
@@ -5530,8 +8691,59 @@
                         "type": "object",
                         "additionalProperties": false
                       },
+                      "resizePolicy": {
+                        "description": "Resources resize policy for the container.",
+                        "items": {
+                          "description": "ContainerResizePolicy represents resource resize policy for the container.",
+                          "properties": {
+                            "resourceName": {
+                              "description": "Name of the resource to which this resource resize policy applies.\nSupported values: cpu, memory.",
+                              "type": "string"
+                            },
+                            "restartPolicy": {
+                              "description": "Restart policy to apply when specified resource is resized.\nIf not specified, it defaults to NotRequired.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "resourceName",
+                            "restartPolicy"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
+                      },
                       "resources": {
+                        "description": "Compute Resources required by this container.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
                         "properties": {
+                          "claims": {
+                            "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
+                            "items": {
+                              "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                              "properties": {
+                                "name": {
+                                  "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
+                                  "type": "string"
+                                },
+                                "request": {
+                                  "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-map-keys": [
+                              "name"
+                            ],
+                            "x-kubernetes-list-type": "map"
+                          },
                           "limits": {
                             "additionalProperties": {
                               "anyOf": [
@@ -5545,6 +8757,7 @@
                               "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                               "x-kubernetes-int-or-string": true
                             },
+                            "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
                             "type": "object"
                           },
                           "requests": {
@@ -5560,82 +8773,151 @@
                               "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                               "x-kubernetes-int-or-string": true
                             },
+                            "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
                             "type": "object"
                           }
                         },
                         "type": "object",
                         "additionalProperties": false
                       },
+                      "restartPolicy": {
+                        "description": "RestartPolicy defines the restart behavior of individual containers in a pod.\nThis field may only be set for init containers, and the only allowed value is \"Always\".\nFor non-init containers or when this field is not specified,\nthe restart behavior is defined by the Pod's restart policy and the container type.\nSetting the RestartPolicy as \"Always\" for the init container will have the following effect:\nthis init container will be continually restarted on\nexit until all regular containers have terminated. Once all regular\ncontainers have completed, all init containers with restartPolicy \"Always\"\nwill be shut down. This lifecycle differs from normal init containers and\nis often referred to as a \"sidecar\" container. Although this init\ncontainer still starts in the init container sequence, it does not wait\nfor the container to complete before proceeding to the next init\ncontainer. Instead, the next init container starts immediately after this\ninit container is started, or after any startupProbe has successfully\ncompleted.",
+                        "type": "string"
+                      },
                       "securityContext": {
+                        "description": "SecurityContext defines the security options the container should be run with.\nIf set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.\nMore info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/",
                         "properties": {
                           "allowPrivilegeEscalation": {
+                            "description": "AllowPrivilegeEscalation controls whether a process can gain more\nprivileges than its parent process. This bool directly controls if\nthe no_new_privs flag will be set on the container process.\nAllowPrivilegeEscalation is true always when the container is:\n1) run as Privileged\n2) has CAP_SYS_ADMIN\nNote that this field cannot be set when spec.os.name is windows.",
                             "type": "boolean"
                           },
+                          "appArmorProfile": {
+                            "description": "appArmorProfile is the AppArmor options to use by this container. If set, this profile\noverrides the pod's appArmorProfile.\nNote that this field cannot be set when spec.os.name is windows.",
+                            "properties": {
+                              "localhostProfile": {
+                                "description": "localhostProfile indicates a profile loaded on the node that should be used.\nThe profile must be preconfigured on the node to work.\nMust match the loaded name of the profile.\nMust be set if and only if type is \"Localhost\".",
+                                "type": "string"
+                              },
+                              "type": {
+                                "description": "type indicates which kind of AppArmor profile will be applied.\nValid options are:\n  Localhost - a profile pre-loaded on the node.\n  RuntimeDefault - the container runtime's default profile.\n  Unconfined - no AppArmor enforcement.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "type"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
                           "capabilities": {
+                            "description": "The capabilities to add/drop when running containers.\nDefaults to the default set of capabilities granted by the container runtime.\nNote that this field cannot be set when spec.os.name is windows.",
                             "properties": {
                               "add": {
+                                "description": "Added capabilities",
                                 "items": {
+                                  "description": "Capability represent POSIX capabilities type",
                                   "type": "string"
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "drop": {
+                                "description": "Removed capabilities",
                                 "items": {
+                                  "description": "Capability represent POSIX capabilities type",
                                   "type": "string"
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               }
                             },
                             "type": "object",
                             "additionalProperties": false
                           },
                           "privileged": {
+                            "description": "Run container in privileged mode.\nProcesses in privileged containers are essentially equivalent to root on the host.\nDefaults to false.\nNote that this field cannot be set when spec.os.name is windows.",
                             "type": "boolean"
                           },
                           "procMount": {
+                            "description": "procMount denotes the type of proc mount to use for the containers.\nThe default value is Default which uses the container runtime defaults for\nreadonly paths and masked paths.\nThis requires the ProcMountType feature flag to be enabled.\nNote that this field cannot be set when spec.os.name is windows.",
                             "type": "string"
                           },
                           "readOnlyRootFilesystem": {
+                            "description": "Whether this container has a read-only root filesystem.\nDefault is false.\nNote that this field cannot be set when spec.os.name is windows.",
                             "type": "boolean"
                           },
                           "runAsGroup": {
+                            "description": "The GID to run the entrypoint of the container process.\nUses runtime default if unset.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
                             "format": "int64",
                             "type": "integer"
                           },
                           "runAsNonRoot": {
+                            "description": "Indicates that the container must run as a non-root user.\nIf true, the Kubelet will validate the image at runtime to ensure that it\ndoes not run as UID 0 (root) and fail to start the container if it does.\nIf unset or false, no such validation will be performed.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
                             "type": "boolean"
                           },
                           "runAsUser": {
+                            "description": "The UID to run the entrypoint of the container process.\nDefaults to user specified in image metadata if unspecified.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
                             "format": "int64",
                             "type": "integer"
                           },
                           "seLinuxOptions": {
+                            "description": "The SELinux context to be applied to the container.\nIf unspecified, the container runtime will allocate a random SELinux context for each\ncontainer.  May also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
                             "properties": {
                               "level": {
+                                "description": "Level is SELinux level label that applies to the container.",
                                 "type": "string"
                               },
                               "role": {
+                                "description": "Role is a SELinux role label that applies to the container.",
                                 "type": "string"
                               },
                               "type": {
+                                "description": "Type is a SELinux type label that applies to the container.",
                                 "type": "string"
                               },
                               "user": {
+                                "description": "User is a SELinux user label that applies to the container.",
                                 "type": "string"
                               }
                             },
                             "type": "object",
                             "additionalProperties": false
                           },
+                          "seccompProfile": {
+                            "description": "The seccomp options to use by this container. If seccomp options are\nprovided at both the pod & container level, the container options\noverride the pod options.\nNote that this field cannot be set when spec.os.name is windows.",
+                            "properties": {
+                              "localhostProfile": {
+                                "description": "localhostProfile indicates a profile defined in a file on the node should be used.\nThe profile must be preconfigured on the node to work.\nMust be a descending path, relative to the kubelet's configured seccomp profile location.\nMust be set if type is \"Localhost\". Must NOT be set for any other type.",
+                                "type": "string"
+                              },
+                              "type": {
+                                "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "type"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
                           "windowsOptions": {
+                            "description": "The Windows specific settings applied to all containers.\nIf unspecified, the options from the PodSecurityContext will be used.\nIf set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is linux.",
                             "properties": {
                               "gmsaCredentialSpec": {
+                                "description": "GMSACredentialSpec is where the GMSA admission webhook\n(https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the\nGMSA credential spec named by the GMSACredentialSpecName field.",
                                 "type": "string"
                               },
                               "gmsaCredentialSpecName": {
+                                "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
                                 "type": "string"
                               },
+                              "hostProcess": {
+                                "description": "HostProcess determines if a container should be run as a 'Host Process' container.\nAll of a Pod's containers must have the same effective HostProcess value\n(it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).\nIn addition, if HostProcess is true then HostNetwork must also be set to true.",
+                                "type": "boolean"
+                              },
                               "runAsUserName": {
+                                "description": "The UserName in Windows to run the entrypoint of the container process.\nDefaults to the user specified in image metadata if unspecified.\nMay also be set in PodSecurityContext. If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
                                 "type": "string"
                               }
                             },
@@ -5647,35 +8929,66 @@
                         "additionalProperties": false
                       },
                       "startupProbe": {
+                        "description": "StartupProbe indicates that the Pod has successfully initialized.\nIf specified, no other probes are executed until this completes successfully.\nIf this probe fails, the Pod will be restarted, just as if the livenessProbe failed.\nThis can be used to provide different probe parameters at the beginning of a Pod's lifecycle,\nwhen it might take a long time to load data or warm a cache, than during steady-state operation.\nThis cannot be updated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
                         "properties": {
                           "exec": {
+                            "description": "Exec specifies a command to execute in the container.",
                             "properties": {
                               "command": {
+                                "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
                                 "items": {
                                   "type": "string"
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               }
                             },
                             "type": "object",
                             "additionalProperties": false
                           },
                           "failureThreshold": {
+                            "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded.\nDefaults to 3. Minimum value is 1.",
                             "format": "int32",
                             "type": "integer"
                           },
+                          "grpc": {
+                            "description": "GRPC specifies a GRPC HealthCheckRequest.",
+                            "properties": {
+                              "port": {
+                                "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "service": {
+                                "default": "",
+                                "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
                           "httpGet": {
+                            "description": "HTTPGet specifies an HTTP GET request to perform.",
                             "properties": {
                               "host": {
+                                "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
                                 "type": "string"
                               },
                               "httpHeaders": {
+                                "description": "Custom headers to set in the request. HTTP allows repeated headers.",
                                 "items": {
+                                  "description": "HTTPHeader describes a custom header to be used in HTTP probes",
                                   "properties": {
                                     "name": {
+                                      "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
                                       "type": "string"
                                     },
                                     "value": {
+                                      "description": "The header field value",
                                       "type": "string"
                                     }
                                   },
@@ -5686,9 +8999,11 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "path": {
+                                "description": "Path to access on the HTTP server.",
                                 "type": "string"
                               },
                               "port": {
@@ -5700,9 +9015,11 @@
                                     "type": "string"
                                   }
                                 ],
+                                "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
                                 "x-kubernetes-int-or-string": true
                               },
                               "scheme": {
+                                "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
                                 "type": "string"
                               }
                             },
@@ -5713,20 +9030,25 @@
                             "additionalProperties": false
                           },
                           "initialDelaySeconds": {
+                            "description": "Number of seconds after the container has started before liveness probes are initiated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
                             "format": "int32",
                             "type": "integer"
                           },
                           "periodSeconds": {
+                            "description": "How often (in seconds) to perform the probe.\nDefault to 10 seconds. Minimum value is 1.",
                             "format": "int32",
                             "type": "integer"
                           },
                           "successThreshold": {
+                            "description": "Minimum consecutive successes for the probe to be considered successful after having failed.\nDefaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
                             "format": "int32",
                             "type": "integer"
                           },
                           "tcpSocket": {
+                            "description": "TCPSocket specifies a connection to a TCP port.",
                             "properties": {
                               "host": {
+                                "description": "Optional: Host name to connect to, defaults to the pod IP.",
                                 "type": "string"
                               },
                               "port": {
@@ -5738,6 +9060,7 @@
                                     "type": "string"
                                   }
                                 ],
+                                "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
                                 "x-kubernetes-int-or-string": true
                               }
                             },
@@ -5747,7 +9070,13 @@
                             "type": "object",
                             "additionalProperties": false
                           },
+                          "terminationGracePeriodSeconds": {
+                            "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure.\nThe grace period is the duration in seconds after the processes running in the pod are sent\na termination signal and the time when the processes are forcibly halted with a kill signal.\nSet this value longer than the expected cleanup time for your process.\nIf this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this\nvalue overrides the value provided by the pod spec.\nValue must be non-negative integer. The value zero indicates stop immediately via\nthe kill signal (no opportunity to shut down).\nThis is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.\nMinimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+                            "format": "int64",
+                            "type": "integer"
+                          },
                           "timeoutSeconds": {
+                            "description": "Number of seconds after which the probe times out.\nDefaults to 1 second. Minimum value is 1.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
                             "format": "int32",
                             "type": "integer"
                           }
@@ -5756,27 +9085,36 @@
                         "additionalProperties": false
                       },
                       "stdin": {
+                        "description": "Whether this container should allocate a buffer for stdin in the container runtime. If this\nis not set, reads from stdin in the container will always result in EOF.\nDefault is false.",
                         "type": "boolean"
                       },
                       "stdinOnce": {
+                        "description": "Whether the container runtime should close the stdin channel after it has been opened by\na single attach. When stdin is true the stdin stream will remain open across multiple attach\nsessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the\nfirst client attaches to stdin, and then remains open and accepts data until the client disconnects,\nat which time stdin is closed and remains closed until the container is restarted. If this\nflag is false, a container processes that reads from stdin will never receive an EOF.\nDefault is false",
                         "type": "boolean"
                       },
                       "terminationMessagePath": {
+                        "description": "Optional: Path at which the file to which the container's termination message\nwill be written is mounted into the container's filesystem.\nMessage written is intended to be brief final status, such as an assertion failure message.\nWill be truncated by the node if greater than 4096 bytes. The total message length across\nall containers will be limited to 12kb.\nDefaults to /dev/termination-log.\nCannot be updated.",
                         "type": "string"
                       },
                       "terminationMessagePolicy": {
+                        "description": "Indicate how the termination message should be populated. File will use the contents of\nterminationMessagePath to populate the container status message on both success and failure.\nFallbackToLogsOnError will use the last chunk of container log output if the termination\nmessage file is empty and the container exited with an error.\nThe log output is limited to 2048 bytes or 80 lines, whichever is smaller.\nDefaults to File.\nCannot be updated.",
                         "type": "string"
                       },
                       "tty": {
+                        "description": "Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.\nDefault is false.",
                         "type": "boolean"
                       },
                       "volumeDevices": {
+                        "description": "volumeDevices is the list of block devices to be used by the container.",
                         "items": {
+                          "description": "volumeDevice describes a mapping of a raw block device within a container.",
                           "properties": {
                             "devicePath": {
+                              "description": "devicePath is the path inside of the container that the device will be mapped to.",
                               "type": "string"
                             },
                             "name": {
+                              "description": "name must match the name of a persistentVolumeClaim in the pod",
                               "type": "string"
                             }
                           },
@@ -5787,27 +9125,43 @@
                           "type": "object",
                           "additionalProperties": false
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-map-keys": [
+                          "devicePath"
+                        ],
+                        "x-kubernetes-list-type": "map"
                       },
                       "volumeMounts": {
+                        "description": "Pod volumes to mount into the container's filesystem.\nCannot be updated.",
                         "items": {
+                          "description": "VolumeMount describes a mounting of a Volume within a container.",
                           "properties": {
                             "mountPath": {
+                              "description": "Path within the container at which the volume should be mounted.  Must\nnot contain ':'.",
                               "type": "string"
                             },
                             "mountPropagation": {
+                              "description": "mountPropagation determines how mounts are propagated from the host\nto container and the other way around.\nWhen not set, MountPropagationNone is used.\nThis field is beta in 1.10.\nWhen RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified\n(which defaults to None).",
                               "type": "string"
                             },
                             "name": {
+                              "description": "This must match the Name of a Volume.",
                               "type": "string"
                             },
                             "readOnly": {
+                              "description": "Mounted read-only if true, read-write otherwise (false or unspecified).\nDefaults to false.",
                               "type": "boolean"
                             },
+                            "recursiveReadOnly": {
+                              "description": "RecursiveReadOnly specifies whether read-only mounts should be handled\nrecursively.\n\nIf ReadOnly is false, this field has no meaning and must be unspecified.\n\nIf ReadOnly is true, and this field is set to Disabled, the mount is not made\nrecursively read-only.  If this field is set to IfPossible, the mount is made\nrecursively read-only, if it is supported by the container runtime.  If this\nfield is set to Enabled, the mount is made recursively read-only if it is\nsupported by the container runtime, otherwise the pod will not be started and\nan error will be generated to indicate the reason.\n\nIf this field is set to IfPossible or Enabled, MountPropagation must be set to\nNone (or be unspecified, which defaults to None).\n\nIf this field is not specified, it is treated as an equivalent of Disabled.",
+                              "type": "string"
+                            },
                             "subPath": {
+                              "description": "Path within the volume from which the container's volume should be mounted.\nDefaults to \"\" (volume's root).",
                               "type": "string"
                             },
                             "subPathExpr": {
+                              "description": "Expanded path within the volume from which the container's volume should be mounted.\nBehaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.\nDefaults to \"\" (volume's root).\nSubPathExpr and SubPath are mutually exclusive.",
                               "type": "string"
                             }
                           },
@@ -5818,9 +9172,14 @@
                           "type": "object",
                           "additionalProperties": false
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-map-keys": [
+                          "mountPath"
+                        ],
+                        "x-kubernetes-list-type": "map"
                       },
                       "workingDir": {
+                        "description": "Container's working directory.\nIf not specified, the container runtime's default will be used, which\nmight be configured in the container image.\nCannot be updated.",
                         "type": "string"
                       }
                     },
@@ -5832,27 +9191,40 @@
                   },
                   "type": "array"
                 },
+                "template": {
+                  "description": "Template is a pod template that can be used to define the driver or executor pod configurations that Spark configurations do not support.\nSpark version >= 3.0.0 is required.\nRef: https://spark.apache.org/docs/latest/running-on-kubernetes.html#pod-template.",
+                  "type": "object",
+                  "x-kubernetes-preserve-unknown-fields": true
+                },
                 "terminationGracePeriodSeconds": {
+                  "description": "Termination grace period seconds for the pod",
                   "format": "int64",
                   "type": "integer"
                 },
                 "tolerations": {
+                  "description": "Tolerations specifies the tolerations listed in \".spec.tolerations\" to be applied to the pod.",
                   "items": {
+                    "description": "The pod this Toleration is attached to tolerates any taint that matches\nthe triple <key,value,effect> using the matching operator <operator>.",
                     "properties": {
                       "effect": {
+                        "description": "Effect indicates the taint effect to match. Empty means match all taint effects.\nWhen specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
                         "type": "string"
                       },
                       "key": {
+                        "description": "Key is the taint key that the toleration applies to. Empty means match all taint keys.\nIf the key is empty, operator must be Exists; this combination means to match all values and all keys.",
                         "type": "string"
                       },
                       "operator": {
+                        "description": "Operator represents a key's relationship to the value.\nValid operators are Exists and Equal. Defaults to Equal.\nExists is equivalent to wildcard for value, so that a pod can\ntolerate all taints of a particular category.",
                         "type": "string"
                       },
                       "tolerationSeconds": {
+                        "description": "TolerationSeconds represents the period of time the toleration (which must be\nof effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,\nit is not set, which means tolerate the taint forever (do not evict). Zero and\nnegative values will be treated as 0 (evict immediately) by the system.",
                         "format": "int64",
                         "type": "integer"
                       },
                       "value": {
+                        "description": "Value is the taint value the toleration matches to.\nIf the operator is Exists, the value should be empty, otherwise just a regular string.",
                         "type": "string"
                       }
                     },
@@ -5862,24 +9234,36 @@
                   "type": "array"
                 },
                 "volumeMounts": {
+                  "description": "VolumeMounts specifies the volumes listed in \".spec.volumes\" to mount into the main container's filesystem.",
                   "items": {
+                    "description": "VolumeMount describes a mounting of a Volume within a container.",
                     "properties": {
                       "mountPath": {
+                        "description": "Path within the container at which the volume should be mounted.  Must\nnot contain ':'.",
                         "type": "string"
                       },
                       "mountPropagation": {
+                        "description": "mountPropagation determines how mounts are propagated from the host\nto container and the other way around.\nWhen not set, MountPropagationNone is used.\nThis field is beta in 1.10.\nWhen RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified\n(which defaults to None).",
                         "type": "string"
                       },
                       "name": {
+                        "description": "This must match the Name of a Volume.",
                         "type": "string"
                       },
                       "readOnly": {
+                        "description": "Mounted read-only if true, read-write otherwise (false or unspecified).\nDefaults to false.",
                         "type": "boolean"
                       },
+                      "recursiveReadOnly": {
+                        "description": "RecursiveReadOnly specifies whether read-only mounts should be handled\nrecursively.\n\nIf ReadOnly is false, this field has no meaning and must be unspecified.\n\nIf ReadOnly is true, and this field is set to Disabled, the mount is not made\nrecursively read-only.  If this field is set to IfPossible, the mount is made\nrecursively read-only, if it is supported by the container runtime.  If this\nfield is set to Enabled, the mount is made recursively read-only if it is\nsupported by the container runtime, otherwise the pod will not be started and\nan error will be generated to indicate the reason.\n\nIf this field is set to IfPossible or Enabled, MountPropagation must be set to\nNone (or be unspecified, which defaults to None).\n\nIf this field is not specified, it is treated as an equivalent of Disabled.",
+                        "type": "string"
+                      },
                       "subPath": {
+                        "description": "Path within the volume from which the container's volume should be mounted.\nDefaults to \"\" (volume's root).",
                         "type": "string"
                       },
                       "subPathExpr": {
+                        "description": "Expanded path within the volume from which the container's volume should be mounted.\nBehaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.\nDefaults to \"\" (volume's root).\nSubPathExpr and SubPath are mutually exclusive.",
                         "type": "string"
                       }
                     },
@@ -5897,6 +9281,7 @@
               "additionalProperties": false
             },
             "failureRetries": {
+              "description": "FailureRetries is the number of times to retry a failed application before giving up.\nThis is best effort and actual retry attempts can be >= the value specified.",
               "format": "int32",
               "type": "integer"
             },
@@ -5904,33 +9289,42 @@
               "additionalProperties": {
                 "type": "string"
               },
+              "description": "HadoopConf carries user-specified Hadoop configuration properties as they would use the \"--conf\" option\nin spark-submit. The SparkApplication controller automatically adds prefix \"spark.hadoop.\" to Hadoop\nconfiguration properties.",
               "type": "object"
             },
             "hadoopConfigMap": {
+              "description": "HadoopConfigMap carries the name of the ConfigMap containing Hadoop configuration files such as core-site.xml.\nThe controller will add environment variable HADOOP_CONF_DIR to the path where the ConfigMap is mounted to.",
               "type": "string"
             },
             "image": {
+              "description": "Image is the container image for the driver, executor, and init-container. Any custom container images for the\ndriver, executor, or init-container takes precedence over this.",
               "type": "string"
             },
             "imagePullPolicy": {
+              "description": "ImagePullPolicy is the image pull policy for the driver, executor, and init-container.",
               "type": "string"
             },
             "imagePullSecrets": {
+              "description": "ImagePullSecrets is the list of image-pull secrets.",
               "items": {
                 "type": "string"
               },
               "type": "array"
             },
             "mainApplicationFile": {
+              "description": "MainFile is the path to a bundled JAR, Python, or R file of the application.",
               "type": "string"
             },
             "mainClass": {
+              "description": "MainClass is the fully-qualified main class of the Spark application.\nThis only applies to Java/Scala Spark applications.",
               "type": "string"
             },
             "memoryOverheadFactor": {
+              "description": "This sets the Memory Overhead Factor that will allocate memory to non-JVM memory.\nFor JVM-based jobs this value will default to 0.10, for non-JVM jobs 0.40. Value of this field will\nbe overridden by `Spec.Driver.MemoryOverhead` and `Spec.Executor.MemoryOverhead` if they are set.",
               "type": "string"
             },
             "mode": {
+              "description": "Mode is the deployment mode of the Spark application.",
               "enum": [
                 "cluster",
                 "client"
@@ -5938,37 +9332,48 @@
               "type": "string"
             },
             "monitoring": {
+              "description": "Monitoring configures how monitoring is handled.",
               "properties": {
                 "exposeDriverMetrics": {
+                  "description": "ExposeDriverMetrics specifies whether to expose metrics on the driver.",
                   "type": "boolean"
                 },
                 "exposeExecutorMetrics": {
+                  "description": "ExposeExecutorMetrics specifies whether to expose metrics on the executors.",
                   "type": "boolean"
                 },
                 "metricsProperties": {
+                  "description": "MetricsProperties is the content of a custom metrics.properties for configuring the Spark metric system.\nIf not specified, the content in spark-docker/conf/metrics.properties will be used.",
                   "type": "string"
                 },
                 "metricsPropertiesFile": {
+                  "description": "MetricsPropertiesFile is the container local path of file metrics.properties for configuring\nthe Spark metric system. If not specified, value /etc/metrics/conf/metrics.properties will be used.",
                   "type": "string"
                 },
                 "prometheus": {
+                  "description": "Prometheus is for configuring the Prometheus JMX exporter.",
                   "properties": {
                     "configFile": {
+                      "description": "ConfigFile is the path to the custom Prometheus configuration file provided in the Spark image.\nConfigFile takes precedence over Configuration, which is shown below.",
                       "type": "string"
                     },
                     "configuration": {
+                      "description": "Configuration is the content of the Prometheus configuration needed by the Prometheus JMX exporter.\nIf not specified, the content in spark-docker/conf/prometheus.yaml will be used.\nConfiguration has no effect if ConfigFile is set.",
                       "type": "string"
                     },
                     "jmxExporterJar": {
+                      "description": "JmxExporterJar is the path to the Prometheus JMX exporter jar in the container.",
                       "type": "string"
                     },
                     "port": {
+                      "description": "Port is the port of the HTTP server run by the Prometheus JMX exporter.\nIf not specified, 8090 will be used as the default.",
                       "format": "int32",
                       "maximum": 49151,
                       "minimum": 1024,
                       "type": "integer"
                     },
                     "portName": {
+                      "description": "PortName is the port name of prometheus JMX exporter port.\nIf not specified, jmx-exporter will be used as the default.",
                       "type": "string"
                     }
                   },
@@ -5990,12 +9395,15 @@
               "additionalProperties": {
                 "type": "string"
               },
+              "description": "NodeSelector is the Kubernetes node selector to be added to the driver and executor pods.\nThis field is mutually exclusive with nodeSelector at podSpec level (driver or executor).\nThis field will be deprecated in future versions (at SparkApplicationSpec level).",
               "type": "object"
             },
             "proxyUser": {
+              "description": "ProxyUser specifies the user to impersonate when submitting the application.\nIt maps to the command-line flag \"--proxy-user\" in spark-submit.",
               "type": "string"
             },
             "pythonVersion": {
+              "description": "This sets the major Python version of the docker\nimage used to run the driver and executor containers. Can either be 2 or 3, default 2.",
               "enum": [
                 "2",
                 "3"
@@ -6003,28 +9411,34 @@
               "type": "string"
             },
             "restartPolicy": {
+              "description": "RestartPolicy defines the policy on if and in which conditions the controller should restart an application.",
               "properties": {
                 "onFailureRetries": {
+                  "description": "OnFailureRetries the number of times to retry running an application before giving up.",
                   "format": "int32",
                   "minimum": 0,
                   "type": "integer"
                 },
                 "onFailureRetryInterval": {
+                  "description": "OnFailureRetryInterval is the interval in seconds between retries on failed runs.",
                   "format": "int64",
                   "minimum": 1,
                   "type": "integer"
                 },
                 "onSubmissionFailureRetries": {
+                  "description": "OnSubmissionFailureRetries is the number of times to retry submitting an application before giving up.\nThis is best effort and actual retry attempts can be >= the value specified due to caching.\nThese are required if RestartPolicy is OnFailure.",
                   "format": "int32",
                   "minimum": 0,
                   "type": "integer"
                 },
                 "onSubmissionFailureRetryInterval": {
+                  "description": "OnSubmissionFailureRetryInterval is the interval in seconds between retries on failed submissions.",
                   "format": "int64",
                   "minimum": 1,
                   "type": "integer"
                 },
                 "type": {
+                  "description": "Type specifies the RestartPolicyType.",
                   "enum": [
                     "Never",
                     "Always",
@@ -6037,6 +9451,7 @@
               "additionalProperties": false
             },
             "retryInterval": {
+              "description": "RetryInterval is the unit of intervals in seconds between submission retries.",
               "format": "int64",
               "type": "integer"
             },
@@ -6044,29 +9459,38 @@
               "additionalProperties": {
                 "type": "string"
               },
+              "description": "SparkConf carries user-specified Spark configuration properties as they would use the  \"--conf\" option in\nspark-submit.",
               "type": "object"
             },
             "sparkConfigMap": {
+              "description": "SparkConfigMap carries the name of the ConfigMap containing Spark configuration files such as log4j.properties.\nThe controller will add environment variable SPARK_CONF_DIR to the path where the ConfigMap is mounted to.",
               "type": "string"
             },
             "sparkUIOptions": {
+              "description": "SparkUIOptions allows configuring the Service and the Ingress to expose the sparkUI",
               "properties": {
                 "ingressAnnotations": {
                   "additionalProperties": {
                     "type": "string"
                   },
+                  "description": "IngressAnnotations is a map of key,value pairs of annotations that might be added to the ingress object. i.e. specify nginx as ingress.class",
                   "type": "object"
                 },
                 "ingressTLS": {
+                  "description": "TlsHosts is useful If we need to declare SSL certificates to the ingress object",
                   "items": {
+                    "description": "IngressTLS describes the transport layer security associated with an ingress.",
                     "properties": {
                       "hosts": {
+                        "description": "hosts is a list of hosts included in the TLS certificate. The values in\nthis list must match the name/s used in the tlsSecret. Defaults to the\nwildcard host setting for the loadbalancer controller fulfilling this\nIngress, if left unspecified.",
                         "items": {
                           "type": "string"
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "secretName": {
+                        "description": "secretName is the name of the secret used to terminate TLS traffic on\nport 443. Field is left optional to allow TLS routing based on SNI\nhostname alone. If the SNI host in a listener conflicts with the \"Host\"\nheader field used by an IngressRule, the SNI host is used for termination\nand value of the \"Host\" header is used for routing.",
                         "type": "string"
                       }
                     },
@@ -6079,13 +9503,27 @@
                   "additionalProperties": {
                     "type": "string"
                   },
+                  "description": "ServiceAnnotations is a map of key,value pairs of annotations that might be added to the service object.",
+                  "type": "object"
+                },
+                "serviceLabels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "ServiceLabels is a map of key,value pairs of labels that might be added to the service object.",
                   "type": "object"
                 },
                 "servicePort": {
+                  "description": "ServicePort allows configuring the port at service level that might be different from the targetPort.\nTargetPort should be the same as the one defined in spark.ui.port",
                   "format": "int32",
                   "type": "integer"
                 },
+                "servicePortName": {
+                  "description": "ServicePortName allows configuring the name of the service port.\nThis may be useful for sidecar proxies like Envoy injected by Istio which require specific ports names to treat traffic as proper HTTP.\nDefaults to spark-driver-ui-port.",
+                  "type": "string"
+                },
                 "serviceType": {
+                  "description": "ServiceType allows configuring the type of the service. Defaults to ClusterIP.",
                   "type": "string"
                 }
               },
@@ -6093,13 +9531,16 @@
               "additionalProperties": false
             },
             "sparkVersion": {
+              "description": "SparkVersion is the version of Spark the application uses.",
               "type": "string"
             },
             "timeToLiveSeconds": {
+              "description": "TimeToLiveSeconds defines the Time-To-Live (TTL) duration in seconds for this SparkApplication\nafter its termination.\nThe SparkApplication object will be garbage collected if the current time is more than the\nTimeToLiveSeconds since its termination.",
               "format": "int64",
               "type": "integer"
             },
             "type": {
+              "description": "Type tells the type of the Spark application.",
               "enum": [
                 "Java",
                 "Python",
@@ -6109,21 +9550,28 @@
               "type": "string"
             },
             "volumes": {
+              "description": "Volumes is the list of Kubernetes volumes that can be mounted by the driver and/or executors.",
               "items": {
+                "description": "Volume represents a named volume in a pod that may be accessed by any container in the pod.",
                 "properties": {
                   "awsElasticBlockStore": {
+                    "description": "awsElasticBlockStore represents an AWS Disk resource that is attached to a\nkubelet's host machine and then exposed to the pod.\nDeprecated: AWSElasticBlockStore is deprecated. All operations for the in-tree\nawsElasticBlockStore type are redirected to the ebs.csi.aws.com CSI driver.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
                     "properties": {
                       "fsType": {
+                        "description": "fsType is the filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
                         "type": "string"
                       },
                       "partition": {
+                        "description": "partition is the partition in the volume that you want to mount.\nIf omitted, the default is to mount by volume name.\nExamples: For volume /dev/sda1, you specify the partition as \"1\".\nSimilarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty).",
                         "format": "int32",
                         "type": "integer"
                       },
                       "readOnly": {
+                        "description": "readOnly value true will force the readOnly setting in VolumeMounts.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
                         "type": "boolean"
                       },
                       "volumeID": {
+                        "description": "volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
                         "type": "string"
                       }
                     },
@@ -6134,23 +9582,32 @@
                     "additionalProperties": false
                   },
                   "azureDisk": {
+                    "description": "azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.\nDeprecated: AzureDisk is deprecated. All operations for the in-tree azureDisk type\nare redirected to the disk.csi.azure.com CSI driver.",
                     "properties": {
                       "cachingMode": {
+                        "description": "cachingMode is the Host Caching mode: None, Read Only, Read Write.",
                         "type": "string"
                       },
                       "diskName": {
+                        "description": "diskName is the Name of the data disk in the blob storage",
                         "type": "string"
                       },
                       "diskURI": {
+                        "description": "diskURI is the URI of data disk in the blob storage",
                         "type": "string"
                       },
                       "fsType": {
+                        "default": "ext4",
+                        "description": "fsType is Filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
                         "type": "string"
                       },
                       "kind": {
+                        "description": "kind expected values are Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared",
                         "type": "string"
                       },
                       "readOnly": {
+                        "default": false,
+                        "description": "readOnly Defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
                         "type": "boolean"
                       }
                     },
@@ -6162,14 +9619,18 @@
                     "additionalProperties": false
                   },
                   "azureFile": {
+                    "description": "azureFile represents an Azure File Service mount on the host and bind mount to the pod.\nDeprecated: AzureFile is deprecated. All operations for the in-tree azureFile type\nare redirected to the file.csi.azure.com CSI driver.",
                     "properties": {
                       "readOnly": {
+                        "description": "readOnly defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
                         "type": "boolean"
                       },
                       "secretName": {
+                        "description": "secretName is the  name of secret that contains Azure Storage Account Name and Key",
                         "type": "string"
                       },
                       "shareName": {
+                        "description": "shareName is the azure share Name",
                         "type": "string"
                       }
                     },
@@ -6181,32 +9642,43 @@
                     "additionalProperties": false
                   },
                   "cephfs": {
+                    "description": "cephFS represents a Ceph FS mount on the host that shares a pod's lifetime.\nDeprecated: CephFS is deprecated and the in-tree cephfs type is no longer supported.",
                     "properties": {
                       "monitors": {
+                        "description": "monitors is Required: Monitors is a collection of Ceph monitors\nMore info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
                         "items": {
                           "type": "string"
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "path": {
+                        "description": "path is Optional: Used as the mounted root, rather than the full Ceph tree, default is /",
                         "type": "string"
                       },
                       "readOnly": {
+                        "description": "readOnly is Optional: Defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.\nMore info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
                         "type": "boolean"
                       },
                       "secretFile": {
+                        "description": "secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret\nMore info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
                         "type": "string"
                       },
                       "secretRef": {
+                        "description": "secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.\nMore info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
                         "properties": {
                           "name": {
+                            "default": "",
+                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                             "type": "string"
                           }
                         },
                         "type": "object",
+                        "x-kubernetes-map-type": "atomic",
                         "additionalProperties": false
                       },
                       "user": {
+                        "description": "user is optional: User is the rados user name, default is admin\nMore info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
                         "type": "string"
                       }
                     },
@@ -6217,23 +9689,31 @@
                     "additionalProperties": false
                   },
                   "cinder": {
+                    "description": "cinder represents a cinder volume attached and mounted on kubelets host machine.\nDeprecated: Cinder is deprecated. All operations for the in-tree cinder type\nare redirected to the cinder.csi.openstack.org CSI driver.\nMore info: https://examples.k8s.io/mysql-cinder-pd/README.md",
                     "properties": {
                       "fsType": {
+                        "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://examples.k8s.io/mysql-cinder-pd/README.md",
                         "type": "string"
                       },
                       "readOnly": {
+                        "description": "readOnly defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.\nMore info: https://examples.k8s.io/mysql-cinder-pd/README.md",
                         "type": "boolean"
                       },
                       "secretRef": {
+                        "description": "secretRef is optional: points to a secret object containing parameters used to connect\nto OpenStack.",
                         "properties": {
                           "name": {
+                            "default": "",
+                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                             "type": "string"
                           }
                         },
                         "type": "object",
+                        "x-kubernetes-map-type": "atomic",
                         "additionalProperties": false
                       },
                       "volumeID": {
+                        "description": "volumeID used to identify the volume in cinder.\nMore info: https://examples.k8s.io/mysql-cinder-pd/README.md",
                         "type": "string"
                       }
                     },
@@ -6244,22 +9724,29 @@
                     "additionalProperties": false
                   },
                   "configMap": {
+                    "description": "configMap represents a configMap that should populate this volume",
                     "properties": {
                       "defaultMode": {
+                        "description": "defaultMode is optional: mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nDefaults to 0644.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
                         "format": "int32",
                         "type": "integer"
                       },
                       "items": {
+                        "description": "items if unspecified, each key-value pair in the Data field of the referenced\nConfigMap will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the ConfigMap,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
                         "items": {
+                          "description": "Maps a string key to a path within a volume.",
                           "properties": {
                             "key": {
+                              "description": "key is the key to project.",
                               "type": "string"
                             },
                             "mode": {
+                              "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
                               "format": "int32",
                               "type": "integer"
                             },
                             "path": {
+                              "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
                               "type": "string"
                             }
                           },
@@ -6270,42 +9757,56 @@
                           "type": "object",
                           "additionalProperties": false
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "name": {
+                        "default": "",
+                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                         "type": "string"
                       },
                       "optional": {
+                        "description": "optional specify whether the ConfigMap or its keys must be defined",
                         "type": "boolean"
                       }
                     },
                     "type": "object",
+                    "x-kubernetes-map-type": "atomic",
                     "additionalProperties": false
                   },
                   "csi": {
+                    "description": "csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers.",
                     "properties": {
                       "driver": {
+                        "description": "driver is the name of the CSI driver that handles this volume.\nConsult with your admin for the correct name as registered in the cluster.",
                         "type": "string"
                       },
                       "fsType": {
+                        "description": "fsType to mount. Ex. \"ext4\", \"xfs\", \"ntfs\".\nIf not provided, the empty value is passed to the associated CSI driver\nwhich will determine the default filesystem to apply.",
                         "type": "string"
                       },
                       "nodePublishSecretRef": {
+                        "description": "nodePublishSecretRef is a reference to the secret object containing\nsensitive information to pass to the CSI driver to complete the CSI\nNodePublishVolume and NodeUnpublishVolume calls.\nThis field is optional, and  may be empty if no secret is required. If the\nsecret object contains more than one secret, all secret references are passed.",
                         "properties": {
                           "name": {
+                            "default": "",
+                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                             "type": "string"
                           }
                         },
                         "type": "object",
+                        "x-kubernetes-map-type": "atomic",
                         "additionalProperties": false
                       },
                       "readOnly": {
+                        "description": "readOnly specifies a read-only configuration for the volume.\nDefaults to false (read/write).",
                         "type": "boolean"
                       },
                       "volumeAttributes": {
                         "additionalProperties": {
                           "type": "string"
                         },
+                        "description": "volumeAttributes stores driver-specific properties that are passed to the CSI\ndriver. Consult your driver's documentation for supported values.",
                         "type": "object"
                       }
                     },
@@ -6316,20 +9817,27 @@
                     "additionalProperties": false
                   },
                   "downwardAPI": {
+                    "description": "downwardAPI represents downward API about the pod that should populate this volume",
                     "properties": {
                       "defaultMode": {
+                        "description": "Optional: mode bits to use on created files by default. Must be a\nOptional: mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nDefaults to 0644.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
                         "format": "int32",
                         "type": "integer"
                       },
                       "items": {
+                        "description": "Items is a list of downward API volume file",
                         "items": {
+                          "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
                           "properties": {
                             "fieldRef": {
+                              "description": "Required: Selects a field of the pod: only annotations, labels, name, namespace and uid are supported.",
                               "properties": {
                                 "apiVersion": {
+                                  "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
                                   "type": "string"
                                 },
                                 "fieldPath": {
+                                  "description": "Path of the field to select in the specified API version.",
                                   "type": "string"
                                 }
                               },
@@ -6337,18 +9845,23 @@
                                 "fieldPath"
                               ],
                               "type": "object",
+                              "x-kubernetes-map-type": "atomic",
                               "additionalProperties": false
                             },
                             "mode": {
+                              "description": "Optional: mode bits used to set permissions on this file, must be an octal value\nbetween 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
                               "format": "int32",
                               "type": "integer"
                             },
                             "path": {
+                              "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'",
                               "type": "string"
                             },
                             "resourceFieldRef": {
+                              "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.",
                               "properties": {
                                 "containerName": {
+                                  "description": "Container name: required for volumes, optional for env vars",
                                   "type": "string"
                                 },
                                 "divisor": {
@@ -6360,10 +9873,12 @@
                                       "type": "string"
                                     }
                                   ],
+                                  "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
                                   "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                                   "x-kubernetes-int-or-string": true
                                 },
                                 "resource": {
+                                  "description": "Required: resource to select",
                                   "type": "string"
                                 }
                               },
@@ -6371,6 +9886,7 @@
                                 "resource"
                               ],
                               "type": "object",
+                              "x-kubernetes-map-type": "atomic",
                               "additionalProperties": false
                             }
                           },
@@ -6380,15 +9896,18 @@
                           "type": "object",
                           "additionalProperties": false
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       }
                     },
                     "type": "object",
                     "additionalProperties": false
                   },
                   "emptyDir": {
+                    "description": "emptyDir represents a temporary directory that shares a pod's lifetime.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
                     "properties": {
                       "medium": {
+                        "description": "medium represents what type of storage medium should back this directory.\nThe default is \"\" which means to use the node's default medium.\nMust be an empty string (default) or Memory.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
                         "type": "string"
                       },
                       "sizeLimit": {
@@ -6400,6 +9919,7 @@
                             "type": "string"
                           }
                         ],
+                        "description": "sizeLimit is the total amount of local storage required for this EmptyDir volume.\nThe size limit is also applicable for memory medium.\nThe maximum usage on memory medium EmptyDir would be the minimum value between\nthe SizeLimit specified here and the sum of memory limits of all containers in a pod.\nThe default is nil which means that the limit is undefined.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
                         "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                         "x-kubernetes-int-or-string": true
                       }
@@ -6407,58 +9927,291 @@
                     "type": "object",
                     "additionalProperties": false
                   },
+                  "ephemeral": {
+                    "description": "ephemeral represents a volume that is handled by a cluster storage driver.\nThe volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,\nand deleted when the pod is removed.\n\nUse this if:\na) the volume is only needed while the pod runs,\nb) features of normal volumes like restoring from snapshot or capacity\n   tracking are needed,\nc) the storage driver is specified through a storage class, and\nd) the storage driver supports dynamic volume provisioning through\n   a PersistentVolumeClaim (see EphemeralVolumeSource for more\n   information on the connection between this volume type\n   and PersistentVolumeClaim).\n\nUse PersistentVolumeClaim or one of the vendor-specific\nAPIs for volumes that persist for longer than the lifecycle\nof an individual pod.\n\nUse CSI for light-weight local ephemeral volumes if the CSI driver is meant to\nbe used that way - see the documentation of the driver for\nmore information.\n\nA pod can use both types of ephemeral volumes and\npersistent volumes at the same time.",
+                    "properties": {
+                      "volumeClaimTemplate": {
+                        "description": "Will be used to create a stand-alone PVC to provision the volume.\nThe pod in which this EphemeralVolumeSource is embedded will be the\nowner of the PVC, i.e. the PVC will be deleted together with the\npod.  The name of the PVC will be `<pod name>-<volume name>` where\n`<volume name>` is the name from the `PodSpec.Volumes` array\nentry. Pod validation will reject the pod if the concatenated name\nis not valid for a PVC (for example, too long).\n\nAn existing PVC with that name that is not owned by the pod\nwill *not* be used for the pod to avoid using an unrelated\nvolume by mistake. Starting the pod is then blocked until\nthe unrelated PVC is removed. If such a pre-created PVC is\nmeant to be used by the pod, the PVC has to updated with an\nowner reference to the pod once the pod exists. Normally\nthis should not be necessary, but it may be useful when\nmanually reconstructing a broken cluster.\n\nThis field is read-only and no changes will be made by Kubernetes\nto the PVC after it has been created.\n\nRequired, must not be nil.",
+                        "properties": {
+                          "metadata": {
+                            "description": "May contain labels and annotations that will be copied into the PVC\nwhen creating it. No other fields are allowed and will be rejected during\nvalidation.",
+                            "properties": {
+                              "annotations": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              },
+                              "finalizers": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "labels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "namespace": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "spec": {
+                            "description": "The specification for the PersistentVolumeClaim. The entire content is\ncopied unchanged into the PVC that gets created from this\ntemplate. The same fields as in a PersistentVolumeClaim\nare also valid here.",
+                            "properties": {
+                              "accessModes": {
+                                "description": "accessModes contains the desired access modes the volume should have.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "dataSource": {
+                                "description": "dataSource field can be used to specify either:\n* An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)\n* An existing PVC (PersistentVolumeClaim)\nIf the provisioner or an external controller can support the specified data source,\nit will create a new volume based on the contents of the specified data source.\nWhen the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,\nand dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.\nIf the namespace is specified, then dataSourceRef will not be copied to dataSource.",
+                                "properties": {
+                                  "apiGroup": {
+                                    "description": "APIGroup is the group for the resource being referenced.\nIf APIGroup is not specified, the specified Kind must be in the core API group.\nFor any other third-party types, APIGroup is required.",
+                                    "type": "string"
+                                  },
+                                  "kind": {
+                                    "description": "Kind is the type of resource being referenced",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name is the name of resource being referenced",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "kind",
+                                  "name"
+                                ],
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "dataSourceRef": {
+                                "description": "dataSourceRef specifies the object from which to populate the volume with data, if a non-empty\nvolume is desired. This may be any object from a non-empty API group (non\ncore object) or a PersistentVolumeClaim object.\nWhen this field is specified, volume binding will only succeed if the type of\nthe specified object matches some installed volume populator or dynamic\nprovisioner.\nThis field will replace the functionality of the dataSource field and as such\nif both fields are non-empty, they must have the same value. For backwards\ncompatibility, when namespace isn't specified in dataSourceRef,\nboth fields (dataSource and dataSourceRef) will be set to the same\nvalue automatically if one of them is empty and the other is non-empty.\nWhen namespace is specified in dataSourceRef,\ndataSource isn't set to the same value and must be empty.\nThere are three important differences between dataSource and dataSourceRef:\n* While dataSource only allows two specific types of objects, dataSourceRef\n  allows any non-core object, as well as PersistentVolumeClaim objects.\n* While dataSource ignores disallowed values (dropping them), dataSourceRef\n  preserves all values, and generates an error if a disallowed value is\n  specified.\n* While dataSource only allows local objects, dataSourceRef allows objects\n  in any namespaces.\n(Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.\n(Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.",
+                                "properties": {
+                                  "apiGroup": {
+                                    "description": "APIGroup is the group for the resource being referenced.\nIf APIGroup is not specified, the specified Kind must be in the core API group.\nFor any other third-party types, APIGroup is required.",
+                                    "type": "string"
+                                  },
+                                  "kind": {
+                                    "description": "Kind is the type of resource being referenced",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name is the name of resource being referenced",
+                                    "type": "string"
+                                  },
+                                  "namespace": {
+                                    "description": "Namespace is the namespace of resource being referenced\nNote that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.\n(Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "kind",
+                                  "name"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "resources": {
+                                "description": "resources represents the minimum resources the volume should have.\nIf RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements\nthat are lower than previous value but must still be higher than capacity recorded in the\nstatus field of the claim.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources",
+                                "properties": {
+                                  "limits": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                    "type": "object"
+                                  },
+                                  "requests": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "selector": {
+                                "description": "selector is a label query over volumes to consider for binding.",
+                                "properties": {
+                                  "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                    "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                      "properties": {
+                                        "key": {
+                                          "description": "key is the label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "storageClassName": {
+                                "description": "storageClassName is the name of the StorageClass required by the claim.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1",
+                                "type": "string"
+                              },
+                              "volumeAttributesClassName": {
+                                "description": "volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.\nIf specified, the CSI driver will create or update the volume with the attributes defined\nin the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,\nit can be changed after the claim is created. An empty string value means that no VolumeAttributesClass\nwill be applied to the claim but it's not allowed to reset this field to empty string once it is set.\nIf unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass\nwill be set by the persistentvolume controller if it exists.\nIf the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be\nset to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource\nexists.\nMore info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/\n(Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).",
+                                "type": "string"
+                              },
+                              "volumeMode": {
+                                "description": "volumeMode defines what type of volume is required by the claim.\nValue of Filesystem is implied when not included in claim spec.",
+                                "type": "string"
+                              },
+                              "volumeName": {
+                                "description": "volumeName is the binding reference to the PersistentVolume backing this claim.",
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "spec"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
                   "fc": {
+                    "description": "fc represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.",
                     "properties": {
                       "fsType": {
+                        "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
                         "type": "string"
                       },
                       "lun": {
+                        "description": "lun is Optional: FC target lun number",
                         "format": "int32",
                         "type": "integer"
                       },
                       "readOnly": {
+                        "description": "readOnly is Optional: Defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
                         "type": "boolean"
                       },
                       "targetWWNs": {
+                        "description": "targetWWNs is Optional: FC target worldwide names (WWNs)",
                         "items": {
                           "type": "string"
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "wwids": {
+                        "description": "wwids Optional: FC volume world wide identifiers (wwids)\nEither wwids or combination of targetWWNs and lun must be set, but not both simultaneously.",
                         "items": {
                           "type": "string"
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       }
                     },
                     "type": "object",
                     "additionalProperties": false
                   },
                   "flexVolume": {
+                    "description": "flexVolume represents a generic volume resource that is\nprovisioned/attached using an exec based plugin.\nDeprecated: FlexVolume is deprecated. Consider using a CSIDriver instead.",
                     "properties": {
                       "driver": {
+                        "description": "driver is the name of the driver to use for this volume.",
                         "type": "string"
                       },
                       "fsType": {
+                        "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". The default filesystem depends on FlexVolume script.",
                         "type": "string"
                       },
                       "options": {
                         "additionalProperties": {
                           "type": "string"
                         },
+                        "description": "options is Optional: this field holds extra command options if any.",
                         "type": "object"
                       },
                       "readOnly": {
+                        "description": "readOnly is Optional: defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
                         "type": "boolean"
                       },
                       "secretRef": {
+                        "description": "secretRef is Optional: secretRef is reference to the secret object containing\nsensitive information to pass to the plugin scripts. This may be\nempty if no secret object is specified. If the secret object\ncontains more than one secret, all secrets are passed to the plugin\nscripts.",
                         "properties": {
                           "name": {
+                            "default": "",
+                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                             "type": "string"
                           }
                         },
                         "type": "object",
+                        "x-kubernetes-map-type": "atomic",
                         "additionalProperties": false
                       }
                     },
@@ -6469,11 +10222,14 @@
                     "additionalProperties": false
                   },
                   "flocker": {
+                    "description": "flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running.\nDeprecated: Flocker is deprecated and the in-tree flocker type is no longer supported.",
                     "properties": {
                       "datasetName": {
+                        "description": "datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker\nshould be considered as deprecated",
                         "type": "string"
                       },
                       "datasetUUID": {
+                        "description": "datasetUUID is the UUID of the dataset. This is unique identifier of a Flocker dataset",
                         "type": "string"
                       }
                     },
@@ -6481,18 +10237,23 @@
                     "additionalProperties": false
                   },
                   "gcePersistentDisk": {
+                    "description": "gcePersistentDisk represents a GCE Disk resource that is attached to a\nkubelet's host machine and then exposed to the pod.\nDeprecated: GCEPersistentDisk is deprecated. All operations for the in-tree\ngcePersistentDisk type are redirected to the pd.csi.storage.gke.io CSI driver.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
                     "properties": {
                       "fsType": {
+                        "description": "fsType is filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
                         "type": "string"
                       },
                       "partition": {
+                        "description": "partition is the partition in the volume that you want to mount.\nIf omitted, the default is to mount by volume name.\nExamples: For volume /dev/sda1, you specify the partition as \"1\".\nSimilarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty).\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
                         "format": "int32",
                         "type": "integer"
                       },
                       "pdName": {
+                        "description": "pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
                         "type": "string"
                       },
                       "readOnly": {
+                        "description": "readOnly here will force the ReadOnly setting in VolumeMounts.\nDefaults to false.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
                         "type": "boolean"
                       }
                     },
@@ -6503,14 +10264,18 @@
                     "additionalProperties": false
                   },
                   "gitRepo": {
+                    "description": "gitRepo represents a git repository at a particular revision.\nDeprecated: GitRepo is deprecated. To provision a container with a git repo, mount an\nEmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir\ninto the Pod's container.",
                     "properties": {
                       "directory": {
+                        "description": "directory is the target directory name.\nMust not contain or start with '..'.  If '.' is supplied, the volume directory will be the\ngit repository.  Otherwise, if specified, the volume will contain the git repository in\nthe subdirectory with the given name.",
                         "type": "string"
                       },
                       "repository": {
+                        "description": "repository is the URL",
                         "type": "string"
                       },
                       "revision": {
+                        "description": "revision is the commit hash for the specified revision.",
                         "type": "string"
                       }
                     },
@@ -6521,14 +10286,18 @@
                     "additionalProperties": false
                   },
                   "glusterfs": {
+                    "description": "glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.\nDeprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.\nMore info: https://examples.k8s.io/volumes/glusterfs/README.md",
                     "properties": {
                       "endpoints": {
+                        "description": "endpoints is the endpoint name that details Glusterfs topology.\nMore info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
                         "type": "string"
                       },
                       "path": {
+                        "description": "path is the Glusterfs volume path.\nMore info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
                         "type": "string"
                       },
                       "readOnly": {
+                        "description": "readOnly here will force the Glusterfs volume to be mounted with read-only permissions.\nDefaults to false.\nMore info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
                         "type": "boolean"
                       }
                     },
@@ -6540,11 +10309,14 @@
                     "additionalProperties": false
                   },
                   "hostPath": {
+                    "description": "hostPath represents a pre-existing file or directory on the host\nmachine that is directly exposed to the container. This is generally\nused for system agents or other privileged things that are allowed\nto see the host machine. Most containers will NOT need this.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
                     "properties": {
                       "path": {
+                        "description": "path of the directory on the host.\nIf the path is a symlink, it will follow the link to the real path.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
                         "type": "string"
                       },
                       "type": {
+                        "description": "type for HostPath Volume\nDefaults to \"\"\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
                         "type": "string"
                       }
                     },
@@ -6554,49 +10326,81 @@
                     "type": "object",
                     "additionalProperties": false
                   },
+                  "image": {
+                    "description": "image represents an OCI object (a container image or artifact) pulled and mounted on the kubelet's host machine.\nThe volume is resolved at pod startup depending on which PullPolicy value is provided:\n\n- Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.\n- Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.\n- IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.\n\nThe volume gets re-resolved if the pod gets deleted and recreated, which means that new remote content will become available on pod recreation.\nA failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.\nThe types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.\nThe OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.\nThe volume will be mounted read-only (ro) and non-executable files (noexec).\nSub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath).\nThe field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.",
+                    "properties": {
+                      "pullPolicy": {
+                        "description": "Policy for pulling OCI objects. Possible values are:\nAlways: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.\nNever: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.\nIfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.\nDefaults to Always if :latest tag is specified, or IfNotPresent otherwise.",
+                        "type": "string"
+                      },
+                      "reference": {
+                        "description": "Required: Image or artifact reference to be used.\nBehaves in the same way as pod.spec.containers[*].image.\nPull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.\nMore info: https://kubernetes.io/docs/concepts/containers/images\nThis field is optional to allow higher level config management to default or override\ncontainer images in workload controllers like Deployments and StatefulSets.",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
                   "iscsi": {
+                    "description": "iscsi represents an ISCSI Disk resource that is attached to a\nkubelet's host machine and then exposed to the pod.\nMore info: https://examples.k8s.io/volumes/iscsi/README.md",
                     "properties": {
                       "chapAuthDiscovery": {
+                        "description": "chapAuthDiscovery defines whether support iSCSI Discovery CHAP authentication",
                         "type": "boolean"
                       },
                       "chapAuthSession": {
+                        "description": "chapAuthSession defines whether support iSCSI Session CHAP authentication",
                         "type": "boolean"
                       },
                       "fsType": {
+                        "description": "fsType is the filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi",
                         "type": "string"
                       },
                       "initiatorName": {
+                        "description": "initiatorName is the custom iSCSI Initiator Name.\nIf initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface\n<target portal>:<volume name> will be created for the connection.",
                         "type": "string"
                       },
                       "iqn": {
+                        "description": "iqn is the target iSCSI Qualified Name.",
                         "type": "string"
                       },
                       "iscsiInterface": {
+                        "default": "default",
+                        "description": "iscsiInterface is the interface Name that uses an iSCSI transport.\nDefaults to 'default' (tcp).",
                         "type": "string"
                       },
                       "lun": {
+                        "description": "lun represents iSCSI Target Lun number.",
                         "format": "int32",
                         "type": "integer"
                       },
                       "portals": {
+                        "description": "portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port\nis other than default (typically TCP ports 860 and 3260).",
                         "items": {
                           "type": "string"
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "readOnly": {
+                        "description": "readOnly here will force the ReadOnly setting in VolumeMounts.\nDefaults to false.",
                         "type": "boolean"
                       },
                       "secretRef": {
+                        "description": "secretRef is the CHAP Secret for iSCSI target and initiator authentication",
                         "properties": {
                           "name": {
+                            "default": "",
+                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                             "type": "string"
                           }
                         },
                         "type": "object",
+                        "x-kubernetes-map-type": "atomic",
                         "additionalProperties": false
                       },
                       "targetPortal": {
+                        "description": "targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port\nis other than default (typically TCP ports 860 and 3260).",
                         "type": "string"
                       }
                     },
@@ -6609,17 +10413,22 @@
                     "additionalProperties": false
                   },
                   "name": {
+                    "description": "name of the volume.\nMust be a DNS_LABEL and unique within the pod.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                     "type": "string"
                   },
                   "nfs": {
+                    "description": "nfs represents an NFS mount on the host that shares a pod's lifetime\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
                     "properties": {
                       "path": {
+                        "description": "path that is exported by the NFS server.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
                         "type": "string"
                       },
                       "readOnly": {
+                        "description": "readOnly here will force the NFS export to be mounted with read-only permissions.\nDefaults to false.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
                         "type": "boolean"
                       },
                       "server": {
+                        "description": "server is the hostname or IP address of the NFS server.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
                         "type": "string"
                       }
                     },
@@ -6631,11 +10440,14 @@
                     "additionalProperties": false
                   },
                   "persistentVolumeClaim": {
+                    "description": "persistentVolumeClaimVolumeSource represents a reference to a\nPersistentVolumeClaim in the same namespace.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
                     "properties": {
                       "claimName": {
+                        "description": "claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
                         "type": "string"
                       },
                       "readOnly": {
+                        "description": "readOnly Will force the ReadOnly setting in VolumeMounts.\nDefault false.",
                         "type": "boolean"
                       }
                     },
@@ -6646,11 +10458,14 @@
                     "additionalProperties": false
                   },
                   "photonPersistentDisk": {
+                    "description": "photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine.\nDeprecated: PhotonPersistentDisk is deprecated and the in-tree photonPersistentDisk type is no longer supported.",
                     "properties": {
                       "fsType": {
+                        "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
                         "type": "string"
                       },
                       "pdID": {
+                        "description": "pdID is the ID that identifies Photon Controller persistent disk",
                         "type": "string"
                       }
                     },
@@ -6661,14 +10476,18 @@
                     "additionalProperties": false
                   },
                   "portworxVolume": {
+                    "description": "portworxVolume represents a portworx volume attached and mounted on kubelets host machine.\nDeprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type\nare redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate\nis on.",
                     "properties": {
                       "fsType": {
+                        "description": "fSType represents the filesystem type to mount\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\". Implicitly inferred to be \"ext4\" if unspecified.",
                         "type": "string"
                       },
                       "readOnly": {
+                        "description": "readOnly defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
                         "type": "boolean"
                       },
                       "volumeID": {
+                        "description": "volumeID uniquely identifies a Portworx volume",
                         "type": "string"
                       }
                     },
@@ -6679,27 +10498,110 @@
                     "additionalProperties": false
                   },
                   "projected": {
+                    "description": "projected items for all in one resources secrets, configmaps, and downward API",
                     "properties": {
                       "defaultMode": {
+                        "description": "defaultMode are the mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
                         "format": "int32",
                         "type": "integer"
                       },
                       "sources": {
+                        "description": "sources is the list of volume projections. Each entry in this list\nhandles one source.",
                         "items": {
+                          "description": "Projection that may be projected along with other supported volume types.\nExactly one of these fields must be set.",
                           "properties": {
+                            "clusterTrustBundle": {
+                              "description": "ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field\nof ClusterTrustBundle objects in an auto-updating file.\n\nAlpha, gated by the ClusterTrustBundleProjection feature gate.\n\nClusterTrustBundle objects can either be selected by name, or by the\ncombination of signer name and a label selector.\n\nKubelet performs aggressive normalization of the PEM contents written\ninto the pod filesystem.  Esoteric PEM features such as inter-block\ncomments and block headers are stripped.  Certificates are deduplicated.\nThe ordering of certificates within the file is arbitrary, and Kubelet\nmay change the order over time.",
+                              "properties": {
+                                "labelSelector": {
+                                  "description": "Select all ClusterTrustBundles that match this label selector.  Only has\neffect if signerName is set.  Mutually-exclusive with name.  If unset,\ninterpreted as \"match nothing\".  If set but empty, interpreted as \"match\neverything\".",
+                                  "properties": {
+                                    "matchExpressions": {
+                                      "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                      "items": {
+                                        "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                        "properties": {
+                                          "key": {
+                                            "description": "key is the label key that the selector applies to.",
+                                            "type": "string"
+                                          },
+                                          "operator": {
+                                            "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                            "type": "string"
+                                          },
+                                          "values": {
+                                            "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
+                                          }
+                                        },
+                                        "required": [
+                                          "key",
+                                          "operator"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    },
+                                    "matchLabels": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                },
+                                "name": {
+                                  "description": "Select a single ClusterTrustBundle by object name.  Mutually-exclusive\nwith signerName and labelSelector.",
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "description": "If true, don't block pod startup if the referenced ClusterTrustBundle(s)\naren't available.  If using name, then the named ClusterTrustBundle is\nallowed not to exist.  If using signerName, then the combination of\nsignerName and labelSelector is allowed to match zero\nClusterTrustBundles.",
+                                  "type": "boolean"
+                                },
+                                "path": {
+                                  "description": "Relative path from the volume root to write the bundle.",
+                                  "type": "string"
+                                },
+                                "signerName": {
+                                  "description": "Select all ClusterTrustBundles that match this signer name.\nMutually-exclusive with name.  The contents of all selected\nClusterTrustBundles will be unified and deduplicated.",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "path"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
                             "configMap": {
+                              "description": "configMap information about the configMap data to project",
                               "properties": {
                                 "items": {
+                                  "description": "items if unspecified, each key-value pair in the Data field of the referenced\nConfigMap will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the ConfigMap,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
                                   "items": {
+                                    "description": "Maps a string key to a path within a volume.",
                                     "properties": {
                                       "key": {
+                                        "description": "key is the key to project.",
                                         "type": "string"
                                       },
                                       "mode": {
+                                        "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
                                         "format": "int32",
                                         "type": "integer"
                                       },
                                       "path": {
+                                        "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
                                         "type": "string"
                                       }
                                     },
@@ -6710,29 +10612,40 @@
                                     "type": "object",
                                     "additionalProperties": false
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "name": {
+                                  "default": "",
+                                  "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                   "type": "string"
                                 },
                                 "optional": {
+                                  "description": "optional specify whether the ConfigMap or its keys must be defined",
                                   "type": "boolean"
                                 }
                               },
                               "type": "object",
+                              "x-kubernetes-map-type": "atomic",
                               "additionalProperties": false
                             },
                             "downwardAPI": {
+                              "description": "downwardAPI information about the downwardAPI data to project",
                               "properties": {
                                 "items": {
+                                  "description": "Items is a list of DownwardAPIVolume file",
                                   "items": {
+                                    "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
                                     "properties": {
                                       "fieldRef": {
+                                        "description": "Required: Selects a field of the pod: only annotations, labels, name, namespace and uid are supported.",
                                         "properties": {
                                           "apiVersion": {
+                                            "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
                                             "type": "string"
                                           },
                                           "fieldPath": {
+                                            "description": "Path of the field to select in the specified API version.",
                                             "type": "string"
                                           }
                                         },
@@ -6740,18 +10653,23 @@
                                           "fieldPath"
                                         ],
                                         "type": "object",
+                                        "x-kubernetes-map-type": "atomic",
                                         "additionalProperties": false
                                       },
                                       "mode": {
+                                        "description": "Optional: mode bits used to set permissions on this file, must be an octal value\nbetween 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
                                         "format": "int32",
                                         "type": "integer"
                                       },
                                       "path": {
+                                        "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'",
                                         "type": "string"
                                       },
                                       "resourceFieldRef": {
+                                        "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.",
                                         "properties": {
                                           "containerName": {
+                                            "description": "Container name: required for volumes, optional for env vars",
                                             "type": "string"
                                           },
                                           "divisor": {
@@ -6763,10 +10681,12 @@
                                                 "type": "string"
                                               }
                                             ],
+                                            "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
                                             "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                                             "x-kubernetes-int-or-string": true
                                           },
                                           "resource": {
+                                            "description": "Required: resource to select",
                                             "type": "string"
                                           }
                                         },
@@ -6774,6 +10694,7 @@
                                           "resource"
                                         ],
                                         "type": "object",
+                                        "x-kubernetes-map-type": "atomic",
                                         "additionalProperties": false
                                       }
                                     },
@@ -6783,25 +10704,32 @@
                                     "type": "object",
                                     "additionalProperties": false
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               },
                               "type": "object",
                               "additionalProperties": false
                             },
                             "secret": {
+                              "description": "secret information about the secret data to project",
                               "properties": {
                                 "items": {
+                                  "description": "items if unspecified, each key-value pair in the Data field of the referenced\nSecret will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the Secret,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
                                   "items": {
+                                    "description": "Maps a string key to a path within a volume.",
                                     "properties": {
                                       "key": {
+                                        "description": "key is the key to project.",
                                         "type": "string"
                                       },
                                       "mode": {
+                                        "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
                                         "format": "int32",
                                         "type": "integer"
                                       },
                                       "path": {
+                                        "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
                                         "type": "string"
                                       }
                                     },
@@ -6812,28 +10740,37 @@
                                     "type": "object",
                                     "additionalProperties": false
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "name": {
+                                  "default": "",
+                                  "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                   "type": "string"
                                 },
                                 "optional": {
+                                  "description": "optional field specify whether the Secret or its key must be defined",
                                   "type": "boolean"
                                 }
                               },
                               "type": "object",
+                              "x-kubernetes-map-type": "atomic",
                               "additionalProperties": false
                             },
                             "serviceAccountToken": {
+                              "description": "serviceAccountToken is information about the serviceAccountToken data to project",
                               "properties": {
                                 "audience": {
+                                  "description": "audience is the intended audience of the token. A recipient of a token\nmust identify itself with an identifier specified in the audience of the\ntoken, and otherwise should reject the token. The audience defaults to the\nidentifier of the apiserver.",
                                   "type": "string"
                                 },
                                 "expirationSeconds": {
+                                  "description": "expirationSeconds is the requested duration of validity of the service\naccount token. As the token approaches expiration, the kubelet volume\nplugin will proactively rotate the service account token. The kubelet will\nstart trying to rotate the token if the token is older than 80 percent of\nits time to live or if the token is older than 24 hours.Defaults to 1 hour\nand must be at least 10 minutes.",
                                   "format": "int64",
                                   "type": "integer"
                                 },
                                 "path": {
+                                  "description": "path is the path relative to the mount point of the file to project the\ntoken into.",
                                   "type": "string"
                                 }
                               },
@@ -6847,33 +10784,38 @@
                           "type": "object",
                           "additionalProperties": false
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       }
                     },
-                    "required": [
-                      "sources"
-                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
                   "quobyte": {
+                    "description": "quobyte represents a Quobyte mount on the host that shares a pod's lifetime.\nDeprecated: Quobyte is deprecated and the in-tree quobyte type is no longer supported.",
                     "properties": {
                       "group": {
+                        "description": "group to map volume access to\nDefault is no group",
                         "type": "string"
                       },
                       "readOnly": {
+                        "description": "readOnly here will force the Quobyte volume to be mounted with read-only permissions.\nDefaults to false.",
                         "type": "boolean"
                       },
                       "registry": {
+                        "description": "registry represents a single or multiple Quobyte Registry services\nspecified as a string as host:port pair (multiple entries are separated with commas)\nwhich acts as the central registry for volumes",
                         "type": "string"
                       },
                       "tenant": {
+                        "description": "tenant owning the given Quobyte volume in the Backend\nUsed with dynamically provisioned Quobyte volumes, value is set by the plugin",
                         "type": "string"
                       },
                       "user": {
+                        "description": "user to map volume access to\nDefaults to serivceaccount user",
                         "type": "string"
                       },
                       "volume": {
+                        "description": "volume is a string that references an already created Quobyte volume by name.",
                         "type": "string"
                       }
                     },
@@ -6885,38 +10827,54 @@
                     "additionalProperties": false
                   },
                   "rbd": {
+                    "description": "rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.\nDeprecated: RBD is deprecated and the in-tree rbd type is no longer supported.\nMore info: https://examples.k8s.io/volumes/rbd/README.md",
                     "properties": {
                       "fsType": {
+                        "description": "fsType is the filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#rbd",
                         "type": "string"
                       },
                       "image": {
+                        "description": "image is the rados image name.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
                         "type": "string"
                       },
                       "keyring": {
+                        "default": "/etc/ceph/keyring",
+                        "description": "keyring is the path to key ring for RBDUser.\nDefault is /etc/ceph/keyring.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
                         "type": "string"
                       },
                       "monitors": {
+                        "description": "monitors is a collection of Ceph monitors.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
                         "items": {
                           "type": "string"
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "pool": {
+                        "default": "rbd",
+                        "description": "pool is the rados pool name.\nDefault is rbd.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
                         "type": "string"
                       },
                       "readOnly": {
+                        "description": "readOnly here will force the ReadOnly setting in VolumeMounts.\nDefaults to false.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
                         "type": "boolean"
                       },
                       "secretRef": {
+                        "description": "secretRef is name of the authentication secret for RBDUser. If provided\noverrides keyring.\nDefault is nil.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
                         "properties": {
                           "name": {
+                            "default": "",
+                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                             "type": "string"
                           }
                         },
                         "type": "object",
+                        "x-kubernetes-map-type": "atomic",
                         "additionalProperties": false
                       },
                       "user": {
+                        "default": "admin",
+                        "description": "user is the rados user name.\nDefault is admin.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
                         "type": "string"
                       }
                     },
@@ -6928,41 +10886,57 @@
                     "additionalProperties": false
                   },
                   "scaleIO": {
+                    "description": "scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.\nDeprecated: ScaleIO is deprecated and the in-tree scaleIO type is no longer supported.",
                     "properties": {
                       "fsType": {
+                        "default": "xfs",
+                        "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\".\nDefault is \"xfs\".",
                         "type": "string"
                       },
                       "gateway": {
+                        "description": "gateway is the host address of the ScaleIO API Gateway.",
                         "type": "string"
                       },
                       "protectionDomain": {
+                        "description": "protectionDomain is the name of the ScaleIO Protection Domain for the configured storage.",
                         "type": "string"
                       },
                       "readOnly": {
+                        "description": "readOnly Defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
                         "type": "boolean"
                       },
                       "secretRef": {
+                        "description": "secretRef references to the secret for ScaleIO user and other\nsensitive information. If this is not provided, Login operation will fail.",
                         "properties": {
                           "name": {
+                            "default": "",
+                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                             "type": "string"
                           }
                         },
                         "type": "object",
+                        "x-kubernetes-map-type": "atomic",
                         "additionalProperties": false
                       },
                       "sslEnabled": {
+                        "description": "sslEnabled Flag enable/disable SSL communication with Gateway, default false",
                         "type": "boolean"
                       },
                       "storageMode": {
+                        "default": "ThinProvisioned",
+                        "description": "storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.\nDefault is ThinProvisioned.",
                         "type": "string"
                       },
                       "storagePool": {
+                        "description": "storagePool is the ScaleIO Storage Pool associated with the protection domain.",
                         "type": "string"
                       },
                       "system": {
+                        "description": "system is the name of the storage system as configured in ScaleIO.",
                         "type": "string"
                       },
                       "volumeName": {
+                        "description": "volumeName is the name of a volume already created in the ScaleIO system\nthat is associated with this volume source.",
                         "type": "string"
                       }
                     },
@@ -6975,22 +10949,29 @@
                     "additionalProperties": false
                   },
                   "secret": {
+                    "description": "secret represents a secret that should populate this volume.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
                     "properties": {
                       "defaultMode": {
+                        "description": "defaultMode is Optional: mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values\nfor mode bits. Defaults to 0644.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
                         "format": "int32",
                         "type": "integer"
                       },
                       "items": {
+                        "description": "items If unspecified, each key-value pair in the Data field of the referenced\nSecret will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the Secret,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
                         "items": {
+                          "description": "Maps a string key to a path within a volume.",
                           "properties": {
                             "key": {
+                              "description": "key is the key to project.",
                               "type": "string"
                             },
                             "mode": {
+                              "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
                               "format": "int32",
                               "type": "integer"
                             },
                             "path": {
+                              "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
                               "type": "string"
                             }
                           },
@@ -7001,12 +10982,15 @@
                           "type": "object",
                           "additionalProperties": false
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "optional": {
+                        "description": "optional field specify whether the Secret or its keys must be defined",
                         "type": "boolean"
                       },
                       "secretName": {
+                        "description": "secretName is the name of the secret in the pod's namespace to use.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
                         "type": "string"
                       }
                     },
@@ -7014,26 +10998,35 @@
                     "additionalProperties": false
                   },
                   "storageos": {
+                    "description": "storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.\nDeprecated: StorageOS is deprecated and the in-tree storageos type is no longer supported.",
                     "properties": {
                       "fsType": {
+                        "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
                         "type": "string"
                       },
                       "readOnly": {
+                        "description": "readOnly defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
                         "type": "boolean"
                       },
                       "secretRef": {
+                        "description": "secretRef specifies the secret to use for obtaining the StorageOS API\ncredentials.  If not specified, default values will be attempted.",
                         "properties": {
                           "name": {
+                            "default": "",
+                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                             "type": "string"
                           }
                         },
                         "type": "object",
+                        "x-kubernetes-map-type": "atomic",
                         "additionalProperties": false
                       },
                       "volumeName": {
+                        "description": "volumeName is the human-readable name of the StorageOS volume.  Volume\nnames are only unique within a namespace.",
                         "type": "string"
                       },
                       "volumeNamespace": {
+                        "description": "volumeNamespace specifies the scope of the volume within StorageOS.  If no\nnamespace is specified then the Pod's namespace will be used.  This allows the\nKubernetes name scoping to be mirrored within StorageOS for tighter integration.\nSet VolumeName to any name to override the default behaviour.\nSet to \"default\" if you are not using namespaces within StorageOS.\nNamespaces that do not pre-exist within StorageOS will be created.",
                         "type": "string"
                       }
                     },
@@ -7041,17 +11034,22 @@
                     "additionalProperties": false
                   },
                   "vsphereVolume": {
+                    "description": "vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine.\nDeprecated: VsphereVolume is deprecated. All operations for the in-tree vsphereVolume type\nare redirected to the csi.vsphere.vmware.com CSI driver.",
                     "properties": {
                       "fsType": {
+                        "description": "fsType is filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
                         "type": "string"
                       },
                       "storagePolicyID": {
+                        "description": "storagePolicyID is the storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.",
                         "type": "string"
                       },
                       "storagePolicyName": {
+                        "description": "storagePolicyName is the storage Policy Based Management (SPBM) profile name.",
                         "type": "string"
                       },
                       "volumePath": {
+                        "description": "volumePath is the path that identifies vSphere volume vmdk",
                         "type": "string"
                       }
                     },
@@ -7074,6 +11072,7 @@
           "required": [
             "driver",
             "executor",
+            "mainApplicationFile",
             "sparkVersion",
             "type"
           ],
@@ -7089,36 +11088,44 @@
       "additionalProperties": false
     },
     "status": {
+      "description": "ScheduledSparkApplicationStatus defines the observed state of ScheduledSparkApplication.",
       "properties": {
         "lastRun": {
+          "description": "LastRun is the time when the last run of the application started.",
           "format": "date-time",
           "nullable": true,
           "type": "string"
         },
         "lastRunName": {
+          "description": "LastRunName is the name of the SparkApplication for the most recent run of the application.",
           "type": "string"
         },
         "nextRun": {
+          "description": "NextRun is the time when the next run of the application will start.",
           "format": "date-time",
           "nullable": true,
           "type": "string"
         },
         "pastFailedRunNames": {
+          "description": "PastFailedRunNames keeps the names of SparkApplications for past failed runs.",
           "items": {
             "type": "string"
           },
           "type": "array"
         },
         "pastSuccessfulRunNames": {
+          "description": "PastSuccessfulRunNames keeps the names of SparkApplications for past successful runs.",
           "items": {
             "type": "string"
           },
           "type": "array"
         },
         "reason": {
+          "description": "Reason tells why the ScheduledSparkApplication is in the particular ScheduleState.",
           "type": "string"
         },
         "scheduleState": {
+          "description": "ScheduleState is the current scheduling state of the application.",
           "type": "string"
         }
       },

--- a/sparkoperator.k8s.io/sparkapplication_v1beta2.json
+++ b/sparkoperator.k8s.io/sparkapplication_v1beta2.json
@@ -1,31 +1,40 @@
 {
+  "description": "SparkApplication is the Schema for the sparkapplications API",
   "properties": {
     "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
       "type": "string"
     },
     "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
       "type": "string"
     },
     "metadata": {
       "type": "object"
     },
     "spec": {
+      "description": "SparkApplicationSpec defines the desired state of SparkApplication\nIt carries every pieces of information a spark-submit command takes and recognizes.",
       "properties": {
         "arguments": {
+          "description": "Arguments is a list of arguments to be passed to the application.",
           "items": {
             "type": "string"
           },
           "type": "array"
         },
         "batchScheduler": {
+          "description": "BatchScheduler configures which batch scheduler will be used for scheduling",
           "type": "string"
         },
         "batchSchedulerOptions": {
+          "description": "BatchSchedulerOptions provides fine-grained control on how to batch scheduling.",
           "properties": {
             "priorityClassName": {
+              "description": "PriorityClassName stands for the name of k8s PriorityClass resource, it's being used in Volcano batch scheduler.",
               "type": "string"
             },
             "queue": {
+              "description": "Queue stands for the resource queue which the application belongs to, it's being used in Volcano batch scheduler.",
               "type": "string"
             },
             "resources": {
@@ -41,6 +50,7 @@
                 "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                 "x-kubernetes-int-or-string": true
               },
+              "description": "Resources stands for the resource list custom request for. Usually it is used to define the lower-bound limit.\nIf specified, volcano scheduler will consider it as the resources requested.",
               "type": "object"
             }
           },
@@ -48,38 +58,52 @@
           "additionalProperties": false
         },
         "deps": {
+          "description": "Deps captures all possible types of dependencies of a Spark application.",
           "properties": {
+            "archives": {
+              "description": "Archives is a list of archives to be extracted into the working directory of each executor.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
             "excludePackages": {
+              "description": "ExcludePackages is a list of \"groupId:artifactId\", to exclude while resolving the\ndependencies provided in Packages to avoid dependency conflicts.",
               "items": {
                 "type": "string"
               },
               "type": "array"
             },
             "files": {
+              "description": "Files is a list of files the Spark application depends on.",
               "items": {
                 "type": "string"
               },
               "type": "array"
             },
             "jars": {
+              "description": "Jars is a list of JAR files the Spark application depends on.",
               "items": {
                 "type": "string"
               },
               "type": "array"
             },
             "packages": {
+              "description": "Packages is a list of maven coordinates of jars to include on the driver and executor\nclasspaths. This will search the local maven repo, then maven central and any additional\nremote repositories given by the \"repositories\" option.\nEach package should be of the form \"groupId:artifactId:version\".",
               "items": {
                 "type": "string"
               },
               "type": "array"
             },
             "pyFiles": {
+              "description": "PyFiles is a list of Python files the Spark application depends on.",
               "items": {
                 "type": "string"
               },
               "type": "array"
             },
             "repositories": {
+              "description": "Repositories is a list of additional remote repositories to search for the maven coordinate\ngiven with the \"packages\" option.",
               "items": {
                 "type": "string"
               },
@@ -90,30 +114,42 @@
           "additionalProperties": false
         },
         "driver": {
+          "description": "Driver is the driver specification.",
           "properties": {
             "affinity": {
+              "description": "Affinity specifies the affinity/anti-affinity settings for the pod.",
               "properties": {
                 "nodeAffinity": {
+                  "description": "Describes node affinity scheduling rules for the pod.",
                   "properties": {
                     "preferredDuringSchedulingIgnoredDuringExecution": {
+                      "description": "The scheduler will prefer to schedule pods to nodes that satisfy\nthe affinity expressions specified by this field, but it may choose\na node that violates one or more of the expressions. The node that is\nmost preferred is the one with the greatest sum of weights, i.e.\nfor each node that meets all of the scheduling requirements (resource\nrequest, requiredDuringScheduling affinity expressions, etc.),\ncompute a sum by iterating through the elements of this field and adding\n\"weight\" to the sum if the node matches the corresponding matchExpressions; the\nnode(s) with the highest sum are the most preferred.",
                       "items": {
+                        "description": "An empty preferred scheduling term matches all objects with implicit weight 0\n(i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).",
                         "properties": {
                           "preference": {
+                            "description": "A node selector term, associated with the corresponding weight.",
                             "properties": {
                               "matchExpressions": {
+                                "description": "A list of node selector requirements by node's labels.",
                                 "items": {
+                                  "description": "A node selector requirement is a selector that contains values, a key, and an operator\nthat relates the key and values.",
                                   "properties": {
                                     "key": {
+                                      "description": "The label key that the selector applies to.",
                                       "type": "string"
                                     },
                                     "operator": {
+                                      "description": "Represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
                                       "type": "string"
                                     },
                                     "values": {
+                                      "description": "An array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. If the operator is Gt or Lt, the values\narray must have a single element, which will be interpreted as an integer.\nThis array is replaced during a strategic merge patch.",
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -123,22 +159,29 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchFields": {
+                                "description": "A list of node selector requirements by node's fields.",
                                 "items": {
+                                  "description": "A node selector requirement is a selector that contains values, a key, and an operator\nthat relates the key and values.",
                                   "properties": {
                                     "key": {
+                                      "description": "The label key that the selector applies to.",
                                       "type": "string"
                                     },
                                     "operator": {
+                                      "description": "Represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
                                       "type": "string"
                                     },
                                     "values": {
+                                      "description": "An array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. If the operator is Gt or Lt, the values\narray must have a single element, which will be interpreted as an integer.\nThis array is replaced during a strategic merge patch.",
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -148,13 +191,16 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               }
                             },
                             "type": "object",
+                            "x-kubernetes-map-type": "atomic",
                             "additionalProperties": false
                           },
                           "weight": {
+                            "description": "Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.",
                             "format": "int32",
                             "type": "integer"
                           }
@@ -166,27 +212,37 @@
                         "type": "object",
                         "additionalProperties": false
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     },
                     "requiredDuringSchedulingIgnoredDuringExecution": {
+                      "description": "If the affinity requirements specified by this field are not met at\nscheduling time, the pod will not be scheduled onto the node.\nIf the affinity requirements specified by this field cease to be met\nat some point during pod execution (e.g. due to an update), the system\nmay or may not try to eventually evict the pod from its node.",
                       "properties": {
                         "nodeSelectorTerms": {
+                          "description": "Required. A list of node selector terms. The terms are ORed.",
                           "items": {
+                            "description": "A null or empty node selector term matches no objects. The requirements of\nthem are ANDed.\nThe TopologySelectorTerm type implements a subset of the NodeSelectorTerm.",
                             "properties": {
                               "matchExpressions": {
+                                "description": "A list of node selector requirements by node's labels.",
                                 "items": {
+                                  "description": "A node selector requirement is a selector that contains values, a key, and an operator\nthat relates the key and values.",
                                   "properties": {
                                     "key": {
+                                      "description": "The label key that the selector applies to.",
                                       "type": "string"
                                     },
                                     "operator": {
+                                      "description": "Represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
                                       "type": "string"
                                     },
                                     "values": {
+                                      "description": "An array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. If the operator is Gt or Lt, the values\narray must have a single element, which will be interpreted as an integer.\nThis array is replaced during a strategic merge patch.",
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -196,22 +252,29 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchFields": {
+                                "description": "A list of node selector requirements by node's fields.",
                                 "items": {
+                                  "description": "A node selector requirement is a selector that contains values, a key, and an operator\nthat relates the key and values.",
                                   "properties": {
                                     "key": {
+                                      "description": "The label key that the selector applies to.",
                                       "type": "string"
                                     },
                                     "operator": {
+                                      "description": "Represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
                                       "type": "string"
                                     },
                                     "values": {
+                                      "description": "An array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. If the operator is Gt or Lt, the values\narray must have a single element, which will be interpreted as an integer.\nThis array is replaced during a strategic merge patch.",
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -221,19 +284,23 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               }
                             },
                             "type": "object",
+                            "x-kubernetes-map-type": "atomic",
                             "additionalProperties": false
                           },
-                          "type": "array"
+                          "type": "array",
+                          "x-kubernetes-list-type": "atomic"
                         }
                       },
                       "required": [
                         "nodeSelectorTerms"
                       ],
                       "type": "object",
+                      "x-kubernetes-map-type": "atomic",
                       "additionalProperties": false
                     }
                   },
@@ -241,28 +308,39 @@
                   "additionalProperties": false
                 },
                 "podAffinity": {
+                  "description": "Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).",
                   "properties": {
                     "preferredDuringSchedulingIgnoredDuringExecution": {
+                      "description": "The scheduler will prefer to schedule pods to nodes that satisfy\nthe affinity expressions specified by this field, but it may choose\na node that violates one or more of the expressions. The node that is\nmost preferred is the one with the greatest sum of weights, i.e.\nfor each node that meets all of the scheduling requirements (resource\nrequest, requiredDuringScheduling affinity expressions, etc.),\ncompute a sum by iterating through the elements of this field and adding\n\"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the\nnode(s) with the highest sum are the most preferred.",
                       "items": {
+                        "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
                         "properties": {
                           "podAffinityTerm": {
+                            "description": "Required. A pod affinity term, associated with the corresponding weight.",
                             "properties": {
                               "labelSelector": {
+                                "description": "A label query over a set of resources, in this case pods.\nIf it's null, this PodAffinityTerm matches with no Pods.",
                                 "properties": {
                                   "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
                                     "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
                                       "properties": {
                                         "key": {
+                                          "description": "key is the label key that the selector applies to.",
                                           "type": "string"
                                         },
                                         "operator": {
+                                          "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
                                           "type": "string"
                                         },
                                         "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
                                           "items": {
                                             "type": "string"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       },
                                       "required": [
@@ -272,25 +350,94 @@
                                       "type": "object",
                                       "additionalProperties": false
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "matchLabels": {
                                     "additionalProperties": {
                                       "type": "string"
                                     },
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                                     "type": "object"
                                   }
                                 },
                                 "type": "object",
+                                "x-kubernetes-map-type": "atomic",
                                 "additionalProperties": false
                               },
-                              "namespaces": {
+                              "matchLabelKeys": {
+                                "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both matchLabelKeys and labelSelector.\nAlso, matchLabelKeys cannot be set when labelSelector isn't set.\nThis is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).",
                                 "items": {
                                   "type": "string"
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "mismatchLabelKeys": {
+                                "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both mismatchLabelKeys and labelSelector.\nAlso, mismatchLabelKeys cannot be set when labelSelector isn't set.\nThis is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "namespaceSelector": {
+                                "description": "A label query over the set of namespaces that the term applies to.\nThe term is applied to the union of the namespaces selected by this field\nand the ones listed in the namespaces field.\nnull selector and null or empty namespaces list means \"this pod's namespace\".\nAn empty selector ({}) matches all namespaces.",
+                                "properties": {
+                                  "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                    "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                      "properties": {
+                                        "key": {
+                                          "description": "key is the label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "namespaces": {
+                                "description": "namespaces specifies a static list of namespace names that the term applies to.\nThe term is applied to the union of the namespaces listed in this field\nand the ones selected by namespaceSelector.\nnull or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "topologyKey": {
+                                "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
                                 "type": "string"
                               }
                             },
@@ -301,6 +448,7 @@
                             "additionalProperties": false
                           },
                           "weight": {
+                            "description": "weight associated with matching the corresponding podAffinityTerm,\nin the range 1-100.",
                             "format": "int32",
                             "type": "integer"
                           }
@@ -312,27 +460,37 @@
                         "type": "object",
                         "additionalProperties": false
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     },
                     "requiredDuringSchedulingIgnoredDuringExecution": {
+                      "description": "If the affinity requirements specified by this field are not met at\nscheduling time, the pod will not be scheduled onto the node.\nIf the affinity requirements specified by this field cease to be met\nat some point during pod execution (e.g. due to a pod label update), the\nsystem may or may not try to eventually evict the pod from its node.\nWhen there are multiple elements, the lists of nodes corresponding to each\npodAffinityTerm are intersected, i.e. all terms must be satisfied.",
                       "items": {
+                        "description": "Defines a set of pods (namely those matching the labelSelector\nrelative to the given namespace(s)) that this pod should be\nco-located (affinity) or not co-located (anti-affinity) with,\nwhere co-located is defined as running on a node whose value of\nthe label with key <topologyKey> matches that of any node on which\na pod of the set of pods is running",
                         "properties": {
                           "labelSelector": {
+                            "description": "A label query over a set of resources, in this case pods.\nIf it's null, this PodAffinityTerm matches with no Pods.",
                             "properties": {
                               "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
                                 "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
                                   "properties": {
                                     "key": {
+                                      "description": "key is the label key that the selector applies to.",
                                       "type": "string"
                                     },
                                     "operator": {
+                                      "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
                                       "type": "string"
                                     },
                                     "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -342,25 +500,94 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchLabels": {
                                 "additionalProperties": {
                                   "type": "string"
                                 },
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                                 "type": "object"
                               }
                             },
                             "type": "object",
+                            "x-kubernetes-map-type": "atomic",
                             "additionalProperties": false
                           },
-                          "namespaces": {
+                          "matchLabelKeys": {
+                            "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both matchLabelKeys and labelSelector.\nAlso, matchLabelKeys cannot be set when labelSelector isn't set.\nThis is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).",
                             "items": {
                               "type": "string"
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "mismatchLabelKeys": {
+                            "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both mismatchLabelKeys and labelSelector.\nAlso, mismatchLabelKeys cannot be set when labelSelector isn't set.\nThis is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "namespaceSelector": {
+                            "description": "A label query over the set of namespaces that the term applies to.\nThe term is applied to the union of the namespaces selected by this field\nand the ones listed in the namespaces field.\nnull selector and null or empty namespaces list means \"this pod's namespace\".\nAn empty selector ({}) matches all namespaces.",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "key is the label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "namespaces": {
+                            "description": "namespaces specifies a static list of namespace names that the term applies to.\nThe term is applied to the union of the namespaces listed in this field\nand the ones selected by namespaceSelector.\nnull or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "topologyKey": {
+                            "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
                             "type": "string"
                           }
                         },
@@ -370,35 +597,47 @@
                         "type": "object",
                         "additionalProperties": false
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     }
                   },
                   "type": "object",
                   "additionalProperties": false
                 },
                 "podAntiAffinity": {
+                  "description": "Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).",
                   "properties": {
                     "preferredDuringSchedulingIgnoredDuringExecution": {
+                      "description": "The scheduler will prefer to schedule pods to nodes that satisfy\nthe anti-affinity expressions specified by this field, but it may choose\na node that violates one or more of the expressions. The node that is\nmost preferred is the one with the greatest sum of weights, i.e.\nfor each node that meets all of the scheduling requirements (resource\nrequest, requiredDuringScheduling anti-affinity expressions, etc.),\ncompute a sum by iterating through the elements of this field and adding\n\"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the\nnode(s) with the highest sum are the most preferred.",
                       "items": {
+                        "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
                         "properties": {
                           "podAffinityTerm": {
+                            "description": "Required. A pod affinity term, associated with the corresponding weight.",
                             "properties": {
                               "labelSelector": {
+                                "description": "A label query over a set of resources, in this case pods.\nIf it's null, this PodAffinityTerm matches with no Pods.",
                                 "properties": {
                                   "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
                                     "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
                                       "properties": {
                                         "key": {
+                                          "description": "key is the label key that the selector applies to.",
                                           "type": "string"
                                         },
                                         "operator": {
+                                          "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
                                           "type": "string"
                                         },
                                         "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
                                           "items": {
                                             "type": "string"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       },
                                       "required": [
@@ -408,25 +647,94 @@
                                       "type": "object",
                                       "additionalProperties": false
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "matchLabels": {
                                     "additionalProperties": {
                                       "type": "string"
                                     },
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                                     "type": "object"
                                   }
                                 },
                                 "type": "object",
+                                "x-kubernetes-map-type": "atomic",
                                 "additionalProperties": false
                               },
-                              "namespaces": {
+                              "matchLabelKeys": {
+                                "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both matchLabelKeys and labelSelector.\nAlso, matchLabelKeys cannot be set when labelSelector isn't set.\nThis is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).",
                                 "items": {
                                   "type": "string"
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "mismatchLabelKeys": {
+                                "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both mismatchLabelKeys and labelSelector.\nAlso, mismatchLabelKeys cannot be set when labelSelector isn't set.\nThis is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "namespaceSelector": {
+                                "description": "A label query over the set of namespaces that the term applies to.\nThe term is applied to the union of the namespaces selected by this field\nand the ones listed in the namespaces field.\nnull selector and null or empty namespaces list means \"this pod's namespace\".\nAn empty selector ({}) matches all namespaces.",
+                                "properties": {
+                                  "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                    "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                      "properties": {
+                                        "key": {
+                                          "description": "key is the label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "namespaces": {
+                                "description": "namespaces specifies a static list of namespace names that the term applies to.\nThe term is applied to the union of the namespaces listed in this field\nand the ones selected by namespaceSelector.\nnull or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "topologyKey": {
+                                "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
                                 "type": "string"
                               }
                             },
@@ -437,6 +745,7 @@
                             "additionalProperties": false
                           },
                           "weight": {
+                            "description": "weight associated with matching the corresponding podAffinityTerm,\nin the range 1-100.",
                             "format": "int32",
                             "type": "integer"
                           }
@@ -448,27 +757,37 @@
                         "type": "object",
                         "additionalProperties": false
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     },
                     "requiredDuringSchedulingIgnoredDuringExecution": {
+                      "description": "If the anti-affinity requirements specified by this field are not met at\nscheduling time, the pod will not be scheduled onto the node.\nIf the anti-affinity requirements specified by this field cease to be met\nat some point during pod execution (e.g. due to a pod label update), the\nsystem may or may not try to eventually evict the pod from its node.\nWhen there are multiple elements, the lists of nodes corresponding to each\npodAffinityTerm are intersected, i.e. all terms must be satisfied.",
                       "items": {
+                        "description": "Defines a set of pods (namely those matching the labelSelector\nrelative to the given namespace(s)) that this pod should be\nco-located (affinity) or not co-located (anti-affinity) with,\nwhere co-located is defined as running on a node whose value of\nthe label with key <topologyKey> matches that of any node on which\na pod of the set of pods is running",
                         "properties": {
                           "labelSelector": {
+                            "description": "A label query over a set of resources, in this case pods.\nIf it's null, this PodAffinityTerm matches with no Pods.",
                             "properties": {
                               "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
                                 "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
                                   "properties": {
                                     "key": {
+                                      "description": "key is the label key that the selector applies to.",
                                       "type": "string"
                                     },
                                     "operator": {
+                                      "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
                                       "type": "string"
                                     },
                                     "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -478,25 +797,94 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchLabels": {
                                 "additionalProperties": {
                                   "type": "string"
                                 },
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                                 "type": "object"
                               }
                             },
                             "type": "object",
+                            "x-kubernetes-map-type": "atomic",
                             "additionalProperties": false
                           },
-                          "namespaces": {
+                          "matchLabelKeys": {
+                            "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both matchLabelKeys and labelSelector.\nAlso, matchLabelKeys cannot be set when labelSelector isn't set.\nThis is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).",
                             "items": {
                               "type": "string"
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "mismatchLabelKeys": {
+                            "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both mismatchLabelKeys and labelSelector.\nAlso, mismatchLabelKeys cannot be set when labelSelector isn't set.\nThis is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "namespaceSelector": {
+                            "description": "A label query over the set of namespaces that the term applies to.\nThe term is applied to the union of the namespaces selected by this field\nand the ones listed in the namespaces field.\nnull selector and null or empty namespaces list means \"this pod's namespace\".\nAn empty selector ({}) matches all namespaces.",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "key is the label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "namespaces": {
+                            "description": "namespaces specifies a static list of namespace names that the term applies to.\nThe term is applied to the union of the namespaces listed in this field\nand the ones selected by namespaceSelector.\nnull or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "topologyKey": {
+                            "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
                             "type": "string"
                           }
                         },
@@ -506,7 +894,8 @@
                         "type": "object",
                         "additionalProperties": false
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     }
                   },
                   "type": "object",
@@ -520,10 +909,13 @@
               "additionalProperties": {
                 "type": "string"
               },
+              "description": "Annotations are the Kubernetes annotations to be added to the pod.",
               "type": "object"
             },
             "configMaps": {
+              "description": "ConfigMaps carries information of other ConfigMaps to add to the pod.",
               "items": {
+                "description": "NamePath is a pair of a name and a path to which the named objects should be mounted to.",
                 "properties": {
                   "name": {
                     "type": "string"
@@ -542,69 +934,92 @@
               "type": "array"
             },
             "coreLimit": {
+              "description": "CoreLimit specifies a hard limit on CPU cores for the pod.\nOptional",
               "type": "string"
             },
             "coreRequest": {
+              "description": "CoreRequest is the physical CPU core request for the driver.\nMaps to `spark.kubernetes.driver.request.cores` that is available since Spark 3.0.",
               "type": "string"
             },
             "cores": {
+              "description": "Cores maps to `spark.driver.cores` or `spark.executor.cores` for the driver and executors, respectively.",
               "format": "int32",
               "minimum": 1,
               "type": "integer"
             },
             "dnsConfig": {
+              "description": "DnsConfig dns settings for the pod, following the Kubernetes specifications.",
               "properties": {
                 "nameservers": {
+                  "description": "A list of DNS name server IP addresses.\nThis will be appended to the base nameservers generated from DNSPolicy.\nDuplicated nameservers will be removed.",
                   "items": {
                     "type": "string"
                   },
-                  "type": "array"
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
                 },
                 "options": {
+                  "description": "A list of DNS resolver options.\nThis will be merged with the base options generated from DNSPolicy.\nDuplicated entries will be removed. Resolution options given in Options\nwill override those that appear in the base DNSPolicy.",
                   "items": {
+                    "description": "PodDNSConfigOption defines DNS resolver options of a pod.",
                     "properties": {
                       "name": {
+                        "description": "Name is this DNS resolver option's name.\nRequired.",
                         "type": "string"
                       },
                       "value": {
+                        "description": "Value is this DNS resolver option's value.",
                         "type": "string"
                       }
                     },
                     "type": "object",
                     "additionalProperties": false
                   },
-                  "type": "array"
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
                 },
                 "searches": {
+                  "description": "A list of DNS search domains for host-name lookup.\nThis will be appended to the base search paths generated from DNSPolicy.\nDuplicated search paths will be removed.",
                   "items": {
                     "type": "string"
                   },
-                  "type": "array"
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
                 }
               },
               "type": "object",
               "additionalProperties": false
             },
             "env": {
+              "description": "Env carries the environment variables to add to the pod.",
               "items": {
+                "description": "EnvVar represents an environment variable present in a Container.",
                 "properties": {
                   "name": {
+                    "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
                     "type": "string"
                   },
                   "value": {
+                    "description": "Variable references $(VAR_NAME) are expanded\nusing the previously defined environment variables in the container and\nany service environment variables. If a variable cannot be resolved,\nthe reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.\n\"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\".\nEscaped references will never be expanded, regardless of whether the variable\nexists or not.\nDefaults to \"\".",
                     "type": "string"
                   },
                   "valueFrom": {
+                    "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
                     "properties": {
                       "configMapKeyRef": {
+                        "description": "Selects a key of a ConfigMap.",
                         "properties": {
                           "key": {
+                            "description": "The key to select.",
                             "type": "string"
                           },
                           "name": {
+                            "default": "",
+                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                             "type": "string"
                           },
                           "optional": {
+                            "description": "Specify whether the ConfigMap or its key must be defined",
                             "type": "boolean"
                           }
                         },
@@ -612,14 +1027,18 @@
                           "key"
                         ],
                         "type": "object",
+                        "x-kubernetes-map-type": "atomic",
                         "additionalProperties": false
                       },
                       "fieldRef": {
+                        "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,\nspec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
                         "properties": {
                           "apiVersion": {
+                            "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
                             "type": "string"
                           },
                           "fieldPath": {
+                            "description": "Path of the field to select in the specified API version.",
                             "type": "string"
                           }
                         },
@@ -627,11 +1046,14 @@
                           "fieldPath"
                         ],
                         "type": "object",
+                        "x-kubernetes-map-type": "atomic",
                         "additionalProperties": false
                       },
                       "resourceFieldRef": {
+                        "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
                         "properties": {
                           "containerName": {
+                            "description": "Container name: required for volumes, optional for env vars",
                             "type": "string"
                           },
                           "divisor": {
@@ -643,10 +1065,12 @@
                                 "type": "string"
                               }
                             ],
+                            "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
                             "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                             "x-kubernetes-int-or-string": true
                           },
                           "resource": {
+                            "description": "Required: resource to select",
                             "type": "string"
                           }
                         },
@@ -654,17 +1078,23 @@
                           "resource"
                         ],
                         "type": "object",
+                        "x-kubernetes-map-type": "atomic",
                         "additionalProperties": false
                       },
                       "secretKeyRef": {
+                        "description": "Selects a key of a secret in the pod's namespace",
                         "properties": {
                           "key": {
+                            "description": "The key of the secret to select from.  Must be a valid secret key.",
                             "type": "string"
                           },
                           "name": {
+                            "default": "",
+                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                             "type": "string"
                           },
                           "optional": {
+                            "description": "Specify whether the Secret or its key must be defined",
                             "type": "boolean"
                           }
                         },
@@ -672,6 +1102,7 @@
                           "key"
                         ],
                         "type": "object",
+                        "x-kubernetes-map-type": "atomic",
                         "additionalProperties": false
                       }
                     },
@@ -688,33 +1119,46 @@
               "type": "array"
             },
             "envFrom": {
+              "description": "EnvFrom is a list of sources to populate environment variables in the container.",
               "items": {
+                "description": "EnvFromSource represents the source of a set of ConfigMaps",
                 "properties": {
                   "configMapRef": {
+                    "description": "The ConfigMap to select from",
                     "properties": {
                       "name": {
+                        "default": "",
+                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                         "type": "string"
                       },
                       "optional": {
+                        "description": "Specify whether the ConfigMap must be defined",
                         "type": "boolean"
                       }
                     },
                     "type": "object",
+                    "x-kubernetes-map-type": "atomic",
                     "additionalProperties": false
                   },
                   "prefix": {
+                    "description": "An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.",
                     "type": "string"
                   },
                   "secretRef": {
+                    "description": "The Secret to select from",
                     "properties": {
                       "name": {
+                        "default": "",
+                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                         "type": "string"
                       },
                       "optional": {
+                        "description": "Specify whether the Secret must be defined",
                         "type": "boolean"
                       }
                     },
                     "type": "object",
+                    "x-kubernetes-map-type": "atomic",
                     "additionalProperties": false
                   }
                 },
@@ -725,6 +1169,7 @@
             },
             "envSecretKeyRefs": {
               "additionalProperties": {
+                "description": "NameKey represents the name and key of a SecretKeyRef.",
                 "properties": {
                   "key": {
                     "type": "string"
@@ -740,20 +1185,25 @@
                 "type": "object",
                 "additionalProperties": false
               },
+              "description": "EnvSecretKeyRefs holds a mapping from environment variable names to SecretKeyRefs.\nDeprecated. Consider using `env` instead.",
               "type": "object"
             },
             "envVars": {
               "additionalProperties": {
                 "type": "string"
               },
+              "description": "EnvVars carries the environment variables to add to the pod.\nDeprecated. Consider using `env` instead.",
               "type": "object"
             },
             "gpu": {
+              "description": "GPU specifies GPU requirement for the pod.",
               "properties": {
                 "name": {
+                  "description": "Name is GPU resource name, such as: nvidia.com/gpu or amd.com/gpu",
                   "type": "string"
                 },
                 "quantity": {
+                  "description": "Quantity is the number of GPUs to request for driver or executor.",
                   "format": "int64",
                   "type": "integer"
                 }
@@ -766,64 +1216,90 @@
               "additionalProperties": false
             },
             "hostAliases": {
+              "description": "HostAliases settings for the pod, following the Kubernetes specifications.",
               "items": {
+                "description": "HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the\npod's hosts file.",
                 "properties": {
                   "hostnames": {
+                    "description": "Hostnames for the above IP address.",
                     "items": {
                       "type": "string"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   },
                   "ip": {
+                    "description": "IP address of the host file entry.",
                     "type": "string"
                   }
                 },
+                "required": [
+                  "ip"
+                ],
                 "type": "object",
                 "additionalProperties": false
               },
               "type": "array"
             },
             "hostNetwork": {
+              "description": "HostNetwork indicates whether to request host networking for the pod or not.",
               "type": "boolean"
             },
             "image": {
+              "description": "Image is the container image to use. Overrides Spec.Image if set.",
               "type": "string"
             },
             "initContainers": {
+              "description": "InitContainers is a list of init-containers that run to completion before the main Spark container.",
               "items": {
+                "description": "A single application container that you want to run within a pod.",
                 "properties": {
                   "args": {
+                    "description": "Arguments to the entrypoint.\nThe container image's CMD is used if this is not provided.\nVariable references $(VAR_NAME) are expanded using the container's environment. If a variable\ncannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will\nproduce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless\nof whether the variable exists or not. Cannot be updated.\nMore info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
                     "items": {
                       "type": "string"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   },
                   "command": {
+                    "description": "Entrypoint array. Not executed within a shell.\nThe container image's ENTRYPOINT is used if this is not provided.\nVariable references $(VAR_NAME) are expanded using the container's environment. If a variable\ncannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will\nproduce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless\nof whether the variable exists or not. Cannot be updated.\nMore info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
                     "items": {
                       "type": "string"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   },
                   "env": {
+                    "description": "List of environment variables to set in the container.\nCannot be updated.",
                     "items": {
+                      "description": "EnvVar represents an environment variable present in a Container.",
                       "properties": {
                         "name": {
+                          "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
                           "type": "string"
                         },
                         "value": {
+                          "description": "Variable references $(VAR_NAME) are expanded\nusing the previously defined environment variables in the container and\nany service environment variables. If a variable cannot be resolved,\nthe reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.\n\"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\".\nEscaped references will never be expanded, regardless of whether the variable\nexists or not.\nDefaults to \"\".",
                           "type": "string"
                         },
                         "valueFrom": {
+                          "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
                           "properties": {
                             "configMapKeyRef": {
+                              "description": "Selects a key of a ConfigMap.",
                               "properties": {
                                 "key": {
+                                  "description": "The key to select.",
                                   "type": "string"
                                 },
                                 "name": {
+                                  "default": "",
+                                  "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                   "type": "string"
                                 },
                                 "optional": {
+                                  "description": "Specify whether the ConfigMap or its key must be defined",
                                   "type": "boolean"
                                 }
                               },
@@ -831,14 +1307,18 @@
                                 "key"
                               ],
                               "type": "object",
+                              "x-kubernetes-map-type": "atomic",
                               "additionalProperties": false
                             },
                             "fieldRef": {
+                              "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,\nspec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
                               "properties": {
                                 "apiVersion": {
+                                  "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
                                   "type": "string"
                                 },
                                 "fieldPath": {
+                                  "description": "Path of the field to select in the specified API version.",
                                   "type": "string"
                                 }
                               },
@@ -846,11 +1326,14 @@
                                 "fieldPath"
                               ],
                               "type": "object",
+                              "x-kubernetes-map-type": "atomic",
                               "additionalProperties": false
                             },
                             "resourceFieldRef": {
+                              "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
                               "properties": {
                                 "containerName": {
+                                  "description": "Container name: required for volumes, optional for env vars",
                                   "type": "string"
                                 },
                                 "divisor": {
@@ -862,10 +1345,12 @@
                                       "type": "string"
                                     }
                                   ],
+                                  "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
                                   "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                                   "x-kubernetes-int-or-string": true
                                 },
                                 "resource": {
+                                  "description": "Required: resource to select",
                                   "type": "string"
                                 }
                               },
@@ -873,17 +1358,23 @@
                                 "resource"
                               ],
                               "type": "object",
+                              "x-kubernetes-map-type": "atomic",
                               "additionalProperties": false
                             },
                             "secretKeyRef": {
+                              "description": "Selects a key of a secret in the pod's namespace",
                               "properties": {
                                 "key": {
+                                  "description": "The key of the secret to select from.  Must be a valid secret key.",
                                   "type": "string"
                                 },
                                 "name": {
+                                  "default": "",
+                                  "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                   "type": "string"
                                 },
                                 "optional": {
+                                  "description": "Specify whether the Secret or its key must be defined",
                                   "type": "boolean"
                                 }
                               },
@@ -891,6 +1382,7 @@
                                 "key"
                               ],
                               "type": "object",
+                              "x-kubernetes-map-type": "atomic",
                               "additionalProperties": false
                             }
                           },
@@ -904,78 +1396,109 @@
                       "type": "object",
                       "additionalProperties": false
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-map-keys": [
+                      "name"
+                    ],
+                    "x-kubernetes-list-type": "map"
                   },
                   "envFrom": {
+                    "description": "List of sources to populate environment variables in the container.\nThe keys defined within a source must be a C_IDENTIFIER. All invalid keys\nwill be reported as an event when the container is starting. When a key exists in multiple\nsources, the value associated with the last source will take precedence.\nValues defined by an Env with a duplicate key will take precedence.\nCannot be updated.",
                     "items": {
+                      "description": "EnvFromSource represents the source of a set of ConfigMaps",
                       "properties": {
                         "configMapRef": {
+                          "description": "The ConfigMap to select from",
                           "properties": {
                             "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                               "type": "string"
                             },
                             "optional": {
+                              "description": "Specify whether the ConfigMap must be defined",
                               "type": "boolean"
                             }
                           },
                           "type": "object",
+                          "x-kubernetes-map-type": "atomic",
                           "additionalProperties": false
                         },
                         "prefix": {
+                          "description": "An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.",
                           "type": "string"
                         },
                         "secretRef": {
+                          "description": "The Secret to select from",
                           "properties": {
                             "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                               "type": "string"
                             },
                             "optional": {
+                              "description": "Specify whether the Secret must be defined",
                               "type": "boolean"
                             }
                           },
                           "type": "object",
+                          "x-kubernetes-map-type": "atomic",
                           "additionalProperties": false
                         }
                       },
                       "type": "object",
                       "additionalProperties": false
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   },
                   "image": {
+                    "description": "Container image name.\nMore info: https://kubernetes.io/docs/concepts/containers/images\nThis field is optional to allow higher level config management to default or override\ncontainer images in workload controllers like Deployments and StatefulSets.",
                     "type": "string"
                   },
                   "imagePullPolicy": {
+                    "description": "Image pull policy.\nOne of Always, Never, IfNotPresent.\nDefaults to Always if :latest tag is specified, or IfNotPresent otherwise.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/containers/images#updating-images",
                     "type": "string"
                   },
                   "lifecycle": {
+                    "description": "Actions that the management system should take in response to container lifecycle events.\nCannot be updated.",
                     "properties": {
                       "postStart": {
+                        "description": "PostStart is called immediately after a container is created. If the handler fails,\nthe container is terminated and restarted according to its restart policy.\nOther management of the container blocks until the hook completes.\nMore info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks",
                         "properties": {
                           "exec": {
+                            "description": "Exec specifies a command to execute in the container.",
                             "properties": {
                               "command": {
+                                "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
                                 "items": {
                                   "type": "string"
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               }
                             },
                             "type": "object",
                             "additionalProperties": false
                           },
                           "httpGet": {
+                            "description": "HTTPGet specifies an HTTP GET request to perform.",
                             "properties": {
                               "host": {
+                                "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
                                 "type": "string"
                               },
                               "httpHeaders": {
+                                "description": "Custom headers to set in the request. HTTP allows repeated headers.",
                                 "items": {
+                                  "description": "HTTPHeader describes a custom header to be used in HTTP probes",
                                   "properties": {
                                     "name": {
+                                      "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
                                       "type": "string"
                                     },
                                     "value": {
+                                      "description": "The header field value",
                                       "type": "string"
                                     }
                                   },
@@ -986,9 +1509,11 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "path": {
+                                "description": "Path to access on the HTTP server.",
                                 "type": "string"
                               },
                               "port": {
@@ -1000,9 +1525,11 @@
                                     "type": "string"
                                   }
                                 ],
+                                "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
                                 "x-kubernetes-int-or-string": true
                               },
                               "scheme": {
+                                "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
                                 "type": "string"
                               }
                             },
@@ -1012,9 +1539,26 @@
                             "type": "object",
                             "additionalProperties": false
                           },
+                          "sleep": {
+                            "description": "Sleep represents a duration that the container should sleep.",
+                            "properties": {
+                              "seconds": {
+                                "description": "Seconds is the number of seconds to sleep.",
+                                "format": "int64",
+                                "type": "integer"
+                              }
+                            },
+                            "required": [
+                              "seconds"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
                           "tcpSocket": {
+                            "description": "Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept\nfor backward compatibility. There is no validation of this field and\nlifecycle hooks will fail at runtime when it is specified.",
                             "properties": {
                               "host": {
+                                "description": "Optional: Host name to connect to, defaults to the pod IP.",
                                 "type": "string"
                               },
                               "port": {
@@ -1026,6 +1570,7 @@
                                     "type": "string"
                                   }
                                 ],
+                                "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
                                 "x-kubernetes-int-or-string": true
                               }
                             },
@@ -1040,31 +1585,41 @@
                         "additionalProperties": false
                       },
                       "preStop": {
+                        "description": "PreStop is called immediately before a container is terminated due to an\nAPI request or management event such as liveness/startup probe failure,\npreemption, resource contention, etc. The handler is not called if the\ncontainer crashes or exits. The Pod's termination grace period countdown begins before the\nPreStop hook is executed. Regardless of the outcome of the handler, the\ncontainer will eventually terminate within the Pod's termination grace\nperiod (unless delayed by finalizers). Other management of the container blocks until the hook completes\nor until the termination grace period is reached.\nMore info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks",
                         "properties": {
                           "exec": {
+                            "description": "Exec specifies a command to execute in the container.",
                             "properties": {
                               "command": {
+                                "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
                                 "items": {
                                   "type": "string"
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               }
                             },
                             "type": "object",
                             "additionalProperties": false
                           },
                           "httpGet": {
+                            "description": "HTTPGet specifies an HTTP GET request to perform.",
                             "properties": {
                               "host": {
+                                "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
                                 "type": "string"
                               },
                               "httpHeaders": {
+                                "description": "Custom headers to set in the request. HTTP allows repeated headers.",
                                 "items": {
+                                  "description": "HTTPHeader describes a custom header to be used in HTTP probes",
                                   "properties": {
                                     "name": {
+                                      "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
                                       "type": "string"
                                     },
                                     "value": {
+                                      "description": "The header field value",
                                       "type": "string"
                                     }
                                   },
@@ -1075,9 +1630,11 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "path": {
+                                "description": "Path to access on the HTTP server.",
                                 "type": "string"
                               },
                               "port": {
@@ -1089,9 +1646,11 @@
                                     "type": "string"
                                   }
                                 ],
+                                "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
                                 "x-kubernetes-int-or-string": true
                               },
                               "scheme": {
+                                "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
                                 "type": "string"
                               }
                             },
@@ -1101,9 +1660,26 @@
                             "type": "object",
                             "additionalProperties": false
                           },
+                          "sleep": {
+                            "description": "Sleep represents a duration that the container should sleep.",
+                            "properties": {
+                              "seconds": {
+                                "description": "Seconds is the number of seconds to sleep.",
+                                "format": "int64",
+                                "type": "integer"
+                              }
+                            },
+                            "required": [
+                              "seconds"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
                           "tcpSocket": {
+                            "description": "Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept\nfor backward compatibility. There is no validation of this field and\nlifecycle hooks will fail at runtime when it is specified.",
                             "properties": {
                               "host": {
+                                "description": "Optional: Host name to connect to, defaults to the pod IP.",
                                 "type": "string"
                               },
                               "port": {
@@ -1115,6 +1691,7 @@
                                     "type": "string"
                                   }
                                 ],
+                                "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
                                 "x-kubernetes-int-or-string": true
                               }
                             },
@@ -1133,35 +1710,66 @@
                     "additionalProperties": false
                   },
                   "livenessProbe": {
+                    "description": "Periodic probe of container liveness.\nContainer will be restarted if the probe fails.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
                     "properties": {
                       "exec": {
+                        "description": "Exec specifies a command to execute in the container.",
                         "properties": {
                           "command": {
+                            "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
                             "items": {
                               "type": "string"
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           }
                         },
                         "type": "object",
                         "additionalProperties": false
                       },
                       "failureThreshold": {
+                        "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded.\nDefaults to 3. Minimum value is 1.",
                         "format": "int32",
                         "type": "integer"
                       },
+                      "grpc": {
+                        "description": "GRPC specifies a GRPC HealthCheckRequest.",
+                        "properties": {
+                          "port": {
+                            "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "service": {
+                            "default": "",
+                            "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "port"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
                       "httpGet": {
+                        "description": "HTTPGet specifies an HTTP GET request to perform.",
                         "properties": {
                           "host": {
+                            "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
                             "type": "string"
                           },
                           "httpHeaders": {
+                            "description": "Custom headers to set in the request. HTTP allows repeated headers.",
                             "items": {
+                              "description": "HTTPHeader describes a custom header to be used in HTTP probes",
                               "properties": {
                                 "name": {
+                                  "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
                                   "type": "string"
                                 },
                                 "value": {
+                                  "description": "The header field value",
                                   "type": "string"
                                 }
                               },
@@ -1172,9 +1780,11 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "path": {
+                            "description": "Path to access on the HTTP server.",
                             "type": "string"
                           },
                           "port": {
@@ -1186,9 +1796,11 @@
                                 "type": "string"
                               }
                             ],
+                            "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
                             "x-kubernetes-int-or-string": true
                           },
                           "scheme": {
+                            "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
                             "type": "string"
                           }
                         },
@@ -1199,20 +1811,25 @@
                         "additionalProperties": false
                       },
                       "initialDelaySeconds": {
+                        "description": "Number of seconds after the container has started before liveness probes are initiated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
                         "format": "int32",
                         "type": "integer"
                       },
                       "periodSeconds": {
+                        "description": "How often (in seconds) to perform the probe.\nDefault to 10 seconds. Minimum value is 1.",
                         "format": "int32",
                         "type": "integer"
                       },
                       "successThreshold": {
+                        "description": "Minimum consecutive successes for the probe to be considered successful after having failed.\nDefaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
                         "format": "int32",
                         "type": "integer"
                       },
                       "tcpSocket": {
+                        "description": "TCPSocket specifies a connection to a TCP port.",
                         "properties": {
                           "host": {
+                            "description": "Optional: Host name to connect to, defaults to the pod IP.",
                             "type": "string"
                           },
                           "port": {
@@ -1224,6 +1841,7 @@
                                 "type": "string"
                               }
                             ],
+                            "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
                             "x-kubernetes-int-or-string": true
                           }
                         },
@@ -1233,7 +1851,13 @@
                         "type": "object",
                         "additionalProperties": false
                       },
+                      "terminationGracePeriodSeconds": {
+                        "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure.\nThe grace period is the duration in seconds after the processes running in the pod are sent\na termination signal and the time when the processes are forcibly halted with a kill signal.\nSet this value longer than the expected cleanup time for your process.\nIf this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this\nvalue overrides the value provided by the pod spec.\nValue must be non-negative integer. The value zero indicates stop immediately via\nthe kill signal (no opportunity to shut down).\nThis is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.\nMinimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+                        "format": "int64",
+                        "type": "integer"
+                      },
                       "timeoutSeconds": {
+                        "description": "Number of seconds after which the probe times out.\nDefaults to 1 second. Minimum value is 1.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
                         "format": "int32",
                         "type": "integer"
                       }
@@ -1242,32 +1866,40 @@
                     "additionalProperties": false
                   },
                   "name": {
+                    "description": "Name of the container specified as a DNS_LABEL.\nEach container in a pod must have a unique name (DNS_LABEL).\nCannot be updated.",
                     "type": "string"
                   },
                   "ports": {
+                    "description": "List of ports to expose from the container. Not specifying a port here\nDOES NOT prevent that port from being exposed. Any port which is\nlistening on the default \"0.0.0.0\" address inside a container will be\naccessible from the network.\nModifying this array with strategic merge patch may corrupt the data.\nFor more information See https://github.com/kubernetes/kubernetes/issues/108255.\nCannot be updated.",
                     "items": {
+                      "description": "ContainerPort represents a network port in a single container.",
                       "properties": {
                         "containerPort": {
+                          "description": "Number of port to expose on the pod's IP address.\nThis must be a valid port number, 0 < x < 65536.",
                           "format": "int32",
                           "type": "integer"
                         },
                         "hostIP": {
+                          "description": "What host IP to bind the external port to.",
                           "type": "string"
                         },
                         "hostPort": {
+                          "description": "Number of port to expose on the host.\nIf specified, this must be a valid port number, 0 < x < 65536.\nIf HostNetwork is specified, this must match ContainerPort.\nMost containers do not need this.",
                           "format": "int32",
                           "type": "integer"
                         },
                         "name": {
+                          "description": "If specified, this must be an IANA_SVC_NAME and unique within the pod. Each\nnamed port in a pod must have a unique name. Name for the port that can be\nreferred to by services.",
                           "type": "string"
                         },
                         "protocol": {
+                          "default": "TCP",
+                          "description": "Protocol for port. Must be UDP, TCP, or SCTP.\nDefaults to \"TCP\".",
                           "type": "string"
                         }
                       },
                       "required": [
-                        "containerPort",
-                        "protocol"
+                        "containerPort"
                       ],
                       "type": "object",
                       "additionalProperties": false
@@ -1280,35 +1912,66 @@
                     "x-kubernetes-list-type": "map"
                   },
                   "readinessProbe": {
+                    "description": "Periodic probe of container service readiness.\nContainer will be removed from service endpoints if the probe fails.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
                     "properties": {
                       "exec": {
+                        "description": "Exec specifies a command to execute in the container.",
                         "properties": {
                           "command": {
+                            "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
                             "items": {
                               "type": "string"
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           }
                         },
                         "type": "object",
                         "additionalProperties": false
                       },
                       "failureThreshold": {
+                        "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded.\nDefaults to 3. Minimum value is 1.",
                         "format": "int32",
                         "type": "integer"
                       },
+                      "grpc": {
+                        "description": "GRPC specifies a GRPC HealthCheckRequest.",
+                        "properties": {
+                          "port": {
+                            "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "service": {
+                            "default": "",
+                            "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "port"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
                       "httpGet": {
+                        "description": "HTTPGet specifies an HTTP GET request to perform.",
                         "properties": {
                           "host": {
+                            "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
                             "type": "string"
                           },
                           "httpHeaders": {
+                            "description": "Custom headers to set in the request. HTTP allows repeated headers.",
                             "items": {
+                              "description": "HTTPHeader describes a custom header to be used in HTTP probes",
                               "properties": {
                                 "name": {
+                                  "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
                                   "type": "string"
                                 },
                                 "value": {
+                                  "description": "The header field value",
                                   "type": "string"
                                 }
                               },
@@ -1319,9 +1982,11 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "path": {
+                            "description": "Path to access on the HTTP server.",
                             "type": "string"
                           },
                           "port": {
@@ -1333,9 +1998,11 @@
                                 "type": "string"
                               }
                             ],
+                            "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
                             "x-kubernetes-int-or-string": true
                           },
                           "scheme": {
+                            "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
                             "type": "string"
                           }
                         },
@@ -1346,20 +2013,25 @@
                         "additionalProperties": false
                       },
                       "initialDelaySeconds": {
+                        "description": "Number of seconds after the container has started before liveness probes are initiated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
                         "format": "int32",
                         "type": "integer"
                       },
                       "periodSeconds": {
+                        "description": "How often (in seconds) to perform the probe.\nDefault to 10 seconds. Minimum value is 1.",
                         "format": "int32",
                         "type": "integer"
                       },
                       "successThreshold": {
+                        "description": "Minimum consecutive successes for the probe to be considered successful after having failed.\nDefaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
                         "format": "int32",
                         "type": "integer"
                       },
                       "tcpSocket": {
+                        "description": "TCPSocket specifies a connection to a TCP port.",
                         "properties": {
                           "host": {
+                            "description": "Optional: Host name to connect to, defaults to the pod IP.",
                             "type": "string"
                           },
                           "port": {
@@ -1371,6 +2043,7 @@
                                 "type": "string"
                               }
                             ],
+                            "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
                             "x-kubernetes-int-or-string": true
                           }
                         },
@@ -1380,7 +2053,13 @@
                         "type": "object",
                         "additionalProperties": false
                       },
+                      "terminationGracePeriodSeconds": {
+                        "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure.\nThe grace period is the duration in seconds after the processes running in the pod are sent\na termination signal and the time when the processes are forcibly halted with a kill signal.\nSet this value longer than the expected cleanup time for your process.\nIf this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this\nvalue overrides the value provided by the pod spec.\nValue must be non-negative integer. The value zero indicates stop immediately via\nthe kill signal (no opportunity to shut down).\nThis is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.\nMinimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+                        "format": "int64",
+                        "type": "integer"
+                      },
                       "timeoutSeconds": {
+                        "description": "Number of seconds after which the probe times out.\nDefaults to 1 second. Minimum value is 1.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
                         "format": "int32",
                         "type": "integer"
                       }
@@ -1388,8 +2067,59 @@
                     "type": "object",
                     "additionalProperties": false
                   },
+                  "resizePolicy": {
+                    "description": "Resources resize policy for the container.",
+                    "items": {
+                      "description": "ContainerResizePolicy represents resource resize policy for the container.",
+                      "properties": {
+                        "resourceName": {
+                          "description": "Name of the resource to which this resource resize policy applies.\nSupported values: cpu, memory.",
+                          "type": "string"
+                        },
+                        "restartPolicy": {
+                          "description": "Restart policy to apply when specified resource is resized.\nIf not specified, it defaults to NotRequired.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "resourceName",
+                        "restartPolicy"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  },
                   "resources": {
+                    "description": "Compute Resources required by this container.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
                     "properties": {
+                      "claims": {
+                        "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
+                        "items": {
+                          "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                          "properties": {
+                            "name": {
+                              "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
+                              "type": "string"
+                            },
+                            "request": {
+                              "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-map-keys": [
+                          "name"
+                        ],
+                        "x-kubernetes-list-type": "map"
+                      },
                       "limits": {
                         "additionalProperties": {
                           "anyOf": [
@@ -1403,6 +2133,7 @@
                           "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                           "x-kubernetes-int-or-string": true
                         },
+                        "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
                         "type": "object"
                       },
                       "requests": {
@@ -1418,82 +2149,151 @@
                           "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                           "x-kubernetes-int-or-string": true
                         },
+                        "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
                         "type": "object"
                       }
                     },
                     "type": "object",
                     "additionalProperties": false
                   },
+                  "restartPolicy": {
+                    "description": "RestartPolicy defines the restart behavior of individual containers in a pod.\nThis field may only be set for init containers, and the only allowed value is \"Always\".\nFor non-init containers or when this field is not specified,\nthe restart behavior is defined by the Pod's restart policy and the container type.\nSetting the RestartPolicy as \"Always\" for the init container will have the following effect:\nthis init container will be continually restarted on\nexit until all regular containers have terminated. Once all regular\ncontainers have completed, all init containers with restartPolicy \"Always\"\nwill be shut down. This lifecycle differs from normal init containers and\nis often referred to as a \"sidecar\" container. Although this init\ncontainer still starts in the init container sequence, it does not wait\nfor the container to complete before proceeding to the next init\ncontainer. Instead, the next init container starts immediately after this\ninit container is started, or after any startupProbe has successfully\ncompleted.",
+                    "type": "string"
+                  },
                   "securityContext": {
+                    "description": "SecurityContext defines the security options the container should be run with.\nIf set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.\nMore info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/",
                     "properties": {
                       "allowPrivilegeEscalation": {
+                        "description": "AllowPrivilegeEscalation controls whether a process can gain more\nprivileges than its parent process. This bool directly controls if\nthe no_new_privs flag will be set on the container process.\nAllowPrivilegeEscalation is true always when the container is:\n1) run as Privileged\n2) has CAP_SYS_ADMIN\nNote that this field cannot be set when spec.os.name is windows.",
                         "type": "boolean"
                       },
+                      "appArmorProfile": {
+                        "description": "appArmorProfile is the AppArmor options to use by this container. If set, this profile\noverrides the pod's appArmorProfile.\nNote that this field cannot be set when spec.os.name is windows.",
+                        "properties": {
+                          "localhostProfile": {
+                            "description": "localhostProfile indicates a profile loaded on the node that should be used.\nThe profile must be preconfigured on the node to work.\nMust match the loaded name of the profile.\nMust be set if and only if type is \"Localhost\".",
+                            "type": "string"
+                          },
+                          "type": {
+                            "description": "type indicates which kind of AppArmor profile will be applied.\nValid options are:\n  Localhost - a profile pre-loaded on the node.\n  RuntimeDefault - the container runtime's default profile.\n  Unconfined - no AppArmor enforcement.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "type"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
                       "capabilities": {
+                        "description": "The capabilities to add/drop when running containers.\nDefaults to the default set of capabilities granted by the container runtime.\nNote that this field cannot be set when spec.os.name is windows.",
                         "properties": {
                           "add": {
+                            "description": "Added capabilities",
                             "items": {
+                              "description": "Capability represent POSIX capabilities type",
                               "type": "string"
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "drop": {
+                            "description": "Removed capabilities",
                             "items": {
+                              "description": "Capability represent POSIX capabilities type",
                               "type": "string"
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           }
                         },
                         "type": "object",
                         "additionalProperties": false
                       },
                       "privileged": {
+                        "description": "Run container in privileged mode.\nProcesses in privileged containers are essentially equivalent to root on the host.\nDefaults to false.\nNote that this field cannot be set when spec.os.name is windows.",
                         "type": "boolean"
                       },
                       "procMount": {
+                        "description": "procMount denotes the type of proc mount to use for the containers.\nThe default value is Default which uses the container runtime defaults for\nreadonly paths and masked paths.\nThis requires the ProcMountType feature flag to be enabled.\nNote that this field cannot be set when spec.os.name is windows.",
                         "type": "string"
                       },
                       "readOnlyRootFilesystem": {
+                        "description": "Whether this container has a read-only root filesystem.\nDefault is false.\nNote that this field cannot be set when spec.os.name is windows.",
                         "type": "boolean"
                       },
                       "runAsGroup": {
+                        "description": "The GID to run the entrypoint of the container process.\nUses runtime default if unset.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
                         "format": "int64",
                         "type": "integer"
                       },
                       "runAsNonRoot": {
+                        "description": "Indicates that the container must run as a non-root user.\nIf true, the Kubelet will validate the image at runtime to ensure that it\ndoes not run as UID 0 (root) and fail to start the container if it does.\nIf unset or false, no such validation will be performed.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
                         "type": "boolean"
                       },
                       "runAsUser": {
+                        "description": "The UID to run the entrypoint of the container process.\nDefaults to user specified in image metadata if unspecified.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
                         "format": "int64",
                         "type": "integer"
                       },
                       "seLinuxOptions": {
+                        "description": "The SELinux context to be applied to the container.\nIf unspecified, the container runtime will allocate a random SELinux context for each\ncontainer.  May also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
                         "properties": {
                           "level": {
+                            "description": "Level is SELinux level label that applies to the container.",
                             "type": "string"
                           },
                           "role": {
+                            "description": "Role is a SELinux role label that applies to the container.",
                             "type": "string"
                           },
                           "type": {
+                            "description": "Type is a SELinux type label that applies to the container.",
                             "type": "string"
                           },
                           "user": {
+                            "description": "User is a SELinux user label that applies to the container.",
                             "type": "string"
                           }
                         },
                         "type": "object",
                         "additionalProperties": false
                       },
+                      "seccompProfile": {
+                        "description": "The seccomp options to use by this container. If seccomp options are\nprovided at both the pod & container level, the container options\noverride the pod options.\nNote that this field cannot be set when spec.os.name is windows.",
+                        "properties": {
+                          "localhostProfile": {
+                            "description": "localhostProfile indicates a profile defined in a file on the node should be used.\nThe profile must be preconfigured on the node to work.\nMust be a descending path, relative to the kubelet's configured seccomp profile location.\nMust be set if type is \"Localhost\". Must NOT be set for any other type.",
+                            "type": "string"
+                          },
+                          "type": {
+                            "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "type"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
                       "windowsOptions": {
+                        "description": "The Windows specific settings applied to all containers.\nIf unspecified, the options from the PodSecurityContext will be used.\nIf set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is linux.",
                         "properties": {
                           "gmsaCredentialSpec": {
+                            "description": "GMSACredentialSpec is where the GMSA admission webhook\n(https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the\nGMSA credential spec named by the GMSACredentialSpecName field.",
                             "type": "string"
                           },
                           "gmsaCredentialSpecName": {
+                            "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
                             "type": "string"
                           },
+                          "hostProcess": {
+                            "description": "HostProcess determines if a container should be run as a 'Host Process' container.\nAll of a Pod's containers must have the same effective HostProcess value\n(it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).\nIn addition, if HostProcess is true then HostNetwork must also be set to true.",
+                            "type": "boolean"
+                          },
                           "runAsUserName": {
+                            "description": "The UserName in Windows to run the entrypoint of the container process.\nDefaults to the user specified in image metadata if unspecified.\nMay also be set in PodSecurityContext. If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
                             "type": "string"
                           }
                         },
@@ -1505,35 +2305,66 @@
                     "additionalProperties": false
                   },
                   "startupProbe": {
+                    "description": "StartupProbe indicates that the Pod has successfully initialized.\nIf specified, no other probes are executed until this completes successfully.\nIf this probe fails, the Pod will be restarted, just as if the livenessProbe failed.\nThis can be used to provide different probe parameters at the beginning of a Pod's lifecycle,\nwhen it might take a long time to load data or warm a cache, than during steady-state operation.\nThis cannot be updated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
                     "properties": {
                       "exec": {
+                        "description": "Exec specifies a command to execute in the container.",
                         "properties": {
                           "command": {
+                            "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
                             "items": {
                               "type": "string"
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           }
                         },
                         "type": "object",
                         "additionalProperties": false
                       },
                       "failureThreshold": {
+                        "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded.\nDefaults to 3. Minimum value is 1.",
                         "format": "int32",
                         "type": "integer"
                       },
+                      "grpc": {
+                        "description": "GRPC specifies a GRPC HealthCheckRequest.",
+                        "properties": {
+                          "port": {
+                            "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "service": {
+                            "default": "",
+                            "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "port"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
                       "httpGet": {
+                        "description": "HTTPGet specifies an HTTP GET request to perform.",
                         "properties": {
                           "host": {
+                            "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
                             "type": "string"
                           },
                           "httpHeaders": {
+                            "description": "Custom headers to set in the request. HTTP allows repeated headers.",
                             "items": {
+                              "description": "HTTPHeader describes a custom header to be used in HTTP probes",
                               "properties": {
                                 "name": {
+                                  "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
                                   "type": "string"
                                 },
                                 "value": {
+                                  "description": "The header field value",
                                   "type": "string"
                                 }
                               },
@@ -1544,9 +2375,11 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "path": {
+                            "description": "Path to access on the HTTP server.",
                             "type": "string"
                           },
                           "port": {
@@ -1558,9 +2391,11 @@
                                 "type": "string"
                               }
                             ],
+                            "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
                             "x-kubernetes-int-or-string": true
                           },
                           "scheme": {
+                            "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
                             "type": "string"
                           }
                         },
@@ -1571,20 +2406,25 @@
                         "additionalProperties": false
                       },
                       "initialDelaySeconds": {
+                        "description": "Number of seconds after the container has started before liveness probes are initiated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
                         "format": "int32",
                         "type": "integer"
                       },
                       "periodSeconds": {
+                        "description": "How often (in seconds) to perform the probe.\nDefault to 10 seconds. Minimum value is 1.",
                         "format": "int32",
                         "type": "integer"
                       },
                       "successThreshold": {
+                        "description": "Minimum consecutive successes for the probe to be considered successful after having failed.\nDefaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
                         "format": "int32",
                         "type": "integer"
                       },
                       "tcpSocket": {
+                        "description": "TCPSocket specifies a connection to a TCP port.",
                         "properties": {
                           "host": {
+                            "description": "Optional: Host name to connect to, defaults to the pod IP.",
                             "type": "string"
                           },
                           "port": {
@@ -1596,6 +2436,7 @@
                                 "type": "string"
                               }
                             ],
+                            "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
                             "x-kubernetes-int-or-string": true
                           }
                         },
@@ -1605,7 +2446,13 @@
                         "type": "object",
                         "additionalProperties": false
                       },
+                      "terminationGracePeriodSeconds": {
+                        "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure.\nThe grace period is the duration in seconds after the processes running in the pod are sent\na termination signal and the time when the processes are forcibly halted with a kill signal.\nSet this value longer than the expected cleanup time for your process.\nIf this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this\nvalue overrides the value provided by the pod spec.\nValue must be non-negative integer. The value zero indicates stop immediately via\nthe kill signal (no opportunity to shut down).\nThis is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.\nMinimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+                        "format": "int64",
+                        "type": "integer"
+                      },
                       "timeoutSeconds": {
+                        "description": "Number of seconds after which the probe times out.\nDefaults to 1 second. Minimum value is 1.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
                         "format": "int32",
                         "type": "integer"
                       }
@@ -1614,27 +2461,36 @@
                     "additionalProperties": false
                   },
                   "stdin": {
+                    "description": "Whether this container should allocate a buffer for stdin in the container runtime. If this\nis not set, reads from stdin in the container will always result in EOF.\nDefault is false.",
                     "type": "boolean"
                   },
                   "stdinOnce": {
+                    "description": "Whether the container runtime should close the stdin channel after it has been opened by\na single attach. When stdin is true the stdin stream will remain open across multiple attach\nsessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the\nfirst client attaches to stdin, and then remains open and accepts data until the client disconnects,\nat which time stdin is closed and remains closed until the container is restarted. If this\nflag is false, a container processes that reads from stdin will never receive an EOF.\nDefault is false",
                     "type": "boolean"
                   },
                   "terminationMessagePath": {
+                    "description": "Optional: Path at which the file to which the container's termination message\nwill be written is mounted into the container's filesystem.\nMessage written is intended to be brief final status, such as an assertion failure message.\nWill be truncated by the node if greater than 4096 bytes. The total message length across\nall containers will be limited to 12kb.\nDefaults to /dev/termination-log.\nCannot be updated.",
                     "type": "string"
                   },
                   "terminationMessagePolicy": {
+                    "description": "Indicate how the termination message should be populated. File will use the contents of\nterminationMessagePath to populate the container status message on both success and failure.\nFallbackToLogsOnError will use the last chunk of container log output if the termination\nmessage file is empty and the container exited with an error.\nThe log output is limited to 2048 bytes or 80 lines, whichever is smaller.\nDefaults to File.\nCannot be updated.",
                     "type": "string"
                   },
                   "tty": {
+                    "description": "Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.\nDefault is false.",
                     "type": "boolean"
                   },
                   "volumeDevices": {
+                    "description": "volumeDevices is the list of block devices to be used by the container.",
                     "items": {
+                      "description": "volumeDevice describes a mapping of a raw block device within a container.",
                       "properties": {
                         "devicePath": {
+                          "description": "devicePath is the path inside of the container that the device will be mapped to.",
                           "type": "string"
                         },
                         "name": {
+                          "description": "name must match the name of a persistentVolumeClaim in the pod",
                           "type": "string"
                         }
                       },
@@ -1645,27 +2501,43 @@
                       "type": "object",
                       "additionalProperties": false
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-map-keys": [
+                      "devicePath"
+                    ],
+                    "x-kubernetes-list-type": "map"
                   },
                   "volumeMounts": {
+                    "description": "Pod volumes to mount into the container's filesystem.\nCannot be updated.",
                     "items": {
+                      "description": "VolumeMount describes a mounting of a Volume within a container.",
                       "properties": {
                         "mountPath": {
+                          "description": "Path within the container at which the volume should be mounted.  Must\nnot contain ':'.",
                           "type": "string"
                         },
                         "mountPropagation": {
+                          "description": "mountPropagation determines how mounts are propagated from the host\nto container and the other way around.\nWhen not set, MountPropagationNone is used.\nThis field is beta in 1.10.\nWhen RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified\n(which defaults to None).",
                           "type": "string"
                         },
                         "name": {
+                          "description": "This must match the Name of a Volume.",
                           "type": "string"
                         },
                         "readOnly": {
+                          "description": "Mounted read-only if true, read-write otherwise (false or unspecified).\nDefaults to false.",
                           "type": "boolean"
                         },
+                        "recursiveReadOnly": {
+                          "description": "RecursiveReadOnly specifies whether read-only mounts should be handled\nrecursively.\n\nIf ReadOnly is false, this field has no meaning and must be unspecified.\n\nIf ReadOnly is true, and this field is set to Disabled, the mount is not made\nrecursively read-only.  If this field is set to IfPossible, the mount is made\nrecursively read-only, if it is supported by the container runtime.  If this\nfield is set to Enabled, the mount is made recursively read-only if it is\nsupported by the container runtime, otherwise the pod will not be started and\nan error will be generated to indicate the reason.\n\nIf this field is set to IfPossible or Enabled, MountPropagation must be set to\nNone (or be unspecified, which defaults to None).\n\nIf this field is not specified, it is treated as an equivalent of Disabled.",
+                          "type": "string"
+                        },
                         "subPath": {
+                          "description": "Path within the volume from which the container's volume should be mounted.\nDefaults to \"\" (volume's root).",
                           "type": "string"
                         },
                         "subPathExpr": {
+                          "description": "Expanded path within the volume from which the container's volume should be mounted.\nBehaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.\nDefaults to \"\" (volume's root).\nSubPathExpr and SubPath are mutually exclusive.",
                           "type": "string"
                         }
                       },
@@ -1676,9 +2548,14 @@
                       "type": "object",
                       "additionalProperties": false
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-map-keys": [
+                      "mountPath"
+                    ],
+                    "x-kubernetes-list-type": "map"
                   },
                   "workingDir": {
+                    "description": "Container's working directory.\nIf not specified, the container runtime's default will be used, which\nmight be configured in the container image.\nCannot be updated.",
                     "type": "string"
                   }
                 },
@@ -1691,45 +2568,59 @@
               "type": "array"
             },
             "javaOptions": {
+              "description": "JavaOptions is a string of extra JVM options to pass to the driver. For instance,\nGC settings or other logging.",
               "type": "string"
             },
             "kubernetesMaster": {
+              "description": "KubernetesMaster is the URL of the Kubernetes master used by the driver to manage executor pods and\nother Kubernetes resources. Default to https://kubernetes.default.svc.",
               "type": "string"
             },
             "labels": {
               "additionalProperties": {
                 "type": "string"
               },
+              "description": "Labels are the Kubernetes labels to be added to the pod.",
               "type": "object"
             },
             "lifecycle": {
+              "description": "Lifecycle for running preStop or postStart commands",
               "properties": {
                 "postStart": {
+                  "description": "PostStart is called immediately after a container is created. If the handler fails,\nthe container is terminated and restarted according to its restart policy.\nOther management of the container blocks until the hook completes.\nMore info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks",
                   "properties": {
                     "exec": {
+                      "description": "Exec specifies a command to execute in the container.",
                       "properties": {
                         "command": {
+                          "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
                           "items": {
                             "type": "string"
                           },
-                          "type": "array"
+                          "type": "array",
+                          "x-kubernetes-list-type": "atomic"
                         }
                       },
                       "type": "object",
                       "additionalProperties": false
                     },
                     "httpGet": {
+                      "description": "HTTPGet specifies an HTTP GET request to perform.",
                       "properties": {
                         "host": {
+                          "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
                           "type": "string"
                         },
                         "httpHeaders": {
+                          "description": "Custom headers to set in the request. HTTP allows repeated headers.",
                           "items": {
+                            "description": "HTTPHeader describes a custom header to be used in HTTP probes",
                             "properties": {
                               "name": {
+                                "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
                                 "type": "string"
                               },
                               "value": {
+                                "description": "The header field value",
                                 "type": "string"
                               }
                             },
@@ -1740,9 +2631,11 @@
                             "type": "object",
                             "additionalProperties": false
                           },
-                          "type": "array"
+                          "type": "array",
+                          "x-kubernetes-list-type": "atomic"
                         },
                         "path": {
+                          "description": "Path to access on the HTTP server.",
                           "type": "string"
                         },
                         "port": {
@@ -1754,9 +2647,11 @@
                               "type": "string"
                             }
                           ],
+                          "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
                           "x-kubernetes-int-or-string": true
                         },
                         "scheme": {
+                          "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
                           "type": "string"
                         }
                       },
@@ -1766,9 +2661,26 @@
                       "type": "object",
                       "additionalProperties": false
                     },
+                    "sleep": {
+                      "description": "Sleep represents a duration that the container should sleep.",
+                      "properties": {
+                        "seconds": {
+                          "description": "Seconds is the number of seconds to sleep.",
+                          "format": "int64",
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "seconds"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
                     "tcpSocket": {
+                      "description": "Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept\nfor backward compatibility. There is no validation of this field and\nlifecycle hooks will fail at runtime when it is specified.",
                       "properties": {
                         "host": {
+                          "description": "Optional: Host name to connect to, defaults to the pod IP.",
                           "type": "string"
                         },
                         "port": {
@@ -1780,6 +2692,7 @@
                               "type": "string"
                             }
                           ],
+                          "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
                           "x-kubernetes-int-or-string": true
                         }
                       },
@@ -1794,31 +2707,41 @@
                   "additionalProperties": false
                 },
                 "preStop": {
+                  "description": "PreStop is called immediately before a container is terminated due to an\nAPI request or management event such as liveness/startup probe failure,\npreemption, resource contention, etc. The handler is not called if the\ncontainer crashes or exits. The Pod's termination grace period countdown begins before the\nPreStop hook is executed. Regardless of the outcome of the handler, the\ncontainer will eventually terminate within the Pod's termination grace\nperiod (unless delayed by finalizers). Other management of the container blocks until the hook completes\nor until the termination grace period is reached.\nMore info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks",
                   "properties": {
                     "exec": {
+                      "description": "Exec specifies a command to execute in the container.",
                       "properties": {
                         "command": {
+                          "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
                           "items": {
                             "type": "string"
                           },
-                          "type": "array"
+                          "type": "array",
+                          "x-kubernetes-list-type": "atomic"
                         }
                       },
                       "type": "object",
                       "additionalProperties": false
                     },
                     "httpGet": {
+                      "description": "HTTPGet specifies an HTTP GET request to perform.",
                       "properties": {
                         "host": {
+                          "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
                           "type": "string"
                         },
                         "httpHeaders": {
+                          "description": "Custom headers to set in the request. HTTP allows repeated headers.",
                           "items": {
+                            "description": "HTTPHeader describes a custom header to be used in HTTP probes",
                             "properties": {
                               "name": {
+                                "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
                                 "type": "string"
                               },
                               "value": {
+                                "description": "The header field value",
                                 "type": "string"
                               }
                             },
@@ -1829,9 +2752,11 @@
                             "type": "object",
                             "additionalProperties": false
                           },
-                          "type": "array"
+                          "type": "array",
+                          "x-kubernetes-list-type": "atomic"
                         },
                         "path": {
+                          "description": "Path to access on the HTTP server.",
                           "type": "string"
                         },
                         "port": {
@@ -1843,9 +2768,11 @@
                               "type": "string"
                             }
                           ],
+                          "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
                           "x-kubernetes-int-or-string": true
                         },
                         "scheme": {
+                          "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
                           "type": "string"
                         }
                       },
@@ -1855,9 +2782,26 @@
                       "type": "object",
                       "additionalProperties": false
                     },
+                    "sleep": {
+                      "description": "Sleep represents a duration that the container should sleep.",
+                      "properties": {
+                        "seconds": {
+                          "description": "Seconds is the number of seconds to sleep.",
+                          "format": "int64",
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "seconds"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
                     "tcpSocket": {
+                      "description": "Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept\nfor backward compatibility. There is no validation of this field and\nlifecycle hooks will fail at runtime when it is specified.",
                       "properties": {
                         "host": {
+                          "description": "Optional: Host name to connect to, defaults to the pod IP.",
                           "type": "string"
                         },
                         "port": {
@@ -1869,6 +2813,7 @@
                               "type": "string"
                             }
                           ],
+                          "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
                           "x-kubernetes-int-or-string": true
                         }
                       },
@@ -1887,70 +2832,138 @@
               "additionalProperties": false
             },
             "memory": {
+              "description": "Memory is the amount of memory to request for the pod.",
               "type": "string"
             },
             "memoryOverhead": {
+              "description": "MemoryOverhead is the amount of off-heap memory to allocate in cluster mode, in MiB unless otherwise specified.",
               "type": "string"
             },
             "nodeSelector": {
               "additionalProperties": {
                 "type": "string"
               },
+              "description": "NodeSelector is the Kubernetes node selector to be added to the driver and executor pods.\nThis field is mutually exclusive with nodeSelector at SparkApplication level (which will be deprecated).",
               "type": "object"
             },
             "podName": {
+              "description": "PodName is the name of the driver pod that the user creates. This is used for the\nin-cluster client mode in which the user creates a client pod where the driver of\nthe user application runs. It's an error to set this field if Mode is not\nin-cluster-client.",
               "pattern": "[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*",
               "type": "string"
             },
             "podSecurityContext": {
+              "description": "PodSecurityContext specifies the PodSecurityContext to apply.",
               "properties": {
+                "appArmorProfile": {
+                  "description": "appArmorProfile is the AppArmor options to use by the containers in this pod.\nNote that this field cannot be set when spec.os.name is windows.",
+                  "properties": {
+                    "localhostProfile": {
+                      "description": "localhostProfile indicates a profile loaded on the node that should be used.\nThe profile must be preconfigured on the node to work.\nMust match the loaded name of the profile.\nMust be set if and only if type is \"Localhost\".",
+                      "type": "string"
+                    },
+                    "type": {
+                      "description": "type indicates which kind of AppArmor profile will be applied.\nValid options are:\n  Localhost - a profile pre-loaded on the node.\n  RuntimeDefault - the container runtime's default profile.\n  Unconfined - no AppArmor enforcement.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
                 "fsGroup": {
+                  "description": "A special supplemental group that applies to all containers in a pod.\nSome volume types allow the Kubelet to change the ownership of that volume\nto be owned by the pod:\n\n1. The owning GID will be the FSGroup\n2. The setgid bit is set (new files created in the volume will be owned by FSGroup)\n3. The permission bits are OR'd with rw-rw----\n\nIf unset, the Kubelet will not modify the ownership and permissions of any volume.\nNote that this field cannot be set when spec.os.name is windows.",
                   "format": "int64",
                   "type": "integer"
                 },
+                "fsGroupChangePolicy": {
+                  "description": "fsGroupChangePolicy defines behavior of changing ownership and permission of the volume\nbefore being exposed inside Pod. This field will only apply to\nvolume types which support fsGroup based ownership(and permissions).\nIt will have no effect on ephemeral volume types such as: secret, configmaps\nand emptydir.\nValid values are \"OnRootMismatch\" and \"Always\". If not specified, \"Always\" is used.\nNote that this field cannot be set when spec.os.name is windows.",
+                  "type": "string"
+                },
                 "runAsGroup": {
+                  "description": "The GID to run the entrypoint of the container process.\nUses runtime default if unset.\nMay also be set in SecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence\nfor that container.\nNote that this field cannot be set when spec.os.name is windows.",
                   "format": "int64",
                   "type": "integer"
                 },
                 "runAsNonRoot": {
+                  "description": "Indicates that the container must run as a non-root user.\nIf true, the Kubelet will validate the image at runtime to ensure that it\ndoes not run as UID 0 (root) and fail to start the container if it does.\nIf unset or false, no such validation will be performed.\nMay also be set in SecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
                   "type": "boolean"
                 },
                 "runAsUser": {
+                  "description": "The UID to run the entrypoint of the container process.\nDefaults to user specified in image metadata if unspecified.\nMay also be set in SecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence\nfor that container.\nNote that this field cannot be set when spec.os.name is windows.",
                   "format": "int64",
                   "type": "integer"
                 },
+                "seLinuxChangePolicy": {
+                  "description": "seLinuxChangePolicy defines how the container's SELinux label is applied to all volumes used by the Pod.\nIt has no effect on nodes that do not support SELinux or to volumes does not support SELinux.\nValid values are \"MountOption\" and \"Recursive\".\n\n\"Recursive\" means relabeling of all files on all Pod volumes by the container runtime.\nThis may be slow for large volumes, but allows mixing privileged and unprivileged Pods sharing the same volume on the same node.\n\n\"MountOption\" mounts all eligible Pod volumes with `-o context` mount option.\nThis requires all Pods that share the same volume to use the same SELinux label.\nIt is not possible to share the same volume among privileged and unprivileged Pods.\nEligible volumes are in-tree FibreChannel and iSCSI volumes, and all CSI volumes\nwhose CSI driver announces SELinux support by setting spec.seLinuxMount: true in their\nCSIDriver instance. Other volumes are always re-labelled recursively.\n\"MountOption\" value is allowed only when SELinuxMount feature gate is enabled.\n\nIf not specified and SELinuxMount feature gate is enabled, \"MountOption\" is used.\nIf not specified and SELinuxMount feature gate is disabled, \"MountOption\" is used for ReadWriteOncePod volumes\nand \"Recursive\" for all other volumes.\n\nThis field affects only Pods that have SELinux label set, either in PodSecurityContext or in SecurityContext of all containers.\n\nAll Pods that use the same volume should use the same seLinuxChangePolicy, otherwise some pods can get stuck in ContainerCreating state.\nNote that this field cannot be set when spec.os.name is windows.",
+                  "type": "string"
+                },
                 "seLinuxOptions": {
+                  "description": "The SELinux context to be applied to all containers.\nIf unspecified, the container runtime will allocate a random SELinux context for each\ncontainer.  May also be set in SecurityContext.  If set in\nboth SecurityContext and PodSecurityContext, the value specified in SecurityContext\ntakes precedence for that container.\nNote that this field cannot be set when spec.os.name is windows.",
                   "properties": {
                     "level": {
+                      "description": "Level is SELinux level label that applies to the container.",
                       "type": "string"
                     },
                     "role": {
+                      "description": "Role is a SELinux role label that applies to the container.",
                       "type": "string"
                     },
                     "type": {
+                      "description": "Type is a SELinux type label that applies to the container.",
                       "type": "string"
                     },
                     "user": {
+                      "description": "User is a SELinux user label that applies to the container.",
                       "type": "string"
                     }
                   },
                   "type": "object",
                   "additionalProperties": false
                 },
+                "seccompProfile": {
+                  "description": "The seccomp options to use by the containers in this pod.\nNote that this field cannot be set when spec.os.name is windows.",
+                  "properties": {
+                    "localhostProfile": {
+                      "description": "localhostProfile indicates a profile defined in a file on the node should be used.\nThe profile must be preconfigured on the node to work.\nMust be a descending path, relative to the kubelet's configured seccomp profile location.\nMust be set if type is \"Localhost\". Must NOT be set for any other type.",
+                      "type": "string"
+                    },
+                    "type": {
+                      "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
                 "supplementalGroups": {
+                  "description": "A list of groups applied to the first process run in each container, in\naddition to the container's primary GID and fsGroup (if specified).  If\nthe SupplementalGroupsPolicy feature is enabled, the\nsupplementalGroupsPolicy field determines whether these are in addition\nto or instead of any group memberships defined in the container image.\nIf unspecified, no additional groups are added, though group memberships\ndefined in the container image may still be used, depending on the\nsupplementalGroupsPolicy field.\nNote that this field cannot be set when spec.os.name is windows.",
                   "items": {
                     "format": "int64",
                     "type": "integer"
                   },
-                  "type": "array"
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                },
+                "supplementalGroupsPolicy": {
+                  "description": "Defines how supplemental groups of the first container processes are calculated.\nValid values are \"Merge\" and \"Strict\". If not specified, \"Merge\" is used.\n(Alpha) Using the field requires the SupplementalGroupsPolicy feature gate to be enabled\nand the container runtime must implement support for this feature.\nNote that this field cannot be set when spec.os.name is windows.",
+                  "type": "string"
                 },
                 "sysctls": {
+                  "description": "Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported\nsysctls (by the container runtime) might fail to launch.\nNote that this field cannot be set when spec.os.name is windows.",
                   "items": {
+                    "description": "Sysctl defines a kernel parameter to be set",
                     "properties": {
                       "name": {
+                        "description": "Name of a property to set",
                         "type": "string"
                       },
                       "value": {
+                        "description": "Value of a property to set",
                         "type": "string"
                       }
                     },
@@ -1961,17 +2974,26 @@
                     "type": "object",
                     "additionalProperties": false
                   },
-                  "type": "array"
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
                 },
                 "windowsOptions": {
+                  "description": "The Windows specific settings applied to all containers.\nIf unspecified, the options within a container's SecurityContext will be used.\nIf set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is linux.",
                   "properties": {
                     "gmsaCredentialSpec": {
+                      "description": "GMSACredentialSpec is where the GMSA admission webhook\n(https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the\nGMSA credential spec named by the GMSACredentialSpecName field.",
                       "type": "string"
                     },
                     "gmsaCredentialSpecName": {
+                      "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
                       "type": "string"
                     },
+                    "hostProcess": {
+                      "description": "HostProcess determines if a container should be run as a 'Host Process' container.\nAll of a Pod's containers must have the same effective HostProcess value\n(it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).\nIn addition, if HostProcess is true then HostNetwork must also be set to true.",
+                      "type": "boolean"
+                    },
                     "runAsUserName": {
+                      "description": "The UserName in Windows to run the entrypoint of the container process.\nDefaults to the user specified in image metadata if unspecified.\nMay also be set in PodSecurityContext. If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
                       "type": "string"
                     }
                   },
@@ -1982,11 +3004,44 @@
               "type": "object",
               "additionalProperties": false
             },
+            "ports": {
+              "description": "Ports settings for the pods, following the Kubernetes specifications.",
+              "items": {
+                "description": "Port represents the port definition in the pods objects.",
+                "properties": {
+                  "containerPort": {
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "protocol": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "containerPort",
+                  "name",
+                  "protocol"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "priorityClassName": {
+              "description": "PriorityClassName is the name of the PriorityClass for the driver pod.",
+              "type": "string"
+            },
             "schedulerName": {
+              "description": "SchedulerName specifies the scheduler that will be used for scheduling",
               "type": "string"
             },
             "secrets": {
+              "description": "Secrets carries information of secrets to add to the pod.",
               "items": {
+                "description": "SecretInfo captures information of a secret.",
                 "properties": {
                   "name": {
                     "type": "string"
@@ -1995,6 +3050,7 @@
                     "type": "string"
                   },
                   "secretType": {
+                    "description": "SecretType tells the type of a secret.",
                     "type": "string"
                   }
                 },
@@ -2009,75 +3065,139 @@
               "type": "array"
             },
             "securityContext": {
+              "description": "SecurityContext specifies the container's SecurityContext to apply.",
               "properties": {
                 "allowPrivilegeEscalation": {
+                  "description": "AllowPrivilegeEscalation controls whether a process can gain more\nprivileges than its parent process. This bool directly controls if\nthe no_new_privs flag will be set on the container process.\nAllowPrivilegeEscalation is true always when the container is:\n1) run as Privileged\n2) has CAP_SYS_ADMIN\nNote that this field cannot be set when spec.os.name is windows.",
                   "type": "boolean"
                 },
+                "appArmorProfile": {
+                  "description": "appArmorProfile is the AppArmor options to use by this container. If set, this profile\noverrides the pod's appArmorProfile.\nNote that this field cannot be set when spec.os.name is windows.",
+                  "properties": {
+                    "localhostProfile": {
+                      "description": "localhostProfile indicates a profile loaded on the node that should be used.\nThe profile must be preconfigured on the node to work.\nMust match the loaded name of the profile.\nMust be set if and only if type is \"Localhost\".",
+                      "type": "string"
+                    },
+                    "type": {
+                      "description": "type indicates which kind of AppArmor profile will be applied.\nValid options are:\n  Localhost - a profile pre-loaded on the node.\n  RuntimeDefault - the container runtime's default profile.\n  Unconfined - no AppArmor enforcement.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
                 "capabilities": {
+                  "description": "The capabilities to add/drop when running containers.\nDefaults to the default set of capabilities granted by the container runtime.\nNote that this field cannot be set when spec.os.name is windows.",
                   "properties": {
                     "add": {
+                      "description": "Added capabilities",
                       "items": {
+                        "description": "Capability represent POSIX capabilities type",
                         "type": "string"
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     },
                     "drop": {
+                      "description": "Removed capabilities",
                       "items": {
+                        "description": "Capability represent POSIX capabilities type",
                         "type": "string"
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     }
                   },
                   "type": "object",
                   "additionalProperties": false
                 },
                 "privileged": {
+                  "description": "Run container in privileged mode.\nProcesses in privileged containers are essentially equivalent to root on the host.\nDefaults to false.\nNote that this field cannot be set when spec.os.name is windows.",
                   "type": "boolean"
                 },
                 "procMount": {
+                  "description": "procMount denotes the type of proc mount to use for the containers.\nThe default value is Default which uses the container runtime defaults for\nreadonly paths and masked paths.\nThis requires the ProcMountType feature flag to be enabled.\nNote that this field cannot be set when spec.os.name is windows.",
                   "type": "string"
                 },
                 "readOnlyRootFilesystem": {
+                  "description": "Whether this container has a read-only root filesystem.\nDefault is false.\nNote that this field cannot be set when spec.os.name is windows.",
                   "type": "boolean"
                 },
                 "runAsGroup": {
+                  "description": "The GID to run the entrypoint of the container process.\nUses runtime default if unset.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
                   "format": "int64",
                   "type": "integer"
                 },
                 "runAsNonRoot": {
+                  "description": "Indicates that the container must run as a non-root user.\nIf true, the Kubelet will validate the image at runtime to ensure that it\ndoes not run as UID 0 (root) and fail to start the container if it does.\nIf unset or false, no such validation will be performed.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
                   "type": "boolean"
                 },
                 "runAsUser": {
+                  "description": "The UID to run the entrypoint of the container process.\nDefaults to user specified in image metadata if unspecified.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
                   "format": "int64",
                   "type": "integer"
                 },
                 "seLinuxOptions": {
+                  "description": "The SELinux context to be applied to the container.\nIf unspecified, the container runtime will allocate a random SELinux context for each\ncontainer.  May also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
                   "properties": {
                     "level": {
+                      "description": "Level is SELinux level label that applies to the container.",
                       "type": "string"
                     },
                     "role": {
+                      "description": "Role is a SELinux role label that applies to the container.",
                       "type": "string"
                     },
                     "type": {
+                      "description": "Type is a SELinux type label that applies to the container.",
                       "type": "string"
                     },
                     "user": {
+                      "description": "User is a SELinux user label that applies to the container.",
                       "type": "string"
                     }
                   },
                   "type": "object",
                   "additionalProperties": false
                 },
+                "seccompProfile": {
+                  "description": "The seccomp options to use by this container. If seccomp options are\nprovided at both the pod & container level, the container options\noverride the pod options.\nNote that this field cannot be set when spec.os.name is windows.",
+                  "properties": {
+                    "localhostProfile": {
+                      "description": "localhostProfile indicates a profile defined in a file on the node should be used.\nThe profile must be preconfigured on the node to work.\nMust be a descending path, relative to the kubelet's configured seccomp profile location.\nMust be set if type is \"Localhost\". Must NOT be set for any other type.",
+                      "type": "string"
+                    },
+                    "type": {
+                      "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
                 "windowsOptions": {
+                  "description": "The Windows specific settings applied to all containers.\nIf unspecified, the options from the PodSecurityContext will be used.\nIf set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is linux.",
                   "properties": {
                     "gmsaCredentialSpec": {
+                      "description": "GMSACredentialSpec is where the GMSA admission webhook\n(https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the\nGMSA credential spec named by the GMSACredentialSpecName field.",
                       "type": "string"
                     },
                     "gmsaCredentialSpecName": {
+                      "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
                       "type": "string"
                     },
+                    "hostProcess": {
+                      "description": "HostProcess determines if a container should be run as a 'Host Process' container.\nAll of a Pod's containers must have the same effective HostProcess value\n(it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).\nIn addition, if HostProcess is true then HostNetwork must also be set to true.",
+                      "type": "boolean"
+                    },
                     "runAsUserName": {
+                      "description": "The UserName in Windows to run the entrypoint of the container process.\nDefaults to the user specified in image metadata if unspecified.\nMay also be set in PodSecurityContext. If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
                       "type": "string"
                     }
                   },
@@ -2089,52 +3209,78 @@
               "additionalProperties": false
             },
             "serviceAccount": {
+              "description": "ServiceAccount is the name of the custom Kubernetes service account used by the pod.",
               "type": "string"
             },
             "serviceAnnotations": {
               "additionalProperties": {
                 "type": "string"
               },
+              "description": "ServiceAnnotations defines the annotations to be added to the Kubernetes headless service used by\nexecutors to connect to the driver.",
+              "type": "object"
+            },
+            "serviceLabels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "ServiceLabels defines the labels to be added to the Kubernetes headless service used by\nexecutors to connect to the driver.",
               "type": "object"
             },
             "shareProcessNamespace": {
+              "description": "ShareProcessNamespace settings for the pod, following the Kubernetes specifications.",
               "type": "boolean"
             },
             "sidecars": {
+              "description": "Sidecars is a list of sidecar containers that run along side the main Spark container.",
               "items": {
+                "description": "A single application container that you want to run within a pod.",
                 "properties": {
                   "args": {
+                    "description": "Arguments to the entrypoint.\nThe container image's CMD is used if this is not provided.\nVariable references $(VAR_NAME) are expanded using the container's environment. If a variable\ncannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will\nproduce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless\nof whether the variable exists or not. Cannot be updated.\nMore info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
                     "items": {
                       "type": "string"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   },
                   "command": {
+                    "description": "Entrypoint array. Not executed within a shell.\nThe container image's ENTRYPOINT is used if this is not provided.\nVariable references $(VAR_NAME) are expanded using the container's environment. If a variable\ncannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will\nproduce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless\nof whether the variable exists or not. Cannot be updated.\nMore info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
                     "items": {
                       "type": "string"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   },
                   "env": {
+                    "description": "List of environment variables to set in the container.\nCannot be updated.",
                     "items": {
+                      "description": "EnvVar represents an environment variable present in a Container.",
                       "properties": {
                         "name": {
+                          "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
                           "type": "string"
                         },
                         "value": {
+                          "description": "Variable references $(VAR_NAME) are expanded\nusing the previously defined environment variables in the container and\nany service environment variables. If a variable cannot be resolved,\nthe reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.\n\"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\".\nEscaped references will never be expanded, regardless of whether the variable\nexists or not.\nDefaults to \"\".",
                           "type": "string"
                         },
                         "valueFrom": {
+                          "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
                           "properties": {
                             "configMapKeyRef": {
+                              "description": "Selects a key of a ConfigMap.",
                               "properties": {
                                 "key": {
+                                  "description": "The key to select.",
                                   "type": "string"
                                 },
                                 "name": {
+                                  "default": "",
+                                  "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                   "type": "string"
                                 },
                                 "optional": {
+                                  "description": "Specify whether the ConfigMap or its key must be defined",
                                   "type": "boolean"
                                 }
                               },
@@ -2142,14 +3288,18 @@
                                 "key"
                               ],
                               "type": "object",
+                              "x-kubernetes-map-type": "atomic",
                               "additionalProperties": false
                             },
                             "fieldRef": {
+                              "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,\nspec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
                               "properties": {
                                 "apiVersion": {
+                                  "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
                                   "type": "string"
                                 },
                                 "fieldPath": {
+                                  "description": "Path of the field to select in the specified API version.",
                                   "type": "string"
                                 }
                               },
@@ -2157,11 +3307,14 @@
                                 "fieldPath"
                               ],
                               "type": "object",
+                              "x-kubernetes-map-type": "atomic",
                               "additionalProperties": false
                             },
                             "resourceFieldRef": {
+                              "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
                               "properties": {
                                 "containerName": {
+                                  "description": "Container name: required for volumes, optional for env vars",
                                   "type": "string"
                                 },
                                 "divisor": {
@@ -2173,10 +3326,12 @@
                                       "type": "string"
                                     }
                                   ],
+                                  "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
                                   "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                                   "x-kubernetes-int-or-string": true
                                 },
                                 "resource": {
+                                  "description": "Required: resource to select",
                                   "type": "string"
                                 }
                               },
@@ -2184,17 +3339,23 @@
                                 "resource"
                               ],
                               "type": "object",
+                              "x-kubernetes-map-type": "atomic",
                               "additionalProperties": false
                             },
                             "secretKeyRef": {
+                              "description": "Selects a key of a secret in the pod's namespace",
                               "properties": {
                                 "key": {
+                                  "description": "The key of the secret to select from.  Must be a valid secret key.",
                                   "type": "string"
                                 },
                                 "name": {
+                                  "default": "",
+                                  "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                   "type": "string"
                                 },
                                 "optional": {
+                                  "description": "Specify whether the Secret or its key must be defined",
                                   "type": "boolean"
                                 }
                               },
@@ -2202,6 +3363,7 @@
                                 "key"
                               ],
                               "type": "object",
+                              "x-kubernetes-map-type": "atomic",
                               "additionalProperties": false
                             }
                           },
@@ -2215,78 +3377,109 @@
                       "type": "object",
                       "additionalProperties": false
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-map-keys": [
+                      "name"
+                    ],
+                    "x-kubernetes-list-type": "map"
                   },
                   "envFrom": {
+                    "description": "List of sources to populate environment variables in the container.\nThe keys defined within a source must be a C_IDENTIFIER. All invalid keys\nwill be reported as an event when the container is starting. When a key exists in multiple\nsources, the value associated with the last source will take precedence.\nValues defined by an Env with a duplicate key will take precedence.\nCannot be updated.",
                     "items": {
+                      "description": "EnvFromSource represents the source of a set of ConfigMaps",
                       "properties": {
                         "configMapRef": {
+                          "description": "The ConfigMap to select from",
                           "properties": {
                             "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                               "type": "string"
                             },
                             "optional": {
+                              "description": "Specify whether the ConfigMap must be defined",
                               "type": "boolean"
                             }
                           },
                           "type": "object",
+                          "x-kubernetes-map-type": "atomic",
                           "additionalProperties": false
                         },
                         "prefix": {
+                          "description": "An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.",
                           "type": "string"
                         },
                         "secretRef": {
+                          "description": "The Secret to select from",
                           "properties": {
                             "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                               "type": "string"
                             },
                             "optional": {
+                              "description": "Specify whether the Secret must be defined",
                               "type": "boolean"
                             }
                           },
                           "type": "object",
+                          "x-kubernetes-map-type": "atomic",
                           "additionalProperties": false
                         }
                       },
                       "type": "object",
                       "additionalProperties": false
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   },
                   "image": {
+                    "description": "Container image name.\nMore info: https://kubernetes.io/docs/concepts/containers/images\nThis field is optional to allow higher level config management to default or override\ncontainer images in workload controllers like Deployments and StatefulSets.",
                     "type": "string"
                   },
                   "imagePullPolicy": {
+                    "description": "Image pull policy.\nOne of Always, Never, IfNotPresent.\nDefaults to Always if :latest tag is specified, or IfNotPresent otherwise.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/containers/images#updating-images",
                     "type": "string"
                   },
                   "lifecycle": {
+                    "description": "Actions that the management system should take in response to container lifecycle events.\nCannot be updated.",
                     "properties": {
                       "postStart": {
+                        "description": "PostStart is called immediately after a container is created. If the handler fails,\nthe container is terminated and restarted according to its restart policy.\nOther management of the container blocks until the hook completes.\nMore info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks",
                         "properties": {
                           "exec": {
+                            "description": "Exec specifies a command to execute in the container.",
                             "properties": {
                               "command": {
+                                "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
                                 "items": {
                                   "type": "string"
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               }
                             },
                             "type": "object",
                             "additionalProperties": false
                           },
                           "httpGet": {
+                            "description": "HTTPGet specifies an HTTP GET request to perform.",
                             "properties": {
                               "host": {
+                                "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
                                 "type": "string"
                               },
                               "httpHeaders": {
+                                "description": "Custom headers to set in the request. HTTP allows repeated headers.",
                                 "items": {
+                                  "description": "HTTPHeader describes a custom header to be used in HTTP probes",
                                   "properties": {
                                     "name": {
+                                      "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
                                       "type": "string"
                                     },
                                     "value": {
+                                      "description": "The header field value",
                                       "type": "string"
                                     }
                                   },
@@ -2297,9 +3490,11 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "path": {
+                                "description": "Path to access on the HTTP server.",
                                 "type": "string"
                               },
                               "port": {
@@ -2311,9 +3506,11 @@
                                     "type": "string"
                                   }
                                 ],
+                                "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
                                 "x-kubernetes-int-or-string": true
                               },
                               "scheme": {
+                                "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
                                 "type": "string"
                               }
                             },
@@ -2323,9 +3520,26 @@
                             "type": "object",
                             "additionalProperties": false
                           },
+                          "sleep": {
+                            "description": "Sleep represents a duration that the container should sleep.",
+                            "properties": {
+                              "seconds": {
+                                "description": "Seconds is the number of seconds to sleep.",
+                                "format": "int64",
+                                "type": "integer"
+                              }
+                            },
+                            "required": [
+                              "seconds"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
                           "tcpSocket": {
+                            "description": "Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept\nfor backward compatibility. There is no validation of this field and\nlifecycle hooks will fail at runtime when it is specified.",
                             "properties": {
                               "host": {
+                                "description": "Optional: Host name to connect to, defaults to the pod IP.",
                                 "type": "string"
                               },
                               "port": {
@@ -2337,6 +3551,7 @@
                                     "type": "string"
                                   }
                                 ],
+                                "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
                                 "x-kubernetes-int-or-string": true
                               }
                             },
@@ -2351,31 +3566,41 @@
                         "additionalProperties": false
                       },
                       "preStop": {
+                        "description": "PreStop is called immediately before a container is terminated due to an\nAPI request or management event such as liveness/startup probe failure,\npreemption, resource contention, etc. The handler is not called if the\ncontainer crashes or exits. The Pod's termination grace period countdown begins before the\nPreStop hook is executed. Regardless of the outcome of the handler, the\ncontainer will eventually terminate within the Pod's termination grace\nperiod (unless delayed by finalizers). Other management of the container blocks until the hook completes\nor until the termination grace period is reached.\nMore info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks",
                         "properties": {
                           "exec": {
+                            "description": "Exec specifies a command to execute in the container.",
                             "properties": {
                               "command": {
+                                "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
                                 "items": {
                                   "type": "string"
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               }
                             },
                             "type": "object",
                             "additionalProperties": false
                           },
                           "httpGet": {
+                            "description": "HTTPGet specifies an HTTP GET request to perform.",
                             "properties": {
                               "host": {
+                                "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
                                 "type": "string"
                               },
                               "httpHeaders": {
+                                "description": "Custom headers to set in the request. HTTP allows repeated headers.",
                                 "items": {
+                                  "description": "HTTPHeader describes a custom header to be used in HTTP probes",
                                   "properties": {
                                     "name": {
+                                      "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
                                       "type": "string"
                                     },
                                     "value": {
+                                      "description": "The header field value",
                                       "type": "string"
                                     }
                                   },
@@ -2386,9 +3611,11 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "path": {
+                                "description": "Path to access on the HTTP server.",
                                 "type": "string"
                               },
                               "port": {
@@ -2400,9 +3627,11 @@
                                     "type": "string"
                                   }
                                 ],
+                                "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
                                 "x-kubernetes-int-or-string": true
                               },
                               "scheme": {
+                                "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
                                 "type": "string"
                               }
                             },
@@ -2412,9 +3641,26 @@
                             "type": "object",
                             "additionalProperties": false
                           },
+                          "sleep": {
+                            "description": "Sleep represents a duration that the container should sleep.",
+                            "properties": {
+                              "seconds": {
+                                "description": "Seconds is the number of seconds to sleep.",
+                                "format": "int64",
+                                "type": "integer"
+                              }
+                            },
+                            "required": [
+                              "seconds"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
                           "tcpSocket": {
+                            "description": "Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept\nfor backward compatibility. There is no validation of this field and\nlifecycle hooks will fail at runtime when it is specified.",
                             "properties": {
                               "host": {
+                                "description": "Optional: Host name to connect to, defaults to the pod IP.",
                                 "type": "string"
                               },
                               "port": {
@@ -2426,6 +3672,7 @@
                                     "type": "string"
                                   }
                                 ],
+                                "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
                                 "x-kubernetes-int-or-string": true
                               }
                             },
@@ -2444,35 +3691,66 @@
                     "additionalProperties": false
                   },
                   "livenessProbe": {
+                    "description": "Periodic probe of container liveness.\nContainer will be restarted if the probe fails.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
                     "properties": {
                       "exec": {
+                        "description": "Exec specifies a command to execute in the container.",
                         "properties": {
                           "command": {
+                            "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
                             "items": {
                               "type": "string"
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           }
                         },
                         "type": "object",
                         "additionalProperties": false
                       },
                       "failureThreshold": {
+                        "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded.\nDefaults to 3. Minimum value is 1.",
                         "format": "int32",
                         "type": "integer"
                       },
+                      "grpc": {
+                        "description": "GRPC specifies a GRPC HealthCheckRequest.",
+                        "properties": {
+                          "port": {
+                            "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "service": {
+                            "default": "",
+                            "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "port"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
                       "httpGet": {
+                        "description": "HTTPGet specifies an HTTP GET request to perform.",
                         "properties": {
                           "host": {
+                            "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
                             "type": "string"
                           },
                           "httpHeaders": {
+                            "description": "Custom headers to set in the request. HTTP allows repeated headers.",
                             "items": {
+                              "description": "HTTPHeader describes a custom header to be used in HTTP probes",
                               "properties": {
                                 "name": {
+                                  "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
                                   "type": "string"
                                 },
                                 "value": {
+                                  "description": "The header field value",
                                   "type": "string"
                                 }
                               },
@@ -2483,9 +3761,11 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "path": {
+                            "description": "Path to access on the HTTP server.",
                             "type": "string"
                           },
                           "port": {
@@ -2497,9 +3777,11 @@
                                 "type": "string"
                               }
                             ],
+                            "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
                             "x-kubernetes-int-or-string": true
                           },
                           "scheme": {
+                            "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
                             "type": "string"
                           }
                         },
@@ -2510,20 +3792,25 @@
                         "additionalProperties": false
                       },
                       "initialDelaySeconds": {
+                        "description": "Number of seconds after the container has started before liveness probes are initiated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
                         "format": "int32",
                         "type": "integer"
                       },
                       "periodSeconds": {
+                        "description": "How often (in seconds) to perform the probe.\nDefault to 10 seconds. Minimum value is 1.",
                         "format": "int32",
                         "type": "integer"
                       },
                       "successThreshold": {
+                        "description": "Minimum consecutive successes for the probe to be considered successful after having failed.\nDefaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
                         "format": "int32",
                         "type": "integer"
                       },
                       "tcpSocket": {
+                        "description": "TCPSocket specifies a connection to a TCP port.",
                         "properties": {
                           "host": {
+                            "description": "Optional: Host name to connect to, defaults to the pod IP.",
                             "type": "string"
                           },
                           "port": {
@@ -2535,6 +3822,7 @@
                                 "type": "string"
                               }
                             ],
+                            "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
                             "x-kubernetes-int-or-string": true
                           }
                         },
@@ -2544,7 +3832,13 @@
                         "type": "object",
                         "additionalProperties": false
                       },
+                      "terminationGracePeriodSeconds": {
+                        "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure.\nThe grace period is the duration in seconds after the processes running in the pod are sent\na termination signal and the time when the processes are forcibly halted with a kill signal.\nSet this value longer than the expected cleanup time for your process.\nIf this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this\nvalue overrides the value provided by the pod spec.\nValue must be non-negative integer. The value zero indicates stop immediately via\nthe kill signal (no opportunity to shut down).\nThis is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.\nMinimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+                        "format": "int64",
+                        "type": "integer"
+                      },
                       "timeoutSeconds": {
+                        "description": "Number of seconds after which the probe times out.\nDefaults to 1 second. Minimum value is 1.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
                         "format": "int32",
                         "type": "integer"
                       }
@@ -2553,32 +3847,40 @@
                     "additionalProperties": false
                   },
                   "name": {
+                    "description": "Name of the container specified as a DNS_LABEL.\nEach container in a pod must have a unique name (DNS_LABEL).\nCannot be updated.",
                     "type": "string"
                   },
                   "ports": {
+                    "description": "List of ports to expose from the container. Not specifying a port here\nDOES NOT prevent that port from being exposed. Any port which is\nlistening on the default \"0.0.0.0\" address inside a container will be\naccessible from the network.\nModifying this array with strategic merge patch may corrupt the data.\nFor more information See https://github.com/kubernetes/kubernetes/issues/108255.\nCannot be updated.",
                     "items": {
+                      "description": "ContainerPort represents a network port in a single container.",
                       "properties": {
                         "containerPort": {
+                          "description": "Number of port to expose on the pod's IP address.\nThis must be a valid port number, 0 < x < 65536.",
                           "format": "int32",
                           "type": "integer"
                         },
                         "hostIP": {
+                          "description": "What host IP to bind the external port to.",
                           "type": "string"
                         },
                         "hostPort": {
+                          "description": "Number of port to expose on the host.\nIf specified, this must be a valid port number, 0 < x < 65536.\nIf HostNetwork is specified, this must match ContainerPort.\nMost containers do not need this.",
                           "format": "int32",
                           "type": "integer"
                         },
                         "name": {
+                          "description": "If specified, this must be an IANA_SVC_NAME and unique within the pod. Each\nnamed port in a pod must have a unique name. Name for the port that can be\nreferred to by services.",
                           "type": "string"
                         },
                         "protocol": {
+                          "default": "TCP",
+                          "description": "Protocol for port. Must be UDP, TCP, or SCTP.\nDefaults to \"TCP\".",
                           "type": "string"
                         }
                       },
                       "required": [
-                        "containerPort",
-                        "protocol"
+                        "containerPort"
                       ],
                       "type": "object",
                       "additionalProperties": false
@@ -2591,35 +3893,66 @@
                     "x-kubernetes-list-type": "map"
                   },
                   "readinessProbe": {
+                    "description": "Periodic probe of container service readiness.\nContainer will be removed from service endpoints if the probe fails.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
                     "properties": {
                       "exec": {
+                        "description": "Exec specifies a command to execute in the container.",
                         "properties": {
                           "command": {
+                            "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
                             "items": {
                               "type": "string"
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           }
                         },
                         "type": "object",
                         "additionalProperties": false
                       },
                       "failureThreshold": {
+                        "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded.\nDefaults to 3. Minimum value is 1.",
                         "format": "int32",
                         "type": "integer"
                       },
+                      "grpc": {
+                        "description": "GRPC specifies a GRPC HealthCheckRequest.",
+                        "properties": {
+                          "port": {
+                            "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "service": {
+                            "default": "",
+                            "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "port"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
                       "httpGet": {
+                        "description": "HTTPGet specifies an HTTP GET request to perform.",
                         "properties": {
                           "host": {
+                            "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
                             "type": "string"
                           },
                           "httpHeaders": {
+                            "description": "Custom headers to set in the request. HTTP allows repeated headers.",
                             "items": {
+                              "description": "HTTPHeader describes a custom header to be used in HTTP probes",
                               "properties": {
                                 "name": {
+                                  "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
                                   "type": "string"
                                 },
                                 "value": {
+                                  "description": "The header field value",
                                   "type": "string"
                                 }
                               },
@@ -2630,9 +3963,11 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "path": {
+                            "description": "Path to access on the HTTP server.",
                             "type": "string"
                           },
                           "port": {
@@ -2644,9 +3979,11 @@
                                 "type": "string"
                               }
                             ],
+                            "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
                             "x-kubernetes-int-or-string": true
                           },
                           "scheme": {
+                            "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
                             "type": "string"
                           }
                         },
@@ -2657,20 +3994,25 @@
                         "additionalProperties": false
                       },
                       "initialDelaySeconds": {
+                        "description": "Number of seconds after the container has started before liveness probes are initiated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
                         "format": "int32",
                         "type": "integer"
                       },
                       "periodSeconds": {
+                        "description": "How often (in seconds) to perform the probe.\nDefault to 10 seconds. Minimum value is 1.",
                         "format": "int32",
                         "type": "integer"
                       },
                       "successThreshold": {
+                        "description": "Minimum consecutive successes for the probe to be considered successful after having failed.\nDefaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
                         "format": "int32",
                         "type": "integer"
                       },
                       "tcpSocket": {
+                        "description": "TCPSocket specifies a connection to a TCP port.",
                         "properties": {
                           "host": {
+                            "description": "Optional: Host name to connect to, defaults to the pod IP.",
                             "type": "string"
                           },
                           "port": {
@@ -2682,6 +4024,7 @@
                                 "type": "string"
                               }
                             ],
+                            "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
                             "x-kubernetes-int-or-string": true
                           }
                         },
@@ -2691,7 +4034,13 @@
                         "type": "object",
                         "additionalProperties": false
                       },
+                      "terminationGracePeriodSeconds": {
+                        "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure.\nThe grace period is the duration in seconds after the processes running in the pod are sent\na termination signal and the time when the processes are forcibly halted with a kill signal.\nSet this value longer than the expected cleanup time for your process.\nIf this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this\nvalue overrides the value provided by the pod spec.\nValue must be non-negative integer. The value zero indicates stop immediately via\nthe kill signal (no opportunity to shut down).\nThis is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.\nMinimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+                        "format": "int64",
+                        "type": "integer"
+                      },
                       "timeoutSeconds": {
+                        "description": "Number of seconds after which the probe times out.\nDefaults to 1 second. Minimum value is 1.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
                         "format": "int32",
                         "type": "integer"
                       }
@@ -2699,8 +4048,59 @@
                     "type": "object",
                     "additionalProperties": false
                   },
+                  "resizePolicy": {
+                    "description": "Resources resize policy for the container.",
+                    "items": {
+                      "description": "ContainerResizePolicy represents resource resize policy for the container.",
+                      "properties": {
+                        "resourceName": {
+                          "description": "Name of the resource to which this resource resize policy applies.\nSupported values: cpu, memory.",
+                          "type": "string"
+                        },
+                        "restartPolicy": {
+                          "description": "Restart policy to apply when specified resource is resized.\nIf not specified, it defaults to NotRequired.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "resourceName",
+                        "restartPolicy"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  },
                   "resources": {
+                    "description": "Compute Resources required by this container.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
                     "properties": {
+                      "claims": {
+                        "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
+                        "items": {
+                          "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                          "properties": {
+                            "name": {
+                              "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
+                              "type": "string"
+                            },
+                            "request": {
+                              "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-map-keys": [
+                          "name"
+                        ],
+                        "x-kubernetes-list-type": "map"
+                      },
                       "limits": {
                         "additionalProperties": {
                           "anyOf": [
@@ -2714,6 +4114,7 @@
                           "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                           "x-kubernetes-int-or-string": true
                         },
+                        "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
                         "type": "object"
                       },
                       "requests": {
@@ -2729,82 +4130,151 @@
                           "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                           "x-kubernetes-int-or-string": true
                         },
+                        "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
                         "type": "object"
                       }
                     },
                     "type": "object",
                     "additionalProperties": false
                   },
+                  "restartPolicy": {
+                    "description": "RestartPolicy defines the restart behavior of individual containers in a pod.\nThis field may only be set for init containers, and the only allowed value is \"Always\".\nFor non-init containers or when this field is not specified,\nthe restart behavior is defined by the Pod's restart policy and the container type.\nSetting the RestartPolicy as \"Always\" for the init container will have the following effect:\nthis init container will be continually restarted on\nexit until all regular containers have terminated. Once all regular\ncontainers have completed, all init containers with restartPolicy \"Always\"\nwill be shut down. This lifecycle differs from normal init containers and\nis often referred to as a \"sidecar\" container. Although this init\ncontainer still starts in the init container sequence, it does not wait\nfor the container to complete before proceeding to the next init\ncontainer. Instead, the next init container starts immediately after this\ninit container is started, or after any startupProbe has successfully\ncompleted.",
+                    "type": "string"
+                  },
                   "securityContext": {
+                    "description": "SecurityContext defines the security options the container should be run with.\nIf set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.\nMore info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/",
                     "properties": {
                       "allowPrivilegeEscalation": {
+                        "description": "AllowPrivilegeEscalation controls whether a process can gain more\nprivileges than its parent process. This bool directly controls if\nthe no_new_privs flag will be set on the container process.\nAllowPrivilegeEscalation is true always when the container is:\n1) run as Privileged\n2) has CAP_SYS_ADMIN\nNote that this field cannot be set when spec.os.name is windows.",
                         "type": "boolean"
                       },
+                      "appArmorProfile": {
+                        "description": "appArmorProfile is the AppArmor options to use by this container. If set, this profile\noverrides the pod's appArmorProfile.\nNote that this field cannot be set when spec.os.name is windows.",
+                        "properties": {
+                          "localhostProfile": {
+                            "description": "localhostProfile indicates a profile loaded on the node that should be used.\nThe profile must be preconfigured on the node to work.\nMust match the loaded name of the profile.\nMust be set if and only if type is \"Localhost\".",
+                            "type": "string"
+                          },
+                          "type": {
+                            "description": "type indicates which kind of AppArmor profile will be applied.\nValid options are:\n  Localhost - a profile pre-loaded on the node.\n  RuntimeDefault - the container runtime's default profile.\n  Unconfined - no AppArmor enforcement.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "type"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
                       "capabilities": {
+                        "description": "The capabilities to add/drop when running containers.\nDefaults to the default set of capabilities granted by the container runtime.\nNote that this field cannot be set when spec.os.name is windows.",
                         "properties": {
                           "add": {
+                            "description": "Added capabilities",
                             "items": {
+                              "description": "Capability represent POSIX capabilities type",
                               "type": "string"
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "drop": {
+                            "description": "Removed capabilities",
                             "items": {
+                              "description": "Capability represent POSIX capabilities type",
                               "type": "string"
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           }
                         },
                         "type": "object",
                         "additionalProperties": false
                       },
                       "privileged": {
+                        "description": "Run container in privileged mode.\nProcesses in privileged containers are essentially equivalent to root on the host.\nDefaults to false.\nNote that this field cannot be set when spec.os.name is windows.",
                         "type": "boolean"
                       },
                       "procMount": {
+                        "description": "procMount denotes the type of proc mount to use for the containers.\nThe default value is Default which uses the container runtime defaults for\nreadonly paths and masked paths.\nThis requires the ProcMountType feature flag to be enabled.\nNote that this field cannot be set when spec.os.name is windows.",
                         "type": "string"
                       },
                       "readOnlyRootFilesystem": {
+                        "description": "Whether this container has a read-only root filesystem.\nDefault is false.\nNote that this field cannot be set when spec.os.name is windows.",
                         "type": "boolean"
                       },
                       "runAsGroup": {
+                        "description": "The GID to run the entrypoint of the container process.\nUses runtime default if unset.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
                         "format": "int64",
                         "type": "integer"
                       },
                       "runAsNonRoot": {
+                        "description": "Indicates that the container must run as a non-root user.\nIf true, the Kubelet will validate the image at runtime to ensure that it\ndoes not run as UID 0 (root) and fail to start the container if it does.\nIf unset or false, no such validation will be performed.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
                         "type": "boolean"
                       },
                       "runAsUser": {
+                        "description": "The UID to run the entrypoint of the container process.\nDefaults to user specified in image metadata if unspecified.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
                         "format": "int64",
                         "type": "integer"
                       },
                       "seLinuxOptions": {
+                        "description": "The SELinux context to be applied to the container.\nIf unspecified, the container runtime will allocate a random SELinux context for each\ncontainer.  May also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
                         "properties": {
                           "level": {
+                            "description": "Level is SELinux level label that applies to the container.",
                             "type": "string"
                           },
                           "role": {
+                            "description": "Role is a SELinux role label that applies to the container.",
                             "type": "string"
                           },
                           "type": {
+                            "description": "Type is a SELinux type label that applies to the container.",
                             "type": "string"
                           },
                           "user": {
+                            "description": "User is a SELinux user label that applies to the container.",
                             "type": "string"
                           }
                         },
                         "type": "object",
                         "additionalProperties": false
                       },
+                      "seccompProfile": {
+                        "description": "The seccomp options to use by this container. If seccomp options are\nprovided at both the pod & container level, the container options\noverride the pod options.\nNote that this field cannot be set when spec.os.name is windows.",
+                        "properties": {
+                          "localhostProfile": {
+                            "description": "localhostProfile indicates a profile defined in a file on the node should be used.\nThe profile must be preconfigured on the node to work.\nMust be a descending path, relative to the kubelet's configured seccomp profile location.\nMust be set if type is \"Localhost\". Must NOT be set for any other type.",
+                            "type": "string"
+                          },
+                          "type": {
+                            "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "type"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
                       "windowsOptions": {
+                        "description": "The Windows specific settings applied to all containers.\nIf unspecified, the options from the PodSecurityContext will be used.\nIf set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is linux.",
                         "properties": {
                           "gmsaCredentialSpec": {
+                            "description": "GMSACredentialSpec is where the GMSA admission webhook\n(https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the\nGMSA credential spec named by the GMSACredentialSpecName field.",
                             "type": "string"
                           },
                           "gmsaCredentialSpecName": {
+                            "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
                             "type": "string"
                           },
+                          "hostProcess": {
+                            "description": "HostProcess determines if a container should be run as a 'Host Process' container.\nAll of a Pod's containers must have the same effective HostProcess value\n(it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).\nIn addition, if HostProcess is true then HostNetwork must also be set to true.",
+                            "type": "boolean"
+                          },
                           "runAsUserName": {
+                            "description": "The UserName in Windows to run the entrypoint of the container process.\nDefaults to the user specified in image metadata if unspecified.\nMay also be set in PodSecurityContext. If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
                             "type": "string"
                           }
                         },
@@ -2816,35 +4286,66 @@
                     "additionalProperties": false
                   },
                   "startupProbe": {
+                    "description": "StartupProbe indicates that the Pod has successfully initialized.\nIf specified, no other probes are executed until this completes successfully.\nIf this probe fails, the Pod will be restarted, just as if the livenessProbe failed.\nThis can be used to provide different probe parameters at the beginning of a Pod's lifecycle,\nwhen it might take a long time to load data or warm a cache, than during steady-state operation.\nThis cannot be updated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
                     "properties": {
                       "exec": {
+                        "description": "Exec specifies a command to execute in the container.",
                         "properties": {
                           "command": {
+                            "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
                             "items": {
                               "type": "string"
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           }
                         },
                         "type": "object",
                         "additionalProperties": false
                       },
                       "failureThreshold": {
+                        "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded.\nDefaults to 3. Minimum value is 1.",
                         "format": "int32",
                         "type": "integer"
                       },
+                      "grpc": {
+                        "description": "GRPC specifies a GRPC HealthCheckRequest.",
+                        "properties": {
+                          "port": {
+                            "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "service": {
+                            "default": "",
+                            "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "port"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
                       "httpGet": {
+                        "description": "HTTPGet specifies an HTTP GET request to perform.",
                         "properties": {
                           "host": {
+                            "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
                             "type": "string"
                           },
                           "httpHeaders": {
+                            "description": "Custom headers to set in the request. HTTP allows repeated headers.",
                             "items": {
+                              "description": "HTTPHeader describes a custom header to be used in HTTP probes",
                               "properties": {
                                 "name": {
+                                  "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
                                   "type": "string"
                                 },
                                 "value": {
+                                  "description": "The header field value",
                                   "type": "string"
                                 }
                               },
@@ -2855,9 +4356,11 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "path": {
+                            "description": "Path to access on the HTTP server.",
                             "type": "string"
                           },
                           "port": {
@@ -2869,9 +4372,11 @@
                                 "type": "string"
                               }
                             ],
+                            "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
                             "x-kubernetes-int-or-string": true
                           },
                           "scheme": {
+                            "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
                             "type": "string"
                           }
                         },
@@ -2882,20 +4387,25 @@
                         "additionalProperties": false
                       },
                       "initialDelaySeconds": {
+                        "description": "Number of seconds after the container has started before liveness probes are initiated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
                         "format": "int32",
                         "type": "integer"
                       },
                       "periodSeconds": {
+                        "description": "How often (in seconds) to perform the probe.\nDefault to 10 seconds. Minimum value is 1.",
                         "format": "int32",
                         "type": "integer"
                       },
                       "successThreshold": {
+                        "description": "Minimum consecutive successes for the probe to be considered successful after having failed.\nDefaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
                         "format": "int32",
                         "type": "integer"
                       },
                       "tcpSocket": {
+                        "description": "TCPSocket specifies a connection to a TCP port.",
                         "properties": {
                           "host": {
+                            "description": "Optional: Host name to connect to, defaults to the pod IP.",
                             "type": "string"
                           },
                           "port": {
@@ -2907,6 +4417,7 @@
                                 "type": "string"
                               }
                             ],
+                            "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
                             "x-kubernetes-int-or-string": true
                           }
                         },
@@ -2916,7 +4427,13 @@
                         "type": "object",
                         "additionalProperties": false
                       },
+                      "terminationGracePeriodSeconds": {
+                        "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure.\nThe grace period is the duration in seconds after the processes running in the pod are sent\na termination signal and the time when the processes are forcibly halted with a kill signal.\nSet this value longer than the expected cleanup time for your process.\nIf this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this\nvalue overrides the value provided by the pod spec.\nValue must be non-negative integer. The value zero indicates stop immediately via\nthe kill signal (no opportunity to shut down).\nThis is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.\nMinimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+                        "format": "int64",
+                        "type": "integer"
+                      },
                       "timeoutSeconds": {
+                        "description": "Number of seconds after which the probe times out.\nDefaults to 1 second. Minimum value is 1.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
                         "format": "int32",
                         "type": "integer"
                       }
@@ -2925,27 +4442,36 @@
                     "additionalProperties": false
                   },
                   "stdin": {
+                    "description": "Whether this container should allocate a buffer for stdin in the container runtime. If this\nis not set, reads from stdin in the container will always result in EOF.\nDefault is false.",
                     "type": "boolean"
                   },
                   "stdinOnce": {
+                    "description": "Whether the container runtime should close the stdin channel after it has been opened by\na single attach. When stdin is true the stdin stream will remain open across multiple attach\nsessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the\nfirst client attaches to stdin, and then remains open and accepts data until the client disconnects,\nat which time stdin is closed and remains closed until the container is restarted. If this\nflag is false, a container processes that reads from stdin will never receive an EOF.\nDefault is false",
                     "type": "boolean"
                   },
                   "terminationMessagePath": {
+                    "description": "Optional: Path at which the file to which the container's termination message\nwill be written is mounted into the container's filesystem.\nMessage written is intended to be brief final status, such as an assertion failure message.\nWill be truncated by the node if greater than 4096 bytes. The total message length across\nall containers will be limited to 12kb.\nDefaults to /dev/termination-log.\nCannot be updated.",
                     "type": "string"
                   },
                   "terminationMessagePolicy": {
+                    "description": "Indicate how the termination message should be populated. File will use the contents of\nterminationMessagePath to populate the container status message on both success and failure.\nFallbackToLogsOnError will use the last chunk of container log output if the termination\nmessage file is empty and the container exited with an error.\nThe log output is limited to 2048 bytes or 80 lines, whichever is smaller.\nDefaults to File.\nCannot be updated.",
                     "type": "string"
                   },
                   "tty": {
+                    "description": "Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.\nDefault is false.",
                     "type": "boolean"
                   },
                   "volumeDevices": {
+                    "description": "volumeDevices is the list of block devices to be used by the container.",
                     "items": {
+                      "description": "volumeDevice describes a mapping of a raw block device within a container.",
                       "properties": {
                         "devicePath": {
+                          "description": "devicePath is the path inside of the container that the device will be mapped to.",
                           "type": "string"
                         },
                         "name": {
+                          "description": "name must match the name of a persistentVolumeClaim in the pod",
                           "type": "string"
                         }
                       },
@@ -2956,27 +4482,43 @@
                       "type": "object",
                       "additionalProperties": false
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-map-keys": [
+                      "devicePath"
+                    ],
+                    "x-kubernetes-list-type": "map"
                   },
                   "volumeMounts": {
+                    "description": "Pod volumes to mount into the container's filesystem.\nCannot be updated.",
                     "items": {
+                      "description": "VolumeMount describes a mounting of a Volume within a container.",
                       "properties": {
                         "mountPath": {
+                          "description": "Path within the container at which the volume should be mounted.  Must\nnot contain ':'.",
                           "type": "string"
                         },
                         "mountPropagation": {
+                          "description": "mountPropagation determines how mounts are propagated from the host\nto container and the other way around.\nWhen not set, MountPropagationNone is used.\nThis field is beta in 1.10.\nWhen RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified\n(which defaults to None).",
                           "type": "string"
                         },
                         "name": {
+                          "description": "This must match the Name of a Volume.",
                           "type": "string"
                         },
                         "readOnly": {
+                          "description": "Mounted read-only if true, read-write otherwise (false or unspecified).\nDefaults to false.",
                           "type": "boolean"
                         },
+                        "recursiveReadOnly": {
+                          "description": "RecursiveReadOnly specifies whether read-only mounts should be handled\nrecursively.\n\nIf ReadOnly is false, this field has no meaning and must be unspecified.\n\nIf ReadOnly is true, and this field is set to Disabled, the mount is not made\nrecursively read-only.  If this field is set to IfPossible, the mount is made\nrecursively read-only, if it is supported by the container runtime.  If this\nfield is set to Enabled, the mount is made recursively read-only if it is\nsupported by the container runtime, otherwise the pod will not be started and\nan error will be generated to indicate the reason.\n\nIf this field is set to IfPossible or Enabled, MountPropagation must be set to\nNone (or be unspecified, which defaults to None).\n\nIf this field is not specified, it is treated as an equivalent of Disabled.",
+                          "type": "string"
+                        },
                         "subPath": {
+                          "description": "Path within the volume from which the container's volume should be mounted.\nDefaults to \"\" (volume's root).",
                           "type": "string"
                         },
                         "subPathExpr": {
+                          "description": "Expanded path within the volume from which the container's volume should be mounted.\nBehaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.\nDefaults to \"\" (volume's root).\nSubPathExpr and SubPath are mutually exclusive.",
                           "type": "string"
                         }
                       },
@@ -2987,9 +4529,14 @@
                       "type": "object",
                       "additionalProperties": false
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-map-keys": [
+                      "mountPath"
+                    ],
+                    "x-kubernetes-list-type": "map"
                   },
                   "workingDir": {
+                    "description": "Container's working directory.\nIf not specified, the container runtime's default will be used, which\nmight be configured in the container image.\nCannot be updated.",
                     "type": "string"
                   }
                 },
@@ -3001,27 +4548,40 @@
               },
               "type": "array"
             },
+            "template": {
+              "description": "Template is a pod template that can be used to define the driver or executor pod configurations that Spark configurations do not support.\nSpark version >= 3.0.0 is required.\nRef: https://spark.apache.org/docs/latest/running-on-kubernetes.html#pod-template.",
+              "type": "object",
+              "x-kubernetes-preserve-unknown-fields": true
+            },
             "terminationGracePeriodSeconds": {
+              "description": "Termination grace period seconds for the pod",
               "format": "int64",
               "type": "integer"
             },
             "tolerations": {
+              "description": "Tolerations specifies the tolerations listed in \".spec.tolerations\" to be applied to the pod.",
               "items": {
+                "description": "The pod this Toleration is attached to tolerates any taint that matches\nthe triple <key,value,effect> using the matching operator <operator>.",
                 "properties": {
                   "effect": {
+                    "description": "Effect indicates the taint effect to match. Empty means match all taint effects.\nWhen specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
                     "type": "string"
                   },
                   "key": {
+                    "description": "Key is the taint key that the toleration applies to. Empty means match all taint keys.\nIf the key is empty, operator must be Exists; this combination means to match all values and all keys.",
                     "type": "string"
                   },
                   "operator": {
+                    "description": "Operator represents a key's relationship to the value.\nValid operators are Exists and Equal. Defaults to Equal.\nExists is equivalent to wildcard for value, so that a pod can\ntolerate all taints of a particular category.",
                     "type": "string"
                   },
                   "tolerationSeconds": {
+                    "description": "TolerationSeconds represents the period of time the toleration (which must be\nof effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,\nit is not set, which means tolerate the taint forever (do not evict). Zero and\nnegative values will be treated as 0 (evict immediately) by the system.",
                     "format": "int64",
                     "type": "integer"
                   },
                   "value": {
+                    "description": "Value is the taint value the toleration matches to.\nIf the operator is Exists, the value should be empty, otherwise just a regular string.",
                     "type": "string"
                   }
                 },
@@ -3031,24 +4591,36 @@
               "type": "array"
             },
             "volumeMounts": {
+              "description": "VolumeMounts specifies the volumes listed in \".spec.volumes\" to mount into the main container's filesystem.",
               "items": {
+                "description": "VolumeMount describes a mounting of a Volume within a container.",
                 "properties": {
                   "mountPath": {
+                    "description": "Path within the container at which the volume should be mounted.  Must\nnot contain ':'.",
                     "type": "string"
                   },
                   "mountPropagation": {
+                    "description": "mountPropagation determines how mounts are propagated from the host\nto container and the other way around.\nWhen not set, MountPropagationNone is used.\nThis field is beta in 1.10.\nWhen RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified\n(which defaults to None).",
                     "type": "string"
                   },
                   "name": {
+                    "description": "This must match the Name of a Volume.",
                     "type": "string"
                   },
                   "readOnly": {
+                    "description": "Mounted read-only if true, read-write otherwise (false or unspecified).\nDefaults to false.",
                     "type": "boolean"
                   },
+                  "recursiveReadOnly": {
+                    "description": "RecursiveReadOnly specifies whether read-only mounts should be handled\nrecursively.\n\nIf ReadOnly is false, this field has no meaning and must be unspecified.\n\nIf ReadOnly is true, and this field is set to Disabled, the mount is not made\nrecursively read-only.  If this field is set to IfPossible, the mount is made\nrecursively read-only, if it is supported by the container runtime.  If this\nfield is set to Enabled, the mount is made recursively read-only if it is\nsupported by the container runtime, otherwise the pod will not be started and\nan error will be generated to indicate the reason.\n\nIf this field is set to IfPossible or Enabled, MountPropagation must be set to\nNone (or be unspecified, which defaults to None).\n\nIf this field is not specified, it is treated as an equivalent of Disabled.",
+                    "type": "string"
+                  },
                   "subPath": {
+                    "description": "Path within the volume from which the container's volume should be mounted.\nDefaults to \"\" (volume's root).",
                     "type": "string"
                   },
                   "subPathExpr": {
+                    "description": "Expanded path within the volume from which the container's volume should be mounted.\nBehaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.\nDefaults to \"\" (volume's root).\nSubPathExpr and SubPath are mutually exclusive.",
                     "type": "string"
                   }
                 },
@@ -3065,24 +4637,106 @@
           "type": "object",
           "additionalProperties": false
         },
+        "driverIngressOptions": {
+          "description": "DriverIngressOptions allows configuring the Service and the Ingress to expose ports inside Spark Driver",
+          "items": {
+            "description": "DriverIngressConfiguration is for driver ingress specific configuration parameters.",
+            "properties": {
+              "ingressAnnotations": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "description": "IngressAnnotations is a map of key,value pairs of annotations that might be added to the ingress object. i.e. specify nginx as ingress.class",
+                "type": "object"
+              },
+              "ingressTLS": {
+                "description": "TlsHosts is useful If we need to declare SSL certificates to the ingress object",
+                "items": {
+                  "description": "IngressTLS describes the transport layer security associated with an ingress.",
+                  "properties": {
+                    "hosts": {
+                      "description": "hosts is a list of hosts included in the TLS certificate. The values in\nthis list must match the name/s used in the tlsSecret. Defaults to the\nwildcard host setting for the loadbalancer controller fulfilling this\nIngress, if left unspecified.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
+                    },
+                    "secretName": {
+                      "description": "secretName is the name of the secret used to terminate TLS traffic on\nport 443. Field is left optional to allow TLS routing based on SNI\nhostname alone. If the SNI host in a listener conflicts with the \"Host\"\nheader field used by an IngressRule, the SNI host is used for termination\nand value of the \"Host\" header is used for routing.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "ingressURLFormat": {
+                "description": "IngressURLFormat is the URL for the ingress.",
+                "type": "string"
+              },
+              "serviceAnnotations": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "description": "ServiceAnnotations is a map of key,value pairs of annotations that might be added to the service object.",
+                "type": "object"
+              },
+              "serviceLabels": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "description": "ServiceLabels is a map of key,value pairs of labels that might be added to the service object.",
+                "type": "object"
+              },
+              "servicePort": {
+                "description": "ServicePort allows configuring the port at service level that might be different from the targetPort.",
+                "format": "int32",
+                "type": "integer"
+              },
+              "servicePortName": {
+                "description": "ServicePortName allows configuring the name of the service port.\nThis may be useful for sidecar proxies like Envoy injected by Istio which require specific ports names to treat traffic as proper HTTP.",
+                "type": "string"
+              },
+              "serviceType": {
+                "description": "ServiceType allows configuring the type of the service. Defaults to ClusterIP.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "servicePort",
+              "servicePortName"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
         "dynamicAllocation": {
+          "description": "DynamicAllocation configures dynamic allocation that becomes available for the Kubernetes\nscheduler backend since Spark 3.0.",
           "properties": {
             "enabled": {
+              "description": "Enabled controls whether dynamic allocation is enabled or not.",
               "type": "boolean"
             },
             "initialExecutors": {
+              "description": "InitialExecutors is the initial number of executors to request. If .spec.executor.instances\nis also set, the initial number of executors is set to the bigger of that and this option.",
               "format": "int32",
               "type": "integer"
             },
             "maxExecutors": {
+              "description": "MaxExecutors is the upper bound for the number of executors if dynamic allocation is enabled.",
               "format": "int32",
               "type": "integer"
             },
             "minExecutors": {
+              "description": "MinExecutors is the lower bound for the number of executors if dynamic allocation is enabled.",
               "format": "int32",
               "type": "integer"
             },
             "shuffleTrackingTimeout": {
+              "description": "ShuffleTrackingTimeout controls the timeout in milliseconds for executors that are holding\nshuffle data if shuffle tracking is enabled (true by default if dynamic allocation is enabled).",
               "format": "int64",
               "type": "integer"
             }
@@ -3091,30 +4745,42 @@
           "additionalProperties": false
         },
         "executor": {
+          "description": "Executor is the executor specification.",
           "properties": {
             "affinity": {
+              "description": "Affinity specifies the affinity/anti-affinity settings for the pod.",
               "properties": {
                 "nodeAffinity": {
+                  "description": "Describes node affinity scheduling rules for the pod.",
                   "properties": {
                     "preferredDuringSchedulingIgnoredDuringExecution": {
+                      "description": "The scheduler will prefer to schedule pods to nodes that satisfy\nthe affinity expressions specified by this field, but it may choose\na node that violates one or more of the expressions. The node that is\nmost preferred is the one with the greatest sum of weights, i.e.\nfor each node that meets all of the scheduling requirements (resource\nrequest, requiredDuringScheduling affinity expressions, etc.),\ncompute a sum by iterating through the elements of this field and adding\n\"weight\" to the sum if the node matches the corresponding matchExpressions; the\nnode(s) with the highest sum are the most preferred.",
                       "items": {
+                        "description": "An empty preferred scheduling term matches all objects with implicit weight 0\n(i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).",
                         "properties": {
                           "preference": {
+                            "description": "A node selector term, associated with the corresponding weight.",
                             "properties": {
                               "matchExpressions": {
+                                "description": "A list of node selector requirements by node's labels.",
                                 "items": {
+                                  "description": "A node selector requirement is a selector that contains values, a key, and an operator\nthat relates the key and values.",
                                   "properties": {
                                     "key": {
+                                      "description": "The label key that the selector applies to.",
                                       "type": "string"
                                     },
                                     "operator": {
+                                      "description": "Represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
                                       "type": "string"
                                     },
                                     "values": {
+                                      "description": "An array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. If the operator is Gt or Lt, the values\narray must have a single element, which will be interpreted as an integer.\nThis array is replaced during a strategic merge patch.",
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -3124,22 +4790,29 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchFields": {
+                                "description": "A list of node selector requirements by node's fields.",
                                 "items": {
+                                  "description": "A node selector requirement is a selector that contains values, a key, and an operator\nthat relates the key and values.",
                                   "properties": {
                                     "key": {
+                                      "description": "The label key that the selector applies to.",
                                       "type": "string"
                                     },
                                     "operator": {
+                                      "description": "Represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
                                       "type": "string"
                                     },
                                     "values": {
+                                      "description": "An array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. If the operator is Gt or Lt, the values\narray must have a single element, which will be interpreted as an integer.\nThis array is replaced during a strategic merge patch.",
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -3149,13 +4822,16 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               }
                             },
                             "type": "object",
+                            "x-kubernetes-map-type": "atomic",
                             "additionalProperties": false
                           },
                           "weight": {
+                            "description": "Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.",
                             "format": "int32",
                             "type": "integer"
                           }
@@ -3167,27 +4843,37 @@
                         "type": "object",
                         "additionalProperties": false
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     },
                     "requiredDuringSchedulingIgnoredDuringExecution": {
+                      "description": "If the affinity requirements specified by this field are not met at\nscheduling time, the pod will not be scheduled onto the node.\nIf the affinity requirements specified by this field cease to be met\nat some point during pod execution (e.g. due to an update), the system\nmay or may not try to eventually evict the pod from its node.",
                       "properties": {
                         "nodeSelectorTerms": {
+                          "description": "Required. A list of node selector terms. The terms are ORed.",
                           "items": {
+                            "description": "A null or empty node selector term matches no objects. The requirements of\nthem are ANDed.\nThe TopologySelectorTerm type implements a subset of the NodeSelectorTerm.",
                             "properties": {
                               "matchExpressions": {
+                                "description": "A list of node selector requirements by node's labels.",
                                 "items": {
+                                  "description": "A node selector requirement is a selector that contains values, a key, and an operator\nthat relates the key and values.",
                                   "properties": {
                                     "key": {
+                                      "description": "The label key that the selector applies to.",
                                       "type": "string"
                                     },
                                     "operator": {
+                                      "description": "Represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
                                       "type": "string"
                                     },
                                     "values": {
+                                      "description": "An array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. If the operator is Gt or Lt, the values\narray must have a single element, which will be interpreted as an integer.\nThis array is replaced during a strategic merge patch.",
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -3197,22 +4883,29 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchFields": {
+                                "description": "A list of node selector requirements by node's fields.",
                                 "items": {
+                                  "description": "A node selector requirement is a selector that contains values, a key, and an operator\nthat relates the key and values.",
                                   "properties": {
                                     "key": {
+                                      "description": "The label key that the selector applies to.",
                                       "type": "string"
                                     },
                                     "operator": {
+                                      "description": "Represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
                                       "type": "string"
                                     },
                                     "values": {
+                                      "description": "An array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. If the operator is Gt or Lt, the values\narray must have a single element, which will be interpreted as an integer.\nThis array is replaced during a strategic merge patch.",
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -3222,19 +4915,23 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               }
                             },
                             "type": "object",
+                            "x-kubernetes-map-type": "atomic",
                             "additionalProperties": false
                           },
-                          "type": "array"
+                          "type": "array",
+                          "x-kubernetes-list-type": "atomic"
                         }
                       },
                       "required": [
                         "nodeSelectorTerms"
                       ],
                       "type": "object",
+                      "x-kubernetes-map-type": "atomic",
                       "additionalProperties": false
                     }
                   },
@@ -3242,28 +4939,39 @@
                   "additionalProperties": false
                 },
                 "podAffinity": {
+                  "description": "Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).",
                   "properties": {
                     "preferredDuringSchedulingIgnoredDuringExecution": {
+                      "description": "The scheduler will prefer to schedule pods to nodes that satisfy\nthe affinity expressions specified by this field, but it may choose\na node that violates one or more of the expressions. The node that is\nmost preferred is the one with the greatest sum of weights, i.e.\nfor each node that meets all of the scheduling requirements (resource\nrequest, requiredDuringScheduling affinity expressions, etc.),\ncompute a sum by iterating through the elements of this field and adding\n\"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the\nnode(s) with the highest sum are the most preferred.",
                       "items": {
+                        "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
                         "properties": {
                           "podAffinityTerm": {
+                            "description": "Required. A pod affinity term, associated with the corresponding weight.",
                             "properties": {
                               "labelSelector": {
+                                "description": "A label query over a set of resources, in this case pods.\nIf it's null, this PodAffinityTerm matches with no Pods.",
                                 "properties": {
                                   "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
                                     "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
                                       "properties": {
                                         "key": {
+                                          "description": "key is the label key that the selector applies to.",
                                           "type": "string"
                                         },
                                         "operator": {
+                                          "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
                                           "type": "string"
                                         },
                                         "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
                                           "items": {
                                             "type": "string"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       },
                                       "required": [
@@ -3273,25 +4981,94 @@
                                       "type": "object",
                                       "additionalProperties": false
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "matchLabels": {
                                     "additionalProperties": {
                                       "type": "string"
                                     },
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                                     "type": "object"
                                   }
                                 },
                                 "type": "object",
+                                "x-kubernetes-map-type": "atomic",
                                 "additionalProperties": false
                               },
-                              "namespaces": {
+                              "matchLabelKeys": {
+                                "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both matchLabelKeys and labelSelector.\nAlso, matchLabelKeys cannot be set when labelSelector isn't set.\nThis is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).",
                                 "items": {
                                   "type": "string"
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "mismatchLabelKeys": {
+                                "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both mismatchLabelKeys and labelSelector.\nAlso, mismatchLabelKeys cannot be set when labelSelector isn't set.\nThis is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "namespaceSelector": {
+                                "description": "A label query over the set of namespaces that the term applies to.\nThe term is applied to the union of the namespaces selected by this field\nand the ones listed in the namespaces field.\nnull selector and null or empty namespaces list means \"this pod's namespace\".\nAn empty selector ({}) matches all namespaces.",
+                                "properties": {
+                                  "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                    "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                      "properties": {
+                                        "key": {
+                                          "description": "key is the label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "namespaces": {
+                                "description": "namespaces specifies a static list of namespace names that the term applies to.\nThe term is applied to the union of the namespaces listed in this field\nand the ones selected by namespaceSelector.\nnull or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "topologyKey": {
+                                "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
                                 "type": "string"
                               }
                             },
@@ -3302,6 +5079,7 @@
                             "additionalProperties": false
                           },
                           "weight": {
+                            "description": "weight associated with matching the corresponding podAffinityTerm,\nin the range 1-100.",
                             "format": "int32",
                             "type": "integer"
                           }
@@ -3313,27 +5091,37 @@
                         "type": "object",
                         "additionalProperties": false
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     },
                     "requiredDuringSchedulingIgnoredDuringExecution": {
+                      "description": "If the affinity requirements specified by this field are not met at\nscheduling time, the pod will not be scheduled onto the node.\nIf the affinity requirements specified by this field cease to be met\nat some point during pod execution (e.g. due to a pod label update), the\nsystem may or may not try to eventually evict the pod from its node.\nWhen there are multiple elements, the lists of nodes corresponding to each\npodAffinityTerm are intersected, i.e. all terms must be satisfied.",
                       "items": {
+                        "description": "Defines a set of pods (namely those matching the labelSelector\nrelative to the given namespace(s)) that this pod should be\nco-located (affinity) or not co-located (anti-affinity) with,\nwhere co-located is defined as running on a node whose value of\nthe label with key <topologyKey> matches that of any node on which\na pod of the set of pods is running",
                         "properties": {
                           "labelSelector": {
+                            "description": "A label query over a set of resources, in this case pods.\nIf it's null, this PodAffinityTerm matches with no Pods.",
                             "properties": {
                               "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
                                 "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
                                   "properties": {
                                     "key": {
+                                      "description": "key is the label key that the selector applies to.",
                                       "type": "string"
                                     },
                                     "operator": {
+                                      "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
                                       "type": "string"
                                     },
                                     "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -3343,25 +5131,94 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchLabels": {
                                 "additionalProperties": {
                                   "type": "string"
                                 },
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                                 "type": "object"
                               }
                             },
                             "type": "object",
+                            "x-kubernetes-map-type": "atomic",
                             "additionalProperties": false
                           },
-                          "namespaces": {
+                          "matchLabelKeys": {
+                            "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both matchLabelKeys and labelSelector.\nAlso, matchLabelKeys cannot be set when labelSelector isn't set.\nThis is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).",
                             "items": {
                               "type": "string"
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "mismatchLabelKeys": {
+                            "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both mismatchLabelKeys and labelSelector.\nAlso, mismatchLabelKeys cannot be set when labelSelector isn't set.\nThis is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "namespaceSelector": {
+                            "description": "A label query over the set of namespaces that the term applies to.\nThe term is applied to the union of the namespaces selected by this field\nand the ones listed in the namespaces field.\nnull selector and null or empty namespaces list means \"this pod's namespace\".\nAn empty selector ({}) matches all namespaces.",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "key is the label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "namespaces": {
+                            "description": "namespaces specifies a static list of namespace names that the term applies to.\nThe term is applied to the union of the namespaces listed in this field\nand the ones selected by namespaceSelector.\nnull or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "topologyKey": {
+                            "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
                             "type": "string"
                           }
                         },
@@ -3371,35 +5228,47 @@
                         "type": "object",
                         "additionalProperties": false
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     }
                   },
                   "type": "object",
                   "additionalProperties": false
                 },
                 "podAntiAffinity": {
+                  "description": "Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).",
                   "properties": {
                     "preferredDuringSchedulingIgnoredDuringExecution": {
+                      "description": "The scheduler will prefer to schedule pods to nodes that satisfy\nthe anti-affinity expressions specified by this field, but it may choose\na node that violates one or more of the expressions. The node that is\nmost preferred is the one with the greatest sum of weights, i.e.\nfor each node that meets all of the scheduling requirements (resource\nrequest, requiredDuringScheduling anti-affinity expressions, etc.),\ncompute a sum by iterating through the elements of this field and adding\n\"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the\nnode(s) with the highest sum are the most preferred.",
                       "items": {
+                        "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
                         "properties": {
                           "podAffinityTerm": {
+                            "description": "Required. A pod affinity term, associated with the corresponding weight.",
                             "properties": {
                               "labelSelector": {
+                                "description": "A label query over a set of resources, in this case pods.\nIf it's null, this PodAffinityTerm matches with no Pods.",
                                 "properties": {
                                   "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
                                     "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
                                       "properties": {
                                         "key": {
+                                          "description": "key is the label key that the selector applies to.",
                                           "type": "string"
                                         },
                                         "operator": {
+                                          "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
                                           "type": "string"
                                         },
                                         "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
                                           "items": {
                                             "type": "string"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       },
                                       "required": [
@@ -3409,25 +5278,94 @@
                                       "type": "object",
                                       "additionalProperties": false
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "matchLabels": {
                                     "additionalProperties": {
                                       "type": "string"
                                     },
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                                     "type": "object"
                                   }
                                 },
                                 "type": "object",
+                                "x-kubernetes-map-type": "atomic",
                                 "additionalProperties": false
                               },
-                              "namespaces": {
+                              "matchLabelKeys": {
+                                "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both matchLabelKeys and labelSelector.\nAlso, matchLabelKeys cannot be set when labelSelector isn't set.\nThis is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).",
                                 "items": {
                                   "type": "string"
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "mismatchLabelKeys": {
+                                "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both mismatchLabelKeys and labelSelector.\nAlso, mismatchLabelKeys cannot be set when labelSelector isn't set.\nThis is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "namespaceSelector": {
+                                "description": "A label query over the set of namespaces that the term applies to.\nThe term is applied to the union of the namespaces selected by this field\nand the ones listed in the namespaces field.\nnull selector and null or empty namespaces list means \"this pod's namespace\".\nAn empty selector ({}) matches all namespaces.",
+                                "properties": {
+                                  "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                    "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                      "properties": {
+                                        "key": {
+                                          "description": "key is the label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "namespaces": {
+                                "description": "namespaces specifies a static list of namespace names that the term applies to.\nThe term is applied to the union of the namespaces listed in this field\nand the ones selected by namespaceSelector.\nnull or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "topologyKey": {
+                                "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
                                 "type": "string"
                               }
                             },
@@ -3438,6 +5376,7 @@
                             "additionalProperties": false
                           },
                           "weight": {
+                            "description": "weight associated with matching the corresponding podAffinityTerm,\nin the range 1-100.",
                             "format": "int32",
                             "type": "integer"
                           }
@@ -3449,27 +5388,37 @@
                         "type": "object",
                         "additionalProperties": false
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     },
                     "requiredDuringSchedulingIgnoredDuringExecution": {
+                      "description": "If the anti-affinity requirements specified by this field are not met at\nscheduling time, the pod will not be scheduled onto the node.\nIf the anti-affinity requirements specified by this field cease to be met\nat some point during pod execution (e.g. due to a pod label update), the\nsystem may or may not try to eventually evict the pod from its node.\nWhen there are multiple elements, the lists of nodes corresponding to each\npodAffinityTerm are intersected, i.e. all terms must be satisfied.",
                       "items": {
+                        "description": "Defines a set of pods (namely those matching the labelSelector\nrelative to the given namespace(s)) that this pod should be\nco-located (affinity) or not co-located (anti-affinity) with,\nwhere co-located is defined as running on a node whose value of\nthe label with key <topologyKey> matches that of any node on which\na pod of the set of pods is running",
                         "properties": {
                           "labelSelector": {
+                            "description": "A label query over a set of resources, in this case pods.\nIf it's null, this PodAffinityTerm matches with no Pods.",
                             "properties": {
                               "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
                                 "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
                                   "properties": {
                                     "key": {
+                                      "description": "key is the label key that the selector applies to.",
                                       "type": "string"
                                     },
                                     "operator": {
+                                      "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
                                       "type": "string"
                                     },
                                     "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -3479,25 +5428,94 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchLabels": {
                                 "additionalProperties": {
                                   "type": "string"
                                 },
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                                 "type": "object"
                               }
                             },
                             "type": "object",
+                            "x-kubernetes-map-type": "atomic",
                             "additionalProperties": false
                           },
-                          "namespaces": {
+                          "matchLabelKeys": {
+                            "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both matchLabelKeys and labelSelector.\nAlso, matchLabelKeys cannot be set when labelSelector isn't set.\nThis is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).",
                             "items": {
                               "type": "string"
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "mismatchLabelKeys": {
+                            "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both mismatchLabelKeys and labelSelector.\nAlso, mismatchLabelKeys cannot be set when labelSelector isn't set.\nThis is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "namespaceSelector": {
+                            "description": "A label query over the set of namespaces that the term applies to.\nThe term is applied to the union of the namespaces selected by this field\nand the ones listed in the namespaces field.\nnull selector and null or empty namespaces list means \"this pod's namespace\".\nAn empty selector ({}) matches all namespaces.",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "key is the label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "namespaces": {
+                            "description": "namespaces specifies a static list of namespace names that the term applies to.\nThe term is applied to the union of the namespaces listed in this field\nand the ones selected by namespaceSelector.\nnull or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "topologyKey": {
+                            "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
                             "type": "string"
                           }
                         },
@@ -3507,7 +5525,8 @@
                         "type": "object",
                         "additionalProperties": false
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     }
                   },
                   "type": "object",
@@ -3521,10 +5540,13 @@
               "additionalProperties": {
                 "type": "string"
               },
+              "description": "Annotations are the Kubernetes annotations to be added to the pod.",
               "type": "object"
             },
             "configMaps": {
+              "description": "ConfigMaps carries information of other ConfigMaps to add to the pod.",
               "items": {
+                "description": "NamePath is a pair of a name and a path to which the named objects should be mounted to.",
                 "properties": {
                   "name": {
                     "type": "string"
@@ -3543,72 +5565,96 @@
               "type": "array"
             },
             "coreLimit": {
+              "description": "CoreLimit specifies a hard limit on CPU cores for the pod.\nOptional",
               "type": "string"
             },
             "coreRequest": {
+              "description": "CoreRequest is the physical CPU core request for the executors.\nMaps to `spark.kubernetes.executor.request.cores` that is available since Spark 2.4.",
               "type": "string"
             },
             "cores": {
+              "description": "Cores maps to `spark.driver.cores` or `spark.executor.cores` for the driver and executors, respectively.",
               "format": "int32",
               "minimum": 1,
               "type": "integer"
             },
             "deleteOnTermination": {
+              "description": "DeleteOnTermination specify whether executor pods should be deleted in case of failure or normal termination.\nMaps to `spark.kubernetes.executor.deleteOnTermination` that is available since Spark 3.0.",
               "type": "boolean"
             },
             "dnsConfig": {
+              "description": "DnsConfig dns settings for the pod, following the Kubernetes specifications.",
               "properties": {
                 "nameservers": {
+                  "description": "A list of DNS name server IP addresses.\nThis will be appended to the base nameservers generated from DNSPolicy.\nDuplicated nameservers will be removed.",
                   "items": {
                     "type": "string"
                   },
-                  "type": "array"
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
                 },
                 "options": {
+                  "description": "A list of DNS resolver options.\nThis will be merged with the base options generated from DNSPolicy.\nDuplicated entries will be removed. Resolution options given in Options\nwill override those that appear in the base DNSPolicy.",
                   "items": {
+                    "description": "PodDNSConfigOption defines DNS resolver options of a pod.",
                     "properties": {
                       "name": {
+                        "description": "Name is this DNS resolver option's name.\nRequired.",
                         "type": "string"
                       },
                       "value": {
+                        "description": "Value is this DNS resolver option's value.",
                         "type": "string"
                       }
                     },
                     "type": "object",
                     "additionalProperties": false
                   },
-                  "type": "array"
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
                 },
                 "searches": {
+                  "description": "A list of DNS search domains for host-name lookup.\nThis will be appended to the base search paths generated from DNSPolicy.\nDuplicated search paths will be removed.",
                   "items": {
                     "type": "string"
                   },
-                  "type": "array"
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
                 }
               },
               "type": "object",
               "additionalProperties": false
             },
             "env": {
+              "description": "Env carries the environment variables to add to the pod.",
               "items": {
+                "description": "EnvVar represents an environment variable present in a Container.",
                 "properties": {
                   "name": {
+                    "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
                     "type": "string"
                   },
                   "value": {
+                    "description": "Variable references $(VAR_NAME) are expanded\nusing the previously defined environment variables in the container and\nany service environment variables. If a variable cannot be resolved,\nthe reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.\n\"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\".\nEscaped references will never be expanded, regardless of whether the variable\nexists or not.\nDefaults to \"\".",
                     "type": "string"
                   },
                   "valueFrom": {
+                    "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
                     "properties": {
                       "configMapKeyRef": {
+                        "description": "Selects a key of a ConfigMap.",
                         "properties": {
                           "key": {
+                            "description": "The key to select.",
                             "type": "string"
                           },
                           "name": {
+                            "default": "",
+                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                             "type": "string"
                           },
                           "optional": {
+                            "description": "Specify whether the ConfigMap or its key must be defined",
                             "type": "boolean"
                           }
                         },
@@ -3616,14 +5662,18 @@
                           "key"
                         ],
                         "type": "object",
+                        "x-kubernetes-map-type": "atomic",
                         "additionalProperties": false
                       },
                       "fieldRef": {
+                        "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,\nspec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
                         "properties": {
                           "apiVersion": {
+                            "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
                             "type": "string"
                           },
                           "fieldPath": {
+                            "description": "Path of the field to select in the specified API version.",
                             "type": "string"
                           }
                         },
@@ -3631,11 +5681,14 @@
                           "fieldPath"
                         ],
                         "type": "object",
+                        "x-kubernetes-map-type": "atomic",
                         "additionalProperties": false
                       },
                       "resourceFieldRef": {
+                        "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
                         "properties": {
                           "containerName": {
+                            "description": "Container name: required for volumes, optional for env vars",
                             "type": "string"
                           },
                           "divisor": {
@@ -3647,10 +5700,12 @@
                                 "type": "string"
                               }
                             ],
+                            "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
                             "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                             "x-kubernetes-int-or-string": true
                           },
                           "resource": {
+                            "description": "Required: resource to select",
                             "type": "string"
                           }
                         },
@@ -3658,17 +5713,23 @@
                           "resource"
                         ],
                         "type": "object",
+                        "x-kubernetes-map-type": "atomic",
                         "additionalProperties": false
                       },
                       "secretKeyRef": {
+                        "description": "Selects a key of a secret in the pod's namespace",
                         "properties": {
                           "key": {
+                            "description": "The key of the secret to select from.  Must be a valid secret key.",
                             "type": "string"
                           },
                           "name": {
+                            "default": "",
+                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                             "type": "string"
                           },
                           "optional": {
+                            "description": "Specify whether the Secret or its key must be defined",
                             "type": "boolean"
                           }
                         },
@@ -3676,6 +5737,7 @@
                           "key"
                         ],
                         "type": "object",
+                        "x-kubernetes-map-type": "atomic",
                         "additionalProperties": false
                       }
                     },
@@ -3692,33 +5754,46 @@
               "type": "array"
             },
             "envFrom": {
+              "description": "EnvFrom is a list of sources to populate environment variables in the container.",
               "items": {
+                "description": "EnvFromSource represents the source of a set of ConfigMaps",
                 "properties": {
                   "configMapRef": {
+                    "description": "The ConfigMap to select from",
                     "properties": {
                       "name": {
+                        "default": "",
+                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                         "type": "string"
                       },
                       "optional": {
+                        "description": "Specify whether the ConfigMap must be defined",
                         "type": "boolean"
                       }
                     },
                     "type": "object",
+                    "x-kubernetes-map-type": "atomic",
                     "additionalProperties": false
                   },
                   "prefix": {
+                    "description": "An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.",
                     "type": "string"
                   },
                   "secretRef": {
+                    "description": "The Secret to select from",
                     "properties": {
                       "name": {
+                        "default": "",
+                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                         "type": "string"
                       },
                       "optional": {
+                        "description": "Specify whether the Secret must be defined",
                         "type": "boolean"
                       }
                     },
                     "type": "object",
+                    "x-kubernetes-map-type": "atomic",
                     "additionalProperties": false
                   }
                 },
@@ -3729,6 +5804,7 @@
             },
             "envSecretKeyRefs": {
               "additionalProperties": {
+                "description": "NameKey represents the name and key of a SecretKeyRef.",
                 "properties": {
                   "key": {
                     "type": "string"
@@ -3744,20 +5820,25 @@
                 "type": "object",
                 "additionalProperties": false
               },
+              "description": "EnvSecretKeyRefs holds a mapping from environment variable names to SecretKeyRefs.\nDeprecated. Consider using `env` instead.",
               "type": "object"
             },
             "envVars": {
               "additionalProperties": {
                 "type": "string"
               },
+              "description": "EnvVars carries the environment variables to add to the pod.\nDeprecated. Consider using `env` instead.",
               "type": "object"
             },
             "gpu": {
+              "description": "GPU specifies GPU requirement for the pod.",
               "properties": {
                 "name": {
+                  "description": "Name is GPU resource name, such as: nvidia.com/gpu or amd.com/gpu",
                   "type": "string"
                 },
                 "quantity": {
+                  "description": "Quantity is the number of GPUs to request for driver or executor.",
                   "format": "int64",
                   "type": "integer"
                 }
@@ -3770,64 +5851,90 @@
               "additionalProperties": false
             },
             "hostAliases": {
+              "description": "HostAliases settings for the pod, following the Kubernetes specifications.",
               "items": {
+                "description": "HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the\npod's hosts file.",
                 "properties": {
                   "hostnames": {
+                    "description": "Hostnames for the above IP address.",
                     "items": {
                       "type": "string"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   },
                   "ip": {
+                    "description": "IP address of the host file entry.",
                     "type": "string"
                   }
                 },
+                "required": [
+                  "ip"
+                ],
                 "type": "object",
                 "additionalProperties": false
               },
               "type": "array"
             },
             "hostNetwork": {
+              "description": "HostNetwork indicates whether to request host networking for the pod or not.",
               "type": "boolean"
             },
             "image": {
+              "description": "Image is the container image to use. Overrides Spec.Image if set.",
               "type": "string"
             },
             "initContainers": {
+              "description": "InitContainers is a list of init-containers that run to completion before the main Spark container.",
               "items": {
+                "description": "A single application container that you want to run within a pod.",
                 "properties": {
                   "args": {
+                    "description": "Arguments to the entrypoint.\nThe container image's CMD is used if this is not provided.\nVariable references $(VAR_NAME) are expanded using the container's environment. If a variable\ncannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will\nproduce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless\nof whether the variable exists or not. Cannot be updated.\nMore info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
                     "items": {
                       "type": "string"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   },
                   "command": {
+                    "description": "Entrypoint array. Not executed within a shell.\nThe container image's ENTRYPOINT is used if this is not provided.\nVariable references $(VAR_NAME) are expanded using the container's environment. If a variable\ncannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will\nproduce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless\nof whether the variable exists or not. Cannot be updated.\nMore info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
                     "items": {
                       "type": "string"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   },
                   "env": {
+                    "description": "List of environment variables to set in the container.\nCannot be updated.",
                     "items": {
+                      "description": "EnvVar represents an environment variable present in a Container.",
                       "properties": {
                         "name": {
+                          "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
                           "type": "string"
                         },
                         "value": {
+                          "description": "Variable references $(VAR_NAME) are expanded\nusing the previously defined environment variables in the container and\nany service environment variables. If a variable cannot be resolved,\nthe reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.\n\"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\".\nEscaped references will never be expanded, regardless of whether the variable\nexists or not.\nDefaults to \"\".",
                           "type": "string"
                         },
                         "valueFrom": {
+                          "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
                           "properties": {
                             "configMapKeyRef": {
+                              "description": "Selects a key of a ConfigMap.",
                               "properties": {
                                 "key": {
+                                  "description": "The key to select.",
                                   "type": "string"
                                 },
                                 "name": {
+                                  "default": "",
+                                  "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                   "type": "string"
                                 },
                                 "optional": {
+                                  "description": "Specify whether the ConfigMap or its key must be defined",
                                   "type": "boolean"
                                 }
                               },
@@ -3835,14 +5942,18 @@
                                 "key"
                               ],
                               "type": "object",
+                              "x-kubernetes-map-type": "atomic",
                               "additionalProperties": false
                             },
                             "fieldRef": {
+                              "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,\nspec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
                               "properties": {
                                 "apiVersion": {
+                                  "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
                                   "type": "string"
                                 },
                                 "fieldPath": {
+                                  "description": "Path of the field to select in the specified API version.",
                                   "type": "string"
                                 }
                               },
@@ -3850,11 +5961,14 @@
                                 "fieldPath"
                               ],
                               "type": "object",
+                              "x-kubernetes-map-type": "atomic",
                               "additionalProperties": false
                             },
                             "resourceFieldRef": {
+                              "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
                               "properties": {
                                 "containerName": {
+                                  "description": "Container name: required for volumes, optional for env vars",
                                   "type": "string"
                                 },
                                 "divisor": {
@@ -3866,10 +5980,12 @@
                                       "type": "string"
                                     }
                                   ],
+                                  "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
                                   "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                                   "x-kubernetes-int-or-string": true
                                 },
                                 "resource": {
+                                  "description": "Required: resource to select",
                                   "type": "string"
                                 }
                               },
@@ -3877,17 +5993,23 @@
                                 "resource"
                               ],
                               "type": "object",
+                              "x-kubernetes-map-type": "atomic",
                               "additionalProperties": false
                             },
                             "secretKeyRef": {
+                              "description": "Selects a key of a secret in the pod's namespace",
                               "properties": {
                                 "key": {
+                                  "description": "The key of the secret to select from.  Must be a valid secret key.",
                                   "type": "string"
                                 },
                                 "name": {
+                                  "default": "",
+                                  "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                   "type": "string"
                                 },
                                 "optional": {
+                                  "description": "Specify whether the Secret or its key must be defined",
                                   "type": "boolean"
                                 }
                               },
@@ -3895,6 +6017,7 @@
                                 "key"
                               ],
                               "type": "object",
+                              "x-kubernetes-map-type": "atomic",
                               "additionalProperties": false
                             }
                           },
@@ -3908,78 +6031,109 @@
                       "type": "object",
                       "additionalProperties": false
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-map-keys": [
+                      "name"
+                    ],
+                    "x-kubernetes-list-type": "map"
                   },
                   "envFrom": {
+                    "description": "List of sources to populate environment variables in the container.\nThe keys defined within a source must be a C_IDENTIFIER. All invalid keys\nwill be reported as an event when the container is starting. When a key exists in multiple\nsources, the value associated with the last source will take precedence.\nValues defined by an Env with a duplicate key will take precedence.\nCannot be updated.",
                     "items": {
+                      "description": "EnvFromSource represents the source of a set of ConfigMaps",
                       "properties": {
                         "configMapRef": {
+                          "description": "The ConfigMap to select from",
                           "properties": {
                             "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                               "type": "string"
                             },
                             "optional": {
+                              "description": "Specify whether the ConfigMap must be defined",
                               "type": "boolean"
                             }
                           },
                           "type": "object",
+                          "x-kubernetes-map-type": "atomic",
                           "additionalProperties": false
                         },
                         "prefix": {
+                          "description": "An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.",
                           "type": "string"
                         },
                         "secretRef": {
+                          "description": "The Secret to select from",
                           "properties": {
                             "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                               "type": "string"
                             },
                             "optional": {
+                              "description": "Specify whether the Secret must be defined",
                               "type": "boolean"
                             }
                           },
                           "type": "object",
+                          "x-kubernetes-map-type": "atomic",
                           "additionalProperties": false
                         }
                       },
                       "type": "object",
                       "additionalProperties": false
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   },
                   "image": {
+                    "description": "Container image name.\nMore info: https://kubernetes.io/docs/concepts/containers/images\nThis field is optional to allow higher level config management to default or override\ncontainer images in workload controllers like Deployments and StatefulSets.",
                     "type": "string"
                   },
                   "imagePullPolicy": {
+                    "description": "Image pull policy.\nOne of Always, Never, IfNotPresent.\nDefaults to Always if :latest tag is specified, or IfNotPresent otherwise.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/containers/images#updating-images",
                     "type": "string"
                   },
                   "lifecycle": {
+                    "description": "Actions that the management system should take in response to container lifecycle events.\nCannot be updated.",
                     "properties": {
                       "postStart": {
+                        "description": "PostStart is called immediately after a container is created. If the handler fails,\nthe container is terminated and restarted according to its restart policy.\nOther management of the container blocks until the hook completes.\nMore info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks",
                         "properties": {
                           "exec": {
+                            "description": "Exec specifies a command to execute in the container.",
                             "properties": {
                               "command": {
+                                "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
                                 "items": {
                                   "type": "string"
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               }
                             },
                             "type": "object",
                             "additionalProperties": false
                           },
                           "httpGet": {
+                            "description": "HTTPGet specifies an HTTP GET request to perform.",
                             "properties": {
                               "host": {
+                                "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
                                 "type": "string"
                               },
                               "httpHeaders": {
+                                "description": "Custom headers to set in the request. HTTP allows repeated headers.",
                                 "items": {
+                                  "description": "HTTPHeader describes a custom header to be used in HTTP probes",
                                   "properties": {
                                     "name": {
+                                      "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
                                       "type": "string"
                                     },
                                     "value": {
+                                      "description": "The header field value",
                                       "type": "string"
                                     }
                                   },
@@ -3990,9 +6144,11 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "path": {
+                                "description": "Path to access on the HTTP server.",
                                 "type": "string"
                               },
                               "port": {
@@ -4004,9 +6160,11 @@
                                     "type": "string"
                                   }
                                 ],
+                                "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
                                 "x-kubernetes-int-or-string": true
                               },
                               "scheme": {
+                                "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
                                 "type": "string"
                               }
                             },
@@ -4016,9 +6174,26 @@
                             "type": "object",
                             "additionalProperties": false
                           },
+                          "sleep": {
+                            "description": "Sleep represents a duration that the container should sleep.",
+                            "properties": {
+                              "seconds": {
+                                "description": "Seconds is the number of seconds to sleep.",
+                                "format": "int64",
+                                "type": "integer"
+                              }
+                            },
+                            "required": [
+                              "seconds"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
                           "tcpSocket": {
+                            "description": "Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept\nfor backward compatibility. There is no validation of this field and\nlifecycle hooks will fail at runtime when it is specified.",
                             "properties": {
                               "host": {
+                                "description": "Optional: Host name to connect to, defaults to the pod IP.",
                                 "type": "string"
                               },
                               "port": {
@@ -4030,6 +6205,7 @@
                                     "type": "string"
                                   }
                                 ],
+                                "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
                                 "x-kubernetes-int-or-string": true
                               }
                             },
@@ -4044,31 +6220,41 @@
                         "additionalProperties": false
                       },
                       "preStop": {
+                        "description": "PreStop is called immediately before a container is terminated due to an\nAPI request or management event such as liveness/startup probe failure,\npreemption, resource contention, etc. The handler is not called if the\ncontainer crashes or exits. The Pod's termination grace period countdown begins before the\nPreStop hook is executed. Regardless of the outcome of the handler, the\ncontainer will eventually terminate within the Pod's termination grace\nperiod (unless delayed by finalizers). Other management of the container blocks until the hook completes\nor until the termination grace period is reached.\nMore info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks",
                         "properties": {
                           "exec": {
+                            "description": "Exec specifies a command to execute in the container.",
                             "properties": {
                               "command": {
+                                "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
                                 "items": {
                                   "type": "string"
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               }
                             },
                             "type": "object",
                             "additionalProperties": false
                           },
                           "httpGet": {
+                            "description": "HTTPGet specifies an HTTP GET request to perform.",
                             "properties": {
                               "host": {
+                                "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
                                 "type": "string"
                               },
                               "httpHeaders": {
+                                "description": "Custom headers to set in the request. HTTP allows repeated headers.",
                                 "items": {
+                                  "description": "HTTPHeader describes a custom header to be used in HTTP probes",
                                   "properties": {
                                     "name": {
+                                      "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
                                       "type": "string"
                                     },
                                     "value": {
+                                      "description": "The header field value",
                                       "type": "string"
                                     }
                                   },
@@ -4079,9 +6265,11 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "path": {
+                                "description": "Path to access on the HTTP server.",
                                 "type": "string"
                               },
                               "port": {
@@ -4093,9 +6281,11 @@
                                     "type": "string"
                                   }
                                 ],
+                                "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
                                 "x-kubernetes-int-or-string": true
                               },
                               "scheme": {
+                                "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
                                 "type": "string"
                               }
                             },
@@ -4105,9 +6295,26 @@
                             "type": "object",
                             "additionalProperties": false
                           },
+                          "sleep": {
+                            "description": "Sleep represents a duration that the container should sleep.",
+                            "properties": {
+                              "seconds": {
+                                "description": "Seconds is the number of seconds to sleep.",
+                                "format": "int64",
+                                "type": "integer"
+                              }
+                            },
+                            "required": [
+                              "seconds"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
                           "tcpSocket": {
+                            "description": "Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept\nfor backward compatibility. There is no validation of this field and\nlifecycle hooks will fail at runtime when it is specified.",
                             "properties": {
                               "host": {
+                                "description": "Optional: Host name to connect to, defaults to the pod IP.",
                                 "type": "string"
                               },
                               "port": {
@@ -4119,6 +6326,7 @@
                                     "type": "string"
                                   }
                                 ],
+                                "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
                                 "x-kubernetes-int-or-string": true
                               }
                             },
@@ -4137,35 +6345,66 @@
                     "additionalProperties": false
                   },
                   "livenessProbe": {
+                    "description": "Periodic probe of container liveness.\nContainer will be restarted if the probe fails.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
                     "properties": {
                       "exec": {
+                        "description": "Exec specifies a command to execute in the container.",
                         "properties": {
                           "command": {
+                            "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
                             "items": {
                               "type": "string"
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           }
                         },
                         "type": "object",
                         "additionalProperties": false
                       },
                       "failureThreshold": {
+                        "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded.\nDefaults to 3. Minimum value is 1.",
                         "format": "int32",
                         "type": "integer"
                       },
+                      "grpc": {
+                        "description": "GRPC specifies a GRPC HealthCheckRequest.",
+                        "properties": {
+                          "port": {
+                            "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "service": {
+                            "default": "",
+                            "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "port"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
                       "httpGet": {
+                        "description": "HTTPGet specifies an HTTP GET request to perform.",
                         "properties": {
                           "host": {
+                            "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
                             "type": "string"
                           },
                           "httpHeaders": {
+                            "description": "Custom headers to set in the request. HTTP allows repeated headers.",
                             "items": {
+                              "description": "HTTPHeader describes a custom header to be used in HTTP probes",
                               "properties": {
                                 "name": {
+                                  "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
                                   "type": "string"
                                 },
                                 "value": {
+                                  "description": "The header field value",
                                   "type": "string"
                                 }
                               },
@@ -4176,9 +6415,11 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "path": {
+                            "description": "Path to access on the HTTP server.",
                             "type": "string"
                           },
                           "port": {
@@ -4190,9 +6431,11 @@
                                 "type": "string"
                               }
                             ],
+                            "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
                             "x-kubernetes-int-or-string": true
                           },
                           "scheme": {
+                            "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
                             "type": "string"
                           }
                         },
@@ -4203,20 +6446,25 @@
                         "additionalProperties": false
                       },
                       "initialDelaySeconds": {
+                        "description": "Number of seconds after the container has started before liveness probes are initiated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
                         "format": "int32",
                         "type": "integer"
                       },
                       "periodSeconds": {
+                        "description": "How often (in seconds) to perform the probe.\nDefault to 10 seconds. Minimum value is 1.",
                         "format": "int32",
                         "type": "integer"
                       },
                       "successThreshold": {
+                        "description": "Minimum consecutive successes for the probe to be considered successful after having failed.\nDefaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
                         "format": "int32",
                         "type": "integer"
                       },
                       "tcpSocket": {
+                        "description": "TCPSocket specifies a connection to a TCP port.",
                         "properties": {
                           "host": {
+                            "description": "Optional: Host name to connect to, defaults to the pod IP.",
                             "type": "string"
                           },
                           "port": {
@@ -4228,6 +6476,7 @@
                                 "type": "string"
                               }
                             ],
+                            "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
                             "x-kubernetes-int-or-string": true
                           }
                         },
@@ -4237,7 +6486,13 @@
                         "type": "object",
                         "additionalProperties": false
                       },
+                      "terminationGracePeriodSeconds": {
+                        "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure.\nThe grace period is the duration in seconds after the processes running in the pod are sent\na termination signal and the time when the processes are forcibly halted with a kill signal.\nSet this value longer than the expected cleanup time for your process.\nIf this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this\nvalue overrides the value provided by the pod spec.\nValue must be non-negative integer. The value zero indicates stop immediately via\nthe kill signal (no opportunity to shut down).\nThis is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.\nMinimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+                        "format": "int64",
+                        "type": "integer"
+                      },
                       "timeoutSeconds": {
+                        "description": "Number of seconds after which the probe times out.\nDefaults to 1 second. Minimum value is 1.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
                         "format": "int32",
                         "type": "integer"
                       }
@@ -4246,32 +6501,40 @@
                     "additionalProperties": false
                   },
                   "name": {
+                    "description": "Name of the container specified as a DNS_LABEL.\nEach container in a pod must have a unique name (DNS_LABEL).\nCannot be updated.",
                     "type": "string"
                   },
                   "ports": {
+                    "description": "List of ports to expose from the container. Not specifying a port here\nDOES NOT prevent that port from being exposed. Any port which is\nlistening on the default \"0.0.0.0\" address inside a container will be\naccessible from the network.\nModifying this array with strategic merge patch may corrupt the data.\nFor more information See https://github.com/kubernetes/kubernetes/issues/108255.\nCannot be updated.",
                     "items": {
+                      "description": "ContainerPort represents a network port in a single container.",
                       "properties": {
                         "containerPort": {
+                          "description": "Number of port to expose on the pod's IP address.\nThis must be a valid port number, 0 < x < 65536.",
                           "format": "int32",
                           "type": "integer"
                         },
                         "hostIP": {
+                          "description": "What host IP to bind the external port to.",
                           "type": "string"
                         },
                         "hostPort": {
+                          "description": "Number of port to expose on the host.\nIf specified, this must be a valid port number, 0 < x < 65536.\nIf HostNetwork is specified, this must match ContainerPort.\nMost containers do not need this.",
                           "format": "int32",
                           "type": "integer"
                         },
                         "name": {
+                          "description": "If specified, this must be an IANA_SVC_NAME and unique within the pod. Each\nnamed port in a pod must have a unique name. Name for the port that can be\nreferred to by services.",
                           "type": "string"
                         },
                         "protocol": {
+                          "default": "TCP",
+                          "description": "Protocol for port. Must be UDP, TCP, or SCTP.\nDefaults to \"TCP\".",
                           "type": "string"
                         }
                       },
                       "required": [
-                        "containerPort",
-                        "protocol"
+                        "containerPort"
                       ],
                       "type": "object",
                       "additionalProperties": false
@@ -4284,35 +6547,66 @@
                     "x-kubernetes-list-type": "map"
                   },
                   "readinessProbe": {
+                    "description": "Periodic probe of container service readiness.\nContainer will be removed from service endpoints if the probe fails.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
                     "properties": {
                       "exec": {
+                        "description": "Exec specifies a command to execute in the container.",
                         "properties": {
                           "command": {
+                            "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
                             "items": {
                               "type": "string"
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           }
                         },
                         "type": "object",
                         "additionalProperties": false
                       },
                       "failureThreshold": {
+                        "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded.\nDefaults to 3. Minimum value is 1.",
                         "format": "int32",
                         "type": "integer"
                       },
+                      "grpc": {
+                        "description": "GRPC specifies a GRPC HealthCheckRequest.",
+                        "properties": {
+                          "port": {
+                            "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "service": {
+                            "default": "",
+                            "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "port"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
                       "httpGet": {
+                        "description": "HTTPGet specifies an HTTP GET request to perform.",
                         "properties": {
                           "host": {
+                            "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
                             "type": "string"
                           },
                           "httpHeaders": {
+                            "description": "Custom headers to set in the request. HTTP allows repeated headers.",
                             "items": {
+                              "description": "HTTPHeader describes a custom header to be used in HTTP probes",
                               "properties": {
                                 "name": {
+                                  "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
                                   "type": "string"
                                 },
                                 "value": {
+                                  "description": "The header field value",
                                   "type": "string"
                                 }
                               },
@@ -4323,9 +6617,11 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "path": {
+                            "description": "Path to access on the HTTP server.",
                             "type": "string"
                           },
                           "port": {
@@ -4337,9 +6633,11 @@
                                 "type": "string"
                               }
                             ],
+                            "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
                             "x-kubernetes-int-or-string": true
                           },
                           "scheme": {
+                            "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
                             "type": "string"
                           }
                         },
@@ -4350,20 +6648,25 @@
                         "additionalProperties": false
                       },
                       "initialDelaySeconds": {
+                        "description": "Number of seconds after the container has started before liveness probes are initiated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
                         "format": "int32",
                         "type": "integer"
                       },
                       "periodSeconds": {
+                        "description": "How often (in seconds) to perform the probe.\nDefault to 10 seconds. Minimum value is 1.",
                         "format": "int32",
                         "type": "integer"
                       },
                       "successThreshold": {
+                        "description": "Minimum consecutive successes for the probe to be considered successful after having failed.\nDefaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
                         "format": "int32",
                         "type": "integer"
                       },
                       "tcpSocket": {
+                        "description": "TCPSocket specifies a connection to a TCP port.",
                         "properties": {
                           "host": {
+                            "description": "Optional: Host name to connect to, defaults to the pod IP.",
                             "type": "string"
                           },
                           "port": {
@@ -4375,6 +6678,7 @@
                                 "type": "string"
                               }
                             ],
+                            "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
                             "x-kubernetes-int-or-string": true
                           }
                         },
@@ -4384,7 +6688,13 @@
                         "type": "object",
                         "additionalProperties": false
                       },
+                      "terminationGracePeriodSeconds": {
+                        "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure.\nThe grace period is the duration in seconds after the processes running in the pod are sent\na termination signal and the time when the processes are forcibly halted with a kill signal.\nSet this value longer than the expected cleanup time for your process.\nIf this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this\nvalue overrides the value provided by the pod spec.\nValue must be non-negative integer. The value zero indicates stop immediately via\nthe kill signal (no opportunity to shut down).\nThis is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.\nMinimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+                        "format": "int64",
+                        "type": "integer"
+                      },
                       "timeoutSeconds": {
+                        "description": "Number of seconds after which the probe times out.\nDefaults to 1 second. Minimum value is 1.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
                         "format": "int32",
                         "type": "integer"
                       }
@@ -4392,8 +6702,59 @@
                     "type": "object",
                     "additionalProperties": false
                   },
+                  "resizePolicy": {
+                    "description": "Resources resize policy for the container.",
+                    "items": {
+                      "description": "ContainerResizePolicy represents resource resize policy for the container.",
+                      "properties": {
+                        "resourceName": {
+                          "description": "Name of the resource to which this resource resize policy applies.\nSupported values: cpu, memory.",
+                          "type": "string"
+                        },
+                        "restartPolicy": {
+                          "description": "Restart policy to apply when specified resource is resized.\nIf not specified, it defaults to NotRequired.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "resourceName",
+                        "restartPolicy"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  },
                   "resources": {
+                    "description": "Compute Resources required by this container.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
                     "properties": {
+                      "claims": {
+                        "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
+                        "items": {
+                          "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                          "properties": {
+                            "name": {
+                              "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
+                              "type": "string"
+                            },
+                            "request": {
+                              "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-map-keys": [
+                          "name"
+                        ],
+                        "x-kubernetes-list-type": "map"
+                      },
                       "limits": {
                         "additionalProperties": {
                           "anyOf": [
@@ -4407,6 +6768,7 @@
                           "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                           "x-kubernetes-int-or-string": true
                         },
+                        "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
                         "type": "object"
                       },
                       "requests": {
@@ -4422,82 +6784,151 @@
                           "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                           "x-kubernetes-int-or-string": true
                         },
+                        "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
                         "type": "object"
                       }
                     },
                     "type": "object",
                     "additionalProperties": false
                   },
+                  "restartPolicy": {
+                    "description": "RestartPolicy defines the restart behavior of individual containers in a pod.\nThis field may only be set for init containers, and the only allowed value is \"Always\".\nFor non-init containers or when this field is not specified,\nthe restart behavior is defined by the Pod's restart policy and the container type.\nSetting the RestartPolicy as \"Always\" for the init container will have the following effect:\nthis init container will be continually restarted on\nexit until all regular containers have terminated. Once all regular\ncontainers have completed, all init containers with restartPolicy \"Always\"\nwill be shut down. This lifecycle differs from normal init containers and\nis often referred to as a \"sidecar\" container. Although this init\ncontainer still starts in the init container sequence, it does not wait\nfor the container to complete before proceeding to the next init\ncontainer. Instead, the next init container starts immediately after this\ninit container is started, or after any startupProbe has successfully\ncompleted.",
+                    "type": "string"
+                  },
                   "securityContext": {
+                    "description": "SecurityContext defines the security options the container should be run with.\nIf set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.\nMore info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/",
                     "properties": {
                       "allowPrivilegeEscalation": {
+                        "description": "AllowPrivilegeEscalation controls whether a process can gain more\nprivileges than its parent process. This bool directly controls if\nthe no_new_privs flag will be set on the container process.\nAllowPrivilegeEscalation is true always when the container is:\n1) run as Privileged\n2) has CAP_SYS_ADMIN\nNote that this field cannot be set when spec.os.name is windows.",
                         "type": "boolean"
                       },
+                      "appArmorProfile": {
+                        "description": "appArmorProfile is the AppArmor options to use by this container. If set, this profile\noverrides the pod's appArmorProfile.\nNote that this field cannot be set when spec.os.name is windows.",
+                        "properties": {
+                          "localhostProfile": {
+                            "description": "localhostProfile indicates a profile loaded on the node that should be used.\nThe profile must be preconfigured on the node to work.\nMust match the loaded name of the profile.\nMust be set if and only if type is \"Localhost\".",
+                            "type": "string"
+                          },
+                          "type": {
+                            "description": "type indicates which kind of AppArmor profile will be applied.\nValid options are:\n  Localhost - a profile pre-loaded on the node.\n  RuntimeDefault - the container runtime's default profile.\n  Unconfined - no AppArmor enforcement.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "type"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
                       "capabilities": {
+                        "description": "The capabilities to add/drop when running containers.\nDefaults to the default set of capabilities granted by the container runtime.\nNote that this field cannot be set when spec.os.name is windows.",
                         "properties": {
                           "add": {
+                            "description": "Added capabilities",
                             "items": {
+                              "description": "Capability represent POSIX capabilities type",
                               "type": "string"
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "drop": {
+                            "description": "Removed capabilities",
                             "items": {
+                              "description": "Capability represent POSIX capabilities type",
                               "type": "string"
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           }
                         },
                         "type": "object",
                         "additionalProperties": false
                       },
                       "privileged": {
+                        "description": "Run container in privileged mode.\nProcesses in privileged containers are essentially equivalent to root on the host.\nDefaults to false.\nNote that this field cannot be set when spec.os.name is windows.",
                         "type": "boolean"
                       },
                       "procMount": {
+                        "description": "procMount denotes the type of proc mount to use for the containers.\nThe default value is Default which uses the container runtime defaults for\nreadonly paths and masked paths.\nThis requires the ProcMountType feature flag to be enabled.\nNote that this field cannot be set when spec.os.name is windows.",
                         "type": "string"
                       },
                       "readOnlyRootFilesystem": {
+                        "description": "Whether this container has a read-only root filesystem.\nDefault is false.\nNote that this field cannot be set when spec.os.name is windows.",
                         "type": "boolean"
                       },
                       "runAsGroup": {
+                        "description": "The GID to run the entrypoint of the container process.\nUses runtime default if unset.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
                         "format": "int64",
                         "type": "integer"
                       },
                       "runAsNonRoot": {
+                        "description": "Indicates that the container must run as a non-root user.\nIf true, the Kubelet will validate the image at runtime to ensure that it\ndoes not run as UID 0 (root) and fail to start the container if it does.\nIf unset or false, no such validation will be performed.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
                         "type": "boolean"
                       },
                       "runAsUser": {
+                        "description": "The UID to run the entrypoint of the container process.\nDefaults to user specified in image metadata if unspecified.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
                         "format": "int64",
                         "type": "integer"
                       },
                       "seLinuxOptions": {
+                        "description": "The SELinux context to be applied to the container.\nIf unspecified, the container runtime will allocate a random SELinux context for each\ncontainer.  May also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
                         "properties": {
                           "level": {
+                            "description": "Level is SELinux level label that applies to the container.",
                             "type": "string"
                           },
                           "role": {
+                            "description": "Role is a SELinux role label that applies to the container.",
                             "type": "string"
                           },
                           "type": {
+                            "description": "Type is a SELinux type label that applies to the container.",
                             "type": "string"
                           },
                           "user": {
+                            "description": "User is a SELinux user label that applies to the container.",
                             "type": "string"
                           }
                         },
                         "type": "object",
                         "additionalProperties": false
                       },
+                      "seccompProfile": {
+                        "description": "The seccomp options to use by this container. If seccomp options are\nprovided at both the pod & container level, the container options\noverride the pod options.\nNote that this field cannot be set when spec.os.name is windows.",
+                        "properties": {
+                          "localhostProfile": {
+                            "description": "localhostProfile indicates a profile defined in a file on the node should be used.\nThe profile must be preconfigured on the node to work.\nMust be a descending path, relative to the kubelet's configured seccomp profile location.\nMust be set if type is \"Localhost\". Must NOT be set for any other type.",
+                            "type": "string"
+                          },
+                          "type": {
+                            "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "type"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
                       "windowsOptions": {
+                        "description": "The Windows specific settings applied to all containers.\nIf unspecified, the options from the PodSecurityContext will be used.\nIf set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is linux.",
                         "properties": {
                           "gmsaCredentialSpec": {
+                            "description": "GMSACredentialSpec is where the GMSA admission webhook\n(https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the\nGMSA credential spec named by the GMSACredentialSpecName field.",
                             "type": "string"
                           },
                           "gmsaCredentialSpecName": {
+                            "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
                             "type": "string"
                           },
+                          "hostProcess": {
+                            "description": "HostProcess determines if a container should be run as a 'Host Process' container.\nAll of a Pod's containers must have the same effective HostProcess value\n(it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).\nIn addition, if HostProcess is true then HostNetwork must also be set to true.",
+                            "type": "boolean"
+                          },
                           "runAsUserName": {
+                            "description": "The UserName in Windows to run the entrypoint of the container process.\nDefaults to the user specified in image metadata if unspecified.\nMay also be set in PodSecurityContext. If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
                             "type": "string"
                           }
                         },
@@ -4509,35 +6940,66 @@
                     "additionalProperties": false
                   },
                   "startupProbe": {
+                    "description": "StartupProbe indicates that the Pod has successfully initialized.\nIf specified, no other probes are executed until this completes successfully.\nIf this probe fails, the Pod will be restarted, just as if the livenessProbe failed.\nThis can be used to provide different probe parameters at the beginning of a Pod's lifecycle,\nwhen it might take a long time to load data or warm a cache, than during steady-state operation.\nThis cannot be updated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
                     "properties": {
                       "exec": {
+                        "description": "Exec specifies a command to execute in the container.",
                         "properties": {
                           "command": {
+                            "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
                             "items": {
                               "type": "string"
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           }
                         },
                         "type": "object",
                         "additionalProperties": false
                       },
                       "failureThreshold": {
+                        "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded.\nDefaults to 3. Minimum value is 1.",
                         "format": "int32",
                         "type": "integer"
                       },
+                      "grpc": {
+                        "description": "GRPC specifies a GRPC HealthCheckRequest.",
+                        "properties": {
+                          "port": {
+                            "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "service": {
+                            "default": "",
+                            "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "port"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
                       "httpGet": {
+                        "description": "HTTPGet specifies an HTTP GET request to perform.",
                         "properties": {
                           "host": {
+                            "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
                             "type": "string"
                           },
                           "httpHeaders": {
+                            "description": "Custom headers to set in the request. HTTP allows repeated headers.",
                             "items": {
+                              "description": "HTTPHeader describes a custom header to be used in HTTP probes",
                               "properties": {
                                 "name": {
+                                  "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
                                   "type": "string"
                                 },
                                 "value": {
+                                  "description": "The header field value",
                                   "type": "string"
                                 }
                               },
@@ -4548,9 +7010,11 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "path": {
+                            "description": "Path to access on the HTTP server.",
                             "type": "string"
                           },
                           "port": {
@@ -4562,9 +7026,11 @@
                                 "type": "string"
                               }
                             ],
+                            "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
                             "x-kubernetes-int-or-string": true
                           },
                           "scheme": {
+                            "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
                             "type": "string"
                           }
                         },
@@ -4575,20 +7041,25 @@
                         "additionalProperties": false
                       },
                       "initialDelaySeconds": {
+                        "description": "Number of seconds after the container has started before liveness probes are initiated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
                         "format": "int32",
                         "type": "integer"
                       },
                       "periodSeconds": {
+                        "description": "How often (in seconds) to perform the probe.\nDefault to 10 seconds. Minimum value is 1.",
                         "format": "int32",
                         "type": "integer"
                       },
                       "successThreshold": {
+                        "description": "Minimum consecutive successes for the probe to be considered successful after having failed.\nDefaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
                         "format": "int32",
                         "type": "integer"
                       },
                       "tcpSocket": {
+                        "description": "TCPSocket specifies a connection to a TCP port.",
                         "properties": {
                           "host": {
+                            "description": "Optional: Host name to connect to, defaults to the pod IP.",
                             "type": "string"
                           },
                           "port": {
@@ -4600,6 +7071,7 @@
                                 "type": "string"
                               }
                             ],
+                            "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
                             "x-kubernetes-int-or-string": true
                           }
                         },
@@ -4609,7 +7081,13 @@
                         "type": "object",
                         "additionalProperties": false
                       },
+                      "terminationGracePeriodSeconds": {
+                        "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure.\nThe grace period is the duration in seconds after the processes running in the pod are sent\na termination signal and the time when the processes are forcibly halted with a kill signal.\nSet this value longer than the expected cleanup time for your process.\nIf this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this\nvalue overrides the value provided by the pod spec.\nValue must be non-negative integer. The value zero indicates stop immediately via\nthe kill signal (no opportunity to shut down).\nThis is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.\nMinimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+                        "format": "int64",
+                        "type": "integer"
+                      },
                       "timeoutSeconds": {
+                        "description": "Number of seconds after which the probe times out.\nDefaults to 1 second. Minimum value is 1.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
                         "format": "int32",
                         "type": "integer"
                       }
@@ -4618,27 +7096,36 @@
                     "additionalProperties": false
                   },
                   "stdin": {
+                    "description": "Whether this container should allocate a buffer for stdin in the container runtime. If this\nis not set, reads from stdin in the container will always result in EOF.\nDefault is false.",
                     "type": "boolean"
                   },
                   "stdinOnce": {
+                    "description": "Whether the container runtime should close the stdin channel after it has been opened by\na single attach. When stdin is true the stdin stream will remain open across multiple attach\nsessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the\nfirst client attaches to stdin, and then remains open and accepts data until the client disconnects,\nat which time stdin is closed and remains closed until the container is restarted. If this\nflag is false, a container processes that reads from stdin will never receive an EOF.\nDefault is false",
                     "type": "boolean"
                   },
                   "terminationMessagePath": {
+                    "description": "Optional: Path at which the file to which the container's termination message\nwill be written is mounted into the container's filesystem.\nMessage written is intended to be brief final status, such as an assertion failure message.\nWill be truncated by the node if greater than 4096 bytes. The total message length across\nall containers will be limited to 12kb.\nDefaults to /dev/termination-log.\nCannot be updated.",
                     "type": "string"
                   },
                   "terminationMessagePolicy": {
+                    "description": "Indicate how the termination message should be populated. File will use the contents of\nterminationMessagePath to populate the container status message on both success and failure.\nFallbackToLogsOnError will use the last chunk of container log output if the termination\nmessage file is empty and the container exited with an error.\nThe log output is limited to 2048 bytes or 80 lines, whichever is smaller.\nDefaults to File.\nCannot be updated.",
                     "type": "string"
                   },
                   "tty": {
+                    "description": "Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.\nDefault is false.",
                     "type": "boolean"
                   },
                   "volumeDevices": {
+                    "description": "volumeDevices is the list of block devices to be used by the container.",
                     "items": {
+                      "description": "volumeDevice describes a mapping of a raw block device within a container.",
                       "properties": {
                         "devicePath": {
+                          "description": "devicePath is the path inside of the container that the device will be mapped to.",
                           "type": "string"
                         },
                         "name": {
+                          "description": "name must match the name of a persistentVolumeClaim in the pod",
                           "type": "string"
                         }
                       },
@@ -4649,27 +7136,43 @@
                       "type": "object",
                       "additionalProperties": false
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-map-keys": [
+                      "devicePath"
+                    ],
+                    "x-kubernetes-list-type": "map"
                   },
                   "volumeMounts": {
+                    "description": "Pod volumes to mount into the container's filesystem.\nCannot be updated.",
                     "items": {
+                      "description": "VolumeMount describes a mounting of a Volume within a container.",
                       "properties": {
                         "mountPath": {
+                          "description": "Path within the container at which the volume should be mounted.  Must\nnot contain ':'.",
                           "type": "string"
                         },
                         "mountPropagation": {
+                          "description": "mountPropagation determines how mounts are propagated from the host\nto container and the other way around.\nWhen not set, MountPropagationNone is used.\nThis field is beta in 1.10.\nWhen RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified\n(which defaults to None).",
                           "type": "string"
                         },
                         "name": {
+                          "description": "This must match the Name of a Volume.",
                           "type": "string"
                         },
                         "readOnly": {
+                          "description": "Mounted read-only if true, read-write otherwise (false or unspecified).\nDefaults to false.",
                           "type": "boolean"
                         },
+                        "recursiveReadOnly": {
+                          "description": "RecursiveReadOnly specifies whether read-only mounts should be handled\nrecursively.\n\nIf ReadOnly is false, this field has no meaning and must be unspecified.\n\nIf ReadOnly is true, and this field is set to Disabled, the mount is not made\nrecursively read-only.  If this field is set to IfPossible, the mount is made\nrecursively read-only, if it is supported by the container runtime.  If this\nfield is set to Enabled, the mount is made recursively read-only if it is\nsupported by the container runtime, otherwise the pod will not be started and\nan error will be generated to indicate the reason.\n\nIf this field is set to IfPossible or Enabled, MountPropagation must be set to\nNone (or be unspecified, which defaults to None).\n\nIf this field is not specified, it is treated as an equivalent of Disabled.",
+                          "type": "string"
+                        },
                         "subPath": {
+                          "description": "Path within the volume from which the container's volume should be mounted.\nDefaults to \"\" (volume's root).",
                           "type": "string"
                         },
                         "subPathExpr": {
+                          "description": "Expanded path within the volume from which the container's volume should be mounted.\nBehaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.\nDefaults to \"\" (volume's root).\nSubPathExpr and SubPath are mutually exclusive.",
                           "type": "string"
                         }
                       },
@@ -4680,9 +7183,14 @@
                       "type": "object",
                       "additionalProperties": false
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-map-keys": [
+                      "mountPath"
+                    ],
+                    "x-kubernetes-list-type": "map"
                   },
                   "workingDir": {
+                    "description": "Container's working directory.\nIf not specified, the container runtime's default will be used, which\nmight be configured in the container image.\nCannot be updated.",
                     "type": "string"
                   }
                 },
@@ -4695,80 +7203,399 @@
               "type": "array"
             },
             "instances": {
+              "description": "Instances is the number of executor instances.",
               "format": "int32",
               "minimum": 1,
               "type": "integer"
             },
             "javaOptions": {
+              "description": "JavaOptions is a string of extra JVM options to pass to the executors. For instance,\nGC settings or other logging.",
               "type": "string"
             },
             "labels": {
               "additionalProperties": {
                 "type": "string"
               },
+              "description": "Labels are the Kubernetes labels to be added to the pod.",
               "type": "object"
             },
+            "lifecycle": {
+              "description": "Lifecycle for running preStop or postStart commands",
+              "properties": {
+                "postStart": {
+                  "description": "PostStart is called immediately after a container is created. If the handler fails,\nthe container is terminated and restarted according to its restart policy.\nOther management of the container blocks until the hook completes.\nMore info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks",
+                  "properties": {
+                    "exec": {
+                      "description": "Exec specifies a command to execute in the container.",
+                      "properties": {
+                        "command": {
+                          "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array",
+                          "x-kubernetes-list-type": "atomic"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "httpGet": {
+                      "description": "HTTPGet specifies an HTTP GET request to perform.",
+                      "properties": {
+                        "host": {
+                          "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
+                          "type": "string"
+                        },
+                        "httpHeaders": {
+                          "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                          "items": {
+                            "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                            "properties": {
+                              "name": {
+                                "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                "type": "string"
+                              },
+                              "value": {
+                                "description": "The header field value",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name",
+                              "value"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array",
+                          "x-kubernetes-list-type": "atomic"
+                        },
+                        "path": {
+                          "description": "Path to access on the HTTP server.",
+                          "type": "string"
+                        },
+                        "port": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                          "x-kubernetes-int-or-string": true
+                        },
+                        "scheme": {
+                          "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "port"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "sleep": {
+                      "description": "Sleep represents a duration that the container should sleep.",
+                      "properties": {
+                        "seconds": {
+                          "description": "Seconds is the number of seconds to sleep.",
+                          "format": "int64",
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "seconds"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "tcpSocket": {
+                      "description": "Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept\nfor backward compatibility. There is no validation of this field and\nlifecycle hooks will fail at runtime when it is specified.",
+                      "properties": {
+                        "host": {
+                          "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                          "type": "string"
+                        },
+                        "port": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                          "x-kubernetes-int-or-string": true
+                        }
+                      },
+                      "required": [
+                        "port"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "preStop": {
+                  "description": "PreStop is called immediately before a container is terminated due to an\nAPI request or management event such as liveness/startup probe failure,\npreemption, resource contention, etc. The handler is not called if the\ncontainer crashes or exits. The Pod's termination grace period countdown begins before the\nPreStop hook is executed. Regardless of the outcome of the handler, the\ncontainer will eventually terminate within the Pod's termination grace\nperiod (unless delayed by finalizers). Other management of the container blocks until the hook completes\nor until the termination grace period is reached.\nMore info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks",
+                  "properties": {
+                    "exec": {
+                      "description": "Exec specifies a command to execute in the container.",
+                      "properties": {
+                        "command": {
+                          "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array",
+                          "x-kubernetes-list-type": "atomic"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "httpGet": {
+                      "description": "HTTPGet specifies an HTTP GET request to perform.",
+                      "properties": {
+                        "host": {
+                          "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
+                          "type": "string"
+                        },
+                        "httpHeaders": {
+                          "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                          "items": {
+                            "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                            "properties": {
+                              "name": {
+                                "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                "type": "string"
+                              },
+                              "value": {
+                                "description": "The header field value",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name",
+                              "value"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array",
+                          "x-kubernetes-list-type": "atomic"
+                        },
+                        "path": {
+                          "description": "Path to access on the HTTP server.",
+                          "type": "string"
+                        },
+                        "port": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                          "x-kubernetes-int-or-string": true
+                        },
+                        "scheme": {
+                          "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "port"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "sleep": {
+                      "description": "Sleep represents a duration that the container should sleep.",
+                      "properties": {
+                        "seconds": {
+                          "description": "Seconds is the number of seconds to sleep.",
+                          "format": "int64",
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "seconds"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "tcpSocket": {
+                      "description": "Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept\nfor backward compatibility. There is no validation of this field and\nlifecycle hooks will fail at runtime when it is specified.",
+                      "properties": {
+                        "host": {
+                          "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                          "type": "string"
+                        },
+                        "port": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                          "x-kubernetes-int-or-string": true
+                        }
+                      },
+                      "required": [
+                        "port"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
             "memory": {
+              "description": "Memory is the amount of memory to request for the pod.",
               "type": "string"
             },
             "memoryOverhead": {
+              "description": "MemoryOverhead is the amount of off-heap memory to allocate in cluster mode, in MiB unless otherwise specified.",
               "type": "string"
             },
             "nodeSelector": {
               "additionalProperties": {
                 "type": "string"
               },
+              "description": "NodeSelector is the Kubernetes node selector to be added to the driver and executor pods.\nThis field is mutually exclusive with nodeSelector at SparkApplication level (which will be deprecated).",
               "type": "object"
             },
             "podSecurityContext": {
+              "description": "PodSecurityContext specifies the PodSecurityContext to apply.",
               "properties": {
+                "appArmorProfile": {
+                  "description": "appArmorProfile is the AppArmor options to use by the containers in this pod.\nNote that this field cannot be set when spec.os.name is windows.",
+                  "properties": {
+                    "localhostProfile": {
+                      "description": "localhostProfile indicates a profile loaded on the node that should be used.\nThe profile must be preconfigured on the node to work.\nMust match the loaded name of the profile.\nMust be set if and only if type is \"Localhost\".",
+                      "type": "string"
+                    },
+                    "type": {
+                      "description": "type indicates which kind of AppArmor profile will be applied.\nValid options are:\n  Localhost - a profile pre-loaded on the node.\n  RuntimeDefault - the container runtime's default profile.\n  Unconfined - no AppArmor enforcement.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
                 "fsGroup": {
+                  "description": "A special supplemental group that applies to all containers in a pod.\nSome volume types allow the Kubelet to change the ownership of that volume\nto be owned by the pod:\n\n1. The owning GID will be the FSGroup\n2. The setgid bit is set (new files created in the volume will be owned by FSGroup)\n3. The permission bits are OR'd with rw-rw----\n\nIf unset, the Kubelet will not modify the ownership and permissions of any volume.\nNote that this field cannot be set when spec.os.name is windows.",
                   "format": "int64",
                   "type": "integer"
                 },
+                "fsGroupChangePolicy": {
+                  "description": "fsGroupChangePolicy defines behavior of changing ownership and permission of the volume\nbefore being exposed inside Pod. This field will only apply to\nvolume types which support fsGroup based ownership(and permissions).\nIt will have no effect on ephemeral volume types such as: secret, configmaps\nand emptydir.\nValid values are \"OnRootMismatch\" and \"Always\". If not specified, \"Always\" is used.\nNote that this field cannot be set when spec.os.name is windows.",
+                  "type": "string"
+                },
                 "runAsGroup": {
+                  "description": "The GID to run the entrypoint of the container process.\nUses runtime default if unset.\nMay also be set in SecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence\nfor that container.\nNote that this field cannot be set when spec.os.name is windows.",
                   "format": "int64",
                   "type": "integer"
                 },
                 "runAsNonRoot": {
+                  "description": "Indicates that the container must run as a non-root user.\nIf true, the Kubelet will validate the image at runtime to ensure that it\ndoes not run as UID 0 (root) and fail to start the container if it does.\nIf unset or false, no such validation will be performed.\nMay also be set in SecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
                   "type": "boolean"
                 },
                 "runAsUser": {
+                  "description": "The UID to run the entrypoint of the container process.\nDefaults to user specified in image metadata if unspecified.\nMay also be set in SecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence\nfor that container.\nNote that this field cannot be set when spec.os.name is windows.",
                   "format": "int64",
                   "type": "integer"
                 },
+                "seLinuxChangePolicy": {
+                  "description": "seLinuxChangePolicy defines how the container's SELinux label is applied to all volumes used by the Pod.\nIt has no effect on nodes that do not support SELinux or to volumes does not support SELinux.\nValid values are \"MountOption\" and \"Recursive\".\n\n\"Recursive\" means relabeling of all files on all Pod volumes by the container runtime.\nThis may be slow for large volumes, but allows mixing privileged and unprivileged Pods sharing the same volume on the same node.\n\n\"MountOption\" mounts all eligible Pod volumes with `-o context` mount option.\nThis requires all Pods that share the same volume to use the same SELinux label.\nIt is not possible to share the same volume among privileged and unprivileged Pods.\nEligible volumes are in-tree FibreChannel and iSCSI volumes, and all CSI volumes\nwhose CSI driver announces SELinux support by setting spec.seLinuxMount: true in their\nCSIDriver instance. Other volumes are always re-labelled recursively.\n\"MountOption\" value is allowed only when SELinuxMount feature gate is enabled.\n\nIf not specified and SELinuxMount feature gate is enabled, \"MountOption\" is used.\nIf not specified and SELinuxMount feature gate is disabled, \"MountOption\" is used for ReadWriteOncePod volumes\nand \"Recursive\" for all other volumes.\n\nThis field affects only Pods that have SELinux label set, either in PodSecurityContext or in SecurityContext of all containers.\n\nAll Pods that use the same volume should use the same seLinuxChangePolicy, otherwise some pods can get stuck in ContainerCreating state.\nNote that this field cannot be set when spec.os.name is windows.",
+                  "type": "string"
+                },
                 "seLinuxOptions": {
+                  "description": "The SELinux context to be applied to all containers.\nIf unspecified, the container runtime will allocate a random SELinux context for each\ncontainer.  May also be set in SecurityContext.  If set in\nboth SecurityContext and PodSecurityContext, the value specified in SecurityContext\ntakes precedence for that container.\nNote that this field cannot be set when spec.os.name is windows.",
                   "properties": {
                     "level": {
+                      "description": "Level is SELinux level label that applies to the container.",
                       "type": "string"
                     },
                     "role": {
+                      "description": "Role is a SELinux role label that applies to the container.",
                       "type": "string"
                     },
                     "type": {
+                      "description": "Type is a SELinux type label that applies to the container.",
                       "type": "string"
                     },
                     "user": {
+                      "description": "User is a SELinux user label that applies to the container.",
                       "type": "string"
                     }
                   },
                   "type": "object",
                   "additionalProperties": false
                 },
+                "seccompProfile": {
+                  "description": "The seccomp options to use by the containers in this pod.\nNote that this field cannot be set when spec.os.name is windows.",
+                  "properties": {
+                    "localhostProfile": {
+                      "description": "localhostProfile indicates a profile defined in a file on the node should be used.\nThe profile must be preconfigured on the node to work.\nMust be a descending path, relative to the kubelet's configured seccomp profile location.\nMust be set if type is \"Localhost\". Must NOT be set for any other type.",
+                      "type": "string"
+                    },
+                    "type": {
+                      "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
                 "supplementalGroups": {
+                  "description": "A list of groups applied to the first process run in each container, in\naddition to the container's primary GID and fsGroup (if specified).  If\nthe SupplementalGroupsPolicy feature is enabled, the\nsupplementalGroupsPolicy field determines whether these are in addition\nto or instead of any group memberships defined in the container image.\nIf unspecified, no additional groups are added, though group memberships\ndefined in the container image may still be used, depending on the\nsupplementalGroupsPolicy field.\nNote that this field cannot be set when spec.os.name is windows.",
                   "items": {
                     "format": "int64",
                     "type": "integer"
                   },
-                  "type": "array"
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                },
+                "supplementalGroupsPolicy": {
+                  "description": "Defines how supplemental groups of the first container processes are calculated.\nValid values are \"Merge\" and \"Strict\". If not specified, \"Merge\" is used.\n(Alpha) Using the field requires the SupplementalGroupsPolicy feature gate to be enabled\nand the container runtime must implement support for this feature.\nNote that this field cannot be set when spec.os.name is windows.",
+                  "type": "string"
                 },
                 "sysctls": {
+                  "description": "Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported\nsysctls (by the container runtime) might fail to launch.\nNote that this field cannot be set when spec.os.name is windows.",
                   "items": {
+                    "description": "Sysctl defines a kernel parameter to be set",
                     "properties": {
                       "name": {
+                        "description": "Name of a property to set",
                         "type": "string"
                       },
                       "value": {
+                        "description": "Value of a property to set",
                         "type": "string"
                       }
                     },
@@ -4779,17 +7606,26 @@
                     "type": "object",
                     "additionalProperties": false
                   },
-                  "type": "array"
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
                 },
                 "windowsOptions": {
+                  "description": "The Windows specific settings applied to all containers.\nIf unspecified, the options within a container's SecurityContext will be used.\nIf set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is linux.",
                   "properties": {
                     "gmsaCredentialSpec": {
+                      "description": "GMSACredentialSpec is where the GMSA admission webhook\n(https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the\nGMSA credential spec named by the GMSACredentialSpecName field.",
                       "type": "string"
                     },
                     "gmsaCredentialSpecName": {
+                      "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
                       "type": "string"
                     },
+                    "hostProcess": {
+                      "description": "HostProcess determines if a container should be run as a 'Host Process' container.\nAll of a Pod's containers must have the same effective HostProcess value\n(it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).\nIn addition, if HostProcess is true then HostNetwork must also be set to true.",
+                      "type": "boolean"
+                    },
                     "runAsUserName": {
+                      "description": "The UserName in Windows to run the entrypoint of the container process.\nDefaults to the user specified in image metadata if unspecified.\nMay also be set in PodSecurityContext. If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
                       "type": "string"
                     }
                   },
@@ -4800,11 +7636,44 @@
               "type": "object",
               "additionalProperties": false
             },
+            "ports": {
+              "description": "Ports settings for the pods, following the Kubernetes specifications.",
+              "items": {
+                "description": "Port represents the port definition in the pods objects.",
+                "properties": {
+                  "containerPort": {
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "protocol": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "containerPort",
+                  "name",
+                  "protocol"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "priorityClassName": {
+              "description": "PriorityClassName is the name of the PriorityClass for the executor pod.",
+              "type": "string"
+            },
             "schedulerName": {
+              "description": "SchedulerName specifies the scheduler that will be used for scheduling",
               "type": "string"
             },
             "secrets": {
+              "description": "Secrets carries information of secrets to add to the pod.",
               "items": {
+                "description": "SecretInfo captures information of a secret.",
                 "properties": {
                   "name": {
                     "type": "string"
@@ -4813,6 +7682,7 @@
                     "type": "string"
                   },
                   "secretType": {
+                    "description": "SecretType tells the type of a secret.",
                     "type": "string"
                   }
                 },
@@ -4827,75 +7697,139 @@
               "type": "array"
             },
             "securityContext": {
+              "description": "SecurityContext specifies the container's SecurityContext to apply.",
               "properties": {
                 "allowPrivilegeEscalation": {
+                  "description": "AllowPrivilegeEscalation controls whether a process can gain more\nprivileges than its parent process. This bool directly controls if\nthe no_new_privs flag will be set on the container process.\nAllowPrivilegeEscalation is true always when the container is:\n1) run as Privileged\n2) has CAP_SYS_ADMIN\nNote that this field cannot be set when spec.os.name is windows.",
                   "type": "boolean"
                 },
+                "appArmorProfile": {
+                  "description": "appArmorProfile is the AppArmor options to use by this container. If set, this profile\noverrides the pod's appArmorProfile.\nNote that this field cannot be set when spec.os.name is windows.",
+                  "properties": {
+                    "localhostProfile": {
+                      "description": "localhostProfile indicates a profile loaded on the node that should be used.\nThe profile must be preconfigured on the node to work.\nMust match the loaded name of the profile.\nMust be set if and only if type is \"Localhost\".",
+                      "type": "string"
+                    },
+                    "type": {
+                      "description": "type indicates which kind of AppArmor profile will be applied.\nValid options are:\n  Localhost - a profile pre-loaded on the node.\n  RuntimeDefault - the container runtime's default profile.\n  Unconfined - no AppArmor enforcement.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
                 "capabilities": {
+                  "description": "The capabilities to add/drop when running containers.\nDefaults to the default set of capabilities granted by the container runtime.\nNote that this field cannot be set when spec.os.name is windows.",
                   "properties": {
                     "add": {
+                      "description": "Added capabilities",
                       "items": {
+                        "description": "Capability represent POSIX capabilities type",
                         "type": "string"
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     },
                     "drop": {
+                      "description": "Removed capabilities",
                       "items": {
+                        "description": "Capability represent POSIX capabilities type",
                         "type": "string"
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     }
                   },
                   "type": "object",
                   "additionalProperties": false
                 },
                 "privileged": {
+                  "description": "Run container in privileged mode.\nProcesses in privileged containers are essentially equivalent to root on the host.\nDefaults to false.\nNote that this field cannot be set when spec.os.name is windows.",
                   "type": "boolean"
                 },
                 "procMount": {
+                  "description": "procMount denotes the type of proc mount to use for the containers.\nThe default value is Default which uses the container runtime defaults for\nreadonly paths and masked paths.\nThis requires the ProcMountType feature flag to be enabled.\nNote that this field cannot be set when spec.os.name is windows.",
                   "type": "string"
                 },
                 "readOnlyRootFilesystem": {
+                  "description": "Whether this container has a read-only root filesystem.\nDefault is false.\nNote that this field cannot be set when spec.os.name is windows.",
                   "type": "boolean"
                 },
                 "runAsGroup": {
+                  "description": "The GID to run the entrypoint of the container process.\nUses runtime default if unset.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
                   "format": "int64",
                   "type": "integer"
                 },
                 "runAsNonRoot": {
+                  "description": "Indicates that the container must run as a non-root user.\nIf true, the Kubelet will validate the image at runtime to ensure that it\ndoes not run as UID 0 (root) and fail to start the container if it does.\nIf unset or false, no such validation will be performed.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
                   "type": "boolean"
                 },
                 "runAsUser": {
+                  "description": "The UID to run the entrypoint of the container process.\nDefaults to user specified in image metadata if unspecified.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
                   "format": "int64",
                   "type": "integer"
                 },
                 "seLinuxOptions": {
+                  "description": "The SELinux context to be applied to the container.\nIf unspecified, the container runtime will allocate a random SELinux context for each\ncontainer.  May also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
                   "properties": {
                     "level": {
+                      "description": "Level is SELinux level label that applies to the container.",
                       "type": "string"
                     },
                     "role": {
+                      "description": "Role is a SELinux role label that applies to the container.",
                       "type": "string"
                     },
                     "type": {
+                      "description": "Type is a SELinux type label that applies to the container.",
                       "type": "string"
                     },
                     "user": {
+                      "description": "User is a SELinux user label that applies to the container.",
                       "type": "string"
                     }
                   },
                   "type": "object",
                   "additionalProperties": false
                 },
+                "seccompProfile": {
+                  "description": "The seccomp options to use by this container. If seccomp options are\nprovided at both the pod & container level, the container options\noverride the pod options.\nNote that this field cannot be set when spec.os.name is windows.",
+                  "properties": {
+                    "localhostProfile": {
+                      "description": "localhostProfile indicates a profile defined in a file on the node should be used.\nThe profile must be preconfigured on the node to work.\nMust be a descending path, relative to the kubelet's configured seccomp profile location.\nMust be set if type is \"Localhost\". Must NOT be set for any other type.",
+                      "type": "string"
+                    },
+                    "type": {
+                      "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
                 "windowsOptions": {
+                  "description": "The Windows specific settings applied to all containers.\nIf unspecified, the options from the PodSecurityContext will be used.\nIf set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is linux.",
                   "properties": {
                     "gmsaCredentialSpec": {
+                      "description": "GMSACredentialSpec is where the GMSA admission webhook\n(https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the\nGMSA credential spec named by the GMSACredentialSpecName field.",
                       "type": "string"
                     },
                     "gmsaCredentialSpecName": {
+                      "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
                       "type": "string"
                     },
+                    "hostProcess": {
+                      "description": "HostProcess determines if a container should be run as a 'Host Process' container.\nAll of a Pod's containers must have the same effective HostProcess value\n(it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).\nIn addition, if HostProcess is true then HostNetwork must also be set to true.",
+                      "type": "boolean"
+                    },
                     "runAsUserName": {
+                      "description": "The UserName in Windows to run the entrypoint of the container process.\nDefaults to the user specified in image metadata if unspecified.\nMay also be set in PodSecurityContext. If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
                       "type": "string"
                     }
                   },
@@ -4907,46 +7841,64 @@
               "additionalProperties": false
             },
             "serviceAccount": {
+              "description": "ServiceAccount is the name of the custom Kubernetes service account used by the pod.",
               "type": "string"
             },
             "shareProcessNamespace": {
+              "description": "ShareProcessNamespace settings for the pod, following the Kubernetes specifications.",
               "type": "boolean"
             },
             "sidecars": {
+              "description": "Sidecars is a list of sidecar containers that run along side the main Spark container.",
               "items": {
+                "description": "A single application container that you want to run within a pod.",
                 "properties": {
                   "args": {
+                    "description": "Arguments to the entrypoint.\nThe container image's CMD is used if this is not provided.\nVariable references $(VAR_NAME) are expanded using the container's environment. If a variable\ncannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will\nproduce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless\nof whether the variable exists or not. Cannot be updated.\nMore info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
                     "items": {
                       "type": "string"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   },
                   "command": {
+                    "description": "Entrypoint array. Not executed within a shell.\nThe container image's ENTRYPOINT is used if this is not provided.\nVariable references $(VAR_NAME) are expanded using the container's environment. If a variable\ncannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will\nproduce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless\nof whether the variable exists or not. Cannot be updated.\nMore info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
                     "items": {
                       "type": "string"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   },
                   "env": {
+                    "description": "List of environment variables to set in the container.\nCannot be updated.",
                     "items": {
+                      "description": "EnvVar represents an environment variable present in a Container.",
                       "properties": {
                         "name": {
+                          "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
                           "type": "string"
                         },
                         "value": {
+                          "description": "Variable references $(VAR_NAME) are expanded\nusing the previously defined environment variables in the container and\nany service environment variables. If a variable cannot be resolved,\nthe reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.\n\"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\".\nEscaped references will never be expanded, regardless of whether the variable\nexists or not.\nDefaults to \"\".",
                           "type": "string"
                         },
                         "valueFrom": {
+                          "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
                           "properties": {
                             "configMapKeyRef": {
+                              "description": "Selects a key of a ConfigMap.",
                               "properties": {
                                 "key": {
+                                  "description": "The key to select.",
                                   "type": "string"
                                 },
                                 "name": {
+                                  "default": "",
+                                  "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                   "type": "string"
                                 },
                                 "optional": {
+                                  "description": "Specify whether the ConfigMap or its key must be defined",
                                   "type": "boolean"
                                 }
                               },
@@ -4954,14 +7906,18 @@
                                 "key"
                               ],
                               "type": "object",
+                              "x-kubernetes-map-type": "atomic",
                               "additionalProperties": false
                             },
                             "fieldRef": {
+                              "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,\nspec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
                               "properties": {
                                 "apiVersion": {
+                                  "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
                                   "type": "string"
                                 },
                                 "fieldPath": {
+                                  "description": "Path of the field to select in the specified API version.",
                                   "type": "string"
                                 }
                               },
@@ -4969,11 +7925,14 @@
                                 "fieldPath"
                               ],
                               "type": "object",
+                              "x-kubernetes-map-type": "atomic",
                               "additionalProperties": false
                             },
                             "resourceFieldRef": {
+                              "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
                               "properties": {
                                 "containerName": {
+                                  "description": "Container name: required for volumes, optional for env vars",
                                   "type": "string"
                                 },
                                 "divisor": {
@@ -4985,10 +7944,12 @@
                                       "type": "string"
                                     }
                                   ],
+                                  "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
                                   "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                                   "x-kubernetes-int-or-string": true
                                 },
                                 "resource": {
+                                  "description": "Required: resource to select",
                                   "type": "string"
                                 }
                               },
@@ -4996,17 +7957,23 @@
                                 "resource"
                               ],
                               "type": "object",
+                              "x-kubernetes-map-type": "atomic",
                               "additionalProperties": false
                             },
                             "secretKeyRef": {
+                              "description": "Selects a key of a secret in the pod's namespace",
                               "properties": {
                                 "key": {
+                                  "description": "The key of the secret to select from.  Must be a valid secret key.",
                                   "type": "string"
                                 },
                                 "name": {
+                                  "default": "",
+                                  "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                   "type": "string"
                                 },
                                 "optional": {
+                                  "description": "Specify whether the Secret or its key must be defined",
                                   "type": "boolean"
                                 }
                               },
@@ -5014,6 +7981,7 @@
                                 "key"
                               ],
                               "type": "object",
+                              "x-kubernetes-map-type": "atomic",
                               "additionalProperties": false
                             }
                           },
@@ -5027,78 +7995,109 @@
                       "type": "object",
                       "additionalProperties": false
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-map-keys": [
+                      "name"
+                    ],
+                    "x-kubernetes-list-type": "map"
                   },
                   "envFrom": {
+                    "description": "List of sources to populate environment variables in the container.\nThe keys defined within a source must be a C_IDENTIFIER. All invalid keys\nwill be reported as an event when the container is starting. When a key exists in multiple\nsources, the value associated with the last source will take precedence.\nValues defined by an Env with a duplicate key will take precedence.\nCannot be updated.",
                     "items": {
+                      "description": "EnvFromSource represents the source of a set of ConfigMaps",
                       "properties": {
                         "configMapRef": {
+                          "description": "The ConfigMap to select from",
                           "properties": {
                             "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                               "type": "string"
                             },
                             "optional": {
+                              "description": "Specify whether the ConfigMap must be defined",
                               "type": "boolean"
                             }
                           },
                           "type": "object",
+                          "x-kubernetes-map-type": "atomic",
                           "additionalProperties": false
                         },
                         "prefix": {
+                          "description": "An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.",
                           "type": "string"
                         },
                         "secretRef": {
+                          "description": "The Secret to select from",
                           "properties": {
                             "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                               "type": "string"
                             },
                             "optional": {
+                              "description": "Specify whether the Secret must be defined",
                               "type": "boolean"
                             }
                           },
                           "type": "object",
+                          "x-kubernetes-map-type": "atomic",
                           "additionalProperties": false
                         }
                       },
                       "type": "object",
                       "additionalProperties": false
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   },
                   "image": {
+                    "description": "Container image name.\nMore info: https://kubernetes.io/docs/concepts/containers/images\nThis field is optional to allow higher level config management to default or override\ncontainer images in workload controllers like Deployments and StatefulSets.",
                     "type": "string"
                   },
                   "imagePullPolicy": {
+                    "description": "Image pull policy.\nOne of Always, Never, IfNotPresent.\nDefaults to Always if :latest tag is specified, or IfNotPresent otherwise.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/containers/images#updating-images",
                     "type": "string"
                   },
                   "lifecycle": {
+                    "description": "Actions that the management system should take in response to container lifecycle events.\nCannot be updated.",
                     "properties": {
                       "postStart": {
+                        "description": "PostStart is called immediately after a container is created. If the handler fails,\nthe container is terminated and restarted according to its restart policy.\nOther management of the container blocks until the hook completes.\nMore info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks",
                         "properties": {
                           "exec": {
+                            "description": "Exec specifies a command to execute in the container.",
                             "properties": {
                               "command": {
+                                "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
                                 "items": {
                                   "type": "string"
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               }
                             },
                             "type": "object",
                             "additionalProperties": false
                           },
                           "httpGet": {
+                            "description": "HTTPGet specifies an HTTP GET request to perform.",
                             "properties": {
                               "host": {
+                                "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
                                 "type": "string"
                               },
                               "httpHeaders": {
+                                "description": "Custom headers to set in the request. HTTP allows repeated headers.",
                                 "items": {
+                                  "description": "HTTPHeader describes a custom header to be used in HTTP probes",
                                   "properties": {
                                     "name": {
+                                      "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
                                       "type": "string"
                                     },
                                     "value": {
+                                      "description": "The header field value",
                                       "type": "string"
                                     }
                                   },
@@ -5109,9 +8108,11 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "path": {
+                                "description": "Path to access on the HTTP server.",
                                 "type": "string"
                               },
                               "port": {
@@ -5123,9 +8124,11 @@
                                     "type": "string"
                                   }
                                 ],
+                                "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
                                 "x-kubernetes-int-or-string": true
                               },
                               "scheme": {
+                                "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
                                 "type": "string"
                               }
                             },
@@ -5135,9 +8138,26 @@
                             "type": "object",
                             "additionalProperties": false
                           },
+                          "sleep": {
+                            "description": "Sleep represents a duration that the container should sleep.",
+                            "properties": {
+                              "seconds": {
+                                "description": "Seconds is the number of seconds to sleep.",
+                                "format": "int64",
+                                "type": "integer"
+                              }
+                            },
+                            "required": [
+                              "seconds"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
                           "tcpSocket": {
+                            "description": "Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept\nfor backward compatibility. There is no validation of this field and\nlifecycle hooks will fail at runtime when it is specified.",
                             "properties": {
                               "host": {
+                                "description": "Optional: Host name to connect to, defaults to the pod IP.",
                                 "type": "string"
                               },
                               "port": {
@@ -5149,6 +8169,7 @@
                                     "type": "string"
                                   }
                                 ],
+                                "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
                                 "x-kubernetes-int-or-string": true
                               }
                             },
@@ -5163,31 +8184,41 @@
                         "additionalProperties": false
                       },
                       "preStop": {
+                        "description": "PreStop is called immediately before a container is terminated due to an\nAPI request or management event such as liveness/startup probe failure,\npreemption, resource contention, etc. The handler is not called if the\ncontainer crashes or exits. The Pod's termination grace period countdown begins before the\nPreStop hook is executed. Regardless of the outcome of the handler, the\ncontainer will eventually terminate within the Pod's termination grace\nperiod (unless delayed by finalizers). Other management of the container blocks until the hook completes\nor until the termination grace period is reached.\nMore info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks",
                         "properties": {
                           "exec": {
+                            "description": "Exec specifies a command to execute in the container.",
                             "properties": {
                               "command": {
+                                "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
                                 "items": {
                                   "type": "string"
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               }
                             },
                             "type": "object",
                             "additionalProperties": false
                           },
                           "httpGet": {
+                            "description": "HTTPGet specifies an HTTP GET request to perform.",
                             "properties": {
                               "host": {
+                                "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
                                 "type": "string"
                               },
                               "httpHeaders": {
+                                "description": "Custom headers to set in the request. HTTP allows repeated headers.",
                                 "items": {
+                                  "description": "HTTPHeader describes a custom header to be used in HTTP probes",
                                   "properties": {
                                     "name": {
+                                      "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
                                       "type": "string"
                                     },
                                     "value": {
+                                      "description": "The header field value",
                                       "type": "string"
                                     }
                                   },
@@ -5198,9 +8229,11 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "path": {
+                                "description": "Path to access on the HTTP server.",
                                 "type": "string"
                               },
                               "port": {
@@ -5212,9 +8245,11 @@
                                     "type": "string"
                                   }
                                 ],
+                                "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
                                 "x-kubernetes-int-or-string": true
                               },
                               "scheme": {
+                                "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
                                 "type": "string"
                               }
                             },
@@ -5224,9 +8259,26 @@
                             "type": "object",
                             "additionalProperties": false
                           },
+                          "sleep": {
+                            "description": "Sleep represents a duration that the container should sleep.",
+                            "properties": {
+                              "seconds": {
+                                "description": "Seconds is the number of seconds to sleep.",
+                                "format": "int64",
+                                "type": "integer"
+                              }
+                            },
+                            "required": [
+                              "seconds"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
                           "tcpSocket": {
+                            "description": "Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept\nfor backward compatibility. There is no validation of this field and\nlifecycle hooks will fail at runtime when it is specified.",
                             "properties": {
                               "host": {
+                                "description": "Optional: Host name to connect to, defaults to the pod IP.",
                                 "type": "string"
                               },
                               "port": {
@@ -5238,6 +8290,7 @@
                                     "type": "string"
                                   }
                                 ],
+                                "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
                                 "x-kubernetes-int-or-string": true
                               }
                             },
@@ -5256,35 +8309,66 @@
                     "additionalProperties": false
                   },
                   "livenessProbe": {
+                    "description": "Periodic probe of container liveness.\nContainer will be restarted if the probe fails.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
                     "properties": {
                       "exec": {
+                        "description": "Exec specifies a command to execute in the container.",
                         "properties": {
                           "command": {
+                            "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
                             "items": {
                               "type": "string"
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           }
                         },
                         "type": "object",
                         "additionalProperties": false
                       },
                       "failureThreshold": {
+                        "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded.\nDefaults to 3. Minimum value is 1.",
                         "format": "int32",
                         "type": "integer"
                       },
+                      "grpc": {
+                        "description": "GRPC specifies a GRPC HealthCheckRequest.",
+                        "properties": {
+                          "port": {
+                            "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "service": {
+                            "default": "",
+                            "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "port"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
                       "httpGet": {
+                        "description": "HTTPGet specifies an HTTP GET request to perform.",
                         "properties": {
                           "host": {
+                            "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
                             "type": "string"
                           },
                           "httpHeaders": {
+                            "description": "Custom headers to set in the request. HTTP allows repeated headers.",
                             "items": {
+                              "description": "HTTPHeader describes a custom header to be used in HTTP probes",
                               "properties": {
                                 "name": {
+                                  "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
                                   "type": "string"
                                 },
                                 "value": {
+                                  "description": "The header field value",
                                   "type": "string"
                                 }
                               },
@@ -5295,9 +8379,11 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "path": {
+                            "description": "Path to access on the HTTP server.",
                             "type": "string"
                           },
                           "port": {
@@ -5309,9 +8395,11 @@
                                 "type": "string"
                               }
                             ],
+                            "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
                             "x-kubernetes-int-or-string": true
                           },
                           "scheme": {
+                            "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
                             "type": "string"
                           }
                         },
@@ -5322,20 +8410,25 @@
                         "additionalProperties": false
                       },
                       "initialDelaySeconds": {
+                        "description": "Number of seconds after the container has started before liveness probes are initiated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
                         "format": "int32",
                         "type": "integer"
                       },
                       "periodSeconds": {
+                        "description": "How often (in seconds) to perform the probe.\nDefault to 10 seconds. Minimum value is 1.",
                         "format": "int32",
                         "type": "integer"
                       },
                       "successThreshold": {
+                        "description": "Minimum consecutive successes for the probe to be considered successful after having failed.\nDefaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
                         "format": "int32",
                         "type": "integer"
                       },
                       "tcpSocket": {
+                        "description": "TCPSocket specifies a connection to a TCP port.",
                         "properties": {
                           "host": {
+                            "description": "Optional: Host name to connect to, defaults to the pod IP.",
                             "type": "string"
                           },
                           "port": {
@@ -5347,6 +8440,7 @@
                                 "type": "string"
                               }
                             ],
+                            "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
                             "x-kubernetes-int-or-string": true
                           }
                         },
@@ -5356,7 +8450,13 @@
                         "type": "object",
                         "additionalProperties": false
                       },
+                      "terminationGracePeriodSeconds": {
+                        "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure.\nThe grace period is the duration in seconds after the processes running in the pod are sent\na termination signal and the time when the processes are forcibly halted with a kill signal.\nSet this value longer than the expected cleanup time for your process.\nIf this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this\nvalue overrides the value provided by the pod spec.\nValue must be non-negative integer. The value zero indicates stop immediately via\nthe kill signal (no opportunity to shut down).\nThis is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.\nMinimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+                        "format": "int64",
+                        "type": "integer"
+                      },
                       "timeoutSeconds": {
+                        "description": "Number of seconds after which the probe times out.\nDefaults to 1 second. Minimum value is 1.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
                         "format": "int32",
                         "type": "integer"
                       }
@@ -5365,32 +8465,40 @@
                     "additionalProperties": false
                   },
                   "name": {
+                    "description": "Name of the container specified as a DNS_LABEL.\nEach container in a pod must have a unique name (DNS_LABEL).\nCannot be updated.",
                     "type": "string"
                   },
                   "ports": {
+                    "description": "List of ports to expose from the container. Not specifying a port here\nDOES NOT prevent that port from being exposed. Any port which is\nlistening on the default \"0.0.0.0\" address inside a container will be\naccessible from the network.\nModifying this array with strategic merge patch may corrupt the data.\nFor more information See https://github.com/kubernetes/kubernetes/issues/108255.\nCannot be updated.",
                     "items": {
+                      "description": "ContainerPort represents a network port in a single container.",
                       "properties": {
                         "containerPort": {
+                          "description": "Number of port to expose on the pod's IP address.\nThis must be a valid port number, 0 < x < 65536.",
                           "format": "int32",
                           "type": "integer"
                         },
                         "hostIP": {
+                          "description": "What host IP to bind the external port to.",
                           "type": "string"
                         },
                         "hostPort": {
+                          "description": "Number of port to expose on the host.\nIf specified, this must be a valid port number, 0 < x < 65536.\nIf HostNetwork is specified, this must match ContainerPort.\nMost containers do not need this.",
                           "format": "int32",
                           "type": "integer"
                         },
                         "name": {
+                          "description": "If specified, this must be an IANA_SVC_NAME and unique within the pod. Each\nnamed port in a pod must have a unique name. Name for the port that can be\nreferred to by services.",
                           "type": "string"
                         },
                         "protocol": {
+                          "default": "TCP",
+                          "description": "Protocol for port. Must be UDP, TCP, or SCTP.\nDefaults to \"TCP\".",
                           "type": "string"
                         }
                       },
                       "required": [
-                        "containerPort",
-                        "protocol"
+                        "containerPort"
                       ],
                       "type": "object",
                       "additionalProperties": false
@@ -5403,35 +8511,66 @@
                     "x-kubernetes-list-type": "map"
                   },
                   "readinessProbe": {
+                    "description": "Periodic probe of container service readiness.\nContainer will be removed from service endpoints if the probe fails.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
                     "properties": {
                       "exec": {
+                        "description": "Exec specifies a command to execute in the container.",
                         "properties": {
                           "command": {
+                            "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
                             "items": {
                               "type": "string"
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           }
                         },
                         "type": "object",
                         "additionalProperties": false
                       },
                       "failureThreshold": {
+                        "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded.\nDefaults to 3. Minimum value is 1.",
                         "format": "int32",
                         "type": "integer"
                       },
+                      "grpc": {
+                        "description": "GRPC specifies a GRPC HealthCheckRequest.",
+                        "properties": {
+                          "port": {
+                            "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "service": {
+                            "default": "",
+                            "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "port"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
                       "httpGet": {
+                        "description": "HTTPGet specifies an HTTP GET request to perform.",
                         "properties": {
                           "host": {
+                            "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
                             "type": "string"
                           },
                           "httpHeaders": {
+                            "description": "Custom headers to set in the request. HTTP allows repeated headers.",
                             "items": {
+                              "description": "HTTPHeader describes a custom header to be used in HTTP probes",
                               "properties": {
                                 "name": {
+                                  "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
                                   "type": "string"
                                 },
                                 "value": {
+                                  "description": "The header field value",
                                   "type": "string"
                                 }
                               },
@@ -5442,9 +8581,11 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "path": {
+                            "description": "Path to access on the HTTP server.",
                             "type": "string"
                           },
                           "port": {
@@ -5456,9 +8597,11 @@
                                 "type": "string"
                               }
                             ],
+                            "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
                             "x-kubernetes-int-or-string": true
                           },
                           "scheme": {
+                            "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
                             "type": "string"
                           }
                         },
@@ -5469,20 +8612,25 @@
                         "additionalProperties": false
                       },
                       "initialDelaySeconds": {
+                        "description": "Number of seconds after the container has started before liveness probes are initiated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
                         "format": "int32",
                         "type": "integer"
                       },
                       "periodSeconds": {
+                        "description": "How often (in seconds) to perform the probe.\nDefault to 10 seconds. Minimum value is 1.",
                         "format": "int32",
                         "type": "integer"
                       },
                       "successThreshold": {
+                        "description": "Minimum consecutive successes for the probe to be considered successful after having failed.\nDefaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
                         "format": "int32",
                         "type": "integer"
                       },
                       "tcpSocket": {
+                        "description": "TCPSocket specifies a connection to a TCP port.",
                         "properties": {
                           "host": {
+                            "description": "Optional: Host name to connect to, defaults to the pod IP.",
                             "type": "string"
                           },
                           "port": {
@@ -5494,6 +8642,7 @@
                                 "type": "string"
                               }
                             ],
+                            "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
                             "x-kubernetes-int-or-string": true
                           }
                         },
@@ -5503,7 +8652,13 @@
                         "type": "object",
                         "additionalProperties": false
                       },
+                      "terminationGracePeriodSeconds": {
+                        "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure.\nThe grace period is the duration in seconds after the processes running in the pod are sent\na termination signal and the time when the processes are forcibly halted with a kill signal.\nSet this value longer than the expected cleanup time for your process.\nIf this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this\nvalue overrides the value provided by the pod spec.\nValue must be non-negative integer. The value zero indicates stop immediately via\nthe kill signal (no opportunity to shut down).\nThis is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.\nMinimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+                        "format": "int64",
+                        "type": "integer"
+                      },
                       "timeoutSeconds": {
+                        "description": "Number of seconds after which the probe times out.\nDefaults to 1 second. Minimum value is 1.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
                         "format": "int32",
                         "type": "integer"
                       }
@@ -5511,8 +8666,59 @@
                     "type": "object",
                     "additionalProperties": false
                   },
+                  "resizePolicy": {
+                    "description": "Resources resize policy for the container.",
+                    "items": {
+                      "description": "ContainerResizePolicy represents resource resize policy for the container.",
+                      "properties": {
+                        "resourceName": {
+                          "description": "Name of the resource to which this resource resize policy applies.\nSupported values: cpu, memory.",
+                          "type": "string"
+                        },
+                        "restartPolicy": {
+                          "description": "Restart policy to apply when specified resource is resized.\nIf not specified, it defaults to NotRequired.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "resourceName",
+                        "restartPolicy"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  },
                   "resources": {
+                    "description": "Compute Resources required by this container.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
                     "properties": {
+                      "claims": {
+                        "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
+                        "items": {
+                          "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                          "properties": {
+                            "name": {
+                              "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
+                              "type": "string"
+                            },
+                            "request": {
+                              "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-map-keys": [
+                          "name"
+                        ],
+                        "x-kubernetes-list-type": "map"
+                      },
                       "limits": {
                         "additionalProperties": {
                           "anyOf": [
@@ -5526,6 +8732,7 @@
                           "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                           "x-kubernetes-int-or-string": true
                         },
+                        "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
                         "type": "object"
                       },
                       "requests": {
@@ -5541,82 +8748,151 @@
                           "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                           "x-kubernetes-int-or-string": true
                         },
+                        "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
                         "type": "object"
                       }
                     },
                     "type": "object",
                     "additionalProperties": false
                   },
+                  "restartPolicy": {
+                    "description": "RestartPolicy defines the restart behavior of individual containers in a pod.\nThis field may only be set for init containers, and the only allowed value is \"Always\".\nFor non-init containers or when this field is not specified,\nthe restart behavior is defined by the Pod's restart policy and the container type.\nSetting the RestartPolicy as \"Always\" for the init container will have the following effect:\nthis init container will be continually restarted on\nexit until all regular containers have terminated. Once all regular\ncontainers have completed, all init containers with restartPolicy \"Always\"\nwill be shut down. This lifecycle differs from normal init containers and\nis often referred to as a \"sidecar\" container. Although this init\ncontainer still starts in the init container sequence, it does not wait\nfor the container to complete before proceeding to the next init\ncontainer. Instead, the next init container starts immediately after this\ninit container is started, or after any startupProbe has successfully\ncompleted.",
+                    "type": "string"
+                  },
                   "securityContext": {
+                    "description": "SecurityContext defines the security options the container should be run with.\nIf set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.\nMore info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/",
                     "properties": {
                       "allowPrivilegeEscalation": {
+                        "description": "AllowPrivilegeEscalation controls whether a process can gain more\nprivileges than its parent process. This bool directly controls if\nthe no_new_privs flag will be set on the container process.\nAllowPrivilegeEscalation is true always when the container is:\n1) run as Privileged\n2) has CAP_SYS_ADMIN\nNote that this field cannot be set when spec.os.name is windows.",
                         "type": "boolean"
                       },
+                      "appArmorProfile": {
+                        "description": "appArmorProfile is the AppArmor options to use by this container. If set, this profile\noverrides the pod's appArmorProfile.\nNote that this field cannot be set when spec.os.name is windows.",
+                        "properties": {
+                          "localhostProfile": {
+                            "description": "localhostProfile indicates a profile loaded on the node that should be used.\nThe profile must be preconfigured on the node to work.\nMust match the loaded name of the profile.\nMust be set if and only if type is \"Localhost\".",
+                            "type": "string"
+                          },
+                          "type": {
+                            "description": "type indicates which kind of AppArmor profile will be applied.\nValid options are:\n  Localhost - a profile pre-loaded on the node.\n  RuntimeDefault - the container runtime's default profile.\n  Unconfined - no AppArmor enforcement.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "type"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
                       "capabilities": {
+                        "description": "The capabilities to add/drop when running containers.\nDefaults to the default set of capabilities granted by the container runtime.\nNote that this field cannot be set when spec.os.name is windows.",
                         "properties": {
                           "add": {
+                            "description": "Added capabilities",
                             "items": {
+                              "description": "Capability represent POSIX capabilities type",
                               "type": "string"
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "drop": {
+                            "description": "Removed capabilities",
                             "items": {
+                              "description": "Capability represent POSIX capabilities type",
                               "type": "string"
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           }
                         },
                         "type": "object",
                         "additionalProperties": false
                       },
                       "privileged": {
+                        "description": "Run container in privileged mode.\nProcesses in privileged containers are essentially equivalent to root on the host.\nDefaults to false.\nNote that this field cannot be set when spec.os.name is windows.",
                         "type": "boolean"
                       },
                       "procMount": {
+                        "description": "procMount denotes the type of proc mount to use for the containers.\nThe default value is Default which uses the container runtime defaults for\nreadonly paths and masked paths.\nThis requires the ProcMountType feature flag to be enabled.\nNote that this field cannot be set when spec.os.name is windows.",
                         "type": "string"
                       },
                       "readOnlyRootFilesystem": {
+                        "description": "Whether this container has a read-only root filesystem.\nDefault is false.\nNote that this field cannot be set when spec.os.name is windows.",
                         "type": "boolean"
                       },
                       "runAsGroup": {
+                        "description": "The GID to run the entrypoint of the container process.\nUses runtime default if unset.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
                         "format": "int64",
                         "type": "integer"
                       },
                       "runAsNonRoot": {
+                        "description": "Indicates that the container must run as a non-root user.\nIf true, the Kubelet will validate the image at runtime to ensure that it\ndoes not run as UID 0 (root) and fail to start the container if it does.\nIf unset or false, no such validation will be performed.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
                         "type": "boolean"
                       },
                       "runAsUser": {
+                        "description": "The UID to run the entrypoint of the container process.\nDefaults to user specified in image metadata if unspecified.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
                         "format": "int64",
                         "type": "integer"
                       },
                       "seLinuxOptions": {
+                        "description": "The SELinux context to be applied to the container.\nIf unspecified, the container runtime will allocate a random SELinux context for each\ncontainer.  May also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
                         "properties": {
                           "level": {
+                            "description": "Level is SELinux level label that applies to the container.",
                             "type": "string"
                           },
                           "role": {
+                            "description": "Role is a SELinux role label that applies to the container.",
                             "type": "string"
                           },
                           "type": {
+                            "description": "Type is a SELinux type label that applies to the container.",
                             "type": "string"
                           },
                           "user": {
+                            "description": "User is a SELinux user label that applies to the container.",
                             "type": "string"
                           }
                         },
                         "type": "object",
                         "additionalProperties": false
                       },
+                      "seccompProfile": {
+                        "description": "The seccomp options to use by this container. If seccomp options are\nprovided at both the pod & container level, the container options\noverride the pod options.\nNote that this field cannot be set when spec.os.name is windows.",
+                        "properties": {
+                          "localhostProfile": {
+                            "description": "localhostProfile indicates a profile defined in a file on the node should be used.\nThe profile must be preconfigured on the node to work.\nMust be a descending path, relative to the kubelet's configured seccomp profile location.\nMust be set if type is \"Localhost\". Must NOT be set for any other type.",
+                            "type": "string"
+                          },
+                          "type": {
+                            "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "type"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
                       "windowsOptions": {
+                        "description": "The Windows specific settings applied to all containers.\nIf unspecified, the options from the PodSecurityContext will be used.\nIf set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is linux.",
                         "properties": {
                           "gmsaCredentialSpec": {
+                            "description": "GMSACredentialSpec is where the GMSA admission webhook\n(https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the\nGMSA credential spec named by the GMSACredentialSpecName field.",
                             "type": "string"
                           },
                           "gmsaCredentialSpecName": {
+                            "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
                             "type": "string"
                           },
+                          "hostProcess": {
+                            "description": "HostProcess determines if a container should be run as a 'Host Process' container.\nAll of a Pod's containers must have the same effective HostProcess value\n(it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).\nIn addition, if HostProcess is true then HostNetwork must also be set to true.",
+                            "type": "boolean"
+                          },
                           "runAsUserName": {
+                            "description": "The UserName in Windows to run the entrypoint of the container process.\nDefaults to the user specified in image metadata if unspecified.\nMay also be set in PodSecurityContext. If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
                             "type": "string"
                           }
                         },
@@ -5628,35 +8904,66 @@
                     "additionalProperties": false
                   },
                   "startupProbe": {
+                    "description": "StartupProbe indicates that the Pod has successfully initialized.\nIf specified, no other probes are executed until this completes successfully.\nIf this probe fails, the Pod will be restarted, just as if the livenessProbe failed.\nThis can be used to provide different probe parameters at the beginning of a Pod's lifecycle,\nwhen it might take a long time to load data or warm a cache, than during steady-state operation.\nThis cannot be updated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
                     "properties": {
                       "exec": {
+                        "description": "Exec specifies a command to execute in the container.",
                         "properties": {
                           "command": {
+                            "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
                             "items": {
                               "type": "string"
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           }
                         },
                         "type": "object",
                         "additionalProperties": false
                       },
                       "failureThreshold": {
+                        "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded.\nDefaults to 3. Minimum value is 1.",
                         "format": "int32",
                         "type": "integer"
                       },
+                      "grpc": {
+                        "description": "GRPC specifies a GRPC HealthCheckRequest.",
+                        "properties": {
+                          "port": {
+                            "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "service": {
+                            "default": "",
+                            "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "port"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
                       "httpGet": {
+                        "description": "HTTPGet specifies an HTTP GET request to perform.",
                         "properties": {
                           "host": {
+                            "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
                             "type": "string"
                           },
                           "httpHeaders": {
+                            "description": "Custom headers to set in the request. HTTP allows repeated headers.",
                             "items": {
+                              "description": "HTTPHeader describes a custom header to be used in HTTP probes",
                               "properties": {
                                 "name": {
+                                  "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
                                   "type": "string"
                                 },
                                 "value": {
+                                  "description": "The header field value",
                                   "type": "string"
                                 }
                               },
@@ -5667,9 +8974,11 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "path": {
+                            "description": "Path to access on the HTTP server.",
                             "type": "string"
                           },
                           "port": {
@@ -5681,9 +8990,11 @@
                                 "type": "string"
                               }
                             ],
+                            "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
                             "x-kubernetes-int-or-string": true
                           },
                           "scheme": {
+                            "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
                             "type": "string"
                           }
                         },
@@ -5694,20 +9005,25 @@
                         "additionalProperties": false
                       },
                       "initialDelaySeconds": {
+                        "description": "Number of seconds after the container has started before liveness probes are initiated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
                         "format": "int32",
                         "type": "integer"
                       },
                       "periodSeconds": {
+                        "description": "How often (in seconds) to perform the probe.\nDefault to 10 seconds. Minimum value is 1.",
                         "format": "int32",
                         "type": "integer"
                       },
                       "successThreshold": {
+                        "description": "Minimum consecutive successes for the probe to be considered successful after having failed.\nDefaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
                         "format": "int32",
                         "type": "integer"
                       },
                       "tcpSocket": {
+                        "description": "TCPSocket specifies a connection to a TCP port.",
                         "properties": {
                           "host": {
+                            "description": "Optional: Host name to connect to, defaults to the pod IP.",
                             "type": "string"
                           },
                           "port": {
@@ -5719,6 +9035,7 @@
                                 "type": "string"
                               }
                             ],
+                            "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
                             "x-kubernetes-int-or-string": true
                           }
                         },
@@ -5728,7 +9045,13 @@
                         "type": "object",
                         "additionalProperties": false
                       },
+                      "terminationGracePeriodSeconds": {
+                        "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure.\nThe grace period is the duration in seconds after the processes running in the pod are sent\na termination signal and the time when the processes are forcibly halted with a kill signal.\nSet this value longer than the expected cleanup time for your process.\nIf this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this\nvalue overrides the value provided by the pod spec.\nValue must be non-negative integer. The value zero indicates stop immediately via\nthe kill signal (no opportunity to shut down).\nThis is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.\nMinimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+                        "format": "int64",
+                        "type": "integer"
+                      },
                       "timeoutSeconds": {
+                        "description": "Number of seconds after which the probe times out.\nDefaults to 1 second. Minimum value is 1.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
                         "format": "int32",
                         "type": "integer"
                       }
@@ -5737,27 +9060,36 @@
                     "additionalProperties": false
                   },
                   "stdin": {
+                    "description": "Whether this container should allocate a buffer for stdin in the container runtime. If this\nis not set, reads from stdin in the container will always result in EOF.\nDefault is false.",
                     "type": "boolean"
                   },
                   "stdinOnce": {
+                    "description": "Whether the container runtime should close the stdin channel after it has been opened by\na single attach. When stdin is true the stdin stream will remain open across multiple attach\nsessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the\nfirst client attaches to stdin, and then remains open and accepts data until the client disconnects,\nat which time stdin is closed and remains closed until the container is restarted. If this\nflag is false, a container processes that reads from stdin will never receive an EOF.\nDefault is false",
                     "type": "boolean"
                   },
                   "terminationMessagePath": {
+                    "description": "Optional: Path at which the file to which the container's termination message\nwill be written is mounted into the container's filesystem.\nMessage written is intended to be brief final status, such as an assertion failure message.\nWill be truncated by the node if greater than 4096 bytes. The total message length across\nall containers will be limited to 12kb.\nDefaults to /dev/termination-log.\nCannot be updated.",
                     "type": "string"
                   },
                   "terminationMessagePolicy": {
+                    "description": "Indicate how the termination message should be populated. File will use the contents of\nterminationMessagePath to populate the container status message on both success and failure.\nFallbackToLogsOnError will use the last chunk of container log output if the termination\nmessage file is empty and the container exited with an error.\nThe log output is limited to 2048 bytes or 80 lines, whichever is smaller.\nDefaults to File.\nCannot be updated.",
                     "type": "string"
                   },
                   "tty": {
+                    "description": "Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.\nDefault is false.",
                     "type": "boolean"
                   },
                   "volumeDevices": {
+                    "description": "volumeDevices is the list of block devices to be used by the container.",
                     "items": {
+                      "description": "volumeDevice describes a mapping of a raw block device within a container.",
                       "properties": {
                         "devicePath": {
+                          "description": "devicePath is the path inside of the container that the device will be mapped to.",
                           "type": "string"
                         },
                         "name": {
+                          "description": "name must match the name of a persistentVolumeClaim in the pod",
                           "type": "string"
                         }
                       },
@@ -5768,27 +9100,43 @@
                       "type": "object",
                       "additionalProperties": false
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-map-keys": [
+                      "devicePath"
+                    ],
+                    "x-kubernetes-list-type": "map"
                   },
                   "volumeMounts": {
+                    "description": "Pod volumes to mount into the container's filesystem.\nCannot be updated.",
                     "items": {
+                      "description": "VolumeMount describes a mounting of a Volume within a container.",
                       "properties": {
                         "mountPath": {
+                          "description": "Path within the container at which the volume should be mounted.  Must\nnot contain ':'.",
                           "type": "string"
                         },
                         "mountPropagation": {
+                          "description": "mountPropagation determines how mounts are propagated from the host\nto container and the other way around.\nWhen not set, MountPropagationNone is used.\nThis field is beta in 1.10.\nWhen RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified\n(which defaults to None).",
                           "type": "string"
                         },
                         "name": {
+                          "description": "This must match the Name of a Volume.",
                           "type": "string"
                         },
                         "readOnly": {
+                          "description": "Mounted read-only if true, read-write otherwise (false or unspecified).\nDefaults to false.",
                           "type": "boolean"
                         },
+                        "recursiveReadOnly": {
+                          "description": "RecursiveReadOnly specifies whether read-only mounts should be handled\nrecursively.\n\nIf ReadOnly is false, this field has no meaning and must be unspecified.\n\nIf ReadOnly is true, and this field is set to Disabled, the mount is not made\nrecursively read-only.  If this field is set to IfPossible, the mount is made\nrecursively read-only, if it is supported by the container runtime.  If this\nfield is set to Enabled, the mount is made recursively read-only if it is\nsupported by the container runtime, otherwise the pod will not be started and\nan error will be generated to indicate the reason.\n\nIf this field is set to IfPossible or Enabled, MountPropagation must be set to\nNone (or be unspecified, which defaults to None).\n\nIf this field is not specified, it is treated as an equivalent of Disabled.",
+                          "type": "string"
+                        },
                         "subPath": {
+                          "description": "Path within the volume from which the container's volume should be mounted.\nDefaults to \"\" (volume's root).",
                           "type": "string"
                         },
                         "subPathExpr": {
+                          "description": "Expanded path within the volume from which the container's volume should be mounted.\nBehaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.\nDefaults to \"\" (volume's root).\nSubPathExpr and SubPath are mutually exclusive.",
                           "type": "string"
                         }
                       },
@@ -5799,9 +9147,14 @@
                       "type": "object",
                       "additionalProperties": false
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-map-keys": [
+                      "mountPath"
+                    ],
+                    "x-kubernetes-list-type": "map"
                   },
                   "workingDir": {
+                    "description": "Container's working directory.\nIf not specified, the container runtime's default will be used, which\nmight be configured in the container image.\nCannot be updated.",
                     "type": "string"
                   }
                 },
@@ -5813,27 +9166,40 @@
               },
               "type": "array"
             },
+            "template": {
+              "description": "Template is a pod template that can be used to define the driver or executor pod configurations that Spark configurations do not support.\nSpark version >= 3.0.0 is required.\nRef: https://spark.apache.org/docs/latest/running-on-kubernetes.html#pod-template.",
+              "type": "object",
+              "x-kubernetes-preserve-unknown-fields": true
+            },
             "terminationGracePeriodSeconds": {
+              "description": "Termination grace period seconds for the pod",
               "format": "int64",
               "type": "integer"
             },
             "tolerations": {
+              "description": "Tolerations specifies the tolerations listed in \".spec.tolerations\" to be applied to the pod.",
               "items": {
+                "description": "The pod this Toleration is attached to tolerates any taint that matches\nthe triple <key,value,effect> using the matching operator <operator>.",
                 "properties": {
                   "effect": {
+                    "description": "Effect indicates the taint effect to match. Empty means match all taint effects.\nWhen specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
                     "type": "string"
                   },
                   "key": {
+                    "description": "Key is the taint key that the toleration applies to. Empty means match all taint keys.\nIf the key is empty, operator must be Exists; this combination means to match all values and all keys.",
                     "type": "string"
                   },
                   "operator": {
+                    "description": "Operator represents a key's relationship to the value.\nValid operators are Exists and Equal. Defaults to Equal.\nExists is equivalent to wildcard for value, so that a pod can\ntolerate all taints of a particular category.",
                     "type": "string"
                   },
                   "tolerationSeconds": {
+                    "description": "TolerationSeconds represents the period of time the toleration (which must be\nof effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,\nit is not set, which means tolerate the taint forever (do not evict). Zero and\nnegative values will be treated as 0 (evict immediately) by the system.",
                     "format": "int64",
                     "type": "integer"
                   },
                   "value": {
+                    "description": "Value is the taint value the toleration matches to.\nIf the operator is Exists, the value should be empty, otherwise just a regular string.",
                     "type": "string"
                   }
                 },
@@ -5843,24 +9209,36 @@
               "type": "array"
             },
             "volumeMounts": {
+              "description": "VolumeMounts specifies the volumes listed in \".spec.volumes\" to mount into the main container's filesystem.",
               "items": {
+                "description": "VolumeMount describes a mounting of a Volume within a container.",
                 "properties": {
                   "mountPath": {
+                    "description": "Path within the container at which the volume should be mounted.  Must\nnot contain ':'.",
                     "type": "string"
                   },
                   "mountPropagation": {
+                    "description": "mountPropagation determines how mounts are propagated from the host\nto container and the other way around.\nWhen not set, MountPropagationNone is used.\nThis field is beta in 1.10.\nWhen RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified\n(which defaults to None).",
                     "type": "string"
                   },
                   "name": {
+                    "description": "This must match the Name of a Volume.",
                     "type": "string"
                   },
                   "readOnly": {
+                    "description": "Mounted read-only if true, read-write otherwise (false or unspecified).\nDefaults to false.",
                     "type": "boolean"
                   },
+                  "recursiveReadOnly": {
+                    "description": "RecursiveReadOnly specifies whether read-only mounts should be handled\nrecursively.\n\nIf ReadOnly is false, this field has no meaning and must be unspecified.\n\nIf ReadOnly is true, and this field is set to Disabled, the mount is not made\nrecursively read-only.  If this field is set to IfPossible, the mount is made\nrecursively read-only, if it is supported by the container runtime.  If this\nfield is set to Enabled, the mount is made recursively read-only if it is\nsupported by the container runtime, otherwise the pod will not be started and\nan error will be generated to indicate the reason.\n\nIf this field is set to IfPossible or Enabled, MountPropagation must be set to\nNone (or be unspecified, which defaults to None).\n\nIf this field is not specified, it is treated as an equivalent of Disabled.",
+                    "type": "string"
+                  },
                   "subPath": {
+                    "description": "Path within the volume from which the container's volume should be mounted.\nDefaults to \"\" (volume's root).",
                     "type": "string"
                   },
                   "subPathExpr": {
+                    "description": "Expanded path within the volume from which the container's volume should be mounted.\nBehaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.\nDefaults to \"\" (volume's root).\nSubPathExpr and SubPath are mutually exclusive.",
                     "type": "string"
                   }
                 },
@@ -5878,6 +9256,7 @@
           "additionalProperties": false
         },
         "failureRetries": {
+          "description": "FailureRetries is the number of times to retry a failed application before giving up.\nThis is best effort and actual retry attempts can be >= the value specified.",
           "format": "int32",
           "type": "integer"
         },
@@ -5885,33 +9264,42 @@
           "additionalProperties": {
             "type": "string"
           },
+          "description": "HadoopConf carries user-specified Hadoop configuration properties as they would use the \"--conf\" option\nin spark-submit. The SparkApplication controller automatically adds prefix \"spark.hadoop.\" to Hadoop\nconfiguration properties.",
           "type": "object"
         },
         "hadoopConfigMap": {
+          "description": "HadoopConfigMap carries the name of the ConfigMap containing Hadoop configuration files such as core-site.xml.\nThe controller will add environment variable HADOOP_CONF_DIR to the path where the ConfigMap is mounted to.",
           "type": "string"
         },
         "image": {
+          "description": "Image is the container image for the driver, executor, and init-container. Any custom container images for the\ndriver, executor, or init-container takes precedence over this.",
           "type": "string"
         },
         "imagePullPolicy": {
+          "description": "ImagePullPolicy is the image pull policy for the driver, executor, and init-container.",
           "type": "string"
         },
         "imagePullSecrets": {
+          "description": "ImagePullSecrets is the list of image-pull secrets.",
           "items": {
             "type": "string"
           },
           "type": "array"
         },
         "mainApplicationFile": {
+          "description": "MainFile is the path to a bundled JAR, Python, or R file of the application.",
           "type": "string"
         },
         "mainClass": {
+          "description": "MainClass is the fully-qualified main class of the Spark application.\nThis only applies to Java/Scala Spark applications.",
           "type": "string"
         },
         "memoryOverheadFactor": {
+          "description": "This sets the Memory Overhead Factor that will allocate memory to non-JVM memory.\nFor JVM-based jobs this value will default to 0.10, for non-JVM jobs 0.40. Value of this field will\nbe overridden by `Spec.Driver.MemoryOverhead` and `Spec.Executor.MemoryOverhead` if they are set.",
           "type": "string"
         },
         "mode": {
+          "description": "Mode is the deployment mode of the Spark application.",
           "enum": [
             "cluster",
             "client"
@@ -5919,37 +9307,48 @@
           "type": "string"
         },
         "monitoring": {
+          "description": "Monitoring configures how monitoring is handled.",
           "properties": {
             "exposeDriverMetrics": {
+              "description": "ExposeDriverMetrics specifies whether to expose metrics on the driver.",
               "type": "boolean"
             },
             "exposeExecutorMetrics": {
+              "description": "ExposeExecutorMetrics specifies whether to expose metrics on the executors.",
               "type": "boolean"
             },
             "metricsProperties": {
+              "description": "MetricsProperties is the content of a custom metrics.properties for configuring the Spark metric system.\nIf not specified, the content in spark-docker/conf/metrics.properties will be used.",
               "type": "string"
             },
             "metricsPropertiesFile": {
+              "description": "MetricsPropertiesFile is the container local path of file metrics.properties for configuring\nthe Spark metric system. If not specified, value /etc/metrics/conf/metrics.properties will be used.",
               "type": "string"
             },
             "prometheus": {
+              "description": "Prometheus is for configuring the Prometheus JMX exporter.",
               "properties": {
                 "configFile": {
+                  "description": "ConfigFile is the path to the custom Prometheus configuration file provided in the Spark image.\nConfigFile takes precedence over Configuration, which is shown below.",
                   "type": "string"
                 },
                 "configuration": {
+                  "description": "Configuration is the content of the Prometheus configuration needed by the Prometheus JMX exporter.\nIf not specified, the content in spark-docker/conf/prometheus.yaml will be used.\nConfiguration has no effect if ConfigFile is set.",
                   "type": "string"
                 },
                 "jmxExporterJar": {
+                  "description": "JmxExporterJar is the path to the Prometheus JMX exporter jar in the container.",
                   "type": "string"
                 },
                 "port": {
+                  "description": "Port is the port of the HTTP server run by the Prometheus JMX exporter.\nIf not specified, 8090 will be used as the default.",
                   "format": "int32",
                   "maximum": 49151,
                   "minimum": 1024,
                   "type": "integer"
                 },
                 "portName": {
+                  "description": "PortName is the port name of prometheus JMX exporter port.\nIf not specified, jmx-exporter will be used as the default.",
                   "type": "string"
                 }
               },
@@ -5971,12 +9370,15 @@
           "additionalProperties": {
             "type": "string"
           },
+          "description": "NodeSelector is the Kubernetes node selector to be added to the driver and executor pods.\nThis field is mutually exclusive with nodeSelector at podSpec level (driver or executor).\nThis field will be deprecated in future versions (at SparkApplicationSpec level).",
           "type": "object"
         },
         "proxyUser": {
+          "description": "ProxyUser specifies the user to impersonate when submitting the application.\nIt maps to the command-line flag \"--proxy-user\" in spark-submit.",
           "type": "string"
         },
         "pythonVersion": {
+          "description": "This sets the major Python version of the docker\nimage used to run the driver and executor containers. Can either be 2 or 3, default 2.",
           "enum": [
             "2",
             "3"
@@ -5984,28 +9386,34 @@
           "type": "string"
         },
         "restartPolicy": {
+          "description": "RestartPolicy defines the policy on if and in which conditions the controller should restart an application.",
           "properties": {
             "onFailureRetries": {
+              "description": "OnFailureRetries the number of times to retry running an application before giving up.",
               "format": "int32",
               "minimum": 0,
               "type": "integer"
             },
             "onFailureRetryInterval": {
+              "description": "OnFailureRetryInterval is the interval in seconds between retries on failed runs.",
               "format": "int64",
               "minimum": 1,
               "type": "integer"
             },
             "onSubmissionFailureRetries": {
+              "description": "OnSubmissionFailureRetries is the number of times to retry submitting an application before giving up.\nThis is best effort and actual retry attempts can be >= the value specified due to caching.\nThese are required if RestartPolicy is OnFailure.",
               "format": "int32",
               "minimum": 0,
               "type": "integer"
             },
             "onSubmissionFailureRetryInterval": {
+              "description": "OnSubmissionFailureRetryInterval is the interval in seconds between retries on failed submissions.",
               "format": "int64",
               "minimum": 1,
               "type": "integer"
             },
             "type": {
+              "description": "Type specifies the RestartPolicyType.",
               "enum": [
                 "Never",
                 "Always",
@@ -6018,6 +9426,7 @@
           "additionalProperties": false
         },
         "retryInterval": {
+          "description": "RetryInterval is the unit of intervals in seconds between submission retries.",
           "format": "int64",
           "type": "integer"
         },
@@ -6025,29 +9434,38 @@
           "additionalProperties": {
             "type": "string"
           },
+          "description": "SparkConf carries user-specified Spark configuration properties as they would use the  \"--conf\" option in\nspark-submit.",
           "type": "object"
         },
         "sparkConfigMap": {
+          "description": "SparkConfigMap carries the name of the ConfigMap containing Spark configuration files such as log4j.properties.\nThe controller will add environment variable SPARK_CONF_DIR to the path where the ConfigMap is mounted to.",
           "type": "string"
         },
         "sparkUIOptions": {
+          "description": "SparkUIOptions allows configuring the Service and the Ingress to expose the sparkUI",
           "properties": {
             "ingressAnnotations": {
               "additionalProperties": {
                 "type": "string"
               },
+              "description": "IngressAnnotations is a map of key,value pairs of annotations that might be added to the ingress object. i.e. specify nginx as ingress.class",
               "type": "object"
             },
             "ingressTLS": {
+              "description": "TlsHosts is useful If we need to declare SSL certificates to the ingress object",
               "items": {
+                "description": "IngressTLS describes the transport layer security associated with an ingress.",
                 "properties": {
                   "hosts": {
+                    "description": "hosts is a list of hosts included in the TLS certificate. The values in\nthis list must match the name/s used in the tlsSecret. Defaults to the\nwildcard host setting for the loadbalancer controller fulfilling this\nIngress, if left unspecified.",
                     "items": {
                       "type": "string"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   },
                   "secretName": {
+                    "description": "secretName is the name of the secret used to terminate TLS traffic on\nport 443. Field is left optional to allow TLS routing based on SNI\nhostname alone. If the SNI host in a listener conflicts with the \"Host\"\nheader field used by an IngressRule, the SNI host is used for termination\nand value of the \"Host\" header is used for routing.",
                     "type": "string"
                   }
                 },
@@ -6060,16 +9478,27 @@
               "additionalProperties": {
                 "type": "string"
               },
+              "description": "ServiceAnnotations is a map of key,value pairs of annotations that might be added to the service object.",
+              "type": "object"
+            },
+            "serviceLabels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "ServiceLabels is a map of key,value pairs of labels that might be added to the service object.",
               "type": "object"
             },
             "servicePort": {
+              "description": "ServicePort allows configuring the port at service level that might be different from the targetPort.\nTargetPort should be the same as the one defined in spark.ui.port",
               "format": "int32",
               "type": "integer"
             },
             "servicePortName": {
+              "description": "ServicePortName allows configuring the name of the service port.\nThis may be useful for sidecar proxies like Envoy injected by Istio which require specific ports names to treat traffic as proper HTTP.\nDefaults to spark-driver-ui-port.",
               "type": "string"
             },
             "serviceType": {
+              "description": "ServiceType allows configuring the type of the service. Defaults to ClusterIP.",
               "type": "string"
             }
           },
@@ -6077,13 +9506,16 @@
           "additionalProperties": false
         },
         "sparkVersion": {
+          "description": "SparkVersion is the version of Spark the application uses.",
           "type": "string"
         },
         "timeToLiveSeconds": {
+          "description": "TimeToLiveSeconds defines the Time-To-Live (TTL) duration in seconds for this SparkApplication\nafter its termination.\nThe SparkApplication object will be garbage collected if the current time is more than the\nTimeToLiveSeconds since its termination.",
           "format": "int64",
           "type": "integer"
         },
         "type": {
+          "description": "Type tells the type of the Spark application.",
           "enum": [
             "Java",
             "Python",
@@ -6093,21 +9525,28 @@
           "type": "string"
         },
         "volumes": {
+          "description": "Volumes is the list of Kubernetes volumes that can be mounted by the driver and/or executors.",
           "items": {
+            "description": "Volume represents a named volume in a pod that may be accessed by any container in the pod.",
             "properties": {
               "awsElasticBlockStore": {
+                "description": "awsElasticBlockStore represents an AWS Disk resource that is attached to a\nkubelet's host machine and then exposed to the pod.\nDeprecated: AWSElasticBlockStore is deprecated. All operations for the in-tree\nawsElasticBlockStore type are redirected to the ebs.csi.aws.com CSI driver.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
                 "properties": {
                   "fsType": {
+                    "description": "fsType is the filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
                     "type": "string"
                   },
                   "partition": {
+                    "description": "partition is the partition in the volume that you want to mount.\nIf omitted, the default is to mount by volume name.\nExamples: For volume /dev/sda1, you specify the partition as \"1\".\nSimilarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty).",
                     "format": "int32",
                     "type": "integer"
                   },
                   "readOnly": {
+                    "description": "readOnly value true will force the readOnly setting in VolumeMounts.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
                     "type": "boolean"
                   },
                   "volumeID": {
+                    "description": "volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
                     "type": "string"
                   }
                 },
@@ -6118,23 +9557,32 @@
                 "additionalProperties": false
               },
               "azureDisk": {
+                "description": "azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.\nDeprecated: AzureDisk is deprecated. All operations for the in-tree azureDisk type\nare redirected to the disk.csi.azure.com CSI driver.",
                 "properties": {
                   "cachingMode": {
+                    "description": "cachingMode is the Host Caching mode: None, Read Only, Read Write.",
                     "type": "string"
                   },
                   "diskName": {
+                    "description": "diskName is the Name of the data disk in the blob storage",
                     "type": "string"
                   },
                   "diskURI": {
+                    "description": "diskURI is the URI of data disk in the blob storage",
                     "type": "string"
                   },
                   "fsType": {
+                    "default": "ext4",
+                    "description": "fsType is Filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
                     "type": "string"
                   },
                   "kind": {
+                    "description": "kind expected values are Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared",
                     "type": "string"
                   },
                   "readOnly": {
+                    "default": false,
+                    "description": "readOnly Defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
                     "type": "boolean"
                   }
                 },
@@ -6146,14 +9594,18 @@
                 "additionalProperties": false
               },
               "azureFile": {
+                "description": "azureFile represents an Azure File Service mount on the host and bind mount to the pod.\nDeprecated: AzureFile is deprecated. All operations for the in-tree azureFile type\nare redirected to the file.csi.azure.com CSI driver.",
                 "properties": {
                   "readOnly": {
+                    "description": "readOnly defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
                     "type": "boolean"
                   },
                   "secretName": {
+                    "description": "secretName is the  name of secret that contains Azure Storage Account Name and Key",
                     "type": "string"
                   },
                   "shareName": {
+                    "description": "shareName is the azure share Name",
                     "type": "string"
                   }
                 },
@@ -6165,32 +9617,43 @@
                 "additionalProperties": false
               },
               "cephfs": {
+                "description": "cephFS represents a Ceph FS mount on the host that shares a pod's lifetime.\nDeprecated: CephFS is deprecated and the in-tree cephfs type is no longer supported.",
                 "properties": {
                   "monitors": {
+                    "description": "monitors is Required: Monitors is a collection of Ceph monitors\nMore info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
                     "items": {
                       "type": "string"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   },
                   "path": {
+                    "description": "path is Optional: Used as the mounted root, rather than the full Ceph tree, default is /",
                     "type": "string"
                   },
                   "readOnly": {
+                    "description": "readOnly is Optional: Defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.\nMore info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
                     "type": "boolean"
                   },
                   "secretFile": {
+                    "description": "secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret\nMore info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
                     "type": "string"
                   },
                   "secretRef": {
+                    "description": "secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.\nMore info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
                     "properties": {
                       "name": {
+                        "default": "",
+                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                         "type": "string"
                       }
                     },
                     "type": "object",
+                    "x-kubernetes-map-type": "atomic",
                     "additionalProperties": false
                   },
                   "user": {
+                    "description": "user is optional: User is the rados user name, default is admin\nMore info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
                     "type": "string"
                   }
                 },
@@ -6201,23 +9664,31 @@
                 "additionalProperties": false
               },
               "cinder": {
+                "description": "cinder represents a cinder volume attached and mounted on kubelets host machine.\nDeprecated: Cinder is deprecated. All operations for the in-tree cinder type\nare redirected to the cinder.csi.openstack.org CSI driver.\nMore info: https://examples.k8s.io/mysql-cinder-pd/README.md",
                 "properties": {
                   "fsType": {
+                    "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://examples.k8s.io/mysql-cinder-pd/README.md",
                     "type": "string"
                   },
                   "readOnly": {
+                    "description": "readOnly defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.\nMore info: https://examples.k8s.io/mysql-cinder-pd/README.md",
                     "type": "boolean"
                   },
                   "secretRef": {
+                    "description": "secretRef is optional: points to a secret object containing parameters used to connect\nto OpenStack.",
                     "properties": {
                       "name": {
+                        "default": "",
+                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                         "type": "string"
                       }
                     },
                     "type": "object",
+                    "x-kubernetes-map-type": "atomic",
                     "additionalProperties": false
                   },
                   "volumeID": {
+                    "description": "volumeID used to identify the volume in cinder.\nMore info: https://examples.k8s.io/mysql-cinder-pd/README.md",
                     "type": "string"
                   }
                 },
@@ -6228,22 +9699,29 @@
                 "additionalProperties": false
               },
               "configMap": {
+                "description": "configMap represents a configMap that should populate this volume",
                 "properties": {
                   "defaultMode": {
+                    "description": "defaultMode is optional: mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nDefaults to 0644.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
                     "format": "int32",
                     "type": "integer"
                   },
                   "items": {
+                    "description": "items if unspecified, each key-value pair in the Data field of the referenced\nConfigMap will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the ConfigMap,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
                     "items": {
+                      "description": "Maps a string key to a path within a volume.",
                       "properties": {
                         "key": {
+                          "description": "key is the key to project.",
                           "type": "string"
                         },
                         "mode": {
+                          "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
                           "format": "int32",
                           "type": "integer"
                         },
                         "path": {
+                          "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
                           "type": "string"
                         }
                       },
@@ -6254,42 +9732,56 @@
                       "type": "object",
                       "additionalProperties": false
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   },
                   "name": {
+                    "default": "",
+                    "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                     "type": "string"
                   },
                   "optional": {
+                    "description": "optional specify whether the ConfigMap or its keys must be defined",
                     "type": "boolean"
                   }
                 },
                 "type": "object",
+                "x-kubernetes-map-type": "atomic",
                 "additionalProperties": false
               },
               "csi": {
+                "description": "csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers.",
                 "properties": {
                   "driver": {
+                    "description": "driver is the name of the CSI driver that handles this volume.\nConsult with your admin for the correct name as registered in the cluster.",
                     "type": "string"
                   },
                   "fsType": {
+                    "description": "fsType to mount. Ex. \"ext4\", \"xfs\", \"ntfs\".\nIf not provided, the empty value is passed to the associated CSI driver\nwhich will determine the default filesystem to apply.",
                     "type": "string"
                   },
                   "nodePublishSecretRef": {
+                    "description": "nodePublishSecretRef is a reference to the secret object containing\nsensitive information to pass to the CSI driver to complete the CSI\nNodePublishVolume and NodeUnpublishVolume calls.\nThis field is optional, and  may be empty if no secret is required. If the\nsecret object contains more than one secret, all secret references are passed.",
                     "properties": {
                       "name": {
+                        "default": "",
+                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                         "type": "string"
                       }
                     },
                     "type": "object",
+                    "x-kubernetes-map-type": "atomic",
                     "additionalProperties": false
                   },
                   "readOnly": {
+                    "description": "readOnly specifies a read-only configuration for the volume.\nDefaults to false (read/write).",
                     "type": "boolean"
                   },
                   "volumeAttributes": {
                     "additionalProperties": {
                       "type": "string"
                     },
+                    "description": "volumeAttributes stores driver-specific properties that are passed to the CSI\ndriver. Consult your driver's documentation for supported values.",
                     "type": "object"
                   }
                 },
@@ -6300,20 +9792,27 @@
                 "additionalProperties": false
               },
               "downwardAPI": {
+                "description": "downwardAPI represents downward API about the pod that should populate this volume",
                 "properties": {
                   "defaultMode": {
+                    "description": "Optional: mode bits to use on created files by default. Must be a\nOptional: mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nDefaults to 0644.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
                     "format": "int32",
                     "type": "integer"
                   },
                   "items": {
+                    "description": "Items is a list of downward API volume file",
                     "items": {
+                      "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
                       "properties": {
                         "fieldRef": {
+                          "description": "Required: Selects a field of the pod: only annotations, labels, name, namespace and uid are supported.",
                           "properties": {
                             "apiVersion": {
+                              "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
                               "type": "string"
                             },
                             "fieldPath": {
+                              "description": "Path of the field to select in the specified API version.",
                               "type": "string"
                             }
                           },
@@ -6321,18 +9820,23 @@
                             "fieldPath"
                           ],
                           "type": "object",
+                          "x-kubernetes-map-type": "atomic",
                           "additionalProperties": false
                         },
                         "mode": {
+                          "description": "Optional: mode bits used to set permissions on this file, must be an octal value\nbetween 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
                           "format": "int32",
                           "type": "integer"
                         },
                         "path": {
+                          "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'",
                           "type": "string"
                         },
                         "resourceFieldRef": {
+                          "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.",
                           "properties": {
                             "containerName": {
+                              "description": "Container name: required for volumes, optional for env vars",
                               "type": "string"
                             },
                             "divisor": {
@@ -6344,10 +9848,12 @@
                                   "type": "string"
                                 }
                               ],
+                              "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
                               "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                               "x-kubernetes-int-or-string": true
                             },
                             "resource": {
+                              "description": "Required: resource to select",
                               "type": "string"
                             }
                           },
@@ -6355,6 +9861,7 @@
                             "resource"
                           ],
                           "type": "object",
+                          "x-kubernetes-map-type": "atomic",
                           "additionalProperties": false
                         }
                       },
@@ -6364,15 +9871,18 @@
                       "type": "object",
                       "additionalProperties": false
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   }
                 },
                 "type": "object",
                 "additionalProperties": false
               },
               "emptyDir": {
+                "description": "emptyDir represents a temporary directory that shares a pod's lifetime.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
                 "properties": {
                   "medium": {
+                    "description": "medium represents what type of storage medium should back this directory.\nThe default is \"\" which means to use the node's default medium.\nMust be an empty string (default) or Memory.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
                     "type": "string"
                   },
                   "sizeLimit": {
@@ -6384,6 +9894,7 @@
                         "type": "string"
                       }
                     ],
+                    "description": "sizeLimit is the total amount of local storage required for this EmptyDir volume.\nThe size limit is also applicable for memory medium.\nThe maximum usage on memory medium EmptyDir would be the minimum value between\nthe SizeLimit specified here and the sum of memory limits of all containers in a pod.\nThe default is nil which means that the limit is undefined.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
                     "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                     "x-kubernetes-int-or-string": true
                   }
@@ -6391,58 +9902,291 @@
                 "type": "object",
                 "additionalProperties": false
               },
+              "ephemeral": {
+                "description": "ephemeral represents a volume that is handled by a cluster storage driver.\nThe volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,\nand deleted when the pod is removed.\n\nUse this if:\na) the volume is only needed while the pod runs,\nb) features of normal volumes like restoring from snapshot or capacity\n   tracking are needed,\nc) the storage driver is specified through a storage class, and\nd) the storage driver supports dynamic volume provisioning through\n   a PersistentVolumeClaim (see EphemeralVolumeSource for more\n   information on the connection between this volume type\n   and PersistentVolumeClaim).\n\nUse PersistentVolumeClaim or one of the vendor-specific\nAPIs for volumes that persist for longer than the lifecycle\nof an individual pod.\n\nUse CSI for light-weight local ephemeral volumes if the CSI driver is meant to\nbe used that way - see the documentation of the driver for\nmore information.\n\nA pod can use both types of ephemeral volumes and\npersistent volumes at the same time.",
+                "properties": {
+                  "volumeClaimTemplate": {
+                    "description": "Will be used to create a stand-alone PVC to provision the volume.\nThe pod in which this EphemeralVolumeSource is embedded will be the\nowner of the PVC, i.e. the PVC will be deleted together with the\npod.  The name of the PVC will be `<pod name>-<volume name>` where\n`<volume name>` is the name from the `PodSpec.Volumes` array\nentry. Pod validation will reject the pod if the concatenated name\nis not valid for a PVC (for example, too long).\n\nAn existing PVC with that name that is not owned by the pod\nwill *not* be used for the pod to avoid using an unrelated\nvolume by mistake. Starting the pod is then blocked until\nthe unrelated PVC is removed. If such a pre-created PVC is\nmeant to be used by the pod, the PVC has to updated with an\nowner reference to the pod once the pod exists. Normally\nthis should not be necessary, but it may be useful when\nmanually reconstructing a broken cluster.\n\nThis field is read-only and no changes will be made by Kubernetes\nto the PVC after it has been created.\n\nRequired, must not be nil.",
+                    "properties": {
+                      "metadata": {
+                        "description": "May contain labels and annotations that will be copied into the PVC\nwhen creating it. No other fields are allowed and will be rejected during\nvalidation.",
+                        "properties": {
+                          "annotations": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          },
+                          "finalizers": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "labels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "namespace": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "spec": {
+                        "description": "The specification for the PersistentVolumeClaim. The entire content is\ncopied unchanged into the PVC that gets created from this\ntemplate. The same fields as in a PersistentVolumeClaim\nare also valid here.",
+                        "properties": {
+                          "accessModes": {
+                            "description": "accessModes contains the desired access modes the volume should have.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "dataSource": {
+                            "description": "dataSource field can be used to specify either:\n* An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)\n* An existing PVC (PersistentVolumeClaim)\nIf the provisioner or an external controller can support the specified data source,\nit will create a new volume based on the contents of the specified data source.\nWhen the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,\nand dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.\nIf the namespace is specified, then dataSourceRef will not be copied to dataSource.",
+                            "properties": {
+                              "apiGroup": {
+                                "description": "APIGroup is the group for the resource being referenced.\nIf APIGroup is not specified, the specified Kind must be in the core API group.\nFor any other third-party types, APIGroup is required.",
+                                "type": "string"
+                              },
+                              "kind": {
+                                "description": "Kind is the type of resource being referenced",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name is the name of resource being referenced",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "kind",
+                              "name"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "dataSourceRef": {
+                            "description": "dataSourceRef specifies the object from which to populate the volume with data, if a non-empty\nvolume is desired. This may be any object from a non-empty API group (non\ncore object) or a PersistentVolumeClaim object.\nWhen this field is specified, volume binding will only succeed if the type of\nthe specified object matches some installed volume populator or dynamic\nprovisioner.\nThis field will replace the functionality of the dataSource field and as such\nif both fields are non-empty, they must have the same value. For backwards\ncompatibility, when namespace isn't specified in dataSourceRef,\nboth fields (dataSource and dataSourceRef) will be set to the same\nvalue automatically if one of them is empty and the other is non-empty.\nWhen namespace is specified in dataSourceRef,\ndataSource isn't set to the same value and must be empty.\nThere are three important differences between dataSource and dataSourceRef:\n* While dataSource only allows two specific types of objects, dataSourceRef\n  allows any non-core object, as well as PersistentVolumeClaim objects.\n* While dataSource ignores disallowed values (dropping them), dataSourceRef\n  preserves all values, and generates an error if a disallowed value is\n  specified.\n* While dataSource only allows local objects, dataSourceRef allows objects\n  in any namespaces.\n(Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.\n(Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.",
+                            "properties": {
+                              "apiGroup": {
+                                "description": "APIGroup is the group for the resource being referenced.\nIf APIGroup is not specified, the specified Kind must be in the core API group.\nFor any other third-party types, APIGroup is required.",
+                                "type": "string"
+                              },
+                              "kind": {
+                                "description": "Kind is the type of resource being referenced",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name is the name of resource being referenced",
+                                "type": "string"
+                              },
+                              "namespace": {
+                                "description": "Namespace is the namespace of resource being referenced\nNote that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.\n(Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "kind",
+                              "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "resources": {
+                            "description": "resources represents the minimum resources the volume should have.\nIf RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements\nthat are lower than previous value but must still be higher than capacity recorded in the\nstatus field of the claim.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources",
+                            "properties": {
+                              "limits": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                "type": "object"
+                              },
+                              "requests": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "selector": {
+                            "description": "selector is a label query over volumes to consider for binding.",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "key is the label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "storageClassName": {
+                            "description": "storageClassName is the name of the StorageClass required by the claim.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1",
+                            "type": "string"
+                          },
+                          "volumeAttributesClassName": {
+                            "description": "volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.\nIf specified, the CSI driver will create or update the volume with the attributes defined\nin the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,\nit can be changed after the claim is created. An empty string value means that no VolumeAttributesClass\nwill be applied to the claim but it's not allowed to reset this field to empty string once it is set.\nIf unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass\nwill be set by the persistentvolume controller if it exists.\nIf the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be\nset to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource\nexists.\nMore info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/\n(Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).",
+                            "type": "string"
+                          },
+                          "volumeMode": {
+                            "description": "volumeMode defines what type of volume is required by the claim.\nValue of Filesystem is implied when not included in claim spec.",
+                            "type": "string"
+                          },
+                          "volumeName": {
+                            "description": "volumeName is the binding reference to the PersistentVolume backing this claim.",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "spec"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
               "fc": {
+                "description": "fc represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.",
                 "properties": {
                   "fsType": {
+                    "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
                     "type": "string"
                   },
                   "lun": {
+                    "description": "lun is Optional: FC target lun number",
                     "format": "int32",
                     "type": "integer"
                   },
                   "readOnly": {
+                    "description": "readOnly is Optional: Defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
                     "type": "boolean"
                   },
                   "targetWWNs": {
+                    "description": "targetWWNs is Optional: FC target worldwide names (WWNs)",
                     "items": {
                       "type": "string"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   },
                   "wwids": {
+                    "description": "wwids Optional: FC volume world wide identifiers (wwids)\nEither wwids or combination of targetWWNs and lun must be set, but not both simultaneously.",
                     "items": {
                       "type": "string"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   }
                 },
                 "type": "object",
                 "additionalProperties": false
               },
               "flexVolume": {
+                "description": "flexVolume represents a generic volume resource that is\nprovisioned/attached using an exec based plugin.\nDeprecated: FlexVolume is deprecated. Consider using a CSIDriver instead.",
                 "properties": {
                   "driver": {
+                    "description": "driver is the name of the driver to use for this volume.",
                     "type": "string"
                   },
                   "fsType": {
+                    "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". The default filesystem depends on FlexVolume script.",
                     "type": "string"
                   },
                   "options": {
                     "additionalProperties": {
                       "type": "string"
                     },
+                    "description": "options is Optional: this field holds extra command options if any.",
                     "type": "object"
                   },
                   "readOnly": {
+                    "description": "readOnly is Optional: defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
                     "type": "boolean"
                   },
                   "secretRef": {
+                    "description": "secretRef is Optional: secretRef is reference to the secret object containing\nsensitive information to pass to the plugin scripts. This may be\nempty if no secret object is specified. If the secret object\ncontains more than one secret, all secrets are passed to the plugin\nscripts.",
                     "properties": {
                       "name": {
+                        "default": "",
+                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                         "type": "string"
                       }
                     },
                     "type": "object",
+                    "x-kubernetes-map-type": "atomic",
                     "additionalProperties": false
                   }
                 },
@@ -6453,11 +10197,14 @@
                 "additionalProperties": false
               },
               "flocker": {
+                "description": "flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running.\nDeprecated: Flocker is deprecated and the in-tree flocker type is no longer supported.",
                 "properties": {
                   "datasetName": {
+                    "description": "datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker\nshould be considered as deprecated",
                     "type": "string"
                   },
                   "datasetUUID": {
+                    "description": "datasetUUID is the UUID of the dataset. This is unique identifier of a Flocker dataset",
                     "type": "string"
                   }
                 },
@@ -6465,18 +10212,23 @@
                 "additionalProperties": false
               },
               "gcePersistentDisk": {
+                "description": "gcePersistentDisk represents a GCE Disk resource that is attached to a\nkubelet's host machine and then exposed to the pod.\nDeprecated: GCEPersistentDisk is deprecated. All operations for the in-tree\ngcePersistentDisk type are redirected to the pd.csi.storage.gke.io CSI driver.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
                 "properties": {
                   "fsType": {
+                    "description": "fsType is filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
                     "type": "string"
                   },
                   "partition": {
+                    "description": "partition is the partition in the volume that you want to mount.\nIf omitted, the default is to mount by volume name.\nExamples: For volume /dev/sda1, you specify the partition as \"1\".\nSimilarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty).\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
                     "format": "int32",
                     "type": "integer"
                   },
                   "pdName": {
+                    "description": "pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
                     "type": "string"
                   },
                   "readOnly": {
+                    "description": "readOnly here will force the ReadOnly setting in VolumeMounts.\nDefaults to false.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
                     "type": "boolean"
                   }
                 },
@@ -6487,14 +10239,18 @@
                 "additionalProperties": false
               },
               "gitRepo": {
+                "description": "gitRepo represents a git repository at a particular revision.\nDeprecated: GitRepo is deprecated. To provision a container with a git repo, mount an\nEmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir\ninto the Pod's container.",
                 "properties": {
                   "directory": {
+                    "description": "directory is the target directory name.\nMust not contain or start with '..'.  If '.' is supplied, the volume directory will be the\ngit repository.  Otherwise, if specified, the volume will contain the git repository in\nthe subdirectory with the given name.",
                     "type": "string"
                   },
                   "repository": {
+                    "description": "repository is the URL",
                     "type": "string"
                   },
                   "revision": {
+                    "description": "revision is the commit hash for the specified revision.",
                     "type": "string"
                   }
                 },
@@ -6505,14 +10261,18 @@
                 "additionalProperties": false
               },
               "glusterfs": {
+                "description": "glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.\nDeprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.\nMore info: https://examples.k8s.io/volumes/glusterfs/README.md",
                 "properties": {
                   "endpoints": {
+                    "description": "endpoints is the endpoint name that details Glusterfs topology.\nMore info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
                     "type": "string"
                   },
                   "path": {
+                    "description": "path is the Glusterfs volume path.\nMore info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
                     "type": "string"
                   },
                   "readOnly": {
+                    "description": "readOnly here will force the Glusterfs volume to be mounted with read-only permissions.\nDefaults to false.\nMore info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
                     "type": "boolean"
                   }
                 },
@@ -6524,11 +10284,14 @@
                 "additionalProperties": false
               },
               "hostPath": {
+                "description": "hostPath represents a pre-existing file or directory on the host\nmachine that is directly exposed to the container. This is generally\nused for system agents or other privileged things that are allowed\nto see the host machine. Most containers will NOT need this.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
                 "properties": {
                   "path": {
+                    "description": "path of the directory on the host.\nIf the path is a symlink, it will follow the link to the real path.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
                     "type": "string"
                   },
                   "type": {
+                    "description": "type for HostPath Volume\nDefaults to \"\"\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
                     "type": "string"
                   }
                 },
@@ -6538,49 +10301,81 @@
                 "type": "object",
                 "additionalProperties": false
               },
+              "image": {
+                "description": "image represents an OCI object (a container image or artifact) pulled and mounted on the kubelet's host machine.\nThe volume is resolved at pod startup depending on which PullPolicy value is provided:\n\n- Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.\n- Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.\n- IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.\n\nThe volume gets re-resolved if the pod gets deleted and recreated, which means that new remote content will become available on pod recreation.\nA failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.\nThe types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.\nThe OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.\nThe volume will be mounted read-only (ro) and non-executable files (noexec).\nSub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath).\nThe field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.",
+                "properties": {
+                  "pullPolicy": {
+                    "description": "Policy for pulling OCI objects. Possible values are:\nAlways: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.\nNever: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.\nIfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.\nDefaults to Always if :latest tag is specified, or IfNotPresent otherwise.",
+                    "type": "string"
+                  },
+                  "reference": {
+                    "description": "Required: Image or artifact reference to be used.\nBehaves in the same way as pod.spec.containers[*].image.\nPull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.\nMore info: https://kubernetes.io/docs/concepts/containers/images\nThis field is optional to allow higher level config management to default or override\ncontainer images in workload controllers like Deployments and StatefulSets.",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
               "iscsi": {
+                "description": "iscsi represents an ISCSI Disk resource that is attached to a\nkubelet's host machine and then exposed to the pod.\nMore info: https://examples.k8s.io/volumes/iscsi/README.md",
                 "properties": {
                   "chapAuthDiscovery": {
+                    "description": "chapAuthDiscovery defines whether support iSCSI Discovery CHAP authentication",
                     "type": "boolean"
                   },
                   "chapAuthSession": {
+                    "description": "chapAuthSession defines whether support iSCSI Session CHAP authentication",
                     "type": "boolean"
                   },
                   "fsType": {
+                    "description": "fsType is the filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi",
                     "type": "string"
                   },
                   "initiatorName": {
+                    "description": "initiatorName is the custom iSCSI Initiator Name.\nIf initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface\n<target portal>:<volume name> will be created for the connection.",
                     "type": "string"
                   },
                   "iqn": {
+                    "description": "iqn is the target iSCSI Qualified Name.",
                     "type": "string"
                   },
                   "iscsiInterface": {
+                    "default": "default",
+                    "description": "iscsiInterface is the interface Name that uses an iSCSI transport.\nDefaults to 'default' (tcp).",
                     "type": "string"
                   },
                   "lun": {
+                    "description": "lun represents iSCSI Target Lun number.",
                     "format": "int32",
                     "type": "integer"
                   },
                   "portals": {
+                    "description": "portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port\nis other than default (typically TCP ports 860 and 3260).",
                     "items": {
                       "type": "string"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   },
                   "readOnly": {
+                    "description": "readOnly here will force the ReadOnly setting in VolumeMounts.\nDefaults to false.",
                     "type": "boolean"
                   },
                   "secretRef": {
+                    "description": "secretRef is the CHAP Secret for iSCSI target and initiator authentication",
                     "properties": {
                       "name": {
+                        "default": "",
+                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                         "type": "string"
                       }
                     },
                     "type": "object",
+                    "x-kubernetes-map-type": "atomic",
                     "additionalProperties": false
                   },
                   "targetPortal": {
+                    "description": "targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port\nis other than default (typically TCP ports 860 and 3260).",
                     "type": "string"
                   }
                 },
@@ -6593,17 +10388,22 @@
                 "additionalProperties": false
               },
               "name": {
+                "description": "name of the volume.\nMust be a DNS_LABEL and unique within the pod.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                 "type": "string"
               },
               "nfs": {
+                "description": "nfs represents an NFS mount on the host that shares a pod's lifetime\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
                 "properties": {
                   "path": {
+                    "description": "path that is exported by the NFS server.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
                     "type": "string"
                   },
                   "readOnly": {
+                    "description": "readOnly here will force the NFS export to be mounted with read-only permissions.\nDefaults to false.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
                     "type": "boolean"
                   },
                   "server": {
+                    "description": "server is the hostname or IP address of the NFS server.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
                     "type": "string"
                   }
                 },
@@ -6615,11 +10415,14 @@
                 "additionalProperties": false
               },
               "persistentVolumeClaim": {
+                "description": "persistentVolumeClaimVolumeSource represents a reference to a\nPersistentVolumeClaim in the same namespace.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
                 "properties": {
                   "claimName": {
+                    "description": "claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
                     "type": "string"
                   },
                   "readOnly": {
+                    "description": "readOnly Will force the ReadOnly setting in VolumeMounts.\nDefault false.",
                     "type": "boolean"
                   }
                 },
@@ -6630,11 +10433,14 @@
                 "additionalProperties": false
               },
               "photonPersistentDisk": {
+                "description": "photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine.\nDeprecated: PhotonPersistentDisk is deprecated and the in-tree photonPersistentDisk type is no longer supported.",
                 "properties": {
                   "fsType": {
+                    "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
                     "type": "string"
                   },
                   "pdID": {
+                    "description": "pdID is the ID that identifies Photon Controller persistent disk",
                     "type": "string"
                   }
                 },
@@ -6645,14 +10451,18 @@
                 "additionalProperties": false
               },
               "portworxVolume": {
+                "description": "portworxVolume represents a portworx volume attached and mounted on kubelets host machine.\nDeprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type\nare redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate\nis on.",
                 "properties": {
                   "fsType": {
+                    "description": "fSType represents the filesystem type to mount\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\". Implicitly inferred to be \"ext4\" if unspecified.",
                     "type": "string"
                   },
                   "readOnly": {
+                    "description": "readOnly defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
                     "type": "boolean"
                   },
                   "volumeID": {
+                    "description": "volumeID uniquely identifies a Portworx volume",
                     "type": "string"
                   }
                 },
@@ -6663,27 +10473,110 @@
                 "additionalProperties": false
               },
               "projected": {
+                "description": "projected items for all in one resources secrets, configmaps, and downward API",
                 "properties": {
                   "defaultMode": {
+                    "description": "defaultMode are the mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
                     "format": "int32",
                     "type": "integer"
                   },
                   "sources": {
+                    "description": "sources is the list of volume projections. Each entry in this list\nhandles one source.",
                     "items": {
+                      "description": "Projection that may be projected along with other supported volume types.\nExactly one of these fields must be set.",
                       "properties": {
+                        "clusterTrustBundle": {
+                          "description": "ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field\nof ClusterTrustBundle objects in an auto-updating file.\n\nAlpha, gated by the ClusterTrustBundleProjection feature gate.\n\nClusterTrustBundle objects can either be selected by name, or by the\ncombination of signer name and a label selector.\n\nKubelet performs aggressive normalization of the PEM contents written\ninto the pod filesystem.  Esoteric PEM features such as inter-block\ncomments and block headers are stripped.  Certificates are deduplicated.\nThe ordering of certificates within the file is arbitrary, and Kubelet\nmay change the order over time.",
+                          "properties": {
+                            "labelSelector": {
+                              "description": "Select all ClusterTrustBundles that match this label selector.  Only has\neffect if signerName is set.  Mutually-exclusive with name.  If unset,\ninterpreted as \"match nothing\".  If set but empty, interpreted as \"match\neverything\".",
+                              "properties": {
+                                "matchExpressions": {
+                                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                  "items": {
+                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "key is the label key that the selector applies to.",
+                                        "type": "string"
+                                      },
+                                      "operator": {
+                                        "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                        "type": "string"
+                                      },
+                                      "values": {
+                                        "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      }
+                                    },
+                                    "required": [
+                                      "key",
+                                      "operator"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                },
+                                "matchLabels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            },
+                            "name": {
+                              "description": "Select a single ClusterTrustBundle by object name.  Mutually-exclusive\nwith signerName and labelSelector.",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "If true, don't block pod startup if the referenced ClusterTrustBundle(s)\naren't available.  If using name, then the named ClusterTrustBundle is\nallowed not to exist.  If using signerName, then the combination of\nsignerName and labelSelector is allowed to match zero\nClusterTrustBundles.",
+                              "type": "boolean"
+                            },
+                            "path": {
+                              "description": "Relative path from the volume root to write the bundle.",
+                              "type": "string"
+                            },
+                            "signerName": {
+                              "description": "Select all ClusterTrustBundles that match this signer name.\nMutually-exclusive with name.  The contents of all selected\nClusterTrustBundles will be unified and deduplicated.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "path"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
                         "configMap": {
+                          "description": "configMap information about the configMap data to project",
                           "properties": {
                             "items": {
+                              "description": "items if unspecified, each key-value pair in the Data field of the referenced\nConfigMap will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the ConfigMap,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
                               "items": {
+                                "description": "Maps a string key to a path within a volume.",
                                 "properties": {
                                   "key": {
+                                    "description": "key is the key to project.",
                                     "type": "string"
                                   },
                                   "mode": {
+                                    "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
                                     "format": "int32",
                                     "type": "integer"
                                   },
                                   "path": {
+                                    "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
                                     "type": "string"
                                   }
                                 },
@@ -6694,29 +10587,40 @@
                                 "type": "object",
                                 "additionalProperties": false
                               },
-                              "type": "array"
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                               "type": "string"
                             },
                             "optional": {
+                              "description": "optional specify whether the ConfigMap or its keys must be defined",
                               "type": "boolean"
                             }
                           },
                           "type": "object",
+                          "x-kubernetes-map-type": "atomic",
                           "additionalProperties": false
                         },
                         "downwardAPI": {
+                          "description": "downwardAPI information about the downwardAPI data to project",
                           "properties": {
                             "items": {
+                              "description": "Items is a list of DownwardAPIVolume file",
                               "items": {
+                                "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
                                 "properties": {
                                   "fieldRef": {
+                                    "description": "Required: Selects a field of the pod: only annotations, labels, name, namespace and uid are supported.",
                                     "properties": {
                                       "apiVersion": {
+                                        "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
                                         "type": "string"
                                       },
                                       "fieldPath": {
+                                        "description": "Path of the field to select in the specified API version.",
                                         "type": "string"
                                       }
                                     },
@@ -6724,18 +10628,23 @@
                                       "fieldPath"
                                     ],
                                     "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
                                     "additionalProperties": false
                                   },
                                   "mode": {
+                                    "description": "Optional: mode bits used to set permissions on this file, must be an octal value\nbetween 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
                                     "format": "int32",
                                     "type": "integer"
                                   },
                                   "path": {
+                                    "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'",
                                     "type": "string"
                                   },
                                   "resourceFieldRef": {
+                                    "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.",
                                     "properties": {
                                       "containerName": {
+                                        "description": "Container name: required for volumes, optional for env vars",
                                         "type": "string"
                                       },
                                       "divisor": {
@@ -6747,10 +10656,12 @@
                                             "type": "string"
                                           }
                                         ],
+                                        "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
                                         "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                                         "x-kubernetes-int-or-string": true
                                       },
                                       "resource": {
+                                        "description": "Required: resource to select",
                                         "type": "string"
                                       }
                                     },
@@ -6758,6 +10669,7 @@
                                       "resource"
                                     ],
                                     "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
                                     "additionalProperties": false
                                   }
                                 },
@@ -6767,25 +10679,32 @@
                                 "type": "object",
                                 "additionalProperties": false
                               },
-                              "type": "array"
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
                             }
                           },
                           "type": "object",
                           "additionalProperties": false
                         },
                         "secret": {
+                          "description": "secret information about the secret data to project",
                           "properties": {
                             "items": {
+                              "description": "items if unspecified, each key-value pair in the Data field of the referenced\nSecret will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the Secret,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
                               "items": {
+                                "description": "Maps a string key to a path within a volume.",
                                 "properties": {
                                   "key": {
+                                    "description": "key is the key to project.",
                                     "type": "string"
                                   },
                                   "mode": {
+                                    "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
                                     "format": "int32",
                                     "type": "integer"
                                   },
                                   "path": {
+                                    "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
                                     "type": "string"
                                   }
                                 },
@@ -6796,28 +10715,37 @@
                                 "type": "object",
                                 "additionalProperties": false
                               },
-                              "type": "array"
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                               "type": "string"
                             },
                             "optional": {
+                              "description": "optional field specify whether the Secret or its key must be defined",
                               "type": "boolean"
                             }
                           },
                           "type": "object",
+                          "x-kubernetes-map-type": "atomic",
                           "additionalProperties": false
                         },
                         "serviceAccountToken": {
+                          "description": "serviceAccountToken is information about the serviceAccountToken data to project",
                           "properties": {
                             "audience": {
+                              "description": "audience is the intended audience of the token. A recipient of a token\nmust identify itself with an identifier specified in the audience of the\ntoken, and otherwise should reject the token. The audience defaults to the\nidentifier of the apiserver.",
                               "type": "string"
                             },
                             "expirationSeconds": {
+                              "description": "expirationSeconds is the requested duration of validity of the service\naccount token. As the token approaches expiration, the kubelet volume\nplugin will proactively rotate the service account token. The kubelet will\nstart trying to rotate the token if the token is older than 80 percent of\nits time to live or if the token is older than 24 hours.Defaults to 1 hour\nand must be at least 10 minutes.",
                               "format": "int64",
                               "type": "integer"
                             },
                             "path": {
+                              "description": "path is the path relative to the mount point of the file to project the\ntoken into.",
                               "type": "string"
                             }
                           },
@@ -6831,33 +10759,38 @@
                       "type": "object",
                       "additionalProperties": false
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   }
                 },
-                "required": [
-                  "sources"
-                ],
                 "type": "object",
                 "additionalProperties": false
               },
               "quobyte": {
+                "description": "quobyte represents a Quobyte mount on the host that shares a pod's lifetime.\nDeprecated: Quobyte is deprecated and the in-tree quobyte type is no longer supported.",
                 "properties": {
                   "group": {
+                    "description": "group to map volume access to\nDefault is no group",
                     "type": "string"
                   },
                   "readOnly": {
+                    "description": "readOnly here will force the Quobyte volume to be mounted with read-only permissions.\nDefaults to false.",
                     "type": "boolean"
                   },
                   "registry": {
+                    "description": "registry represents a single or multiple Quobyte Registry services\nspecified as a string as host:port pair (multiple entries are separated with commas)\nwhich acts as the central registry for volumes",
                     "type": "string"
                   },
                   "tenant": {
+                    "description": "tenant owning the given Quobyte volume in the Backend\nUsed with dynamically provisioned Quobyte volumes, value is set by the plugin",
                     "type": "string"
                   },
                   "user": {
+                    "description": "user to map volume access to\nDefaults to serivceaccount user",
                     "type": "string"
                   },
                   "volume": {
+                    "description": "volume is a string that references an already created Quobyte volume by name.",
                     "type": "string"
                   }
                 },
@@ -6869,38 +10802,54 @@
                 "additionalProperties": false
               },
               "rbd": {
+                "description": "rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.\nDeprecated: RBD is deprecated and the in-tree rbd type is no longer supported.\nMore info: https://examples.k8s.io/volumes/rbd/README.md",
                 "properties": {
                   "fsType": {
+                    "description": "fsType is the filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#rbd",
                     "type": "string"
                   },
                   "image": {
+                    "description": "image is the rados image name.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
                     "type": "string"
                   },
                   "keyring": {
+                    "default": "/etc/ceph/keyring",
+                    "description": "keyring is the path to key ring for RBDUser.\nDefault is /etc/ceph/keyring.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
                     "type": "string"
                   },
                   "monitors": {
+                    "description": "monitors is a collection of Ceph monitors.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
                     "items": {
                       "type": "string"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   },
                   "pool": {
+                    "default": "rbd",
+                    "description": "pool is the rados pool name.\nDefault is rbd.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
                     "type": "string"
                   },
                   "readOnly": {
+                    "description": "readOnly here will force the ReadOnly setting in VolumeMounts.\nDefaults to false.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
                     "type": "boolean"
                   },
                   "secretRef": {
+                    "description": "secretRef is name of the authentication secret for RBDUser. If provided\noverrides keyring.\nDefault is nil.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
                     "properties": {
                       "name": {
+                        "default": "",
+                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                         "type": "string"
                       }
                     },
                     "type": "object",
+                    "x-kubernetes-map-type": "atomic",
                     "additionalProperties": false
                   },
                   "user": {
+                    "default": "admin",
+                    "description": "user is the rados user name.\nDefault is admin.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
                     "type": "string"
                   }
                 },
@@ -6912,41 +10861,57 @@
                 "additionalProperties": false
               },
               "scaleIO": {
+                "description": "scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.\nDeprecated: ScaleIO is deprecated and the in-tree scaleIO type is no longer supported.",
                 "properties": {
                   "fsType": {
+                    "default": "xfs",
+                    "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\".\nDefault is \"xfs\".",
                     "type": "string"
                   },
                   "gateway": {
+                    "description": "gateway is the host address of the ScaleIO API Gateway.",
                     "type": "string"
                   },
                   "protectionDomain": {
+                    "description": "protectionDomain is the name of the ScaleIO Protection Domain for the configured storage.",
                     "type": "string"
                   },
                   "readOnly": {
+                    "description": "readOnly Defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
                     "type": "boolean"
                   },
                   "secretRef": {
+                    "description": "secretRef references to the secret for ScaleIO user and other\nsensitive information. If this is not provided, Login operation will fail.",
                     "properties": {
                       "name": {
+                        "default": "",
+                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                         "type": "string"
                       }
                     },
                     "type": "object",
+                    "x-kubernetes-map-type": "atomic",
                     "additionalProperties": false
                   },
                   "sslEnabled": {
+                    "description": "sslEnabled Flag enable/disable SSL communication with Gateway, default false",
                     "type": "boolean"
                   },
                   "storageMode": {
+                    "default": "ThinProvisioned",
+                    "description": "storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.\nDefault is ThinProvisioned.",
                     "type": "string"
                   },
                   "storagePool": {
+                    "description": "storagePool is the ScaleIO Storage Pool associated with the protection domain.",
                     "type": "string"
                   },
                   "system": {
+                    "description": "system is the name of the storage system as configured in ScaleIO.",
                     "type": "string"
                   },
                   "volumeName": {
+                    "description": "volumeName is the name of a volume already created in the ScaleIO system\nthat is associated with this volume source.",
                     "type": "string"
                   }
                 },
@@ -6959,22 +10924,29 @@
                 "additionalProperties": false
               },
               "secret": {
+                "description": "secret represents a secret that should populate this volume.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
                 "properties": {
                   "defaultMode": {
+                    "description": "defaultMode is Optional: mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values\nfor mode bits. Defaults to 0644.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
                     "format": "int32",
                     "type": "integer"
                   },
                   "items": {
+                    "description": "items If unspecified, each key-value pair in the Data field of the referenced\nSecret will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the Secret,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
                     "items": {
+                      "description": "Maps a string key to a path within a volume.",
                       "properties": {
                         "key": {
+                          "description": "key is the key to project.",
                           "type": "string"
                         },
                         "mode": {
+                          "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
                           "format": "int32",
                           "type": "integer"
                         },
                         "path": {
+                          "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
                           "type": "string"
                         }
                       },
@@ -6985,12 +10957,15 @@
                       "type": "object",
                       "additionalProperties": false
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   },
                   "optional": {
+                    "description": "optional field specify whether the Secret or its keys must be defined",
                     "type": "boolean"
                   },
                   "secretName": {
+                    "description": "secretName is the name of the secret in the pod's namespace to use.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
                     "type": "string"
                   }
                 },
@@ -6998,26 +10973,35 @@
                 "additionalProperties": false
               },
               "storageos": {
+                "description": "storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.\nDeprecated: StorageOS is deprecated and the in-tree storageos type is no longer supported.",
                 "properties": {
                   "fsType": {
+                    "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
                     "type": "string"
                   },
                   "readOnly": {
+                    "description": "readOnly defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
                     "type": "boolean"
                   },
                   "secretRef": {
+                    "description": "secretRef specifies the secret to use for obtaining the StorageOS API\ncredentials.  If not specified, default values will be attempted.",
                     "properties": {
                       "name": {
+                        "default": "",
+                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                         "type": "string"
                       }
                     },
                     "type": "object",
+                    "x-kubernetes-map-type": "atomic",
                     "additionalProperties": false
                   },
                   "volumeName": {
+                    "description": "volumeName is the human-readable name of the StorageOS volume.  Volume\nnames are only unique within a namespace.",
                     "type": "string"
                   },
                   "volumeNamespace": {
+                    "description": "volumeNamespace specifies the scope of the volume within StorageOS.  If no\nnamespace is specified then the Pod's namespace will be used.  This allows the\nKubernetes name scoping to be mirrored within StorageOS for tighter integration.\nSet VolumeName to any name to override the default behaviour.\nSet to \"default\" if you are not using namespaces within StorageOS.\nNamespaces that do not pre-exist within StorageOS will be created.",
                     "type": "string"
                   }
                 },
@@ -7025,17 +11009,22 @@
                 "additionalProperties": false
               },
               "vsphereVolume": {
+                "description": "vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine.\nDeprecated: VsphereVolume is deprecated. All operations for the in-tree vsphereVolume type\nare redirected to the csi.vsphere.vmware.com CSI driver.",
                 "properties": {
                   "fsType": {
+                    "description": "fsType is filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
                     "type": "string"
                   },
                   "storagePolicyID": {
+                    "description": "storagePolicyID is the storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.",
                     "type": "string"
                   },
                   "storagePolicyName": {
+                    "description": "storagePolicyName is the storage Policy Based Management (SPBM) profile name.",
                     "type": "string"
                   },
                   "volumePath": {
+                    "description": "volumePath is the path that identifies vSphere volume vmdk",
                     "type": "string"
                   }
                 },
@@ -7058,6 +11047,7 @@
       "required": [
         "driver",
         "executor",
+        "mainApplicationFile",
         "sparkVersion",
         "type"
       ],
@@ -7065,13 +11055,16 @@
       "additionalProperties": false
     },
     "status": {
+      "description": "SparkApplicationStatus defines the observed state of SparkApplication",
       "properties": {
         "applicationState": {
+          "description": "AppState tells the overall application state.",
           "properties": {
             "errorMessage": {
               "type": "string"
             },
             "state": {
+              "description": "ApplicationStateType represents the type of the current state of an application.",
               "type": "string"
             }
           },
@@ -7082,17 +11075,20 @@
           "additionalProperties": false
         },
         "driverInfo": {
+          "description": "DriverInfo has information about the driver.",
           "properties": {
             "podName": {
               "type": "string"
             },
             "webUIAddress": {
+              "description": "UI Details for the UI created via ClusterIP service accessible from within the cluster.",
               "type": "string"
             },
             "webUIIngressAddress": {
               "type": "string"
             },
             "webUIIngressName": {
+              "description": "Ingress Details if an ingress for the UI was created.",
               "type": "string"
             },
             "webUIPort": {
@@ -7107,31 +11103,39 @@
           "additionalProperties": false
         },
         "executionAttempts": {
+          "description": "ExecutionAttempts is the total number of attempts to run a submitted application to completion.\nIncremented upon each attempted run of the application and reset upon invalidation.",
           "format": "int32",
           "type": "integer"
         },
         "executorState": {
           "additionalProperties": {
+            "description": "ExecutorState tells the current state of an executor.",
             "type": "string"
           },
+          "description": "ExecutorState records the state of executors by executor Pod names.",
           "type": "object"
         },
         "lastSubmissionAttemptTime": {
+          "description": "LastSubmissionAttemptTime is the time for the last application submission attempt.",
           "format": "date-time",
           "nullable": true,
           "type": "string"
         },
         "sparkApplicationId": {
+          "description": "SparkApplicationID is set by the spark-distribution(via spark.app.id config) on the driver and executor pods",
           "type": "string"
         },
         "submissionAttempts": {
+          "description": "SubmissionAttempts is the total number of attempts to submit an application to run.\nIncremented upon each attempted submission of the application and reset upon invalidation and rerun.",
           "format": "int32",
           "type": "integer"
         },
         "submissionID": {
+          "description": "SubmissionID is a unique ID of the current submission of the application.",
           "type": "string"
         },
         "terminationTime": {
+          "description": "CompletionTime is the time when the application runs to completion if it does.",
           "format": "date-time",
           "nullable": true,
           "type": "string"


### PR DESCRIPTION
## PR Checklist

- [x] I have used the [CRD Extractor](https://github.com/datreeio/CRDs-catalog?tab=readme-ov-file#crd-extractor) tool to generate these CRDs

generated with

```bash
rm -rf $HOME/.datree/crdSchemas && \
  kind create cluster && \
  kubectl create -f https://raw.githubusercontent.com/kubeflow/spark-operator/refs/heads/master/charts/spark-operator-chart/crds/sparkoperator.k8s.io_sparkapplications.yaml && \
  kubectl create -f https://raw.githubusercontent.com/kubeflow/spark-operator/refs/heads/master/charts/spark-operator-chart/crds/sparkoperator.k8s.io_scheduledsparkapplications.yaml && \
  ./Utilities/crd-extractor.sh && \
  cp -r $HOME/.datree/crdSchemas/sparkoperator.k8s.io . && \
  kind delete cluster && \
  git commit -am "Updated sparkoperator crds to argocd v2.1.1"
  ```