### PR TITLE
AWS Karpenter CRD add SSMparameter resolution capability to amiSelectorTerms in Ec2NodeClass

### DIFF
--- a/karpenter.k8s.aws/ec2nodeclass_v1.json
+++ b/karpenter.k8s.aws/ec2nodeclass_v1.json
@@ -64,6 +64,10 @@
                 "description": "Owner is the owner for the ami.\nYou can specify a combination of AWS account IDs, \"self\", \"amazon\", and \"aws-marketplace\"",
                 "type": "string"
               },
+              "ssmParameter": {
+                "description": "SSMParameter is the path to the SSM parameter that contains the AMI ID",
+                "type": "string"
+              },
               "tags": {
                 "additionalProperties": {
                   "type": "string"
@@ -87,20 +91,28 @@
           "type": "array",
           "x-kubernetes-validations": [
             {
-              "message": "expected at least one, got none, ['tags', 'id', 'name', 'alias']",
-              "rule": "self.all(x, has(x.tags) || has(x.id) || has(x.name) || has(x.alias))"
+              "message": "expected at least one, got none, ['tags', 'id', 'name', 'alias', 'ssmParameter']",
+              "rule": "self.all(x, has(x.tags) || has(x.id) || has(x.name) || has(x.alias) || has(x.ssmParameter))"
             },
             {
               "message": "'id' is mutually exclusive, cannot be set with a combination of other fields in amiSelectorTerms",
-              "rule": "!self.exists(x, has(x.id) && (has(x.alias) || has(x.tags) || has(x.name) || has(x.owner)))"
+              "rule": "!self.exists(x, has(x.id) && (has(x.alias) || has(x.tags) || has(x.name) || has(x.owner) || has(x.ssmParameter)))"
             },
             {
               "message": "'alias' is mutually exclusive, cannot be set with a combination of other fields in amiSelectorTerms",
-              "rule": "!self.exists(x, has(x.alias) && (has(x.id) || has(x.tags) || has(x.name) || has(x.owner)))"
+              "rule": "!self.exists(x, has(x.alias) && (has(x.id) || has(x.tags) || has(x.name) || has(x.owner) || has(x.ssmParameter)))"
+            },
+            {
+              "message": "'ssmParameter' is mutually exclusive, cannot be set with a combination of other fields in amiSelectorTerms",
+              "rule": "!self.exists(x, has(x.ssmParameter) && (has(x.id) || has(x.tags) || has(x.name) || has(x.owner) || has(x.alias)))"
             },
             {
               "message": "'alias' is mutually exclusive, cannot be set with a combination of other amiSelectorTerms",
               "rule": "!(self.exists(x, has(x.alias)) && self.size() != 1)"
+            },
+            {
+              "message": "'ssmParameter' is mutually exclusive, cannot be set with a combination of other amiSelectorTerms",
+              "rule": "!(self.exists(x, has(x.ssmParameter)) && self.size() != 1)"
             }
           ]
         },

--- a/karpenter.k8s.aws/ec2nodeclass_v1.json
+++ b/karpenter.k8s.aws/ec2nodeclass_v1.json
@@ -65,14 +65,14 @@
                 "type": "string"
               },
               "ssmParameter": {
-                "description": "SSMParameter is the path to the SSM parameter that contains the AMI ID",
+                "description": "SSMParameter is the name (or ARN) of the SSM parameter containing the Image ID.",
                 "type": "string"
               },
               "tags": {
                 "additionalProperties": {
                   "type": "string"
                 },
-                "description": "Tags is a map of key/value tags used to select subnets\nSpecifying '*' for a value selects all values for a given tag key.",
+                "description": "Tags is a map of key/value tags used to select amis.\nSpecifying '*' for a value selects all values for a given tag key.",
                 "maxProperties": 20,
                 "type": "object",
                 "x-kubernetes-validations": [
@@ -96,23 +96,15 @@
             },
             {
               "message": "'id' is mutually exclusive, cannot be set with a combination of other fields in amiSelectorTerms",
-              "rule": "!self.exists(x, has(x.id) && (has(x.alias) || has(x.tags) || has(x.name) || has(x.owner) || has(x.ssmParameter)))"
+              "rule": "!self.exists(x, has(x.id) && (has(x.alias) || has(x.tags) || has(x.name) || has(x.owner)))"
             },
             {
               "message": "'alias' is mutually exclusive, cannot be set with a combination of other fields in amiSelectorTerms",
-              "rule": "!self.exists(x, has(x.alias) && (has(x.id) || has(x.tags) || has(x.name) || has(x.owner) || has(x.ssmParameter)))"
-            },
-            {
-              "message": "'ssmParameter' is mutually exclusive, cannot be set with a combination of other fields in amiSelectorTerms",
-              "rule": "!self.exists(x, has(x.ssmParameter) && (has(x.id) || has(x.tags) || has(x.name) || has(x.owner) || has(x.alias)))"
+              "rule": "!self.exists(x, has(x.alias) && (has(x.id) || has(x.tags) || has(x.name) || has(x.owner)))"
             },
             {
               "message": "'alias' is mutually exclusive, cannot be set with a combination of other amiSelectorTerms",
               "rule": "!(self.exists(x, has(x.alias)) && self.size() != 1)"
-            },
-            {
-              "message": "'ssmParameter' is mutually exclusive, cannot be set with a combination of other amiSelectorTerms",
-              "rule": "!(self.exists(x, has(x.ssmParameter)) && self.size() != 1)"
             }
           ]
         },
@@ -140,12 +132,12 @@
                     "type": "boolean"
                   },
                   "iops": {
-                    "description": "IOPS is the number of I/O operations per second (IOPS). For gp3, io1, and io2 volumes,\nthis represents the number of IOPS that are provisioned for the volume. For\ngp2 volumes, this represents the baseline performance of the volume and the\nrate at which the volume accumulates I/O credits for bursting.\n\n\nThe following are the supported values for each volume type:\n\n\n   * gp3: 3,000-16,000 IOPS\n\n\n   * io1: 100-64,000 IOPS\n\n\n   * io2: 100-64,000 IOPS\n\n\nFor io1 and io2 volumes, we guarantee 64,000 IOPS only for Instances built\non the Nitro System (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html#ec2-nitro-instances).\nOther instance families guarantee performance up to 32,000 IOPS.\n\n\nThis parameter is supported for io1, io2, and gp3 volumes only. This parameter\nis not supported for gp2, st1, sc1, or standard volumes.",
+                    "description": "IOPS is the number of I/O operations per second (IOPS). For gp3, io1, and io2 volumes,\nthis represents the number of IOPS that are provisioned for the volume. For\ngp2 volumes, this represents the baseline performance of the volume and the\nrate at which the volume accumulates I/O credits for bursting.\n\nThe following are the supported values for each volume type:\n\n   * gp3: 3,000-16,000 IOPS\n\n   * io1: 100-64,000 IOPS\n\n   * io2: 100-64,000 IOPS\n\nFor io1 and io2 volumes, we guarantee 64,000 IOPS only for Instances built\non the Nitro System (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html#ec2-nitro-instances).\nOther instance families guarantee performance up to 32,000 IOPS.\n\nThis parameter is supported for io1, io2, and gp3 volumes only. This parameter\nis not supported for gp2, st1, sc1, or standard volumes.",
                     "format": "int64",
                     "type": "integer"
                   },
                   "kmsKeyID": {
-                    "description": "KMSKeyID (ARN) of the symmetric Key Management Service (KMS) CMK used for encryption.",
+                    "description": "Identifier (key ID, key alias, key ARN, or alias ARN) of the customer managed KMS key to use for EBS encryption.",
                     "type": "string"
                   },
                   "snapshotID": {
@@ -158,7 +150,7 @@
                     "type": "integer"
                   },
                   "volumeSize": {
-                    "description": "VolumeSize in `Gi`, `G`, `Ti`, or `T`. You must specify either a snapshot ID or\na volume size. The following are the supported volumes sizes for each volume\ntype:\n\n\n   * gp2 and gp3: 1-16,384\n\n\n   * io1 and io2: 4-16,384\n\n\n   * st1 and sc1: 125-16,384\n\n\n   * standard: 1-1,024",
+                    "description": "VolumeSize in `Gi`, `G`, `Ti`, or `T`. You must specify either a snapshot ID or\na volume size. The following are the supported volumes sizes for each volume\ntype:\n\n   * gp2 and gp3: 1-16,384\n\n   * io1 and io2: 4-16,384\n\n   * st1 and sc1: 125-16,384\n\n   * standard: 1-1,024",
                     "pattern": "^((?:[1-9][0-9]{0,3}|[1-4][0-9]{4}|[5][0-8][0-9]{3}|59000)Gi|(?:[1-9][0-9]{0,3}|[1-5][0-9]{4}|[6][0-3][0-9]{3}|64000)G|([1-9]||[1-5][0-7]|58)Ti|([1-9]||[1-5][0-9]|6[0-3]|64)T)$",
                     "type": "string"
                   },
@@ -199,6 +191,51 @@
             {
               "message": "must have only one blockDeviceMappings with rootVolume",
               "rule": "self.filter(x, has(x.rootVolume)?x.rootVolume==true:false).size() <= 1"
+            }
+          ]
+        },
+        "capacityReservationSelectorTerms": {
+          "description": "CapacityReservationSelectorTerms is a list of capacity reservation selector terms. Each term is ORed together to\ndetermine the set of eligible capacity reservations.",
+          "items": {
+            "properties": {
+              "id": {
+                "description": "ID is the capacity reservation id in EC2",
+                "pattern": "^cr-[0-9a-z]+$",
+                "type": "string"
+              },
+              "ownerID": {
+                "description": "Owner is the owner id for the ami.",
+                "pattern": "^[0-9]{12}$",
+                "type": "string"
+              },
+              "tags": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "description": "Tags is a map of key/value tags used to select capacity reservations.\nSpecifying '*' for a value selects all values for a given tag key.",
+                "maxProperties": 20,
+                "type": "object",
+                "x-kubernetes-validations": [
+                  {
+                    "message": "empty tag keys or values aren't supported",
+                    "rule": "self.all(k, k != '' && self[k] != '')"
+                  }
+                ]
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "maxItems": 30,
+          "type": "array",
+          "x-kubernetes-validations": [
+            {
+              "message": "expected at least one, got none, ['tags', 'id']",
+              "rule": "self.all(x, has(x.tags) || has(x.id))"
+            },
+            {
+              "message": "'id' is mutually exclusive, cannot be set along with tags in a capacity reservation selector term",
+              "rule": "!self.all(x, has(x.id) && (has(x.tags) || has(x.ownerID)))"
             }
           ]
         },
@@ -374,11 +411,11 @@
             "httpPutResponseHopLimit": 1,
             "httpTokens": "required"
           },
-          "description": "MetadataOptions for the generated launch template of provisioned nodes.\n\n\nThis specifies the exposure of the Instance Metadata Service to\nprovisioned EC2 nodes. For more information,\nsee Instance Metadata and User Data\n(https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html)\nin the Amazon Elastic Compute Cloud User Guide.\n\n\nRefer to recommended, security best practices\n(https://aws.github.io/aws-eks-best-practices/security/docs/iam/#restrict-access-to-the-instance-profile-assigned-to-the-worker-node)\nfor limiting exposure of Instance Metadata and User Data to pods.\nIf omitted, defaults to httpEndpoint enabled, with httpProtocolIPv6\ndisabled, with httpPutResponseLimit of 1, and with httpTokens\nrequired.",
+          "description": "MetadataOptions for the generated launch template of provisioned nodes.\n\nThis specifies the exposure of the Instance Metadata Service to\nprovisioned EC2 nodes. For more information,\nsee Instance Metadata and User Data\n(https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html)\nin the Amazon Elastic Compute Cloud User Guide.\n\nRefer to recommended, security best practices\n(https://aws.github.io/aws-eks-best-practices/security/docs/iam/#restrict-access-to-the-instance-profile-assigned-to-the-worker-node)\nfor limiting exposure of Instance Metadata and User Data to pods.\nIf omitted, defaults to httpEndpoint enabled, with httpProtocolIPv6\ndisabled, with httpPutResponseLimit of 1, and with httpTokens\nrequired.",
           "properties": {
             "httpEndpoint": {
               "default": "enabled",
-              "description": "HTTPEndpoint enables or disables the HTTP metadata endpoint on provisioned\nnodes. If metadata options is non-nil, but this parameter is not specified,\nthe default state is \"enabled\".\n\n\nIf you specify a value of \"disabled\", instance metadata will not be accessible\non the node.",
+              "description": "HTTPEndpoint enables or disables the HTTP metadata endpoint on provisioned\nnodes. If metadata options is non-nil, but this parameter is not specified,\nthe default state is \"enabled\".\n\nIf you specify a value of \"disabled\", instance metadata will not be accessible\non the node.",
               "enum": [
                 "enabled",
                 "disabled"
@@ -404,7 +441,7 @@
             },
             "httpTokens": {
               "default": "required",
-              "description": "HTTPTokens determines the state of token usage for instance metadata\nrequests. If metadata options is non-nil, but this parameter is not\nspecified, the default state is \"required\".\n\n\nIf the state is optional, one can choose to retrieve instance metadata with\nor without a signed token header on the request. If one retrieves the IAM\nrole credentials without a token, the version 1.0 role credentials are\nreturned. If one retrieves the IAM role credentials using a valid signed\ntoken, the version 2.0 role credentials are returned.\n\n\nIf the state is \"required\", one must send a signed token header with any\ninstance metadata retrieval requests. In this state, retrieving the IAM\nrole credentials always returns the version 2.0 credentials; the version\n1.0 credentials are not available.",
+              "description": "HTTPTokens determines the state of token usage for instance metadata\nrequests. If metadata options is non-nil, but this parameter is not\nspecified, the default state is \"required\".\n\nIf the state is optional, one can choose to retrieve instance metadata with\nor without a signed token header on the request. If one retrieves the IAM\nrole credentials without a token, the version 1.0 role credentials are\nreturned. If one retrieves the IAM role credentials using a valid signed\ntoken, the version 2.0 role credentials are returned.\n\nIf the state is \"required\", one must send a signed token header with any\ninstance metadata retrieval requests. In this state, retrieving the IAM\nrole credentials always returns the version 2.0 credentials; the version\n1.0 credentials are not available.",
               "enum": [
                 "required",
                 "optional"
@@ -430,7 +467,7 @@
           ]
         },
         "securityGroupSelectorTerms": {
-          "description": "SecurityGroupSelectorTerms is a list of or security group selector terms. The terms are ORed.",
+          "description": "SecurityGroupSelectorTerms is a list of security group selector terms. The terms are ORed.",
           "items": {
             "description": "SecurityGroupSelectorTerm defines selection logic for a security group used by Karpenter to launch nodes.\nIf multiple fields are used for selection, the requirements are ANDed.",
             "properties": {
@@ -447,7 +484,7 @@
                 "additionalProperties": {
                   "type": "string"
                 },
-                "description": "Tags is a map of key/value tags used to select subnets\nSpecifying '*' for a value selects all values for a given tag key.",
+                "description": "Tags is a map of key/value tags used to select security groups.\nSpecifying '*' for a value selects all values for a given tag key.",
                 "maxProperties": 20,
                 "type": "object",
                 "x-kubernetes-validations": [
@@ -473,17 +510,17 @@
               "rule": "self.all(x, has(x.tags) || has(x.id) || has(x.name))"
             },
             {
-              "message": "'id' is mutually exclusive, cannot be set with a combination of other fields in securityGroupSelectorTerms",
+              "message": "'id' is mutually exclusive, cannot be set with a combination of other fields in a security group selector term",
               "rule": "!self.all(x, has(x.id) && (has(x.tags) || has(x.name)))"
             },
             {
-              "message": "'name' is mutually exclusive, cannot be set with a combination of other fields in securityGroupSelectorTerms",
+              "message": "'name' is mutually exclusive, cannot be set with a combination of other fields in a security group selector term",
               "rule": "!self.all(x, has(x.name) && (has(x.tags) || has(x.id)))"
             }
           ]
         },
         "subnetSelectorTerms": {
-          "description": "SubnetSelectorTerms is a list of or subnet selector terms. The terms are ORed.",
+          "description": "SubnetSelectorTerms is a list of subnet selector terms. The terms are ORed.",
           "items": {
             "description": "SubnetSelectorTerm defines selection logic for a subnet used by Karpenter to launch nodes.\nIf multiple fields are used for selection, the requirements are ANDed.",
             "properties": {
@@ -522,7 +559,7 @@
               "rule": "self.all(x, has(x.tags) || has(x.id))"
             },
             {
-              "message": "'id' is mutually exclusive, cannot be set with a combination of other fields in subnetSelectorTerms",
+              "message": "'id' is mutually exclusive, cannot be set with a combination of other fields in a subnet selector term",
               "rule": "!self.all(x, has(x.id) && has(x.tags))"
             }
           ]
@@ -615,6 +652,10 @@
           "items": {
             "description": "AMI contains resolved AMI selector values utilized for node launch",
             "properties": {
+              "deprecated": {
+                "description": "Deprecation status of the AMI",
+                "type": "boolean"
+              },
               "id": {
                 "description": "ID of the AMI",
                 "type": "string"
@@ -664,6 +705,54 @@
           },
           "type": "array"
         },
+        "capacityReservations": {
+          "description": "CapacityReservations contains the current capacity reservation values that are available to this NodeClass under the\nCapacityReservation selectors.",
+          "items": {
+            "properties": {
+              "availabilityZone": {
+                "description": "The availability zone the capacity reservation is available in.",
+                "type": "string"
+              },
+              "endTime": {
+                "description": "The time at which the capacity reservation expires. Once expired, the reserved capacity is released and Karpenter\nwill no longer be able to launch instances into that reservation.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "id": {
+                "description": "The id for the capacity reservation.",
+                "pattern": "^cr-[0-9a-z]+$",
+                "type": "string"
+              },
+              "instanceMatchCriteria": {
+                "description": "Indicates the type of instance launches the capacity reservation accepts.",
+                "enum": [
+                  "open",
+                  "targeted"
+                ],
+                "type": "string"
+              },
+              "instanceType": {
+                "description": "The instance type for the capacity reservation.",
+                "type": "string"
+              },
+              "ownerID": {
+                "description": "The ID of the AWS account that owns the capacity reservation.",
+                "pattern": "^[0-9]{12}$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "availabilityZone",
+              "id",
+              "instanceMatchCriteria",
+              "instanceType",
+              "ownerID"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
         "conditions": {
           "description": "Conditions contains signals for health and readiness",
           "items": {
@@ -702,7 +791,7 @@
                 "type": "string"
               },
               "type": {
-                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.\n---\nMany .condition.type values are consistent across resources like Available, but because arbitrary conditions can be\nuseful (see .node.status.conditions), the ability to deconflict is important.\nThe regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)",
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
                 "maxLength": 316,
                 "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
                 "type": "string"
@@ -725,7 +814,7 @@
           "type": "string"
         },
         "securityGroups": {
-          "description": "SecurityGroups contains the current Security Groups values that are available to the\ncluster under the SecurityGroups selectors.",
+          "description": "SecurityGroups contains the current security group values that are available to the\ncluster under the SecurityGroups selectors.",
           "items": {
             "description": "SecurityGroup contains resolved SecurityGroup selector values utilized for node launch",
             "properties": {
@@ -747,7 +836,7 @@
           "type": "array"
         },
         "subnets": {
-          "description": "Subnets contains the current Subnet values that are available to the\ncluster under the subnet selectors.",
+          "description": "Subnets contains the current subnet values that are available to the\ncluster under the subnet selectors.",
           "items": {
             "description": "Subnet contains resolved Subnet selector values utilized for node launch",
             "properties": {


### PR DESCRIPTION
## PR Checklist

- [x] I have used the [CRD Extractor](https://github.com/datreeio/CRDs-catalog?tab=readme-ov-file#crd-extractor) tool to generate these CRDs


Karpenter v1.4 introduces SSM parameter resolution for the AMI selector field. 

CRD: https://github.com/aws/karpenter-provider-aws/blob/main/charts/karpenter-crd/templates/karpenter.k8s.aws_ec2nodeclasses.yaml#L79-L143 

Documentation: https://karpenter.sh/docs/concepts/nodeclasses/#specamiselectorterms

Change log:  https://github.com/aws/karpenter-provider-aws/releases/tag/v1.4.0 
`add support for custom ssm parameters in amiSelectorTerms (https://github.com/aws/karpenter-provider-aws/pull/7341) https://github.com/aws/karpenter-provider-aws/pull/7341 ([Wesley Yep](https://github.com/aws/karpenter-provider-aws/commit/c41509eaac02b3b1e394cb20fac4eb8879e399f0))`


Following the instructions in https://github.com/datreeio/CRDs-catalog?tab=readme-ov-file#usage, after running `./crd-extractor.sh` :

test yaml:
```yaml

apiVersion: karpenter.k8s.aws/v1
kind: EC2NodeClass
metadata:
  name: happy-with-defaults
spec:
  amiFamily: AL2
  subnetSelectorTerms:
    - tags:
        aws:cloudformation:logical-id: testA
    - tags:
        aws:cloudformation:logical-id: testB
    - tags:
        aws:cloudformation:logical-id: testC
  securityGroupSelectorTerms:
  - tags:
      Name: K8s Nodes
  instanceProfile: test-cluster-variable-eks-node
  amiSelectorTerms:
    - ssmParameter: /XXXXXXXXXX/resources/eks/EKS_CLUSTER_NAME/ami/EKS_CLUSTER_VERSION
  tags:
    Name: "test-cluster-variable-platform-karpenter-node"
    deeming: "IC"
    eks:cluster-name: "test-cluster-variable"
    environment: "dev-pprd-prod-variable"
    karpenter-node: "test-cluster-variable"
  metadataOptions:
    httpEndpoint: enabled
    httpProtocolIPv6: disabled
    httpPutResponseHopLimit: 2
    httpTokens: required
  detailedMonitoring: true
```

test command:

```
❯ kubeconform -summary -output json -schema-location default -schema-location ec2nodeclass_v1.json test.yaml                                                               took 6s at 15:24:13
{
  "resources": [],
  "summary": {
    "valid": 1,
    "invalid": 0,
    "errors": 0,
    "skipped": 0
  }
}
```