### PR TITLE
Update logging.banzaicloud.io CRDs to v5.3.0

### DIFF
--- a/logging.banzaicloud.io/clusterflow_v1alpha1.json
+++ b/logging.banzaicloud.io/clusterflow_v1alpha1.json
@@ -155,249 +155,6 @@
                 "type": "object",
                 "additionalProperties": false
               },
-              "enhanceK8s": {
-                "properties": {
-                  "api_groups": {
-                    "items": {
-                      "type": "string"
-                    },
-                    "type": "array"
-                  },
-                  "bearer_token_file": {
-                    "type": "string"
-                  },
-                  "ca_file": {
-                    "properties": {
-                      "mountFrom": {
-                        "properties": {
-                          "secretKeyRef": {
-                            "properties": {
-                              "key": {
-                                "type": "string"
-                              },
-                              "name": {
-                                "default": "",
-                                "type": "string"
-                              },
-                              "optional": {
-                                "type": "boolean"
-                              }
-                            },
-                            "required": [
-                              "key"
-                            ],
-                            "type": "object",
-                            "x-kubernetes-map-type": "atomic",
-                            "additionalProperties": false
-                          }
-                        },
-                        "type": "object",
-                        "additionalProperties": false
-                      },
-                      "value": {
-                        "type": "string"
-                      },
-                      "valueFrom": {
-                        "properties": {
-                          "secretKeyRef": {
-                            "properties": {
-                              "key": {
-                                "type": "string"
-                              },
-                              "name": {
-                                "default": "",
-                                "type": "string"
-                              },
-                              "optional": {
-                                "type": "boolean"
-                              }
-                            },
-                            "required": [
-                              "key"
-                            ],
-                            "type": "object",
-                            "x-kubernetes-map-type": "atomic",
-                            "additionalProperties": false
-                          }
-                        },
-                        "type": "object",
-                        "additionalProperties": false
-                      }
-                    },
-                    "type": "object",
-                    "additionalProperties": false
-                  },
-                  "cache_refresh": {
-                    "type": "integer"
-                  },
-                  "cache_refresh_variation": {
-                    "type": "integer"
-                  },
-                  "cache_size": {
-                    "type": "integer"
-                  },
-                  "cache_ttl": {
-                    "type": "integer"
-                  },
-                  "client_cert": {
-                    "properties": {
-                      "mountFrom": {
-                        "properties": {
-                          "secretKeyRef": {
-                            "properties": {
-                              "key": {
-                                "type": "string"
-                              },
-                              "name": {
-                                "default": "",
-                                "type": "string"
-                              },
-                              "optional": {
-                                "type": "boolean"
-                              }
-                            },
-                            "required": [
-                              "key"
-                            ],
-                            "type": "object",
-                            "x-kubernetes-map-type": "atomic",
-                            "additionalProperties": false
-                          }
-                        },
-                        "type": "object",
-                        "additionalProperties": false
-                      },
-                      "value": {
-                        "type": "string"
-                      },
-                      "valueFrom": {
-                        "properties": {
-                          "secretKeyRef": {
-                            "properties": {
-                              "key": {
-                                "type": "string"
-                              },
-                              "name": {
-                                "default": "",
-                                "type": "string"
-                              },
-                              "optional": {
-                                "type": "boolean"
-                              }
-                            },
-                            "required": [
-                              "key"
-                            ],
-                            "type": "object",
-                            "x-kubernetes-map-type": "atomic",
-                            "additionalProperties": false
-                          }
-                        },
-                        "type": "object",
-                        "additionalProperties": false
-                      }
-                    },
-                    "type": "object",
-                    "additionalProperties": false
-                  },
-                  "client_key": {
-                    "properties": {
-                      "mountFrom": {
-                        "properties": {
-                          "secretKeyRef": {
-                            "properties": {
-                              "key": {
-                                "type": "string"
-                              },
-                              "name": {
-                                "default": "",
-                                "type": "string"
-                              },
-                              "optional": {
-                                "type": "boolean"
-                              }
-                            },
-                            "required": [
-                              "key"
-                            ],
-                            "type": "object",
-                            "x-kubernetes-map-type": "atomic",
-                            "additionalProperties": false
-                          }
-                        },
-                        "type": "object",
-                        "additionalProperties": false
-                      },
-                      "value": {
-                        "type": "string"
-                      },
-                      "valueFrom": {
-                        "properties": {
-                          "secretKeyRef": {
-                            "properties": {
-                              "key": {
-                                "type": "string"
-                              },
-                              "name": {
-                                "default": "",
-                                "type": "string"
-                              },
-                              "optional": {
-                                "type": "boolean"
-                              }
-                            },
-                            "required": [
-                              "key"
-                            ],
-                            "type": "object",
-                            "x-kubernetes-map-type": "atomic",
-                            "additionalProperties": false
-                          }
-                        },
-                        "type": "object",
-                        "additionalProperties": false
-                      }
-                    },
-                    "type": "object",
-                    "additionalProperties": false
-                  },
-                  "core_api_versions": {
-                    "items": {
-                      "type": "string"
-                    },
-                    "type": "array"
-                  },
-                  "data_type": {
-                    "type": "string"
-                  },
-                  "in_namespace_path": {
-                    "items": {
-                      "type": "string"
-                    },
-                    "type": "array"
-                  },
-                  "in_pod_path": {
-                    "items": {
-                      "type": "string"
-                    },
-                    "type": "array"
-                  },
-                  "kubernetes_url": {
-                    "type": "string"
-                  },
-                  "secret_dir": {
-                    "type": "string"
-                  },
-                  "ssl_partial_chain": {
-                    "type": "boolean"
-                  },
-                  "verify_ssl": {
-                    "type": "boolean"
-                  }
-                },
-                "type": "object",
-                "additionalProperties": false
-              },
               "geoip": {
                 "properties": {
                   "backend_library": {
@@ -676,6 +433,9 @@
                       "format_firstline": {
                         "type": "string"
                       },
+                      "format_key": {
+                        "type": "string"
+                      },
                       "grok_failure_key": {
                         "type": "string"
                       },
@@ -813,6 +573,9 @@
                               "type": "string"
                             },
                             "format": {
+                              "type": "string"
+                            },
+                            "format_name": {
                               "type": "string"
                             },
                             "grok_failure_key": {
@@ -1003,6 +766,9 @@
                         "format_firstline": {
                           "type": "string"
                         },
+                        "format_key": {
+                          "type": "string"
+                        },
                         "grok_failure_key": {
                           "type": "string"
                         },
@@ -1140,6 +906,9 @@
                                 "type": "string"
                               },
                               "format": {
+                                "type": "string"
+                              },
+                              "format_name": {
                                 "type": "string"
                               },
                               "grok_failure_key": {
@@ -1405,90 +1174,6 @@
                 "type": "object",
                 "additionalProperties": false
               },
-              "sumologic": {
-                "properties": {
-                  "collector_key_name": {
-                    "type": "string"
-                  },
-                  "collector_value": {
-                    "type": "string"
-                  },
-                  "exclude_container_regex": {
-                    "type": "string"
-                  },
-                  "exclude_facility_regex": {
-                    "type": "string"
-                  },
-                  "exclude_host_regex": {
-                    "type": "string"
-                  },
-                  "exclude_namespace_regex": {
-                    "type": "string"
-                  },
-                  "exclude_pod_regex": {
-                    "type": "string"
-                  },
-                  "exclude_priority_regex": {
-                    "type": "string"
-                  },
-                  "exclude_unit_regex": {
-                    "type": "string"
-                  },
-                  "log_format": {
-                    "type": "string"
-                  },
-                  "source_category": {
-                    "type": "string"
-                  },
-                  "source_category_key_name": {
-                    "type": "string"
-                  },
-                  "source_category_prefix": {
-                    "type": "string"
-                  },
-                  "source_category_replace_dash": {
-                    "type": "string"
-                  },
-                  "source_host": {
-                    "type": "string"
-                  },
-                  "source_host_key_name": {
-                    "type": "string"
-                  },
-                  "source_name": {
-                    "type": "string"
-                  },
-                  "source_name_key_name": {
-                    "type": "string"
-                  },
-                  "tracing_annotation_prefix": {
-                    "type": "string"
-                  },
-                  "tracing_container_name": {
-                    "type": "string"
-                  },
-                  "tracing_format": {
-                    "type": "boolean"
-                  },
-                  "tracing_host": {
-                    "type": "string"
-                  },
-                  "tracing_label_prefix": {
-                    "type": "string"
-                  },
-                  "tracing_namespace": {
-                    "type": "string"
-                  },
-                  "tracing_pod": {
-                    "type": "string"
-                  },
-                  "tracing_pod_id": {
-                    "type": "string"
-                  }
-                },
-                "type": "object",
-                "additionalProperties": false
-              },
               "tag_normaliser": {
                 "properties": {
                   "format": {
@@ -1598,6 +1283,12 @@
                       "type": "string"
                     },
                     "type": "array"
+                  },
+                  "namespaces_regex": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
                   }
                 },
                 "type": "object",
@@ -1630,6 +1321,12 @@
                     "type": "object"
                   },
                   "namespaces": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "namespaces_regex": {
                     "items": {
                       "type": "string"
                     },

--- a/logging.banzaicloud.io/clusterflow_v1beta1.json
+++ b/logging.banzaicloud.io/clusterflow_v1beta1.json
@@ -155,249 +155,6 @@
                 "type": "object",
                 "additionalProperties": false
               },
-              "enhanceK8s": {
-                "properties": {
-                  "api_groups": {
-                    "items": {
-                      "type": "string"
-                    },
-                    "type": "array"
-                  },
-                  "bearer_token_file": {
-                    "type": "string"
-                  },
-                  "ca_file": {
-                    "properties": {
-                      "mountFrom": {
-                        "properties": {
-                          "secretKeyRef": {
-                            "properties": {
-                              "key": {
-                                "type": "string"
-                              },
-                              "name": {
-                                "default": "",
-                                "type": "string"
-                              },
-                              "optional": {
-                                "type": "boolean"
-                              }
-                            },
-                            "required": [
-                              "key"
-                            ],
-                            "type": "object",
-                            "x-kubernetes-map-type": "atomic",
-                            "additionalProperties": false
-                          }
-                        },
-                        "type": "object",
-                        "additionalProperties": false
-                      },
-                      "value": {
-                        "type": "string"
-                      },
-                      "valueFrom": {
-                        "properties": {
-                          "secretKeyRef": {
-                            "properties": {
-                              "key": {
-                                "type": "string"
-                              },
-                              "name": {
-                                "default": "",
-                                "type": "string"
-                              },
-                              "optional": {
-                                "type": "boolean"
-                              }
-                            },
-                            "required": [
-                              "key"
-                            ],
-                            "type": "object",
-                            "x-kubernetes-map-type": "atomic",
-                            "additionalProperties": false
-                          }
-                        },
-                        "type": "object",
-                        "additionalProperties": false
-                      }
-                    },
-                    "type": "object",
-                    "additionalProperties": false
-                  },
-                  "cache_refresh": {
-                    "type": "integer"
-                  },
-                  "cache_refresh_variation": {
-                    "type": "integer"
-                  },
-                  "cache_size": {
-                    "type": "integer"
-                  },
-                  "cache_ttl": {
-                    "type": "integer"
-                  },
-                  "client_cert": {
-                    "properties": {
-                      "mountFrom": {
-                        "properties": {
-                          "secretKeyRef": {
-                            "properties": {
-                              "key": {
-                                "type": "string"
-                              },
-                              "name": {
-                                "default": "",
-                                "type": "string"
-                              },
-                              "optional": {
-                                "type": "boolean"
-                              }
-                            },
-                            "required": [
-                              "key"
-                            ],
-                            "type": "object",
-                            "x-kubernetes-map-type": "atomic",
-                            "additionalProperties": false
-                          }
-                        },
-                        "type": "object",
-                        "additionalProperties": false
-                      },
-                      "value": {
-                        "type": "string"
-                      },
-                      "valueFrom": {
-                        "properties": {
-                          "secretKeyRef": {
-                            "properties": {
-                              "key": {
-                                "type": "string"
-                              },
-                              "name": {
-                                "default": "",
-                                "type": "string"
-                              },
-                              "optional": {
-                                "type": "boolean"
-                              }
-                            },
-                            "required": [
-                              "key"
-                            ],
-                            "type": "object",
-                            "x-kubernetes-map-type": "atomic",
-                            "additionalProperties": false
-                          }
-                        },
-                        "type": "object",
-                        "additionalProperties": false
-                      }
-                    },
-                    "type": "object",
-                    "additionalProperties": false
-                  },
-                  "client_key": {
-                    "properties": {
-                      "mountFrom": {
-                        "properties": {
-                          "secretKeyRef": {
-                            "properties": {
-                              "key": {
-                                "type": "string"
-                              },
-                              "name": {
-                                "default": "",
-                                "type": "string"
-                              },
-                              "optional": {
-                                "type": "boolean"
-                              }
-                            },
-                            "required": [
-                              "key"
-                            ],
-                            "type": "object",
-                            "x-kubernetes-map-type": "atomic",
-                            "additionalProperties": false
-                          }
-                        },
-                        "type": "object",
-                        "additionalProperties": false
-                      },
-                      "value": {
-                        "type": "string"
-                      },
-                      "valueFrom": {
-                        "properties": {
-                          "secretKeyRef": {
-                            "properties": {
-                              "key": {
-                                "type": "string"
-                              },
-                              "name": {
-                                "default": "",
-                                "type": "string"
-                              },
-                              "optional": {
-                                "type": "boolean"
-                              }
-                            },
-                            "required": [
-                              "key"
-                            ],
-                            "type": "object",
-                            "x-kubernetes-map-type": "atomic",
-                            "additionalProperties": false
-                          }
-                        },
-                        "type": "object",
-                        "additionalProperties": false
-                      }
-                    },
-                    "type": "object",
-                    "additionalProperties": false
-                  },
-                  "core_api_versions": {
-                    "items": {
-                      "type": "string"
-                    },
-                    "type": "array"
-                  },
-                  "data_type": {
-                    "type": "string"
-                  },
-                  "in_namespace_path": {
-                    "items": {
-                      "type": "string"
-                    },
-                    "type": "array"
-                  },
-                  "in_pod_path": {
-                    "items": {
-                      "type": "string"
-                    },
-                    "type": "array"
-                  },
-                  "kubernetes_url": {
-                    "type": "string"
-                  },
-                  "secret_dir": {
-                    "type": "string"
-                  },
-                  "ssl_partial_chain": {
-                    "type": "boolean"
-                  },
-                  "verify_ssl": {
-                    "type": "boolean"
-                  }
-                },
-                "type": "object",
-                "additionalProperties": false
-              },
               "geoip": {
                 "properties": {
                   "backend_library": {
@@ -676,6 +433,9 @@
                       "format_firstline": {
                         "type": "string"
                       },
+                      "format_key": {
+                        "type": "string"
+                      },
                       "grok_failure_key": {
                         "type": "string"
                       },
@@ -813,6 +573,9 @@
                               "type": "string"
                             },
                             "format": {
+                              "type": "string"
+                            },
+                            "format_name": {
                               "type": "string"
                             },
                             "grok_failure_key": {
@@ -1003,6 +766,9 @@
                         "format_firstline": {
                           "type": "string"
                         },
+                        "format_key": {
+                          "type": "string"
+                        },
                         "grok_failure_key": {
                           "type": "string"
                         },
@@ -1140,6 +906,9 @@
                                 "type": "string"
                               },
                               "format": {
+                                "type": "string"
+                              },
+                              "format_name": {
                                 "type": "string"
                               },
                               "grok_failure_key": {
@@ -1405,90 +1174,6 @@
                 "type": "object",
                 "additionalProperties": false
               },
-              "sumologic": {
-                "properties": {
-                  "collector_key_name": {
-                    "type": "string"
-                  },
-                  "collector_value": {
-                    "type": "string"
-                  },
-                  "exclude_container_regex": {
-                    "type": "string"
-                  },
-                  "exclude_facility_regex": {
-                    "type": "string"
-                  },
-                  "exclude_host_regex": {
-                    "type": "string"
-                  },
-                  "exclude_namespace_regex": {
-                    "type": "string"
-                  },
-                  "exclude_pod_regex": {
-                    "type": "string"
-                  },
-                  "exclude_priority_regex": {
-                    "type": "string"
-                  },
-                  "exclude_unit_regex": {
-                    "type": "string"
-                  },
-                  "log_format": {
-                    "type": "string"
-                  },
-                  "source_category": {
-                    "type": "string"
-                  },
-                  "source_category_key_name": {
-                    "type": "string"
-                  },
-                  "source_category_prefix": {
-                    "type": "string"
-                  },
-                  "source_category_replace_dash": {
-                    "type": "string"
-                  },
-                  "source_host": {
-                    "type": "string"
-                  },
-                  "source_host_key_name": {
-                    "type": "string"
-                  },
-                  "source_name": {
-                    "type": "string"
-                  },
-                  "source_name_key_name": {
-                    "type": "string"
-                  },
-                  "tracing_annotation_prefix": {
-                    "type": "string"
-                  },
-                  "tracing_container_name": {
-                    "type": "string"
-                  },
-                  "tracing_format": {
-                    "type": "boolean"
-                  },
-                  "tracing_host": {
-                    "type": "string"
-                  },
-                  "tracing_label_prefix": {
-                    "type": "string"
-                  },
-                  "tracing_namespace": {
-                    "type": "string"
-                  },
-                  "tracing_pod": {
-                    "type": "string"
-                  },
-                  "tracing_pod_id": {
-                    "type": "string"
-                  }
-                },
-                "type": "object",
-                "additionalProperties": false
-              },
               "tag_normaliser": {
                 "properties": {
                   "format": {
@@ -1598,6 +1283,12 @@
                       "type": "string"
                     },
                     "type": "array"
+                  },
+                  "namespaces_regex": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
                   }
                 },
                 "type": "object",
@@ -1630,6 +1321,12 @@
                     "type": "object"
                   },
                   "namespaces": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "namespaces_regex": {
                     "items": {
                       "type": "string"
                     },

--- a/logging.banzaicloud.io/clusteroutput_v1alpha1.json
+++ b/logging.banzaicloud.io/clusteroutput_v1alpha1.json
@@ -2982,12 +2982,6 @@
           "type": "object",
           "additionalProperties": false
         },
-        "enabledNamespaces": {
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
         "file": {
           "properties": {
             "add_path_suffix": {
@@ -4215,6 +4209,9 @@
                 "type": "string"
               },
               "type": "object"
+            },
+            "udp_transport_type": {
+              "type": "string"
             }
           },
           "required": [
@@ -4463,6 +4460,9 @@
               "type": "object",
               "additionalProperties": false
             },
+            "compress": {
+              "type": "string"
+            },
             "content_type": {
               "type": "string"
             },
@@ -4502,6 +4502,12 @@
               },
               "type": "object"
             },
+            "headers_from_placeholders": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
             "http_method": {
               "type": "string"
             },
@@ -4522,6 +4528,9 @@
                 "type": "integer"
               },
               "type": "array"
+            },
+            "reuse_connections": {
+              "type": "boolean"
             },
             "slow_flush_log_threshold": {
               "type": "string"
@@ -5113,6 +5122,288 @@
             },
             "principal": {
               "type": "string"
+            },
+            "rdkafka_options": {
+              "properties": {
+                "allow.auto.create.topics": {
+                  "type": "boolean"
+                },
+                "api.version.fallback.ms": {
+                  "type": "integer"
+                },
+                "api.version.request": {
+                  "type": "boolean"
+                },
+                "api.version.request.timeout.ms": {
+                  "type": "integer"
+                },
+                "background_event_cb": {
+                  "type": "string"
+                },
+                "bootstrap.servers": {
+                  "type": "string"
+                },
+                "broker.address.family": {
+                  "type": "string"
+                },
+                "broker.address.ttl": {
+                  "type": "integer"
+                },
+                "broker.version.fallback": {
+                  "type": "string"
+                },
+                "builtin.features": {
+                  "type": "string"
+                },
+                "client.id": {
+                  "type": "string"
+                },
+                "closesocket_cb": {
+                  "type": "string"
+                },
+                "connect_cb": {
+                  "type": "string"
+                },
+                "connections.max.idle.ms": {
+                  "type": "integer"
+                },
+                "debug": {
+                  "type": "string"
+                },
+                "default_topic_conf": {
+                  "type": "string"
+                },
+                "enable.random.seed": {
+                  "type": "boolean"
+                },
+                "enable.sasl.oauthbearer.unsecure.jwt": {
+                  "type": "boolean"
+                },
+                "enable.ssl.certificate.verification": {
+                  "type": "boolean"
+                },
+                "enabled_events": {
+                  "type": "integer"
+                },
+                "error_cb": {
+                  "type": "string"
+                },
+                "interceptors": {
+                  "type": "string"
+                },
+                "internal.termination.signal": {
+                  "type": "integer"
+                },
+                "log.connection.close": {
+                  "type": "boolean"
+                },
+                "log.queue": {
+                  "type": "boolean"
+                },
+                "log.thread.name": {
+                  "type": "boolean"
+                },
+                "log_cb": {
+                  "type": "string"
+                },
+                "log_level": {
+                  "type": "integer"
+                },
+                "max.in.flight": {
+                  "type": "integer"
+                },
+                "max.in.flight.requests.per.connection": {
+                  "type": "integer"
+                },
+                "message.copy.max.bytes": {
+                  "type": "integer"
+                },
+                "message.max.bytes": {
+                  "type": "integer"
+                },
+                "metadata.broker.list": {
+                  "type": "string"
+                },
+                "metadata.max.age.ms": {
+                  "type": "integer"
+                },
+                "oauthbearer_token_refresh_cb": {
+                  "type": "string"
+                },
+                "opaque": {
+                  "type": "string"
+                },
+                "open_cb": {
+                  "type": "string"
+                },
+                "plugin.library.paths": {
+                  "type": "string"
+                },
+                "receive.message.max.bytes": {
+                  "type": "integer"
+                },
+                "reconnect.backoff.max.ms": {
+                  "type": "integer"
+                },
+                "reconnect.backoff.ms": {
+                  "type": "integer"
+                },
+                "resolve_cb": {
+                  "type": "string"
+                },
+                "sasl.kerberos.keytab": {
+                  "type": "string"
+                },
+                "sasl.kerberos.kinit.cmd": {
+                  "type": "string"
+                },
+                "sasl.kerberos.min.time.before.relogin": {
+                  "type": "integer"
+                },
+                "sasl.kerberos.principal": {
+                  "type": "string"
+                },
+                "sasl.kerberos.service.name": {
+                  "type": "string"
+                },
+                "sasl.mechanisms": {
+                  "type": "string"
+                },
+                "sasl.oauthbearer.client.id": {
+                  "type": "string"
+                },
+                "sasl.oauthbearer.client.secret": {
+                  "type": "string"
+                },
+                "sasl.oauthbearer.config": {
+                  "type": "string"
+                },
+                "sasl.oauthbearer.extensions": {
+                  "type": "string"
+                },
+                "sasl.oauthbearer.method": {
+                  "type": "string"
+                },
+                "sasl.oauthbearer.scope": {
+                  "type": "string"
+                },
+                "sasl.oauthbearer.token.endpoint.url": {
+                  "type": "string"
+                },
+                "sasl.password": {
+                  "type": "string"
+                },
+                "sasl.username": {
+                  "type": "string"
+                },
+                "security.protocol": {
+                  "type": "string"
+                },
+                "socket.blocking.max.ms": {
+                  "type": "integer"
+                },
+                "socket.connection.setup.timeout.ms": {
+                  "type": "integer"
+                },
+                "socket.keepalive.enable": {
+                  "type": "boolean"
+                },
+                "socket.max.fails": {
+                  "type": "integer"
+                },
+                "socket.nagle.disable": {
+                  "type": "boolean"
+                },
+                "socket.receive.buffer.bytes": {
+                  "type": "integer"
+                },
+                "socket.send.buffer.bytes": {
+                  "type": "integer"
+                },
+                "socket.timeout.ms": {
+                  "type": "integer"
+                },
+                "socket_cb": {
+                  "type": "string"
+                },
+                "ssl.ca.location": {
+                  "type": "string"
+                },
+                "ssl.ca.pem": {
+                  "type": "string"
+                },
+                "ssl.certificate.location": {
+                  "type": "string"
+                },
+                "ssl.certificate.pem": {
+                  "type": "string"
+                },
+                "ssl.cipher.suites": {
+                  "type": "string"
+                },
+                "ssl.crl.location": {
+                  "type": "string"
+                },
+                "ssl.curves.list": {
+                  "type": "string"
+                },
+                "ssl.endpoint.identification.algorithm": {
+                  "type": "string"
+                },
+                "ssl.engine.id": {
+                  "type": "string"
+                },
+                "ssl.engine.location": {
+                  "type": "string"
+                },
+                "ssl.key.location": {
+                  "type": "string"
+                },
+                "ssl.key.password": {
+                  "type": "string"
+                },
+                "ssl.key.pem": {
+                  "type": "string"
+                },
+                "ssl.keystore.location": {
+                  "type": "string"
+                },
+                "ssl.keystore.password": {
+                  "type": "string"
+                },
+                "ssl.providers": {
+                  "type": "string"
+                },
+                "ssl.sigalgs.list": {
+                  "type": "string"
+                },
+                "statistics.interval.ms": {
+                  "type": "integer"
+                },
+                "stats_cb": {
+                  "type": "string"
+                },
+                "throttle_cb": {
+                  "type": "string"
+                },
+                "topic.blacklist": {
+                  "type": "string"
+                },
+                "topic.metadata.propagation.max.ms": {
+                  "type": "integer"
+                },
+                "topic.metadata.refresh.fast.interval.ms": {
+                  "type": "integer"
+                },
+                "topic.metadata.refresh.interval.ms": {
+                  "type": "integer"
+                },
+                "topic.metadata.refresh.sparse": {
+                  "type": "boolean"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
             },
             "required_acks": {
               "type": "integer"
@@ -7448,7 +7739,13 @@
           "additionalProperties": false
         },
         "nullout": {
-          "type": "object"
+          "properties": {
+            "never_flush": {
+              "type": "boolean"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
         },
         "opensearch": {
           "properties": {
@@ -8438,6 +8735,9 @@
             },
             "reload_on_failure": {
               "type": "boolean"
+            },
+            "remove_keys": {
+              "type": "string"
             },
             "remove_keys_on_update": {
               "type": "string"
@@ -10393,248 +10693,6 @@
               "type": "string"
             }
           },
-          "type": "object",
-          "additionalProperties": false
-        },
-        "sumologic": {
-          "properties": {
-            "add_timestamp": {
-              "type": "boolean"
-            },
-            "buffer": {
-              "properties": {
-                "chunk_full_threshold": {
-                  "type": "string"
-                },
-                "chunk_limit_records": {
-                  "type": "integer"
-                },
-                "chunk_limit_size": {
-                  "type": "string"
-                },
-                "compress": {
-                  "type": "string"
-                },
-                "delayed_commit_timeout": {
-                  "type": "string"
-                },
-                "disable_chunk_backup": {
-                  "type": "boolean"
-                },
-                "disabled": {
-                  "type": "boolean"
-                },
-                "flush_at_shutdown": {
-                  "type": "boolean"
-                },
-                "flush_interval": {
-                  "type": "string"
-                },
-                "flush_mode": {
-                  "type": "string"
-                },
-                "flush_thread_burst_interval": {
-                  "type": "string"
-                },
-                "flush_thread_count": {
-                  "type": "integer"
-                },
-                "flush_thread_interval": {
-                  "type": "string"
-                },
-                "overflow_action": {
-                  "type": "string"
-                },
-                "path": {
-                  "type": "string"
-                },
-                "queue_limit_length": {
-                  "type": "integer"
-                },
-                "queued_chunks_limit_size": {
-                  "type": "integer"
-                },
-                "retry_exponential_backoff_base": {
-                  "type": "string"
-                },
-                "retry_forever": {
-                  "type": "boolean"
-                },
-                "retry_max_interval": {
-                  "type": "string"
-                },
-                "retry_max_times": {
-                  "type": "integer"
-                },
-                "retry_randomize": {
-                  "type": "boolean"
-                },
-                "retry_secondary_threshold": {
-                  "type": "string"
-                },
-                "retry_timeout": {
-                  "type": "string"
-                },
-                "retry_type": {
-                  "type": "string"
-                },
-                "retry_wait": {
-                  "type": "string"
-                },
-                "tags": {
-                  "type": "string"
-                },
-                "timekey": {
-                  "type": "string"
-                },
-                "timekey_use_utc": {
-                  "type": "boolean"
-                },
-                "timekey_wait": {
-                  "type": "string"
-                },
-                "timekey_zone": {
-                  "type": "string"
-                },
-                "total_limit_size": {
-                  "type": "string"
-                },
-                "type": {
-                  "type": "string"
-                }
-              },
-              "type": "object",
-              "additionalProperties": false
-            },
-            "compress": {
-              "type": "boolean"
-            },
-            "compress_encoding": {
-              "type": "string"
-            },
-            "custom_dimensions": {
-              "type": "string"
-            },
-            "custom_fields": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "data_type": {
-              "type": "string"
-            },
-            "delimiter": {
-              "type": "string"
-            },
-            "disable_cookies": {
-              "type": "boolean"
-            },
-            "endpoint": {
-              "properties": {
-                "mountFrom": {
-                  "properties": {
-                    "secretKeyRef": {
-                      "properties": {
-                        "key": {
-                          "type": "string"
-                        },
-                        "name": {
-                          "default": "",
-                          "type": "string"
-                        },
-                        "optional": {
-                          "type": "boolean"
-                        }
-                      },
-                      "required": [
-                        "key"
-                      ],
-                      "type": "object",
-                      "x-kubernetes-map-type": "atomic",
-                      "additionalProperties": false
-                    }
-                  },
-                  "type": "object",
-                  "additionalProperties": false
-                },
-                "value": {
-                  "type": "string"
-                },
-                "valueFrom": {
-                  "properties": {
-                    "secretKeyRef": {
-                      "properties": {
-                        "key": {
-                          "type": "string"
-                        },
-                        "name": {
-                          "default": "",
-                          "type": "string"
-                        },
-                        "optional": {
-                          "type": "boolean"
-                        }
-                      },
-                      "required": [
-                        "key"
-                      ],
-                      "type": "object",
-                      "x-kubernetes-map-type": "atomic",
-                      "additionalProperties": false
-                    }
-                  },
-                  "type": "object",
-                  "additionalProperties": false
-                }
-              },
-              "type": "object",
-              "additionalProperties": false
-            },
-            "log_format": {
-              "type": "string"
-            },
-            "log_key": {
-              "type": "string"
-            },
-            "metric_data_format": {
-              "type": "string"
-            },
-            "open_timeout": {
-              "type": "integer"
-            },
-            "proxy_uri": {
-              "type": "string"
-            },
-            "slow_flush_log_threshold": {
-              "type": "string"
-            },
-            "source_category": {
-              "type": "string"
-            },
-            "source_host": {
-              "type": "string"
-            },
-            "source_name": {
-              "type": "string"
-            },
-            "source_name_key": {
-              "type": "string"
-            },
-            "sumo_client": {
-              "type": "string"
-            },
-            "timestamp_key": {
-              "type": "string"
-            },
-            "verify_ssl": {
-              "type": "boolean"
-            }
-          },
-          "required": [
-            "endpoint",
-            "source_name"
-          ],
           "type": "object",
           "additionalProperties": false
         },

--- a/logging.banzaicloud.io/clusteroutput_v1beta1.json
+++ b/logging.banzaicloud.io/clusteroutput_v1beta1.json
@@ -2982,12 +2982,6 @@
           "type": "object",
           "additionalProperties": false
         },
-        "enabledNamespaces": {
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
         "file": {
           "properties": {
             "add_path_suffix": {
@@ -4215,6 +4209,9 @@
                 "type": "string"
               },
               "type": "object"
+            },
+            "udp_transport_type": {
+              "type": "string"
             }
           },
           "required": [
@@ -4463,6 +4460,9 @@
               "type": "object",
               "additionalProperties": false
             },
+            "compress": {
+              "type": "string"
+            },
             "content_type": {
               "type": "string"
             },
@@ -4502,6 +4502,12 @@
               },
               "type": "object"
             },
+            "headers_from_placeholders": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
             "http_method": {
               "type": "string"
             },
@@ -4522,6 +4528,9 @@
                 "type": "integer"
               },
               "type": "array"
+            },
+            "reuse_connections": {
+              "type": "boolean"
             },
             "slow_flush_log_threshold": {
               "type": "string"
@@ -5113,6 +5122,288 @@
             },
             "principal": {
               "type": "string"
+            },
+            "rdkafka_options": {
+              "properties": {
+                "allow.auto.create.topics": {
+                  "type": "boolean"
+                },
+                "api.version.fallback.ms": {
+                  "type": "integer"
+                },
+                "api.version.request": {
+                  "type": "boolean"
+                },
+                "api.version.request.timeout.ms": {
+                  "type": "integer"
+                },
+                "background_event_cb": {
+                  "type": "string"
+                },
+                "bootstrap.servers": {
+                  "type": "string"
+                },
+                "broker.address.family": {
+                  "type": "string"
+                },
+                "broker.address.ttl": {
+                  "type": "integer"
+                },
+                "broker.version.fallback": {
+                  "type": "string"
+                },
+                "builtin.features": {
+                  "type": "string"
+                },
+                "client.id": {
+                  "type": "string"
+                },
+                "closesocket_cb": {
+                  "type": "string"
+                },
+                "connect_cb": {
+                  "type": "string"
+                },
+                "connections.max.idle.ms": {
+                  "type": "integer"
+                },
+                "debug": {
+                  "type": "string"
+                },
+                "default_topic_conf": {
+                  "type": "string"
+                },
+                "enable.random.seed": {
+                  "type": "boolean"
+                },
+                "enable.sasl.oauthbearer.unsecure.jwt": {
+                  "type": "boolean"
+                },
+                "enable.ssl.certificate.verification": {
+                  "type": "boolean"
+                },
+                "enabled_events": {
+                  "type": "integer"
+                },
+                "error_cb": {
+                  "type": "string"
+                },
+                "interceptors": {
+                  "type": "string"
+                },
+                "internal.termination.signal": {
+                  "type": "integer"
+                },
+                "log.connection.close": {
+                  "type": "boolean"
+                },
+                "log.queue": {
+                  "type": "boolean"
+                },
+                "log.thread.name": {
+                  "type": "boolean"
+                },
+                "log_cb": {
+                  "type": "string"
+                },
+                "log_level": {
+                  "type": "integer"
+                },
+                "max.in.flight": {
+                  "type": "integer"
+                },
+                "max.in.flight.requests.per.connection": {
+                  "type": "integer"
+                },
+                "message.copy.max.bytes": {
+                  "type": "integer"
+                },
+                "message.max.bytes": {
+                  "type": "integer"
+                },
+                "metadata.broker.list": {
+                  "type": "string"
+                },
+                "metadata.max.age.ms": {
+                  "type": "integer"
+                },
+                "oauthbearer_token_refresh_cb": {
+                  "type": "string"
+                },
+                "opaque": {
+                  "type": "string"
+                },
+                "open_cb": {
+                  "type": "string"
+                },
+                "plugin.library.paths": {
+                  "type": "string"
+                },
+                "receive.message.max.bytes": {
+                  "type": "integer"
+                },
+                "reconnect.backoff.max.ms": {
+                  "type": "integer"
+                },
+                "reconnect.backoff.ms": {
+                  "type": "integer"
+                },
+                "resolve_cb": {
+                  "type": "string"
+                },
+                "sasl.kerberos.keytab": {
+                  "type": "string"
+                },
+                "sasl.kerberos.kinit.cmd": {
+                  "type": "string"
+                },
+                "sasl.kerberos.min.time.before.relogin": {
+                  "type": "integer"
+                },
+                "sasl.kerberos.principal": {
+                  "type": "string"
+                },
+                "sasl.kerberos.service.name": {
+                  "type": "string"
+                },
+                "sasl.mechanisms": {
+                  "type": "string"
+                },
+                "sasl.oauthbearer.client.id": {
+                  "type": "string"
+                },
+                "sasl.oauthbearer.client.secret": {
+                  "type": "string"
+                },
+                "sasl.oauthbearer.config": {
+                  "type": "string"
+                },
+                "sasl.oauthbearer.extensions": {
+                  "type": "string"
+                },
+                "sasl.oauthbearer.method": {
+                  "type": "string"
+                },
+                "sasl.oauthbearer.scope": {
+                  "type": "string"
+                },
+                "sasl.oauthbearer.token.endpoint.url": {
+                  "type": "string"
+                },
+                "sasl.password": {
+                  "type": "string"
+                },
+                "sasl.username": {
+                  "type": "string"
+                },
+                "security.protocol": {
+                  "type": "string"
+                },
+                "socket.blocking.max.ms": {
+                  "type": "integer"
+                },
+                "socket.connection.setup.timeout.ms": {
+                  "type": "integer"
+                },
+                "socket.keepalive.enable": {
+                  "type": "boolean"
+                },
+                "socket.max.fails": {
+                  "type": "integer"
+                },
+                "socket.nagle.disable": {
+                  "type": "boolean"
+                },
+                "socket.receive.buffer.bytes": {
+                  "type": "integer"
+                },
+                "socket.send.buffer.bytes": {
+                  "type": "integer"
+                },
+                "socket.timeout.ms": {
+                  "type": "integer"
+                },
+                "socket_cb": {
+                  "type": "string"
+                },
+                "ssl.ca.location": {
+                  "type": "string"
+                },
+                "ssl.ca.pem": {
+                  "type": "string"
+                },
+                "ssl.certificate.location": {
+                  "type": "string"
+                },
+                "ssl.certificate.pem": {
+                  "type": "string"
+                },
+                "ssl.cipher.suites": {
+                  "type": "string"
+                },
+                "ssl.crl.location": {
+                  "type": "string"
+                },
+                "ssl.curves.list": {
+                  "type": "string"
+                },
+                "ssl.endpoint.identification.algorithm": {
+                  "type": "string"
+                },
+                "ssl.engine.id": {
+                  "type": "string"
+                },
+                "ssl.engine.location": {
+                  "type": "string"
+                },
+                "ssl.key.location": {
+                  "type": "string"
+                },
+                "ssl.key.password": {
+                  "type": "string"
+                },
+                "ssl.key.pem": {
+                  "type": "string"
+                },
+                "ssl.keystore.location": {
+                  "type": "string"
+                },
+                "ssl.keystore.password": {
+                  "type": "string"
+                },
+                "ssl.providers": {
+                  "type": "string"
+                },
+                "ssl.sigalgs.list": {
+                  "type": "string"
+                },
+                "statistics.interval.ms": {
+                  "type": "integer"
+                },
+                "stats_cb": {
+                  "type": "string"
+                },
+                "throttle_cb": {
+                  "type": "string"
+                },
+                "topic.blacklist": {
+                  "type": "string"
+                },
+                "topic.metadata.propagation.max.ms": {
+                  "type": "integer"
+                },
+                "topic.metadata.refresh.fast.interval.ms": {
+                  "type": "integer"
+                },
+                "topic.metadata.refresh.interval.ms": {
+                  "type": "integer"
+                },
+                "topic.metadata.refresh.sparse": {
+                  "type": "boolean"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
             },
             "required_acks": {
               "type": "integer"
@@ -7448,7 +7739,13 @@
           "additionalProperties": false
         },
         "nullout": {
-          "type": "object"
+          "properties": {
+            "never_flush": {
+              "type": "boolean"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
         },
         "opensearch": {
           "properties": {
@@ -8438,6 +8735,9 @@
             },
             "reload_on_failure": {
               "type": "boolean"
+            },
+            "remove_keys": {
+              "type": "string"
             },
             "remove_keys_on_update": {
               "type": "string"
@@ -10393,248 +10693,6 @@
               "type": "string"
             }
           },
-          "type": "object",
-          "additionalProperties": false
-        },
-        "sumologic": {
-          "properties": {
-            "add_timestamp": {
-              "type": "boolean"
-            },
-            "buffer": {
-              "properties": {
-                "chunk_full_threshold": {
-                  "type": "string"
-                },
-                "chunk_limit_records": {
-                  "type": "integer"
-                },
-                "chunk_limit_size": {
-                  "type": "string"
-                },
-                "compress": {
-                  "type": "string"
-                },
-                "delayed_commit_timeout": {
-                  "type": "string"
-                },
-                "disable_chunk_backup": {
-                  "type": "boolean"
-                },
-                "disabled": {
-                  "type": "boolean"
-                },
-                "flush_at_shutdown": {
-                  "type": "boolean"
-                },
-                "flush_interval": {
-                  "type": "string"
-                },
-                "flush_mode": {
-                  "type": "string"
-                },
-                "flush_thread_burst_interval": {
-                  "type": "string"
-                },
-                "flush_thread_count": {
-                  "type": "integer"
-                },
-                "flush_thread_interval": {
-                  "type": "string"
-                },
-                "overflow_action": {
-                  "type": "string"
-                },
-                "path": {
-                  "type": "string"
-                },
-                "queue_limit_length": {
-                  "type": "integer"
-                },
-                "queued_chunks_limit_size": {
-                  "type": "integer"
-                },
-                "retry_exponential_backoff_base": {
-                  "type": "string"
-                },
-                "retry_forever": {
-                  "type": "boolean"
-                },
-                "retry_max_interval": {
-                  "type": "string"
-                },
-                "retry_max_times": {
-                  "type": "integer"
-                },
-                "retry_randomize": {
-                  "type": "boolean"
-                },
-                "retry_secondary_threshold": {
-                  "type": "string"
-                },
-                "retry_timeout": {
-                  "type": "string"
-                },
-                "retry_type": {
-                  "type": "string"
-                },
-                "retry_wait": {
-                  "type": "string"
-                },
-                "tags": {
-                  "type": "string"
-                },
-                "timekey": {
-                  "type": "string"
-                },
-                "timekey_use_utc": {
-                  "type": "boolean"
-                },
-                "timekey_wait": {
-                  "type": "string"
-                },
-                "timekey_zone": {
-                  "type": "string"
-                },
-                "total_limit_size": {
-                  "type": "string"
-                },
-                "type": {
-                  "type": "string"
-                }
-              },
-              "type": "object",
-              "additionalProperties": false
-            },
-            "compress": {
-              "type": "boolean"
-            },
-            "compress_encoding": {
-              "type": "string"
-            },
-            "custom_dimensions": {
-              "type": "string"
-            },
-            "custom_fields": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "data_type": {
-              "type": "string"
-            },
-            "delimiter": {
-              "type": "string"
-            },
-            "disable_cookies": {
-              "type": "boolean"
-            },
-            "endpoint": {
-              "properties": {
-                "mountFrom": {
-                  "properties": {
-                    "secretKeyRef": {
-                      "properties": {
-                        "key": {
-                          "type": "string"
-                        },
-                        "name": {
-                          "default": "",
-                          "type": "string"
-                        },
-                        "optional": {
-                          "type": "boolean"
-                        }
-                      },
-                      "required": [
-                        "key"
-                      ],
-                      "type": "object",
-                      "x-kubernetes-map-type": "atomic",
-                      "additionalProperties": false
-                    }
-                  },
-                  "type": "object",
-                  "additionalProperties": false
-                },
-                "value": {
-                  "type": "string"
-                },
-                "valueFrom": {
-                  "properties": {
-                    "secretKeyRef": {
-                      "properties": {
-                        "key": {
-                          "type": "string"
-                        },
-                        "name": {
-                          "default": "",
-                          "type": "string"
-                        },
-                        "optional": {
-                          "type": "boolean"
-                        }
-                      },
-                      "required": [
-                        "key"
-                      ],
-                      "type": "object",
-                      "x-kubernetes-map-type": "atomic",
-                      "additionalProperties": false
-                    }
-                  },
-                  "type": "object",
-                  "additionalProperties": false
-                }
-              },
-              "type": "object",
-              "additionalProperties": false
-            },
-            "log_format": {
-              "type": "string"
-            },
-            "log_key": {
-              "type": "string"
-            },
-            "metric_data_format": {
-              "type": "string"
-            },
-            "open_timeout": {
-              "type": "integer"
-            },
-            "proxy_uri": {
-              "type": "string"
-            },
-            "slow_flush_log_threshold": {
-              "type": "string"
-            },
-            "source_category": {
-              "type": "string"
-            },
-            "source_host": {
-              "type": "string"
-            },
-            "source_name": {
-              "type": "string"
-            },
-            "source_name_key": {
-              "type": "string"
-            },
-            "sumo_client": {
-              "type": "string"
-            },
-            "timestamp_key": {
-              "type": "string"
-            },
-            "verify_ssl": {
-              "type": "boolean"
-            }
-          },
-          "required": [
-            "endpoint",
-            "source_name"
-          ],
           "type": "object",
           "additionalProperties": false
         },

--- a/logging.banzaicloud.io/flow_v1alpha1.json
+++ b/logging.banzaicloud.io/flow_v1alpha1.json
@@ -155,249 +155,6 @@
                 "type": "object",
                 "additionalProperties": false
               },
-              "enhanceK8s": {
-                "properties": {
-                  "api_groups": {
-                    "items": {
-                      "type": "string"
-                    },
-                    "type": "array"
-                  },
-                  "bearer_token_file": {
-                    "type": "string"
-                  },
-                  "ca_file": {
-                    "properties": {
-                      "mountFrom": {
-                        "properties": {
-                          "secretKeyRef": {
-                            "properties": {
-                              "key": {
-                                "type": "string"
-                              },
-                              "name": {
-                                "default": "",
-                                "type": "string"
-                              },
-                              "optional": {
-                                "type": "boolean"
-                              }
-                            },
-                            "required": [
-                              "key"
-                            ],
-                            "type": "object",
-                            "x-kubernetes-map-type": "atomic",
-                            "additionalProperties": false
-                          }
-                        },
-                        "type": "object",
-                        "additionalProperties": false
-                      },
-                      "value": {
-                        "type": "string"
-                      },
-                      "valueFrom": {
-                        "properties": {
-                          "secretKeyRef": {
-                            "properties": {
-                              "key": {
-                                "type": "string"
-                              },
-                              "name": {
-                                "default": "",
-                                "type": "string"
-                              },
-                              "optional": {
-                                "type": "boolean"
-                              }
-                            },
-                            "required": [
-                              "key"
-                            ],
-                            "type": "object",
-                            "x-kubernetes-map-type": "atomic",
-                            "additionalProperties": false
-                          }
-                        },
-                        "type": "object",
-                        "additionalProperties": false
-                      }
-                    },
-                    "type": "object",
-                    "additionalProperties": false
-                  },
-                  "cache_refresh": {
-                    "type": "integer"
-                  },
-                  "cache_refresh_variation": {
-                    "type": "integer"
-                  },
-                  "cache_size": {
-                    "type": "integer"
-                  },
-                  "cache_ttl": {
-                    "type": "integer"
-                  },
-                  "client_cert": {
-                    "properties": {
-                      "mountFrom": {
-                        "properties": {
-                          "secretKeyRef": {
-                            "properties": {
-                              "key": {
-                                "type": "string"
-                              },
-                              "name": {
-                                "default": "",
-                                "type": "string"
-                              },
-                              "optional": {
-                                "type": "boolean"
-                              }
-                            },
-                            "required": [
-                              "key"
-                            ],
-                            "type": "object",
-                            "x-kubernetes-map-type": "atomic",
-                            "additionalProperties": false
-                          }
-                        },
-                        "type": "object",
-                        "additionalProperties": false
-                      },
-                      "value": {
-                        "type": "string"
-                      },
-                      "valueFrom": {
-                        "properties": {
-                          "secretKeyRef": {
-                            "properties": {
-                              "key": {
-                                "type": "string"
-                              },
-                              "name": {
-                                "default": "",
-                                "type": "string"
-                              },
-                              "optional": {
-                                "type": "boolean"
-                              }
-                            },
-                            "required": [
-                              "key"
-                            ],
-                            "type": "object",
-                            "x-kubernetes-map-type": "atomic",
-                            "additionalProperties": false
-                          }
-                        },
-                        "type": "object",
-                        "additionalProperties": false
-                      }
-                    },
-                    "type": "object",
-                    "additionalProperties": false
-                  },
-                  "client_key": {
-                    "properties": {
-                      "mountFrom": {
-                        "properties": {
-                          "secretKeyRef": {
-                            "properties": {
-                              "key": {
-                                "type": "string"
-                              },
-                              "name": {
-                                "default": "",
-                                "type": "string"
-                              },
-                              "optional": {
-                                "type": "boolean"
-                              }
-                            },
-                            "required": [
-                              "key"
-                            ],
-                            "type": "object",
-                            "x-kubernetes-map-type": "atomic",
-                            "additionalProperties": false
-                          }
-                        },
-                        "type": "object",
-                        "additionalProperties": false
-                      },
-                      "value": {
-                        "type": "string"
-                      },
-                      "valueFrom": {
-                        "properties": {
-                          "secretKeyRef": {
-                            "properties": {
-                              "key": {
-                                "type": "string"
-                              },
-                              "name": {
-                                "default": "",
-                                "type": "string"
-                              },
-                              "optional": {
-                                "type": "boolean"
-                              }
-                            },
-                            "required": [
-                              "key"
-                            ],
-                            "type": "object",
-                            "x-kubernetes-map-type": "atomic",
-                            "additionalProperties": false
-                          }
-                        },
-                        "type": "object",
-                        "additionalProperties": false
-                      }
-                    },
-                    "type": "object",
-                    "additionalProperties": false
-                  },
-                  "core_api_versions": {
-                    "items": {
-                      "type": "string"
-                    },
-                    "type": "array"
-                  },
-                  "data_type": {
-                    "type": "string"
-                  },
-                  "in_namespace_path": {
-                    "items": {
-                      "type": "string"
-                    },
-                    "type": "array"
-                  },
-                  "in_pod_path": {
-                    "items": {
-                      "type": "string"
-                    },
-                    "type": "array"
-                  },
-                  "kubernetes_url": {
-                    "type": "string"
-                  },
-                  "secret_dir": {
-                    "type": "string"
-                  },
-                  "ssl_partial_chain": {
-                    "type": "boolean"
-                  },
-                  "verify_ssl": {
-                    "type": "boolean"
-                  }
-                },
-                "type": "object",
-                "additionalProperties": false
-              },
               "geoip": {
                 "properties": {
                   "backend_library": {
@@ -676,6 +433,9 @@
                       "format_firstline": {
                         "type": "string"
                       },
+                      "format_key": {
+                        "type": "string"
+                      },
                       "grok_failure_key": {
                         "type": "string"
                       },
@@ -813,6 +573,9 @@
                               "type": "string"
                             },
                             "format": {
+                              "type": "string"
+                            },
+                            "format_name": {
                               "type": "string"
                             },
                             "grok_failure_key": {
@@ -1003,6 +766,9 @@
                         "format_firstline": {
                           "type": "string"
                         },
+                        "format_key": {
+                          "type": "string"
+                        },
                         "grok_failure_key": {
                           "type": "string"
                         },
@@ -1140,6 +906,9 @@
                                 "type": "string"
                               },
                               "format": {
+                                "type": "string"
+                              },
+                              "format_name": {
                                 "type": "string"
                               },
                               "grok_failure_key": {
@@ -1399,90 +1168,6 @@
               "stdout": {
                 "properties": {
                   "output_type": {
-                    "type": "string"
-                  }
-                },
-                "type": "object",
-                "additionalProperties": false
-              },
-              "sumologic": {
-                "properties": {
-                  "collector_key_name": {
-                    "type": "string"
-                  },
-                  "collector_value": {
-                    "type": "string"
-                  },
-                  "exclude_container_regex": {
-                    "type": "string"
-                  },
-                  "exclude_facility_regex": {
-                    "type": "string"
-                  },
-                  "exclude_host_regex": {
-                    "type": "string"
-                  },
-                  "exclude_namespace_regex": {
-                    "type": "string"
-                  },
-                  "exclude_pod_regex": {
-                    "type": "string"
-                  },
-                  "exclude_priority_regex": {
-                    "type": "string"
-                  },
-                  "exclude_unit_regex": {
-                    "type": "string"
-                  },
-                  "log_format": {
-                    "type": "string"
-                  },
-                  "source_category": {
-                    "type": "string"
-                  },
-                  "source_category_key_name": {
-                    "type": "string"
-                  },
-                  "source_category_prefix": {
-                    "type": "string"
-                  },
-                  "source_category_replace_dash": {
-                    "type": "string"
-                  },
-                  "source_host": {
-                    "type": "string"
-                  },
-                  "source_host_key_name": {
-                    "type": "string"
-                  },
-                  "source_name": {
-                    "type": "string"
-                  },
-                  "source_name_key_name": {
-                    "type": "string"
-                  },
-                  "tracing_annotation_prefix": {
-                    "type": "string"
-                  },
-                  "tracing_container_name": {
-                    "type": "string"
-                  },
-                  "tracing_format": {
-                    "type": "boolean"
-                  },
-                  "tracing_host": {
-                    "type": "string"
-                  },
-                  "tracing_label_prefix": {
-                    "type": "string"
-                  },
-                  "tracing_namespace": {
-                    "type": "string"
-                  },
-                  "tracing_pod": {
-                    "type": "string"
-                  },
-                  "tracing_pod_id": {
                     "type": "string"
                   }
                 },

--- a/logging.banzaicloud.io/flow_v1beta1.json
+++ b/logging.banzaicloud.io/flow_v1beta1.json
@@ -155,249 +155,6 @@
                 "type": "object",
                 "additionalProperties": false
               },
-              "enhanceK8s": {
-                "properties": {
-                  "api_groups": {
-                    "items": {
-                      "type": "string"
-                    },
-                    "type": "array"
-                  },
-                  "bearer_token_file": {
-                    "type": "string"
-                  },
-                  "ca_file": {
-                    "properties": {
-                      "mountFrom": {
-                        "properties": {
-                          "secretKeyRef": {
-                            "properties": {
-                              "key": {
-                                "type": "string"
-                              },
-                              "name": {
-                                "default": "",
-                                "type": "string"
-                              },
-                              "optional": {
-                                "type": "boolean"
-                              }
-                            },
-                            "required": [
-                              "key"
-                            ],
-                            "type": "object",
-                            "x-kubernetes-map-type": "atomic",
-                            "additionalProperties": false
-                          }
-                        },
-                        "type": "object",
-                        "additionalProperties": false
-                      },
-                      "value": {
-                        "type": "string"
-                      },
-                      "valueFrom": {
-                        "properties": {
-                          "secretKeyRef": {
-                            "properties": {
-                              "key": {
-                                "type": "string"
-                              },
-                              "name": {
-                                "default": "",
-                                "type": "string"
-                              },
-                              "optional": {
-                                "type": "boolean"
-                              }
-                            },
-                            "required": [
-                              "key"
-                            ],
-                            "type": "object",
-                            "x-kubernetes-map-type": "atomic",
-                            "additionalProperties": false
-                          }
-                        },
-                        "type": "object",
-                        "additionalProperties": false
-                      }
-                    },
-                    "type": "object",
-                    "additionalProperties": false
-                  },
-                  "cache_refresh": {
-                    "type": "integer"
-                  },
-                  "cache_refresh_variation": {
-                    "type": "integer"
-                  },
-                  "cache_size": {
-                    "type": "integer"
-                  },
-                  "cache_ttl": {
-                    "type": "integer"
-                  },
-                  "client_cert": {
-                    "properties": {
-                      "mountFrom": {
-                        "properties": {
-                          "secretKeyRef": {
-                            "properties": {
-                              "key": {
-                                "type": "string"
-                              },
-                              "name": {
-                                "default": "",
-                                "type": "string"
-                              },
-                              "optional": {
-                                "type": "boolean"
-                              }
-                            },
-                            "required": [
-                              "key"
-                            ],
-                            "type": "object",
-                            "x-kubernetes-map-type": "atomic",
-                            "additionalProperties": false
-                          }
-                        },
-                        "type": "object",
-                        "additionalProperties": false
-                      },
-                      "value": {
-                        "type": "string"
-                      },
-                      "valueFrom": {
-                        "properties": {
-                          "secretKeyRef": {
-                            "properties": {
-                              "key": {
-                                "type": "string"
-                              },
-                              "name": {
-                                "default": "",
-                                "type": "string"
-                              },
-                              "optional": {
-                                "type": "boolean"
-                              }
-                            },
-                            "required": [
-                              "key"
-                            ],
-                            "type": "object",
-                            "x-kubernetes-map-type": "atomic",
-                            "additionalProperties": false
-                          }
-                        },
-                        "type": "object",
-                        "additionalProperties": false
-                      }
-                    },
-                    "type": "object",
-                    "additionalProperties": false
-                  },
-                  "client_key": {
-                    "properties": {
-                      "mountFrom": {
-                        "properties": {
-                          "secretKeyRef": {
-                            "properties": {
-                              "key": {
-                                "type": "string"
-                              },
-                              "name": {
-                                "default": "",
-                                "type": "string"
-                              },
-                              "optional": {
-                                "type": "boolean"
-                              }
-                            },
-                            "required": [
-                              "key"
-                            ],
-                            "type": "object",
-                            "x-kubernetes-map-type": "atomic",
-                            "additionalProperties": false
-                          }
-                        },
-                        "type": "object",
-                        "additionalProperties": false
-                      },
-                      "value": {
-                        "type": "string"
-                      },
-                      "valueFrom": {
-                        "properties": {
-                          "secretKeyRef": {
-                            "properties": {
-                              "key": {
-                                "type": "string"
-                              },
-                              "name": {
-                                "default": "",
-                                "type": "string"
-                              },
-                              "optional": {
-                                "type": "boolean"
-                              }
-                            },
-                            "required": [
-                              "key"
-                            ],
-                            "type": "object",
-                            "x-kubernetes-map-type": "atomic",
-                            "additionalProperties": false
-                          }
-                        },
-                        "type": "object",
-                        "additionalProperties": false
-                      }
-                    },
-                    "type": "object",
-                    "additionalProperties": false
-                  },
-                  "core_api_versions": {
-                    "items": {
-                      "type": "string"
-                    },
-                    "type": "array"
-                  },
-                  "data_type": {
-                    "type": "string"
-                  },
-                  "in_namespace_path": {
-                    "items": {
-                      "type": "string"
-                    },
-                    "type": "array"
-                  },
-                  "in_pod_path": {
-                    "items": {
-                      "type": "string"
-                    },
-                    "type": "array"
-                  },
-                  "kubernetes_url": {
-                    "type": "string"
-                  },
-                  "secret_dir": {
-                    "type": "string"
-                  },
-                  "ssl_partial_chain": {
-                    "type": "boolean"
-                  },
-                  "verify_ssl": {
-                    "type": "boolean"
-                  }
-                },
-                "type": "object",
-                "additionalProperties": false
-              },
               "geoip": {
                 "properties": {
                   "backend_library": {
@@ -676,6 +433,9 @@
                       "format_firstline": {
                         "type": "string"
                       },
+                      "format_key": {
+                        "type": "string"
+                      },
                       "grok_failure_key": {
                         "type": "string"
                       },
@@ -813,6 +573,9 @@
                               "type": "string"
                             },
                             "format": {
+                              "type": "string"
+                            },
+                            "format_name": {
                               "type": "string"
                             },
                             "grok_failure_key": {
@@ -1003,6 +766,9 @@
                         "format_firstline": {
                           "type": "string"
                         },
+                        "format_key": {
+                          "type": "string"
+                        },
                         "grok_failure_key": {
                           "type": "string"
                         },
@@ -1140,6 +906,9 @@
                                 "type": "string"
                               },
                               "format": {
+                                "type": "string"
+                              },
+                              "format_name": {
                                 "type": "string"
                               },
                               "grok_failure_key": {
@@ -1399,90 +1168,6 @@
               "stdout": {
                 "properties": {
                   "output_type": {
-                    "type": "string"
-                  }
-                },
-                "type": "object",
-                "additionalProperties": false
-              },
-              "sumologic": {
-                "properties": {
-                  "collector_key_name": {
-                    "type": "string"
-                  },
-                  "collector_value": {
-                    "type": "string"
-                  },
-                  "exclude_container_regex": {
-                    "type": "string"
-                  },
-                  "exclude_facility_regex": {
-                    "type": "string"
-                  },
-                  "exclude_host_regex": {
-                    "type": "string"
-                  },
-                  "exclude_namespace_regex": {
-                    "type": "string"
-                  },
-                  "exclude_pod_regex": {
-                    "type": "string"
-                  },
-                  "exclude_priority_regex": {
-                    "type": "string"
-                  },
-                  "exclude_unit_regex": {
-                    "type": "string"
-                  },
-                  "log_format": {
-                    "type": "string"
-                  },
-                  "source_category": {
-                    "type": "string"
-                  },
-                  "source_category_key_name": {
-                    "type": "string"
-                  },
-                  "source_category_prefix": {
-                    "type": "string"
-                  },
-                  "source_category_replace_dash": {
-                    "type": "string"
-                  },
-                  "source_host": {
-                    "type": "string"
-                  },
-                  "source_host_key_name": {
-                    "type": "string"
-                  },
-                  "source_name": {
-                    "type": "string"
-                  },
-                  "source_name_key_name": {
-                    "type": "string"
-                  },
-                  "tracing_annotation_prefix": {
-                    "type": "string"
-                  },
-                  "tracing_container_name": {
-                    "type": "string"
-                  },
-                  "tracing_format": {
-                    "type": "boolean"
-                  },
-                  "tracing_host": {
-                    "type": "string"
-                  },
-                  "tracing_label_prefix": {
-                    "type": "string"
-                  },
-                  "tracing_namespace": {
-                    "type": "string"
-                  },
-                  "tracing_pod": {
-                    "type": "string"
-                  },
-                  "tracing_pod_id": {
                     "type": "string"
                   }
                 },

--- a/logging.banzaicloud.io/fluentbitagent_v1beta1.json
+++ b/logging.banzaicloud.io/fluentbitagent_v1beta1.json
@@ -818,6 +818,18 @@
             },
             "pvc": {
               "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
                 "source": {
                   "properties": {
                     "claimName": {
@@ -1054,6 +1066,138 @@
             },
             "tag": {
               "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "bufferVolumeLivenessProbe": {
+          "properties": {
+            "exec": {
+              "properties": {
+                "command": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "failureThreshold": {
+              "format": "int32",
+              "type": "integer"
+            },
+            "grpc": {
+              "properties": {
+                "port": {
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "service": {
+                  "default": "",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "port"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "httpGet": {
+              "properties": {
+                "host": {
+                  "type": "string"
+                },
+                "httpHeaders": {
+                  "items": {
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "value": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "name",
+                      "value"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                },
+                "path": {
+                  "type": "string"
+                },
+                "port": {
+                  "anyOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "x-kubernetes-int-or-string": true
+                },
+                "scheme": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "port"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "initialDelaySeconds": {
+              "format": "int32",
+              "type": "integer"
+            },
+            "periodSeconds": {
+              "format": "int32",
+              "type": "integer"
+            },
+            "successThreshold": {
+              "format": "int32",
+              "type": "integer"
+            },
+            "tcpSocket": {
+              "properties": {
+                "host": {
+                  "type": "string"
+                },
+                "port": {
+                  "anyOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "x-kubernetes-int-or-string": true
+                }
+              },
+              "required": [
+                "port"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "terminationGracePeriodSeconds": {
+              "format": "int64",
+              "type": "integer"
+            },
+            "timeoutSeconds": {
+              "format": "int32",
+              "type": "integer"
             }
           },
           "type": "object",
@@ -1593,6 +1737,9 @@
         "disableKubernetesFilter": {
           "type": "boolean"
         },
+        "disableVarLibDockerContainers": {
+          "type": "boolean"
+        },
         "dnsConfig": {
           "properties": {
             "nameservers": {
@@ -1633,6 +1780,9 @@
           "type": "string"
         },
         "enableUpstream": {
+          "type": "boolean"
+        },
+        "enabledIPv6": {
           "type": "boolean"
         },
         "envVars": {
@@ -1798,6 +1948,36 @@
             },
             "vpc_id": {
               "type": "boolean"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "filterGrep": {
+          "properties": {
+            "Exclude": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "LogicalOp": {
+              "default": "legacy",
+              "enum": [
+                "legacy",
+                "AND",
+                "OR"
+              ],
+              "type": "string"
+            },
+            "Match": {
+              "type": "string"
+            },
+            "Regex": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
             }
           },
           "type": "object",
@@ -2146,6 +2326,9 @@
           "format": "int32",
           "type": "integer"
         },
+        "forceHotReloadAfterGrace": {
+          "type": "boolean"
+        },
         "forwardOptions": {
           "properties": {
             "Require_ack_response": {
@@ -2309,6 +2492,9 @@
                 "type": "string"
               },
               "type": "array"
+            },
+            "storage.pause_on_chunks_overlimit": {
+              "type": "string"
             },
             "storage.type": {
               "type": "string"
@@ -2979,6 +3165,18 @@
             },
             "pvc": {
               "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
                 "source": {
                   "properties": {
                     "claimName": {
@@ -3282,6 +3480,18 @@
             },
             "pvc": {
               "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
                 "source": {
                   "properties": {
                     "claimName": {
@@ -3680,6 +3890,9 @@
         },
         "security": {
           "properties": {
+            "createOpenShiftSCC": {
+              "type": "boolean"
+            },
             "podSecurityContext": {
               "properties": {
                 "appArmorProfile": {
@@ -3714,6 +3927,9 @@
                 "runAsUser": {
                   "format": "int64",
                   "type": "integer"
+                },
+                "seLinuxChangePolicy": {
+                  "type": "string"
                 },
                 "seLinuxOptions": {
                   "properties": {

--- a/logging.banzaicloud.io/fluentdconfig_v1beta1.json
+++ b/logging.banzaicloud.io/fluentdconfig_v1beta1.json
@@ -788,6 +788,18 @@
             },
             "pvc": {
               "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
                 "source": {
                   "properties": {
                     "claimName": {
@@ -1024,6 +1036,138 @@
             },
             "tag": {
               "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "bufferVolumeLivenessProbe": {
+          "properties": {
+            "exec": {
+              "properties": {
+                "command": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "failureThreshold": {
+              "format": "int32",
+              "type": "integer"
+            },
+            "grpc": {
+              "properties": {
+                "port": {
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "service": {
+                  "default": "",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "port"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "httpGet": {
+              "properties": {
+                "host": {
+                  "type": "string"
+                },
+                "httpHeaders": {
+                  "items": {
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "value": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "name",
+                      "value"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                },
+                "path": {
+                  "type": "string"
+                },
+                "port": {
+                  "anyOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "x-kubernetes-int-or-string": true
+                },
+                "scheme": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "port"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "initialDelaySeconds": {
+              "format": "int32",
+              "type": "integer"
+            },
+            "periodSeconds": {
+              "format": "int32",
+              "type": "integer"
+            },
+            "successThreshold": {
+              "format": "int32",
+              "type": "integer"
+            },
+            "tcpSocket": {
+              "properties": {
+                "host": {
+                  "type": "string"
+                },
+                "port": {
+                  "anyOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "x-kubernetes-int-or-string": true
+                }
+              },
+              "required": [
+                "port"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "terminationGracePeriodSeconds": {
+              "format": "int64",
+              "type": "integer"
+            },
+            "timeoutSeconds": {
+              "format": "int32",
+              "type": "integer"
             }
           },
           "type": "object",
@@ -1623,6 +1767,9 @@
           "type": "object",
           "additionalProperties": false
         },
+        "configReloaderUseGracefulReloadWebhook": {
+          "type": "boolean"
+        },
         "disablePvc": {
           "type": "boolean"
         },
@@ -1666,6 +1813,9 @@
           "type": "string"
         },
         "enableMsgpackTimeSupport": {
+          "type": "boolean"
+        },
+        "enabledIPv6": {
           "type": "boolean"
         },
         "envVars": {
@@ -1888,6 +2038,18 @@
                   },
                   "pvc": {
                     "properties": {
+                      "annotations": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "type": "object"
+                      },
+                      "labels": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "type": "object"
+                      },
                       "source": {
                         "properties": {
                           "claimName": {
@@ -2224,6 +2386,18 @@
             },
             "pvc": {
               "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
                 "source": {
                   "properties": {
                     "claimName": {
@@ -3631,6 +3805,9 @@
         },
         "security": {
           "properties": {
+            "createOpenShiftSCC": {
+              "type": "boolean"
+            },
             "podSecurityContext": {
               "properties": {
                 "appArmorProfile": {
@@ -3665,6 +3842,9 @@
                 "runAsUser": {
                   "format": "int64",
                   "type": "integer"
+                },
+                "seLinuxChangePolicy": {
+                  "type": "string"
                 },
                 "seLinuxOptions": {
                   "properties": {
@@ -4337,6 +4517,9 @@
                     },
                     "type": "object",
                     "additionalProperties": false
+                  },
+                  "stopSignal": {
+                    "type": "string"
                   }
                 },
                 "type": "object",

--- a/logging.banzaicloud.io/logging_v1beta1.json
+++ b/logging.banzaicloud.io/logging_v1beta1.json
@@ -12,7 +12,13 @@
     "spec": {
       "properties": {
         "allowClusterResourcesFromAllNamespaces": {
-          "type": "boolean"
+          "type": "boolean",
+          "x-kubernetes-validations": [
+            {
+              "message": "Value is immutable, please recreate the resource",
+              "rule": "self == oldSelf"
+            }
+          ]
         },
         "clusterDomain": {
           "type": "string"
@@ -36,7 +42,13 @@
           "additionalProperties": false
         },
         "controlNamespace": {
-          "type": "string"
+          "type": "string",
+          "x-kubernetes-validations": [
+            {
+              "message": "Value is immutable, please recreate the resource",
+              "rule": "self == oldSelf"
+            }
+          ]
         },
         "defaultFlow": {
           "properties": {
@@ -178,249 +190,6 @@
                         "type": "boolean"
                       },
                       "use_record_as_seed": {
-                        "type": "boolean"
-                      }
-                    },
-                    "type": "object",
-                    "additionalProperties": false
-                  },
-                  "enhanceK8s": {
-                    "properties": {
-                      "api_groups": {
-                        "items": {
-                          "type": "string"
-                        },
-                        "type": "array"
-                      },
-                      "bearer_token_file": {
-                        "type": "string"
-                      },
-                      "ca_file": {
-                        "properties": {
-                          "mountFrom": {
-                            "properties": {
-                              "secretKeyRef": {
-                                "properties": {
-                                  "key": {
-                                    "type": "string"
-                                  },
-                                  "name": {
-                                    "default": "",
-                                    "type": "string"
-                                  },
-                                  "optional": {
-                                    "type": "boolean"
-                                  }
-                                },
-                                "required": [
-                                  "key"
-                                ],
-                                "type": "object",
-                                "x-kubernetes-map-type": "atomic",
-                                "additionalProperties": false
-                              }
-                            },
-                            "type": "object",
-                            "additionalProperties": false
-                          },
-                          "value": {
-                            "type": "string"
-                          },
-                          "valueFrom": {
-                            "properties": {
-                              "secretKeyRef": {
-                                "properties": {
-                                  "key": {
-                                    "type": "string"
-                                  },
-                                  "name": {
-                                    "default": "",
-                                    "type": "string"
-                                  },
-                                  "optional": {
-                                    "type": "boolean"
-                                  }
-                                },
-                                "required": [
-                                  "key"
-                                ],
-                                "type": "object",
-                                "x-kubernetes-map-type": "atomic",
-                                "additionalProperties": false
-                              }
-                            },
-                            "type": "object",
-                            "additionalProperties": false
-                          }
-                        },
-                        "type": "object",
-                        "additionalProperties": false
-                      },
-                      "cache_refresh": {
-                        "type": "integer"
-                      },
-                      "cache_refresh_variation": {
-                        "type": "integer"
-                      },
-                      "cache_size": {
-                        "type": "integer"
-                      },
-                      "cache_ttl": {
-                        "type": "integer"
-                      },
-                      "client_cert": {
-                        "properties": {
-                          "mountFrom": {
-                            "properties": {
-                              "secretKeyRef": {
-                                "properties": {
-                                  "key": {
-                                    "type": "string"
-                                  },
-                                  "name": {
-                                    "default": "",
-                                    "type": "string"
-                                  },
-                                  "optional": {
-                                    "type": "boolean"
-                                  }
-                                },
-                                "required": [
-                                  "key"
-                                ],
-                                "type": "object",
-                                "x-kubernetes-map-type": "atomic",
-                                "additionalProperties": false
-                              }
-                            },
-                            "type": "object",
-                            "additionalProperties": false
-                          },
-                          "value": {
-                            "type": "string"
-                          },
-                          "valueFrom": {
-                            "properties": {
-                              "secretKeyRef": {
-                                "properties": {
-                                  "key": {
-                                    "type": "string"
-                                  },
-                                  "name": {
-                                    "default": "",
-                                    "type": "string"
-                                  },
-                                  "optional": {
-                                    "type": "boolean"
-                                  }
-                                },
-                                "required": [
-                                  "key"
-                                ],
-                                "type": "object",
-                                "x-kubernetes-map-type": "atomic",
-                                "additionalProperties": false
-                              }
-                            },
-                            "type": "object",
-                            "additionalProperties": false
-                          }
-                        },
-                        "type": "object",
-                        "additionalProperties": false
-                      },
-                      "client_key": {
-                        "properties": {
-                          "mountFrom": {
-                            "properties": {
-                              "secretKeyRef": {
-                                "properties": {
-                                  "key": {
-                                    "type": "string"
-                                  },
-                                  "name": {
-                                    "default": "",
-                                    "type": "string"
-                                  },
-                                  "optional": {
-                                    "type": "boolean"
-                                  }
-                                },
-                                "required": [
-                                  "key"
-                                ],
-                                "type": "object",
-                                "x-kubernetes-map-type": "atomic",
-                                "additionalProperties": false
-                              }
-                            },
-                            "type": "object",
-                            "additionalProperties": false
-                          },
-                          "value": {
-                            "type": "string"
-                          },
-                          "valueFrom": {
-                            "properties": {
-                              "secretKeyRef": {
-                                "properties": {
-                                  "key": {
-                                    "type": "string"
-                                  },
-                                  "name": {
-                                    "default": "",
-                                    "type": "string"
-                                  },
-                                  "optional": {
-                                    "type": "boolean"
-                                  }
-                                },
-                                "required": [
-                                  "key"
-                                ],
-                                "type": "object",
-                                "x-kubernetes-map-type": "atomic",
-                                "additionalProperties": false
-                              }
-                            },
-                            "type": "object",
-                            "additionalProperties": false
-                          }
-                        },
-                        "type": "object",
-                        "additionalProperties": false
-                      },
-                      "core_api_versions": {
-                        "items": {
-                          "type": "string"
-                        },
-                        "type": "array"
-                      },
-                      "data_type": {
-                        "type": "string"
-                      },
-                      "in_namespace_path": {
-                        "items": {
-                          "type": "string"
-                        },
-                        "type": "array"
-                      },
-                      "in_pod_path": {
-                        "items": {
-                          "type": "string"
-                        },
-                        "type": "array"
-                      },
-                      "kubernetes_url": {
-                        "type": "string"
-                      },
-                      "secret_dir": {
-                        "type": "string"
-                      },
-                      "ssl_partial_chain": {
-                        "type": "boolean"
-                      },
-                      "verify_ssl": {
                         "type": "boolean"
                       }
                     },
@@ -705,6 +474,9 @@
                           "format_firstline": {
                             "type": "string"
                           },
+                          "format_key": {
+                            "type": "string"
+                          },
                           "grok_failure_key": {
                             "type": "string"
                           },
@@ -842,6 +614,9 @@
                                   "type": "string"
                                 },
                                 "format": {
+                                  "type": "string"
+                                },
+                                "format_name": {
                                   "type": "string"
                                 },
                                 "grok_failure_key": {
@@ -1032,6 +807,9 @@
                             "format_firstline": {
                               "type": "string"
                             },
+                            "format_key": {
+                              "type": "string"
+                            },
                             "grok_failure_key": {
                               "type": "string"
                             },
@@ -1169,6 +947,9 @@
                                     "type": "string"
                                   },
                                   "format": {
+                                    "type": "string"
+                                  },
+                                  "format_name": {
                                     "type": "string"
                                   },
                                   "grok_failure_key": {
@@ -1428,90 +1209,6 @@
                   "stdout": {
                     "properties": {
                       "output_type": {
-                        "type": "string"
-                      }
-                    },
-                    "type": "object",
-                    "additionalProperties": false
-                  },
-                  "sumologic": {
-                    "properties": {
-                      "collector_key_name": {
-                        "type": "string"
-                      },
-                      "collector_value": {
-                        "type": "string"
-                      },
-                      "exclude_container_regex": {
-                        "type": "string"
-                      },
-                      "exclude_facility_regex": {
-                        "type": "string"
-                      },
-                      "exclude_host_regex": {
-                        "type": "string"
-                      },
-                      "exclude_namespace_regex": {
-                        "type": "string"
-                      },
-                      "exclude_pod_regex": {
-                        "type": "string"
-                      },
-                      "exclude_priority_regex": {
-                        "type": "string"
-                      },
-                      "exclude_unit_regex": {
-                        "type": "string"
-                      },
-                      "log_format": {
-                        "type": "string"
-                      },
-                      "source_category": {
-                        "type": "string"
-                      },
-                      "source_category_key_name": {
-                        "type": "string"
-                      },
-                      "source_category_prefix": {
-                        "type": "string"
-                      },
-                      "source_category_replace_dash": {
-                        "type": "string"
-                      },
-                      "source_host": {
-                        "type": "string"
-                      },
-                      "source_host_key_name": {
-                        "type": "string"
-                      },
-                      "source_name": {
-                        "type": "string"
-                      },
-                      "source_name_key_name": {
-                        "type": "string"
-                      },
-                      "tracing_annotation_prefix": {
-                        "type": "string"
-                      },
-                      "tracing_container_name": {
-                        "type": "string"
-                      },
-                      "tracing_format": {
-                        "type": "boolean"
-                      },
-                      "tracing_host": {
-                        "type": "string"
-                      },
-                      "tracing_label_prefix": {
-                        "type": "string"
-                      },
-                      "tracing_namespace": {
-                        "type": "string"
-                      },
-                      "tracing_pod": {
-                        "type": "string"
-                      },
-                      "tracing_pod_id": {
                         "type": "string"
                       }
                     },
@@ -2424,6 +2121,18 @@
                 },
                 "pvc": {
                   "properties": {
+                    "annotations": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    },
+                    "labels": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    },
                     "source": {
                       "properties": {
                         "claimName": {
@@ -2660,6 +2369,138 @@
                 },
                 "tag": {
                   "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "bufferVolumeLivenessProbe": {
+              "properties": {
+                "exec": {
+                  "properties": {
+                    "command": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "failureThreshold": {
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "grpc": {
+                  "properties": {
+                    "port": {
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "service": {
+                      "default": "",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "port"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "httpGet": {
+                  "properties": {
+                    "host": {
+                      "type": "string"
+                    },
+                    "httpHeaders": {
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "value": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "value"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
+                    },
+                    "path": {
+                      "type": "string"
+                    },
+                    "port": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "scheme": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "port"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "initialDelaySeconds": {
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "periodSeconds": {
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "successThreshold": {
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "tcpSocket": {
+                  "properties": {
+                    "host": {
+                      "type": "string"
+                    },
+                    "port": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "x-kubernetes-int-or-string": true
+                    }
+                  },
+                  "required": [
+                    "port"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "terminationGracePeriodSeconds": {
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "timeoutSeconds": {
+                  "format": "int32",
+                  "type": "integer"
                 }
               },
               "type": "object",
@@ -3199,6 +3040,9 @@
             "disableKubernetesFilter": {
               "type": "boolean"
             },
+            "disableVarLibDockerContainers": {
+              "type": "boolean"
+            },
             "dnsConfig": {
               "properties": {
                 "nameservers": {
@@ -3239,6 +3083,9 @@
               "type": "string"
             },
             "enableUpstream": {
+              "type": "boolean"
+            },
+            "enabledIPv6": {
               "type": "boolean"
             },
             "envVars": {
@@ -3404,6 +3251,36 @@
                 },
                 "vpc_id": {
                   "type": "boolean"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "filterGrep": {
+              "properties": {
+                "Exclude": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "LogicalOp": {
+                  "default": "legacy",
+                  "enum": [
+                    "legacy",
+                    "AND",
+                    "OR"
+                  ],
+                  "type": "string"
+                },
+                "Match": {
+                  "type": "string"
+                },
+                "Regex": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
                 }
               },
               "type": "object",
@@ -3752,6 +3629,9 @@
               "format": "int32",
               "type": "integer"
             },
+            "forceHotReloadAfterGrace": {
+              "type": "boolean"
+            },
             "forwardOptions": {
               "properties": {
                 "Require_ack_response": {
@@ -3915,6 +3795,9 @@
                     "type": "string"
                   },
                   "type": "array"
+                },
+                "storage.pause_on_chunks_overlimit": {
+                  "type": "string"
                 },
                 "storage.type": {
                   "type": "string"
@@ -4585,6 +4468,18 @@
                 },
                 "pvc": {
                   "properties": {
+                    "annotations": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    },
+                    "labels": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    },
                     "source": {
                       "properties": {
                         "claimName": {
@@ -4888,6 +4783,18 @@
                 },
                 "pvc": {
                   "properties": {
+                    "annotations": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    },
+                    "labels": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    },
                     "source": {
                       "properties": {
                         "claimName": {
@@ -5286,6 +5193,9 @@
             },
             "security": {
               "properties": {
+                "createOpenShiftSCC": {
+                  "type": "boolean"
+                },
                 "podSecurityContext": {
                   "properties": {
                     "appArmorProfile": {
@@ -5320,6 +5230,9 @@
                     "runAsUser": {
                       "format": "int64",
                       "type": "integer"
+                    },
+                    "seLinuxChangePolicy": {
+                      "type": "string"
                     },
                     "seLinuxOptions": {
                       "properties": {
@@ -6495,6 +6408,18 @@
                 },
                 "pvc": {
                   "properties": {
+                    "annotations": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    },
+                    "labels": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    },
                     "source": {
                       "properties": {
                         "claimName": {
@@ -6731,6 +6656,138 @@
                 },
                 "tag": {
                   "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "bufferVolumeLivenessProbe": {
+              "properties": {
+                "exec": {
+                  "properties": {
+                    "command": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "failureThreshold": {
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "grpc": {
+                  "properties": {
+                    "port": {
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "service": {
+                      "default": "",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "port"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "httpGet": {
+                  "properties": {
+                    "host": {
+                      "type": "string"
+                    },
+                    "httpHeaders": {
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "value": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "value"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
+                    },
+                    "path": {
+                      "type": "string"
+                    },
+                    "port": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "scheme": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "port"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "initialDelaySeconds": {
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "periodSeconds": {
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "successThreshold": {
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "tcpSocket": {
+                  "properties": {
+                    "host": {
+                      "type": "string"
+                    },
+                    "port": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "x-kubernetes-int-or-string": true
+                    }
+                  },
+                  "required": [
+                    "port"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "terminationGracePeriodSeconds": {
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "timeoutSeconds": {
+                  "format": "int32",
+                  "type": "integer"
                 }
               },
               "type": "object",
@@ -7330,6 +7387,9 @@
               "type": "object",
               "additionalProperties": false
             },
+            "configReloaderUseGracefulReloadWebhook": {
+              "type": "boolean"
+            },
             "disablePvc": {
               "type": "boolean"
             },
@@ -7373,6 +7433,9 @@
               "type": "string"
             },
             "enableMsgpackTimeSupport": {
+              "type": "boolean"
+            },
+            "enabledIPv6": {
               "type": "boolean"
             },
             "envVars": {
@@ -7595,6 +7658,18 @@
                       },
                       "pvc": {
                         "properties": {
+                          "annotations": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          },
+                          "labels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          },
                           "source": {
                             "properties": {
                               "claimName": {
@@ -7931,6 +8006,18 @@
                 },
                 "pvc": {
                   "properties": {
+                    "annotations": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    },
+                    "labels": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    },
                     "source": {
                       "properties": {
                         "claimName": {
@@ -9338,6 +9425,9 @@
             },
             "security": {
               "properties": {
+                "createOpenShiftSCC": {
+                  "type": "boolean"
+                },
                 "podSecurityContext": {
                   "properties": {
                     "appArmorProfile": {
@@ -9372,6 +9462,9 @@
                     "runAsUser": {
                       "format": "int64",
                       "type": "integer"
+                    },
+                    "seLinuxChangePolicy": {
+                      "type": "string"
                     },
                     "seLinuxOptions": {
                       "properties": {
@@ -10044,6 +10137,9 @@
                         },
                         "type": "object",
                         "additionalProperties": false
+                      },
+                      "stopSignal": {
+                        "type": "string"
                       }
                     },
                     "type": "object",
@@ -11081,249 +11177,6 @@
                 "type": "object",
                 "additionalProperties": false
               },
-              "enhanceK8s": {
-                "properties": {
-                  "api_groups": {
-                    "items": {
-                      "type": "string"
-                    },
-                    "type": "array"
-                  },
-                  "bearer_token_file": {
-                    "type": "string"
-                  },
-                  "ca_file": {
-                    "properties": {
-                      "mountFrom": {
-                        "properties": {
-                          "secretKeyRef": {
-                            "properties": {
-                              "key": {
-                                "type": "string"
-                              },
-                              "name": {
-                                "default": "",
-                                "type": "string"
-                              },
-                              "optional": {
-                                "type": "boolean"
-                              }
-                            },
-                            "required": [
-                              "key"
-                            ],
-                            "type": "object",
-                            "x-kubernetes-map-type": "atomic",
-                            "additionalProperties": false
-                          }
-                        },
-                        "type": "object",
-                        "additionalProperties": false
-                      },
-                      "value": {
-                        "type": "string"
-                      },
-                      "valueFrom": {
-                        "properties": {
-                          "secretKeyRef": {
-                            "properties": {
-                              "key": {
-                                "type": "string"
-                              },
-                              "name": {
-                                "default": "",
-                                "type": "string"
-                              },
-                              "optional": {
-                                "type": "boolean"
-                              }
-                            },
-                            "required": [
-                              "key"
-                            ],
-                            "type": "object",
-                            "x-kubernetes-map-type": "atomic",
-                            "additionalProperties": false
-                          }
-                        },
-                        "type": "object",
-                        "additionalProperties": false
-                      }
-                    },
-                    "type": "object",
-                    "additionalProperties": false
-                  },
-                  "cache_refresh": {
-                    "type": "integer"
-                  },
-                  "cache_refresh_variation": {
-                    "type": "integer"
-                  },
-                  "cache_size": {
-                    "type": "integer"
-                  },
-                  "cache_ttl": {
-                    "type": "integer"
-                  },
-                  "client_cert": {
-                    "properties": {
-                      "mountFrom": {
-                        "properties": {
-                          "secretKeyRef": {
-                            "properties": {
-                              "key": {
-                                "type": "string"
-                              },
-                              "name": {
-                                "default": "",
-                                "type": "string"
-                              },
-                              "optional": {
-                                "type": "boolean"
-                              }
-                            },
-                            "required": [
-                              "key"
-                            ],
-                            "type": "object",
-                            "x-kubernetes-map-type": "atomic",
-                            "additionalProperties": false
-                          }
-                        },
-                        "type": "object",
-                        "additionalProperties": false
-                      },
-                      "value": {
-                        "type": "string"
-                      },
-                      "valueFrom": {
-                        "properties": {
-                          "secretKeyRef": {
-                            "properties": {
-                              "key": {
-                                "type": "string"
-                              },
-                              "name": {
-                                "default": "",
-                                "type": "string"
-                              },
-                              "optional": {
-                                "type": "boolean"
-                              }
-                            },
-                            "required": [
-                              "key"
-                            ],
-                            "type": "object",
-                            "x-kubernetes-map-type": "atomic",
-                            "additionalProperties": false
-                          }
-                        },
-                        "type": "object",
-                        "additionalProperties": false
-                      }
-                    },
-                    "type": "object",
-                    "additionalProperties": false
-                  },
-                  "client_key": {
-                    "properties": {
-                      "mountFrom": {
-                        "properties": {
-                          "secretKeyRef": {
-                            "properties": {
-                              "key": {
-                                "type": "string"
-                              },
-                              "name": {
-                                "default": "",
-                                "type": "string"
-                              },
-                              "optional": {
-                                "type": "boolean"
-                              }
-                            },
-                            "required": [
-                              "key"
-                            ],
-                            "type": "object",
-                            "x-kubernetes-map-type": "atomic",
-                            "additionalProperties": false
-                          }
-                        },
-                        "type": "object",
-                        "additionalProperties": false
-                      },
-                      "value": {
-                        "type": "string"
-                      },
-                      "valueFrom": {
-                        "properties": {
-                          "secretKeyRef": {
-                            "properties": {
-                              "key": {
-                                "type": "string"
-                              },
-                              "name": {
-                                "default": "",
-                                "type": "string"
-                              },
-                              "optional": {
-                                "type": "boolean"
-                              }
-                            },
-                            "required": [
-                              "key"
-                            ],
-                            "type": "object",
-                            "x-kubernetes-map-type": "atomic",
-                            "additionalProperties": false
-                          }
-                        },
-                        "type": "object",
-                        "additionalProperties": false
-                      }
-                    },
-                    "type": "object",
-                    "additionalProperties": false
-                  },
-                  "core_api_versions": {
-                    "items": {
-                      "type": "string"
-                    },
-                    "type": "array"
-                  },
-                  "data_type": {
-                    "type": "string"
-                  },
-                  "in_namespace_path": {
-                    "items": {
-                      "type": "string"
-                    },
-                    "type": "array"
-                  },
-                  "in_pod_path": {
-                    "items": {
-                      "type": "string"
-                    },
-                    "type": "array"
-                  },
-                  "kubernetes_url": {
-                    "type": "string"
-                  },
-                  "secret_dir": {
-                    "type": "string"
-                  },
-                  "ssl_partial_chain": {
-                    "type": "boolean"
-                  },
-                  "verify_ssl": {
-                    "type": "boolean"
-                  }
-                },
-                "type": "object",
-                "additionalProperties": false
-              },
               "geoip": {
                 "properties": {
                   "backend_library": {
@@ -11602,6 +11455,9 @@
                       "format_firstline": {
                         "type": "string"
                       },
+                      "format_key": {
+                        "type": "string"
+                      },
                       "grok_failure_key": {
                         "type": "string"
                       },
@@ -11739,6 +11595,9 @@
                               "type": "string"
                             },
                             "format": {
+                              "type": "string"
+                            },
+                            "format_name": {
                               "type": "string"
                             },
                             "grok_failure_key": {
@@ -11929,6 +11788,9 @@
                         "format_firstline": {
                           "type": "string"
                         },
+                        "format_key": {
+                          "type": "string"
+                        },
                         "grok_failure_key": {
                           "type": "string"
                         },
@@ -12066,6 +11928,9 @@
                                 "type": "string"
                               },
                               "format": {
+                                "type": "string"
+                              },
+                              "format_name": {
                                 "type": "string"
                               },
                               "grok_failure_key": {
@@ -12331,90 +12196,6 @@
                 "type": "object",
                 "additionalProperties": false
               },
-              "sumologic": {
-                "properties": {
-                  "collector_key_name": {
-                    "type": "string"
-                  },
-                  "collector_value": {
-                    "type": "string"
-                  },
-                  "exclude_container_regex": {
-                    "type": "string"
-                  },
-                  "exclude_facility_regex": {
-                    "type": "string"
-                  },
-                  "exclude_host_regex": {
-                    "type": "string"
-                  },
-                  "exclude_namespace_regex": {
-                    "type": "string"
-                  },
-                  "exclude_pod_regex": {
-                    "type": "string"
-                  },
-                  "exclude_priority_regex": {
-                    "type": "string"
-                  },
-                  "exclude_unit_regex": {
-                    "type": "string"
-                  },
-                  "log_format": {
-                    "type": "string"
-                  },
-                  "source_category": {
-                    "type": "string"
-                  },
-                  "source_category_key_name": {
-                    "type": "string"
-                  },
-                  "source_category_prefix": {
-                    "type": "string"
-                  },
-                  "source_category_replace_dash": {
-                    "type": "string"
-                  },
-                  "source_host": {
-                    "type": "string"
-                  },
-                  "source_host_key_name": {
-                    "type": "string"
-                  },
-                  "source_name": {
-                    "type": "string"
-                  },
-                  "source_name_key_name": {
-                    "type": "string"
-                  },
-                  "tracing_annotation_prefix": {
-                    "type": "string"
-                  },
-                  "tracing_container_name": {
-                    "type": "string"
-                  },
-                  "tracing_format": {
-                    "type": "boolean"
-                  },
-                  "tracing_host": {
-                    "type": "string"
-                  },
-                  "tracing_label_prefix": {
-                    "type": "string"
-                  },
-                  "tracing_namespace": {
-                    "type": "string"
-                  },
-                  "tracing_pod": {
-                    "type": "string"
-                  },
-                  "tracing_pod_id": {
-                    "type": "string"
-                  }
-                },
-                "type": "object",
-                "additionalProperties": false
-              },
               "tag_normaliser": {
                 "properties": {
                   "format": {
@@ -12628,6 +12409,18 @@
                       },
                       "pvc": {
                         "properties": {
+                          "annotations": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          },
+                          "labels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          },
                           "source": {
                             "properties": {
                               "claimName": {
@@ -14002,6 +13795,9 @@
                                               },
                                               "type": "object",
                                               "additionalProperties": false
+                                            },
+                                            "stopSignal": {
+                                              "type": "string"
                                             }
                                           },
                                           "type": "object",
@@ -15152,6 +14948,9 @@
                                               },
                                               "type": "object",
                                               "additionalProperties": false
+                                            },
+                                            "stopSignal": {
+                                              "type": "string"
                                             }
                                           },
                                           "type": "object",
@@ -16311,6 +16110,9 @@
                                               },
                                               "type": "object",
                                               "additionalProperties": false
+                                            },
+                                            "stopSignal": {
+                                              "type": "string"
                                             }
                                           },
                                           "type": "object",
@@ -17126,6 +16928,9 @@
                                       "runAsUser": {
                                         "format": "int64",
                                         "type": "integer"
+                                      },
+                                      "seLinuxChangePolicy": {
+                                        "type": "string"
                                       },
                                       "seLinuxOptions": {
                                         "properties": {
@@ -18927,6 +18732,9 @@
                         },
                         "type": "array"
                       },
+                      "storage.pause_on_chunks_overlimit": {
+                        "type": "string"
+                      },
                       "storage.type": {
                         "type": "string"
                       }
@@ -19610,6 +19418,18 @@
                       },
                       "pvc": {
                         "properties": {
+                          "annotations": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          },
+                          "labels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          },
                           "source": {
                             "properties": {
                               "claimName": {
@@ -19818,6 +19638,9 @@
                   },
                   "security": {
                     "properties": {
+                      "createOpenShiftSCC": {
+                        "type": "boolean"
+                      },
                       "podSecurityContext": {
                         "properties": {
                           "appArmorProfile": {
@@ -19852,6 +19675,9 @@
                           "runAsUser": {
                             "format": "int64",
                             "type": "integer"
+                          },
+                          "seLinuxChangePolicy": {
+                            "type": "string"
                           },
                           "seLinuxOptions": {
                             "properties": {
@@ -20179,6 +20005,24 @@
             "additionalProperties": false
           },
           "type": "array"
+        },
+        "routeConfig": {
+          "properties": {
+            "disableLoggingRoute": {
+              "type": "boolean"
+            },
+            "enableTelemetryControllerRoute": {
+              "type": "boolean"
+            },
+            "tenantLabels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
         },
         "skipInvalidResources": {
           "type": "boolean"
@@ -20559,6 +20403,196 @@
                 },
                 "tag": {
                   "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "bufferVolumeMetricsLivenessProbe": {
+              "properties": {
+                "exec": {
+                  "properties": {
+                    "command": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "failureThreshold": {
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "grpc": {
+                  "properties": {
+                    "port": {
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "service": {
+                      "default": "",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "port"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "httpGet": {
+                  "properties": {
+                    "host": {
+                      "type": "string"
+                    },
+                    "httpHeaders": {
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "value": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "value"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
+                    },
+                    "path": {
+                      "type": "string"
+                    },
+                    "port": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "scheme": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "port"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "initialDelaySeconds": {
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "periodSeconds": {
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "successThreshold": {
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "tcpSocket": {
+                  "properties": {
+                    "host": {
+                      "type": "string"
+                    },
+                    "port": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "x-kubernetes-int-or-string": true
+                    }
+                  },
+                  "required": [
+                    "port"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "terminationGracePeriodSeconds": {
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "timeoutSeconds": {
+                  "format": "int32",
+                  "type": "integer"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "bufferVolumeMetricsResources": {
+              "properties": {
+                "claims": {
+                  "items": {
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "request": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-map-keys": [
+                    "name"
+                  ],
+                  "x-kubernetes-list-type": "map"
+                },
+                "limits": {
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ],
+                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                    "x-kubernetes-int-or-string": true
+                  },
+                  "type": "object"
+                },
+                "requests": {
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ],
+                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                    "x-kubernetes-int-or-string": true
+                  },
+                  "type": "object"
                 }
               },
               "type": "object",
@@ -21817,6 +21851,9 @@
                             },
                             "type": "object",
                             "additionalProperties": false
+                          },
+                          "stopSignal": {
+                            "type": "string"
                           }
                         },
                         "type": "object",
@@ -22967,6 +23004,9 @@
                             },
                             "type": "object",
                             "additionalProperties": false
+                          },
+                          "stopSignal": {
+                            "type": "string"
                           }
                         },
                         "type": "object",
@@ -24126,6 +24166,9 @@
                             },
                             "type": "object",
                             "additionalProperties": false
+                          },
+                          "stopSignal": {
+                            "type": "string"
                           }
                         },
                         "type": "object",
@@ -24941,6 +24984,9 @@
                     "runAsUser": {
                       "format": "int64",
                       "type": "integer"
+                    },
+                    "seLinuxChangePolicy": {
+                      "type": "string"
                     },
                     "seLinuxOptions": {
                       "properties": {
@@ -28471,6 +28517,9 @@
                                         },
                                         "type": "object",
                                         "additionalProperties": false
+                                      },
+                                      "stopSignal": {
+                                        "type": "string"
                                       }
                                     },
                                     "type": "object",
@@ -29621,6 +29670,9 @@
                                         },
                                         "type": "object",
                                         "additionalProperties": false
+                                      },
+                                      "stopSignal": {
+                                        "type": "string"
                                       }
                                     },
                                     "type": "object",
@@ -30780,6 +30832,9 @@
                                         },
                                         "type": "object",
                                         "additionalProperties": false
+                                      },
+                                      "stopSignal": {
+                                        "type": "string"
                                       }
                                     },
                                     "type": "object",
@@ -31595,6 +31650,9 @@
                                 "runAsUser": {
                                   "format": "int64",
                                   "type": "integer"
+                                },
+                                "seLinuxChangePolicy": {
+                                  "type": "string"
                                 },
                                 "seLinuxOptions": {
                                   "properties": {

--- a/logging.banzaicloud.io/nodeagent_v1beta1.json
+++ b/logging.banzaicloud.io/nodeagent_v1beta1.json
@@ -158,6 +158,18 @@
                 },
                 "pvc": {
                   "properties": {
+                    "annotations": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    },
+                    "labels": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    },
                     "source": {
                       "properties": {
                         "claimName": {
@@ -1532,6 +1544,9 @@
                                         },
                                         "type": "object",
                                         "additionalProperties": false
+                                      },
+                                      "stopSignal": {
+                                        "type": "string"
                                       }
                                     },
                                     "type": "object",
@@ -2682,6 +2697,9 @@
                                         },
                                         "type": "object",
                                         "additionalProperties": false
+                                      },
+                                      "stopSignal": {
+                                        "type": "string"
                                       }
                                     },
                                     "type": "object",
@@ -3841,6 +3859,9 @@
                                         },
                                         "type": "object",
                                         "additionalProperties": false
+                                      },
+                                      "stopSignal": {
+                                        "type": "string"
                                       }
                                     },
                                     "type": "object",
@@ -4656,6 +4677,9 @@
                                 "runAsUser": {
                                   "format": "int64",
                                   "type": "integer"
+                                },
+                                "seLinuxChangePolicy": {
+                                  "type": "string"
                                 },
                                 "seLinuxOptions": {
                                   "properties": {
@@ -6457,6 +6481,9 @@
                   },
                   "type": "array"
                 },
+                "storage.pause_on_chunks_overlimit": {
+                  "type": "string"
+                },
                 "storage.type": {
                   "type": "string"
                 }
@@ -7140,6 +7167,18 @@
                 },
                 "pvc": {
                   "properties": {
+                    "annotations": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    },
+                    "labels": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    },
                     "source": {
                       "properties": {
                         "claimName": {
@@ -7348,6 +7387,9 @@
             },
             "security": {
               "properties": {
+                "createOpenShiftSCC": {
+                  "type": "boolean"
+                },
                 "podSecurityContext": {
                   "properties": {
                     "appArmorProfile": {
@@ -7382,6 +7424,9 @@
                     "runAsUser": {
                       "format": "int64",
                       "type": "integer"
+                    },
+                    "seLinuxChangePolicy": {
+                      "type": "string"
                     },
                     "seLinuxOptions": {
                       "properties": {

--- a/logging.banzaicloud.io/output_v1alpha1.json
+++ b/logging.banzaicloud.io/output_v1alpha1.json
@@ -4209,6 +4209,9 @@
                 "type": "string"
               },
               "type": "object"
+            },
+            "udp_transport_type": {
+              "type": "string"
             }
           },
           "required": [
@@ -4457,6 +4460,9 @@
               "type": "object",
               "additionalProperties": false
             },
+            "compress": {
+              "type": "string"
+            },
             "content_type": {
               "type": "string"
             },
@@ -4496,6 +4502,12 @@
               },
               "type": "object"
             },
+            "headers_from_placeholders": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
             "http_method": {
               "type": "string"
             },
@@ -4516,6 +4528,9 @@
                 "type": "integer"
               },
               "type": "array"
+            },
+            "reuse_connections": {
+              "type": "boolean"
             },
             "slow_flush_log_threshold": {
               "type": "string"
@@ -5107,6 +5122,288 @@
             },
             "principal": {
               "type": "string"
+            },
+            "rdkafka_options": {
+              "properties": {
+                "allow.auto.create.topics": {
+                  "type": "boolean"
+                },
+                "api.version.fallback.ms": {
+                  "type": "integer"
+                },
+                "api.version.request": {
+                  "type": "boolean"
+                },
+                "api.version.request.timeout.ms": {
+                  "type": "integer"
+                },
+                "background_event_cb": {
+                  "type": "string"
+                },
+                "bootstrap.servers": {
+                  "type": "string"
+                },
+                "broker.address.family": {
+                  "type": "string"
+                },
+                "broker.address.ttl": {
+                  "type": "integer"
+                },
+                "broker.version.fallback": {
+                  "type": "string"
+                },
+                "builtin.features": {
+                  "type": "string"
+                },
+                "client.id": {
+                  "type": "string"
+                },
+                "closesocket_cb": {
+                  "type": "string"
+                },
+                "connect_cb": {
+                  "type": "string"
+                },
+                "connections.max.idle.ms": {
+                  "type": "integer"
+                },
+                "debug": {
+                  "type": "string"
+                },
+                "default_topic_conf": {
+                  "type": "string"
+                },
+                "enable.random.seed": {
+                  "type": "boolean"
+                },
+                "enable.sasl.oauthbearer.unsecure.jwt": {
+                  "type": "boolean"
+                },
+                "enable.ssl.certificate.verification": {
+                  "type": "boolean"
+                },
+                "enabled_events": {
+                  "type": "integer"
+                },
+                "error_cb": {
+                  "type": "string"
+                },
+                "interceptors": {
+                  "type": "string"
+                },
+                "internal.termination.signal": {
+                  "type": "integer"
+                },
+                "log.connection.close": {
+                  "type": "boolean"
+                },
+                "log.queue": {
+                  "type": "boolean"
+                },
+                "log.thread.name": {
+                  "type": "boolean"
+                },
+                "log_cb": {
+                  "type": "string"
+                },
+                "log_level": {
+                  "type": "integer"
+                },
+                "max.in.flight": {
+                  "type": "integer"
+                },
+                "max.in.flight.requests.per.connection": {
+                  "type": "integer"
+                },
+                "message.copy.max.bytes": {
+                  "type": "integer"
+                },
+                "message.max.bytes": {
+                  "type": "integer"
+                },
+                "metadata.broker.list": {
+                  "type": "string"
+                },
+                "metadata.max.age.ms": {
+                  "type": "integer"
+                },
+                "oauthbearer_token_refresh_cb": {
+                  "type": "string"
+                },
+                "opaque": {
+                  "type": "string"
+                },
+                "open_cb": {
+                  "type": "string"
+                },
+                "plugin.library.paths": {
+                  "type": "string"
+                },
+                "receive.message.max.bytes": {
+                  "type": "integer"
+                },
+                "reconnect.backoff.max.ms": {
+                  "type": "integer"
+                },
+                "reconnect.backoff.ms": {
+                  "type": "integer"
+                },
+                "resolve_cb": {
+                  "type": "string"
+                },
+                "sasl.kerberos.keytab": {
+                  "type": "string"
+                },
+                "sasl.kerberos.kinit.cmd": {
+                  "type": "string"
+                },
+                "sasl.kerberos.min.time.before.relogin": {
+                  "type": "integer"
+                },
+                "sasl.kerberos.principal": {
+                  "type": "string"
+                },
+                "sasl.kerberos.service.name": {
+                  "type": "string"
+                },
+                "sasl.mechanisms": {
+                  "type": "string"
+                },
+                "sasl.oauthbearer.client.id": {
+                  "type": "string"
+                },
+                "sasl.oauthbearer.client.secret": {
+                  "type": "string"
+                },
+                "sasl.oauthbearer.config": {
+                  "type": "string"
+                },
+                "sasl.oauthbearer.extensions": {
+                  "type": "string"
+                },
+                "sasl.oauthbearer.method": {
+                  "type": "string"
+                },
+                "sasl.oauthbearer.scope": {
+                  "type": "string"
+                },
+                "sasl.oauthbearer.token.endpoint.url": {
+                  "type": "string"
+                },
+                "sasl.password": {
+                  "type": "string"
+                },
+                "sasl.username": {
+                  "type": "string"
+                },
+                "security.protocol": {
+                  "type": "string"
+                },
+                "socket.blocking.max.ms": {
+                  "type": "integer"
+                },
+                "socket.connection.setup.timeout.ms": {
+                  "type": "integer"
+                },
+                "socket.keepalive.enable": {
+                  "type": "boolean"
+                },
+                "socket.max.fails": {
+                  "type": "integer"
+                },
+                "socket.nagle.disable": {
+                  "type": "boolean"
+                },
+                "socket.receive.buffer.bytes": {
+                  "type": "integer"
+                },
+                "socket.send.buffer.bytes": {
+                  "type": "integer"
+                },
+                "socket.timeout.ms": {
+                  "type": "integer"
+                },
+                "socket_cb": {
+                  "type": "string"
+                },
+                "ssl.ca.location": {
+                  "type": "string"
+                },
+                "ssl.ca.pem": {
+                  "type": "string"
+                },
+                "ssl.certificate.location": {
+                  "type": "string"
+                },
+                "ssl.certificate.pem": {
+                  "type": "string"
+                },
+                "ssl.cipher.suites": {
+                  "type": "string"
+                },
+                "ssl.crl.location": {
+                  "type": "string"
+                },
+                "ssl.curves.list": {
+                  "type": "string"
+                },
+                "ssl.endpoint.identification.algorithm": {
+                  "type": "string"
+                },
+                "ssl.engine.id": {
+                  "type": "string"
+                },
+                "ssl.engine.location": {
+                  "type": "string"
+                },
+                "ssl.key.location": {
+                  "type": "string"
+                },
+                "ssl.key.password": {
+                  "type": "string"
+                },
+                "ssl.key.pem": {
+                  "type": "string"
+                },
+                "ssl.keystore.location": {
+                  "type": "string"
+                },
+                "ssl.keystore.password": {
+                  "type": "string"
+                },
+                "ssl.providers": {
+                  "type": "string"
+                },
+                "ssl.sigalgs.list": {
+                  "type": "string"
+                },
+                "statistics.interval.ms": {
+                  "type": "integer"
+                },
+                "stats_cb": {
+                  "type": "string"
+                },
+                "throttle_cb": {
+                  "type": "string"
+                },
+                "topic.blacklist": {
+                  "type": "string"
+                },
+                "topic.metadata.propagation.max.ms": {
+                  "type": "integer"
+                },
+                "topic.metadata.refresh.fast.interval.ms": {
+                  "type": "integer"
+                },
+                "topic.metadata.refresh.interval.ms": {
+                  "type": "integer"
+                },
+                "topic.metadata.refresh.sparse": {
+                  "type": "boolean"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
             },
             "required_acks": {
               "type": "integer"
@@ -6911,7 +7208,13 @@
           "additionalProperties": false
         },
         "nullout": {
-          "type": "object"
+          "properties": {
+            "never_flush": {
+              "type": "boolean"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
         },
         "opensearch": {
           "properties": {
@@ -7901,6 +8204,9 @@
             },
             "reload_on_failure": {
               "type": "boolean"
+            },
+            "remove_keys": {
+              "type": "string"
             },
             "remove_keys_on_update": {
               "type": "string"
@@ -9853,248 +10159,6 @@
               "type": "string"
             }
           },
-          "type": "object",
-          "additionalProperties": false
-        },
-        "sumologic": {
-          "properties": {
-            "add_timestamp": {
-              "type": "boolean"
-            },
-            "buffer": {
-              "properties": {
-                "chunk_full_threshold": {
-                  "type": "string"
-                },
-                "chunk_limit_records": {
-                  "type": "integer"
-                },
-                "chunk_limit_size": {
-                  "type": "string"
-                },
-                "compress": {
-                  "type": "string"
-                },
-                "delayed_commit_timeout": {
-                  "type": "string"
-                },
-                "disable_chunk_backup": {
-                  "type": "boolean"
-                },
-                "disabled": {
-                  "type": "boolean"
-                },
-                "flush_at_shutdown": {
-                  "type": "boolean"
-                },
-                "flush_interval": {
-                  "type": "string"
-                },
-                "flush_mode": {
-                  "type": "string"
-                },
-                "flush_thread_burst_interval": {
-                  "type": "string"
-                },
-                "flush_thread_count": {
-                  "type": "integer"
-                },
-                "flush_thread_interval": {
-                  "type": "string"
-                },
-                "overflow_action": {
-                  "type": "string"
-                },
-                "path": {
-                  "type": "string"
-                },
-                "queue_limit_length": {
-                  "type": "integer"
-                },
-                "queued_chunks_limit_size": {
-                  "type": "integer"
-                },
-                "retry_exponential_backoff_base": {
-                  "type": "string"
-                },
-                "retry_forever": {
-                  "type": "boolean"
-                },
-                "retry_max_interval": {
-                  "type": "string"
-                },
-                "retry_max_times": {
-                  "type": "integer"
-                },
-                "retry_randomize": {
-                  "type": "boolean"
-                },
-                "retry_secondary_threshold": {
-                  "type": "string"
-                },
-                "retry_timeout": {
-                  "type": "string"
-                },
-                "retry_type": {
-                  "type": "string"
-                },
-                "retry_wait": {
-                  "type": "string"
-                },
-                "tags": {
-                  "type": "string"
-                },
-                "timekey": {
-                  "type": "string"
-                },
-                "timekey_use_utc": {
-                  "type": "boolean"
-                },
-                "timekey_wait": {
-                  "type": "string"
-                },
-                "timekey_zone": {
-                  "type": "string"
-                },
-                "total_limit_size": {
-                  "type": "string"
-                },
-                "type": {
-                  "type": "string"
-                }
-              },
-              "type": "object",
-              "additionalProperties": false
-            },
-            "compress": {
-              "type": "boolean"
-            },
-            "compress_encoding": {
-              "type": "string"
-            },
-            "custom_dimensions": {
-              "type": "string"
-            },
-            "custom_fields": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "data_type": {
-              "type": "string"
-            },
-            "delimiter": {
-              "type": "string"
-            },
-            "disable_cookies": {
-              "type": "boolean"
-            },
-            "endpoint": {
-              "properties": {
-                "mountFrom": {
-                  "properties": {
-                    "secretKeyRef": {
-                      "properties": {
-                        "key": {
-                          "type": "string"
-                        },
-                        "name": {
-                          "default": "",
-                          "type": "string"
-                        },
-                        "optional": {
-                          "type": "boolean"
-                        }
-                      },
-                      "required": [
-                        "key"
-                      ],
-                      "type": "object",
-                      "x-kubernetes-map-type": "atomic",
-                      "additionalProperties": false
-                    }
-                  },
-                  "type": "object",
-                  "additionalProperties": false
-                },
-                "value": {
-                  "type": "string"
-                },
-                "valueFrom": {
-                  "properties": {
-                    "secretKeyRef": {
-                      "properties": {
-                        "key": {
-                          "type": "string"
-                        },
-                        "name": {
-                          "default": "",
-                          "type": "string"
-                        },
-                        "optional": {
-                          "type": "boolean"
-                        }
-                      },
-                      "required": [
-                        "key"
-                      ],
-                      "type": "object",
-                      "x-kubernetes-map-type": "atomic",
-                      "additionalProperties": false
-                    }
-                  },
-                  "type": "object",
-                  "additionalProperties": false
-                }
-              },
-              "type": "object",
-              "additionalProperties": false
-            },
-            "log_format": {
-              "type": "string"
-            },
-            "log_key": {
-              "type": "string"
-            },
-            "metric_data_format": {
-              "type": "string"
-            },
-            "open_timeout": {
-              "type": "integer"
-            },
-            "proxy_uri": {
-              "type": "string"
-            },
-            "slow_flush_log_threshold": {
-              "type": "string"
-            },
-            "source_category": {
-              "type": "string"
-            },
-            "source_host": {
-              "type": "string"
-            },
-            "source_name": {
-              "type": "string"
-            },
-            "source_name_key": {
-              "type": "string"
-            },
-            "sumo_client": {
-              "type": "string"
-            },
-            "timestamp_key": {
-              "type": "string"
-            },
-            "verify_ssl": {
-              "type": "boolean"
-            }
-          },
-          "required": [
-            "endpoint",
-            "source_name"
-          ],
           "type": "object",
           "additionalProperties": false
         },

--- a/logging.banzaicloud.io/output_v1beta1.json
+++ b/logging.banzaicloud.io/output_v1beta1.json
@@ -4209,6 +4209,9 @@
                 "type": "string"
               },
               "type": "object"
+            },
+            "udp_transport_type": {
+              "type": "string"
             }
           },
           "required": [
@@ -4457,6 +4460,9 @@
               "type": "object",
               "additionalProperties": false
             },
+            "compress": {
+              "type": "string"
+            },
             "content_type": {
               "type": "string"
             },
@@ -4496,6 +4502,12 @@
               },
               "type": "object"
             },
+            "headers_from_placeholders": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
             "http_method": {
               "type": "string"
             },
@@ -4516,6 +4528,9 @@
                 "type": "integer"
               },
               "type": "array"
+            },
+            "reuse_connections": {
+              "type": "boolean"
             },
             "slow_flush_log_threshold": {
               "type": "string"
@@ -5107,6 +5122,288 @@
             },
             "principal": {
               "type": "string"
+            },
+            "rdkafka_options": {
+              "properties": {
+                "allow.auto.create.topics": {
+                  "type": "boolean"
+                },
+                "api.version.fallback.ms": {
+                  "type": "integer"
+                },
+                "api.version.request": {
+                  "type": "boolean"
+                },
+                "api.version.request.timeout.ms": {
+                  "type": "integer"
+                },
+                "background_event_cb": {
+                  "type": "string"
+                },
+                "bootstrap.servers": {
+                  "type": "string"
+                },
+                "broker.address.family": {
+                  "type": "string"
+                },
+                "broker.address.ttl": {
+                  "type": "integer"
+                },
+                "broker.version.fallback": {
+                  "type": "string"
+                },
+                "builtin.features": {
+                  "type": "string"
+                },
+                "client.id": {
+                  "type": "string"
+                },
+                "closesocket_cb": {
+                  "type": "string"
+                },
+                "connect_cb": {
+                  "type": "string"
+                },
+                "connections.max.idle.ms": {
+                  "type": "integer"
+                },
+                "debug": {
+                  "type": "string"
+                },
+                "default_topic_conf": {
+                  "type": "string"
+                },
+                "enable.random.seed": {
+                  "type": "boolean"
+                },
+                "enable.sasl.oauthbearer.unsecure.jwt": {
+                  "type": "boolean"
+                },
+                "enable.ssl.certificate.verification": {
+                  "type": "boolean"
+                },
+                "enabled_events": {
+                  "type": "integer"
+                },
+                "error_cb": {
+                  "type": "string"
+                },
+                "interceptors": {
+                  "type": "string"
+                },
+                "internal.termination.signal": {
+                  "type": "integer"
+                },
+                "log.connection.close": {
+                  "type": "boolean"
+                },
+                "log.queue": {
+                  "type": "boolean"
+                },
+                "log.thread.name": {
+                  "type": "boolean"
+                },
+                "log_cb": {
+                  "type": "string"
+                },
+                "log_level": {
+                  "type": "integer"
+                },
+                "max.in.flight": {
+                  "type": "integer"
+                },
+                "max.in.flight.requests.per.connection": {
+                  "type": "integer"
+                },
+                "message.copy.max.bytes": {
+                  "type": "integer"
+                },
+                "message.max.bytes": {
+                  "type": "integer"
+                },
+                "metadata.broker.list": {
+                  "type": "string"
+                },
+                "metadata.max.age.ms": {
+                  "type": "integer"
+                },
+                "oauthbearer_token_refresh_cb": {
+                  "type": "string"
+                },
+                "opaque": {
+                  "type": "string"
+                },
+                "open_cb": {
+                  "type": "string"
+                },
+                "plugin.library.paths": {
+                  "type": "string"
+                },
+                "receive.message.max.bytes": {
+                  "type": "integer"
+                },
+                "reconnect.backoff.max.ms": {
+                  "type": "integer"
+                },
+                "reconnect.backoff.ms": {
+                  "type": "integer"
+                },
+                "resolve_cb": {
+                  "type": "string"
+                },
+                "sasl.kerberos.keytab": {
+                  "type": "string"
+                },
+                "sasl.kerberos.kinit.cmd": {
+                  "type": "string"
+                },
+                "sasl.kerberos.min.time.before.relogin": {
+                  "type": "integer"
+                },
+                "sasl.kerberos.principal": {
+                  "type": "string"
+                },
+                "sasl.kerberos.service.name": {
+                  "type": "string"
+                },
+                "sasl.mechanisms": {
+                  "type": "string"
+                },
+                "sasl.oauthbearer.client.id": {
+                  "type": "string"
+                },
+                "sasl.oauthbearer.client.secret": {
+                  "type": "string"
+                },
+                "sasl.oauthbearer.config": {
+                  "type": "string"
+                },
+                "sasl.oauthbearer.extensions": {
+                  "type": "string"
+                },
+                "sasl.oauthbearer.method": {
+                  "type": "string"
+                },
+                "sasl.oauthbearer.scope": {
+                  "type": "string"
+                },
+                "sasl.oauthbearer.token.endpoint.url": {
+                  "type": "string"
+                },
+                "sasl.password": {
+                  "type": "string"
+                },
+                "sasl.username": {
+                  "type": "string"
+                },
+                "security.protocol": {
+                  "type": "string"
+                },
+                "socket.blocking.max.ms": {
+                  "type": "integer"
+                },
+                "socket.connection.setup.timeout.ms": {
+                  "type": "integer"
+                },
+                "socket.keepalive.enable": {
+                  "type": "boolean"
+                },
+                "socket.max.fails": {
+                  "type": "integer"
+                },
+                "socket.nagle.disable": {
+                  "type": "boolean"
+                },
+                "socket.receive.buffer.bytes": {
+                  "type": "integer"
+                },
+                "socket.send.buffer.bytes": {
+                  "type": "integer"
+                },
+                "socket.timeout.ms": {
+                  "type": "integer"
+                },
+                "socket_cb": {
+                  "type": "string"
+                },
+                "ssl.ca.location": {
+                  "type": "string"
+                },
+                "ssl.ca.pem": {
+                  "type": "string"
+                },
+                "ssl.certificate.location": {
+                  "type": "string"
+                },
+                "ssl.certificate.pem": {
+                  "type": "string"
+                },
+                "ssl.cipher.suites": {
+                  "type": "string"
+                },
+                "ssl.crl.location": {
+                  "type": "string"
+                },
+                "ssl.curves.list": {
+                  "type": "string"
+                },
+                "ssl.endpoint.identification.algorithm": {
+                  "type": "string"
+                },
+                "ssl.engine.id": {
+                  "type": "string"
+                },
+                "ssl.engine.location": {
+                  "type": "string"
+                },
+                "ssl.key.location": {
+                  "type": "string"
+                },
+                "ssl.key.password": {
+                  "type": "string"
+                },
+                "ssl.key.pem": {
+                  "type": "string"
+                },
+                "ssl.keystore.location": {
+                  "type": "string"
+                },
+                "ssl.keystore.password": {
+                  "type": "string"
+                },
+                "ssl.providers": {
+                  "type": "string"
+                },
+                "ssl.sigalgs.list": {
+                  "type": "string"
+                },
+                "statistics.interval.ms": {
+                  "type": "integer"
+                },
+                "stats_cb": {
+                  "type": "string"
+                },
+                "throttle_cb": {
+                  "type": "string"
+                },
+                "topic.blacklist": {
+                  "type": "string"
+                },
+                "topic.metadata.propagation.max.ms": {
+                  "type": "integer"
+                },
+                "topic.metadata.refresh.fast.interval.ms": {
+                  "type": "integer"
+                },
+                "topic.metadata.refresh.interval.ms": {
+                  "type": "integer"
+                },
+                "topic.metadata.refresh.sparse": {
+                  "type": "boolean"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
             },
             "required_acks": {
               "type": "integer"
@@ -7442,7 +7739,13 @@
           "additionalProperties": false
         },
         "nullout": {
-          "type": "object"
+          "properties": {
+            "never_flush": {
+              "type": "boolean"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
         },
         "opensearch": {
           "properties": {
@@ -8432,6 +8735,9 @@
             },
             "reload_on_failure": {
               "type": "boolean"
+            },
+            "remove_keys": {
+              "type": "string"
             },
             "remove_keys_on_update": {
               "type": "string"
@@ -10384,248 +10690,6 @@
               "type": "string"
             }
           },
-          "type": "object",
-          "additionalProperties": false
-        },
-        "sumologic": {
-          "properties": {
-            "add_timestamp": {
-              "type": "boolean"
-            },
-            "buffer": {
-              "properties": {
-                "chunk_full_threshold": {
-                  "type": "string"
-                },
-                "chunk_limit_records": {
-                  "type": "integer"
-                },
-                "chunk_limit_size": {
-                  "type": "string"
-                },
-                "compress": {
-                  "type": "string"
-                },
-                "delayed_commit_timeout": {
-                  "type": "string"
-                },
-                "disable_chunk_backup": {
-                  "type": "boolean"
-                },
-                "disabled": {
-                  "type": "boolean"
-                },
-                "flush_at_shutdown": {
-                  "type": "boolean"
-                },
-                "flush_interval": {
-                  "type": "string"
-                },
-                "flush_mode": {
-                  "type": "string"
-                },
-                "flush_thread_burst_interval": {
-                  "type": "string"
-                },
-                "flush_thread_count": {
-                  "type": "integer"
-                },
-                "flush_thread_interval": {
-                  "type": "string"
-                },
-                "overflow_action": {
-                  "type": "string"
-                },
-                "path": {
-                  "type": "string"
-                },
-                "queue_limit_length": {
-                  "type": "integer"
-                },
-                "queued_chunks_limit_size": {
-                  "type": "integer"
-                },
-                "retry_exponential_backoff_base": {
-                  "type": "string"
-                },
-                "retry_forever": {
-                  "type": "boolean"
-                },
-                "retry_max_interval": {
-                  "type": "string"
-                },
-                "retry_max_times": {
-                  "type": "integer"
-                },
-                "retry_randomize": {
-                  "type": "boolean"
-                },
-                "retry_secondary_threshold": {
-                  "type": "string"
-                },
-                "retry_timeout": {
-                  "type": "string"
-                },
-                "retry_type": {
-                  "type": "string"
-                },
-                "retry_wait": {
-                  "type": "string"
-                },
-                "tags": {
-                  "type": "string"
-                },
-                "timekey": {
-                  "type": "string"
-                },
-                "timekey_use_utc": {
-                  "type": "boolean"
-                },
-                "timekey_wait": {
-                  "type": "string"
-                },
-                "timekey_zone": {
-                  "type": "string"
-                },
-                "total_limit_size": {
-                  "type": "string"
-                },
-                "type": {
-                  "type": "string"
-                }
-              },
-              "type": "object",
-              "additionalProperties": false
-            },
-            "compress": {
-              "type": "boolean"
-            },
-            "compress_encoding": {
-              "type": "string"
-            },
-            "custom_dimensions": {
-              "type": "string"
-            },
-            "custom_fields": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "data_type": {
-              "type": "string"
-            },
-            "delimiter": {
-              "type": "string"
-            },
-            "disable_cookies": {
-              "type": "boolean"
-            },
-            "endpoint": {
-              "properties": {
-                "mountFrom": {
-                  "properties": {
-                    "secretKeyRef": {
-                      "properties": {
-                        "key": {
-                          "type": "string"
-                        },
-                        "name": {
-                          "default": "",
-                          "type": "string"
-                        },
-                        "optional": {
-                          "type": "boolean"
-                        }
-                      },
-                      "required": [
-                        "key"
-                      ],
-                      "type": "object",
-                      "x-kubernetes-map-type": "atomic",
-                      "additionalProperties": false
-                    }
-                  },
-                  "type": "object",
-                  "additionalProperties": false
-                },
-                "value": {
-                  "type": "string"
-                },
-                "valueFrom": {
-                  "properties": {
-                    "secretKeyRef": {
-                      "properties": {
-                        "key": {
-                          "type": "string"
-                        },
-                        "name": {
-                          "default": "",
-                          "type": "string"
-                        },
-                        "optional": {
-                          "type": "boolean"
-                        }
-                      },
-                      "required": [
-                        "key"
-                      ],
-                      "type": "object",
-                      "x-kubernetes-map-type": "atomic",
-                      "additionalProperties": false
-                    }
-                  },
-                  "type": "object",
-                  "additionalProperties": false
-                }
-              },
-              "type": "object",
-              "additionalProperties": false
-            },
-            "log_format": {
-              "type": "string"
-            },
-            "log_key": {
-              "type": "string"
-            },
-            "metric_data_format": {
-              "type": "string"
-            },
-            "open_timeout": {
-              "type": "integer"
-            },
-            "proxy_uri": {
-              "type": "string"
-            },
-            "slow_flush_log_threshold": {
-              "type": "string"
-            },
-            "source_category": {
-              "type": "string"
-            },
-            "source_host": {
-              "type": "string"
-            },
-            "source_name": {
-              "type": "string"
-            },
-            "source_name_key": {
-              "type": "string"
-            },
-            "sumo_client": {
-              "type": "string"
-            },
-            "timestamp_key": {
-              "type": "string"
-            },
-            "verify_ssl": {
-              "type": "boolean"
-            }
-          },
-          "required": [
-            "endpoint",
-            "source_name"
-          ],
           "type": "object",
           "additionalProperties": false
         },

--- a/logging.banzaicloud.io/syslogngclusteroutput_v1beta1.json
+++ b/logging.banzaicloud.io/syslogngclusteroutput_v1beta1.json
@@ -57,7 +57,7 @@
                   "format": "int64",
                   "type": "integer"
                 },
-                "q_out_size": {
+                "qout_size": {
                   "format": "int64",
                   "type": "integer"
                 },
@@ -510,7 +510,7 @@
                   "format": "int64",
                   "type": "integer"
                 },
-                "q_out_size": {
+                "qout_size": {
                   "format": "int64",
                   "type": "integer"
                 },
@@ -905,12 +905,6 @@
           "type": "object",
           "additionalProperties": false
         },
-        "enabledNamespaces": {
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
         "file": {
           "properties": {
             "create_dirs": {
@@ -945,7 +939,7 @@
                   "format": "int64",
                   "type": "integer"
                 },
-                "q_out_size": {
+                "qout_size": {
                   "format": "int64",
                   "type": "integer"
                 },
@@ -1019,7 +1013,7 @@
                   "format": "int64",
                   "type": "integer"
                 },
-                "q_out_size": {
+                "qout_size": {
                   "format": "int64",
                   "type": "integer"
                 },
@@ -1439,7 +1433,7 @@
                   "format": "int64",
                   "type": "integer"
                 },
-                "q_out_size": {
+                "qout_size": {
                   "format": "int64",
                   "type": "integer"
                 },
@@ -1871,7 +1865,7 @@
                   "format": "int64",
                   "type": "integer"
                 },
-                "q_out_size": {
+                "qout_size": {
                   "format": "int64",
                   "type": "integer"
                 },
@@ -2265,7 +2259,7 @@
                   "format": "int64",
                   "type": "integer"
                 },
-                "q_out_size": {
+                "qout_size": {
                   "format": "int64",
                   "type": "integer"
                 },
@@ -2296,6 +2290,9 @@
               "type": "integer"
             },
             "template": {
+              "type": "string"
+            },
+            "tenant-id": {
               "type": "string"
             },
             "time_reopen": {
@@ -2365,7 +2362,7 @@
                   "format": "int64",
                   "type": "integer"
                 },
-                "q_out_size": {
+                "qout_size": {
                   "format": "int64",
                   "type": "integer"
                 },
@@ -2550,7 +2547,7 @@
                   "format": "int64",
                   "type": "integer"
                 },
-                "q_out_size": {
+                "qout_size": {
                   "format": "int64",
                   "type": "integer"
                 },
@@ -3207,7 +3204,7 @@
                   "format": "int64",
                   "type": "integer"
                 },
-                "q_out_size": {
+                "qout_size": {
                   "format": "int64",
                   "type": "integer"
                 },
@@ -3231,6 +3228,9 @@
           ],
           "type": "object",
           "additionalProperties": false
+        },
+        "protected": {
+          "type": "boolean"
         },
         "redis": {
           "properties": {
@@ -3342,7 +3342,7 @@
                   "format": "int64",
                   "type": "integer"
                 },
-                "q_out_size": {
+                "qout_size": {
                   "format": "int64",
                   "type": "integer"
                 },
@@ -3483,7 +3483,7 @@
                   "format": "int64",
                   "type": "integer"
                 },
-                "q_out_size": {
+                "qout_size": {
                   "format": "int64",
                   "type": "integer"
                 },
@@ -3660,7 +3660,7 @@
                   "format": "int64",
                   "type": "integer"
                 },
-                "q_out_size": {
+                "qout_size": {
                   "format": "int64",
                   "type": "integer"
                 },
@@ -4244,7 +4244,7 @@
                   "format": "int64",
                   "type": "integer"
                 },
-                "q_out_size": {
+                "qout_size": {
                   "format": "int64",
                   "type": "integer"
                 },
@@ -4631,7 +4631,7 @@
                   "format": "int64",
                   "type": "integer"
                 },
-                "q_out_size": {
+                "qout_size": {
                   "format": "int64",
                   "type": "integer"
                 },
@@ -4957,7 +4957,7 @@
                   "format": "int64",
                   "type": "integer"
                 },
-                "q_out_size": {
+                "qout_size": {
                   "format": "int64",
                   "type": "integer"
                 },

--- a/logging.banzaicloud.io/syslogngconfig_v1beta1.json
+++ b/logging.banzaicloud.io/syslogngconfig_v1beta1.json
@@ -390,6 +390,196 @@
           "type": "object",
           "additionalProperties": false
         },
+        "bufferVolumeMetricsLivenessProbe": {
+          "properties": {
+            "exec": {
+              "properties": {
+                "command": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "failureThreshold": {
+              "format": "int32",
+              "type": "integer"
+            },
+            "grpc": {
+              "properties": {
+                "port": {
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "service": {
+                  "default": "",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "port"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "httpGet": {
+              "properties": {
+                "host": {
+                  "type": "string"
+                },
+                "httpHeaders": {
+                  "items": {
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "value": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "name",
+                      "value"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                },
+                "path": {
+                  "type": "string"
+                },
+                "port": {
+                  "anyOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "x-kubernetes-int-or-string": true
+                },
+                "scheme": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "port"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "initialDelaySeconds": {
+              "format": "int32",
+              "type": "integer"
+            },
+            "periodSeconds": {
+              "format": "int32",
+              "type": "integer"
+            },
+            "successThreshold": {
+              "format": "int32",
+              "type": "integer"
+            },
+            "tcpSocket": {
+              "properties": {
+                "host": {
+                  "type": "string"
+                },
+                "port": {
+                  "anyOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "x-kubernetes-int-or-string": true
+                }
+              },
+              "required": [
+                "port"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "terminationGracePeriodSeconds": {
+              "format": "int64",
+              "type": "integer"
+            },
+            "timeoutSeconds": {
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "bufferVolumeMetricsResources": {
+          "properties": {
+            "claims": {
+              "items": {
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "request": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array",
+              "x-kubernetes-list-map-keys": [
+                "name"
+              ],
+              "x-kubernetes-list-type": "map"
+            },
+            "limits": {
+              "additionalProperties": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ],
+                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                "x-kubernetes-int-or-string": true
+              },
+              "type": "object"
+            },
+            "requests": {
+              "additionalProperties": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ],
+                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                "x-kubernetes-int-or-string": true
+              },
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
         "bufferVolumeMetricsService": {
           "properties": {
             "metadata": {
@@ -1643,6 +1833,9 @@
                         },
                         "type": "object",
                         "additionalProperties": false
+                      },
+                      "stopSignal": {
+                        "type": "string"
                       }
                     },
                     "type": "object",
@@ -2793,6 +2986,9 @@
                         },
                         "type": "object",
                         "additionalProperties": false
+                      },
+                      "stopSignal": {
+                        "type": "string"
                       }
                     },
                     "type": "object",
@@ -3952,6 +4148,9 @@
                         },
                         "type": "object",
                         "additionalProperties": false
+                      },
+                      "stopSignal": {
+                        "type": "string"
                       }
                     },
                     "type": "object",
@@ -4767,6 +4966,9 @@
                 "runAsUser": {
                   "format": "int64",
                   "type": "integer"
+                },
+                "seLinuxChangePolicy": {
+                  "type": "string"
                 },
                 "seLinuxOptions": {
                   "properties": {
@@ -8297,6 +8499,9 @@
                                     },
                                     "type": "object",
                                     "additionalProperties": false
+                                  },
+                                  "stopSignal": {
+                                    "type": "string"
                                   }
                                 },
                                 "type": "object",
@@ -9447,6 +9652,9 @@
                                     },
                                     "type": "object",
                                     "additionalProperties": false
+                                  },
+                                  "stopSignal": {
+                                    "type": "string"
                                   }
                                 },
                                 "type": "object",
@@ -10606,6 +10814,9 @@
                                     },
                                     "type": "object",
                                     "additionalProperties": false
+                                  },
+                                  "stopSignal": {
+                                    "type": "string"
                                   }
                                 },
                                 "type": "object",
@@ -11421,6 +11632,9 @@
                             "runAsUser": {
                               "format": "int64",
                               "type": "integer"
+                            },
+                            "seLinuxChangePolicy": {
+                              "type": "string"
                             },
                             "seLinuxOptions": {
                               "properties": {

--- a/logging.banzaicloud.io/syslogngoutput_v1beta1.json
+++ b/logging.banzaicloud.io/syslogngoutput_v1beta1.json
@@ -57,7 +57,7 @@
                   "format": "int64",
                   "type": "integer"
                 },
-                "q_out_size": {
+                "qout_size": {
                   "format": "int64",
                   "type": "integer"
                 },
@@ -510,7 +510,7 @@
                   "format": "int64",
                   "type": "integer"
                 },
-                "q_out_size": {
+                "qout_size": {
                   "format": "int64",
                   "type": "integer"
                 },
@@ -939,7 +939,7 @@
                   "format": "int64",
                   "type": "integer"
                 },
-                "q_out_size": {
+                "qout_size": {
                   "format": "int64",
                   "type": "integer"
                 },
@@ -1013,7 +1013,7 @@
                   "format": "int64",
                   "type": "integer"
                 },
-                "q_out_size": {
+                "qout_size": {
                   "format": "int64",
                   "type": "integer"
                 },
@@ -1433,7 +1433,7 @@
                   "format": "int64",
                   "type": "integer"
                 },
-                "q_out_size": {
+                "qout_size": {
                   "format": "int64",
                   "type": "integer"
                 },
@@ -1865,7 +1865,7 @@
                   "format": "int64",
                   "type": "integer"
                 },
-                "q_out_size": {
+                "qout_size": {
                   "format": "int64",
                   "type": "integer"
                 },
@@ -2259,7 +2259,7 @@
                   "format": "int64",
                   "type": "integer"
                 },
-                "q_out_size": {
+                "qout_size": {
                   "format": "int64",
                   "type": "integer"
                 },
@@ -2290,6 +2290,9 @@
               "type": "integer"
             },
             "template": {
+              "type": "string"
+            },
+            "tenant-id": {
               "type": "string"
             },
             "time_reopen": {
@@ -2359,7 +2362,7 @@
                   "format": "int64",
                   "type": "integer"
                 },
-                "q_out_size": {
+                "qout_size": {
                   "format": "int64",
                   "type": "integer"
                 },
@@ -2544,7 +2547,7 @@
                   "format": "int64",
                   "type": "integer"
                 },
-                "q_out_size": {
+                "qout_size": {
                   "format": "int64",
                   "type": "integer"
                 },
@@ -3201,7 +3204,7 @@
                   "format": "int64",
                   "type": "integer"
                 },
-                "q_out_size": {
+                "qout_size": {
                   "format": "int64",
                   "type": "integer"
                 },
@@ -3336,7 +3339,7 @@
                   "format": "int64",
                   "type": "integer"
                 },
-                "q_out_size": {
+                "qout_size": {
                   "format": "int64",
                   "type": "integer"
                 },
@@ -3477,7 +3480,7 @@
                   "format": "int64",
                   "type": "integer"
                 },
-                "q_out_size": {
+                "qout_size": {
                   "format": "int64",
                   "type": "integer"
                 },
@@ -3654,7 +3657,7 @@
                   "format": "int64",
                   "type": "integer"
                 },
-                "q_out_size": {
+                "qout_size": {
                   "format": "int64",
                   "type": "integer"
                 },
@@ -4238,7 +4241,7 @@
                   "format": "int64",
                   "type": "integer"
                 },
-                "q_out_size": {
+                "qout_size": {
                   "format": "int64",
                   "type": "integer"
                 },
@@ -4625,7 +4628,7 @@
                   "format": "int64",
                   "type": "integer"
                 },
-                "q_out_size": {
+                "qout_size": {
                   "format": "int64",
                   "type": "integer"
                 },
@@ -4951,7 +4954,7 @@
                   "format": "int64",
                   "type": "integer"
                 },
-                "q_out_size": {
+                "qout_size": {
                   "format": "int64",
                   "type": "integer"
                 },


### PR DESCRIPTION
Pulled from https://github.com/kube-logging/logging-operator/tree/5.3.0/charts/logging-operator/crds and converted with openapi2jsonschema.py.