### PR TITLE
Update logging-extensions.banzaicloud.io CRDs to v5.3.0

### DIFF
--- a/logging-extensions.banzaicloud.io/eventtailer_v1alpha1.json
+++ b/logging-extensions.banzaicloud.io/eventtailer_v1alpha1.json
@@ -504,7 +504,13 @@
           "additionalProperties": false
         },
         "controlNamespace": {
-          "type": "string"
+          "type": "string",
+          "x-kubernetes-validations": [
+            {
+              "message": "Value is immutable, please recreate the resource",
+              "rule": "self == oldSelf"
+            }
+          ]
         },
         "image": {
           "properties": {
@@ -632,6 +638,18 @@
             },
             "pvc": {
               "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
                 "source": {
                   "properties": {
                     "claimName": {
@@ -2579,6 +2597,9 @@
                 "runAsUser": {
                   "format": "int64",
                   "type": "integer"
+                },
+                "seLinuxChangePolicy": {
+                  "type": "string"
                 },
                 "seLinuxOptions": {
                   "properties": {

--- a/logging-extensions.banzaicloud.io/hosttailer_v1alpha1.json
+++ b/logging-extensions.banzaicloud.io/hosttailer_v1alpha1.json
@@ -558,6 +558,9 @@
               },
               "skip_long_lines": {
                 "type": "string"
+              },
+              "verbose": {
+                "type": "boolean"
               }
             },
             "required": [
@@ -1135,6 +1138,9 @@
               },
               "systemdFilter": {
                 "type": "string"
+              },
+              "verbose": {
+                "type": "boolean"
               }
             },
             "required": [
@@ -2887,6 +2893,9 @@
                   "format": "int64",
                   "type": "integer"
                 },
+                "seLinuxChangePolicy": {
+                  "type": "string"
+                },
                 "seLinuxOptions": {
                   "properties": {
                     "level": {
@@ -4245,9 +4254,6 @@
           "additionalProperties": false
         }
       },
-      "required": [
-        "workloadMetaOverrides"
-      ],
       "type": "object",
       "additionalProperties": false
     },


### PR DESCRIPTION
Pulled from https://github.com/kube-logging/logging-operator/tree/5.3.0/charts/logging-operator/crds and converted with openapi2jsonschema.py.