### PR TITLE
Update bitnami.com/sealedsecret CRD to Fix Incorrect Errors

### DIFF
--- a/bitnami.com/sealedsecret_v1alpha1.json
+++ b/bitnami.com/sealedsecret_v1alpha1.json
@@ -73,7 +73,7 @@
               },
               "type": "object",
               "x-kubernetes-preserve-unknown-fields": true,
-              "additionalProperties": false
+              "additionalProperties": true
             },
             "type": {
               "description": "Used to facilitate programmatic handling of secret data.",


### PR DESCRIPTION
Resolves [sealed-secrets issue](https://github.com/bitnami-labs/sealed-secrets/issues/1717#issuecomment-2797096077)

The CRD contained in the datreeio (and generated by the CRD extractor) incorrectly returns errors for freshly generated sealed secrets as of [the latest change](https://github.com/datreeio/CRDs-catalog/commit/9894f231f39dba4f758f210dc700304f224c9828#diff-8b90cb622f1278648884982a78cda40f55df78ac48c9f4f971271635253b788aL68). Bitnami has confirmed that the CRD used by the sealed secrets controller is correct (see initially linked issue), and that the `spec.template.metadata.creationTimestamp` field is expected. I am setting `/properties/spec/properties/template/properties/metadata/additionalProperties` to true to resolve this issue. I have tested this from my branch with a couple different sealed-secret files and confirmed that those incorrect errors are no longer thrown.

## PR Checklist

- [x] I have used the [CRD Extractor](https://github.com/datreeio/CRDs-catalog?tab=readme-ov-file#crd-extractor) tool to generate these CRDs
