### PR TITLE
GH Workflow: Add job to update index.yaml.

### DIFF
--- a/.github/workflows/update-index.yaml
+++ b/.github/workflows/update-index.yaml
@@ -1,0 +1,24 @@
+name: Update index.yaml
+on:
+  schedule:
+    - cron: '25 2 * * *'
+jobs:
+  update_index:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install pyyaml
+    - name: Run auto-update script
+      run: python Utilities/auto-update-index.py . index.yaml
+    - name: Commit index.yaml
+      uses: stefanzweifel/git-auto-commit-action@v4
+      with:
+        commit_message: Updating index.yaml
+        file_pattern: index.yaml


### PR DESCRIPTION
Added GitHub workflow that updates `index.yaml` automatically. It runs on PR merge and if there are any changes in `index.yaml` it creates a PR.

I considered doing some **auto-merge** thing of the PR, but opted not to do it. I am not sure about the security implications of such a thing :)

There is a down side to this approach: The auto-generated PR is oblivious of other PRs. That means:
 - If an update-index PR is merged and there are other open CRDs PRs, then these will become outdated:
   - If a subsequent CRDs PR is merged "directly", then its subsequent update-index job will result in a PR (with potential conflict) on `index.yaml`
   - **Suggestion:** The open PRs need to be rebased on top of `main`. I believe this can be a one-click action in the GH PR UI.
 - If multiple CRDs PRs are merged (without merging update-index PRs in-between), then each of their update-index PRs will create an `index.yaml` independently of each-other. These changes then need to be merged by git, causing potential conflicts.

**Alternative approaches** to the trigger-on-merge approach are:
 - Keep it as a manual workflow job that you, @eyarz , need to trigger.
 - Create a schedule (e.g. run daily) that runs the job.
   - If the update-index PR is not merged same day, the job will continue to create PRs until main is up-to-date.

In either case (of the alternative approaches) there are no risks of merge conflicts (as long as only the latest update-index PR is merged).

_(Wonder whether one could delete old update-index PRs, or just update an existing one?)_

@eyarz What do you think?
