### PR TITLE
feat: added monitoring.googleapis.com schema using CRD Extractor from a fresh GKE cluster

### DIFF
--- a/monitoring.googleapis.com/clusternodemonitoring_v1.json
+++ b/monitoring.googleapis.com/clusternodemonitoring_v1.json
@@ -1,0 +1,250 @@
+{
+  "description": "ClusterNodeMonitoring defines monitoring for a set of nodes.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Specification of desired node selection for target discovery by\nPrometheus.",
+      "properties": {
+        "endpoints": {
+          "description": "The endpoints to scrape on the selected nodes.",
+          "items": {
+            "description": "ScrapeNodeEndpoint specifies a Prometheus metrics endpoint on a node to scrape.\nIt contains all the fields used in the ScrapeEndpoint except for port and HTTPClientConfig.",
+            "properties": {
+              "interval": {
+                "default": "1m",
+                "description": "Interval at which to scrape metrics. Must be a valid Prometheus duration.",
+                "pattern": "^((([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?|0)$",
+                "type": "string"
+              },
+              "metricRelabeling": {
+                "description": "Relabeling rules for metrics scraped from this endpoint. Relabeling rules that\noverride protected target labels (project_id, location, cluster, namespace, job,\ninstance, or __address__) are not permitted. The labelmap action is not permitted\nin general.",
+                "items": {
+                  "description": "RelabelingRule defines a single Prometheus relabeling rule.",
+                  "properties": {
+                    "action": {
+                      "description": "Action to perform based on regex matching. Defaults to 'replace'.",
+                      "type": "string"
+                    },
+                    "modulus": {
+                      "description": "Modulus to take of the hash of the source label values.",
+                      "format": "int64",
+                      "type": "integer"
+                    },
+                    "regex": {
+                      "description": "Regular expression against which the extracted value is matched. Defaults to '(.*)'.",
+                      "type": "string"
+                    },
+                    "replacement": {
+                      "description": "Replacement value against which a regex replace is performed if the\nregular expression matches. Regex capture groups are available. Defaults to '$1'.",
+                      "type": "string"
+                    },
+                    "separator": {
+                      "description": "Separator placed between concatenated source label values. Defaults to ';'.",
+                      "type": "string"
+                    },
+                    "sourceLabels": {
+                      "description": "The source labels select values from existing labels. Their content is concatenated\nusing the configured separator and matched against the configured regular expression\nfor the replace, keep, and drop actions.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "targetLabel": {
+                      "description": "Label to which the resulting value is written in a replace action.\nIt is mandatory for replace actions. Regex capture groups are available.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "params": {
+                "additionalProperties": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "description": "HTTP GET params to use when scraping.",
+                "type": "object"
+              },
+              "path": {
+                "description": "HTTP path to scrape metrics from. Defaults to \"/metrics\".",
+                "type": "string"
+              },
+              "scheme": {
+                "description": "Protocol scheme to use to scrape.",
+                "type": "string"
+              },
+              "timeout": {
+                "description": "Timeout for metrics scrapes. Must be a valid Prometheus duration.\nMust not be larger then the scrape interval.",
+                "type": "string"
+              },
+              "tls": {
+                "description": "TLS configures the scrape request's TLS settings.",
+                "properties": {
+                  "insecureSkipVerify": {
+                    "description": "InsecureSkipVerify disables target certificate validation.",
+                    "type": "boolean"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "limits": {
+          "description": "Limits to apply at scrape time.",
+          "properties": {
+            "labelNameLength": {
+              "description": "Maximum label name length.\nUses Prometheus default if left unspecified.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "labelValueLength": {
+              "description": "Maximum label value length.\nUses Prometheus default if left unspecified.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "labels": {
+              "description": "Maximum number of labels accepted for a single sample.\nUses Prometheus default if left unspecified.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "samples": {
+              "description": "Maximum number of samples accepted within a single scrape.\nUses Prometheus default if left unspecified.",
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "selector": {
+          "description": "Label selector that specifies which nodes are selected for this monitoring\nconfiguration. If left empty all nodes are selected.",
+          "properties": {
+            "matchExpressions": {
+              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+              "items": {
+                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                "properties": {
+                  "key": {
+                    "description": "key is the label key that the selector applies to.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  }
+                },
+                "required": [
+                  "key",
+                  "operator"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            },
+            "matchLabels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "endpoints"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "Most recently observed status of the resource.",
+      "properties": {
+        "conditions": {
+          "description": "Represents the latest available observations of a podmonitor's current state.",
+          "items": {
+            "description": "MonitoringCondition describes the condition of a PodMonitoring.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "lastUpdateTime": {
+                "description": "The last time this condition was updated.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human-readable message indicating details about the transition.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "MonitoringConditionType is the type of MonitoringCondition.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "observedGeneration": {
+          "description": "The generation observed by the controller.",
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "spec"
+  ],
+  "type": "object"
+}

--- a/monitoring.googleapis.com/clusterpodmonitoring_v1.json
+++ b/monitoring.googleapis.com/clusterpodmonitoring_v1.json
@@ -1,0 +1,751 @@
+{
+  "description": "ClusterPodMonitoring defines monitoring for a set of pods, scoped to all\npods within the cluster.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Specification of desired Pod selection for target discovery by\nPrometheus.",
+      "properties": {
+        "endpoints": {
+          "description": "The endpoints to scrape on the selected pods.",
+          "items": {
+            "description": "ScrapeEndpoint specifies a Prometheus metrics endpoint to scrape.",
+            "properties": {
+              "authorization": {
+                "description": "Authorization is the HTTP authorization credentials for the targets.",
+                "properties": {
+                  "credentials": {
+                    "description": "Credentials uses the secret as the credentials (token) for the authentication header.",
+                    "properties": {
+                      "secret": {
+                        "description": "Secret represents reference to a given key from certain Secret in a given namespace.",
+                        "properties": {
+                          "key": {
+                            "description": "Key of the secret to select from. Must be a valid secret key.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the secret to select from.",
+                            "type": "string"
+                          },
+                          "namespace": {
+                            "description": "Namespace of the secret to select from.\nIf empty the parent resource namespace will be chosen.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "key",
+                          "name"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": {
+                    "description": "Type is the authentication type. Defaults to Bearer.\nBasic will cause an error, as the BasicAuth object should be used instead.",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "basicAuth": {
+                "description": "BasicAuth is the HTTP basic authentication credentials for the targets.",
+                "properties": {
+                  "password": {
+                    "description": "Password uses the secret as the BasicAuth password.",
+                    "properties": {
+                      "secret": {
+                        "description": "Secret represents reference to a given key from certain Secret in a given namespace.",
+                        "properties": {
+                          "key": {
+                            "description": "Key of the secret to select from. Must be a valid secret key.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the secret to select from.",
+                            "type": "string"
+                          },
+                          "namespace": {
+                            "description": "Namespace of the secret to select from.\nIf empty the parent resource namespace will be chosen.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "key",
+                          "name"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "username": {
+                    "description": "Username is the BasicAuth username.",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "interval": {
+                "default": "1m",
+                "description": "Interval at which to scrape metrics. Must be a valid Prometheus duration.",
+                "pattern": "^((([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?|0)$",
+                "type": "string"
+              },
+              "metricRelabeling": {
+                "description": "Relabeling rules for metrics scraped from this endpoint. Relabeling rules that\noverride protected target labels (project_id, location, cluster, namespace, job,\ninstance, top_level_controller, top_level_controller_type, or __address__) are\nnot permitted. The labelmap action is not permitted in general.",
+                "items": {
+                  "description": "RelabelingRule defines a single Prometheus relabeling rule.",
+                  "properties": {
+                    "action": {
+                      "description": "Action to perform based on regex matching. Defaults to 'replace'.",
+                      "type": "string"
+                    },
+                    "modulus": {
+                      "description": "Modulus to take of the hash of the source label values.",
+                      "format": "int64",
+                      "type": "integer"
+                    },
+                    "regex": {
+                      "description": "Regular expression against which the extracted value is matched. Defaults to '(.*)'.",
+                      "type": "string"
+                    },
+                    "replacement": {
+                      "description": "Replacement value against which a regex replace is performed if the\nregular expression matches. Regex capture groups are available. Defaults to '$1'.",
+                      "type": "string"
+                    },
+                    "separator": {
+                      "description": "Separator placed between concatenated source label values. Defaults to ';'.",
+                      "type": "string"
+                    },
+                    "sourceLabels": {
+                      "description": "The source labels select values from existing labels. Their content is concatenated\nusing the configured separator and matched against the configured regular expression\nfor the replace, keep, and drop actions.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "targetLabel": {
+                      "description": "Label to which the resulting value is written in a replace action.\nIt is mandatory for replace actions. Regex capture groups are available.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "oauth2": {
+                "description": "OAuth2 is the OAuth2 client credentials used to fetch a token for the targets.",
+                "properties": {
+                  "clientID": {
+                    "description": "ClientID is the public identifier for the client.",
+                    "type": "string"
+                  },
+                  "clientSecret": {
+                    "description": "ClientSecret uses the secret as the client secret token.",
+                    "properties": {
+                      "secret": {
+                        "description": "Secret represents reference to a given key from certain Secret in a given namespace.",
+                        "properties": {
+                          "key": {
+                            "description": "Key of the secret to select from. Must be a valid secret key.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the secret to select from.",
+                            "type": "string"
+                          },
+                          "namespace": {
+                            "description": "Namespace of the secret to select from.\nIf empty the parent resource namespace will be chosen.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "key",
+                          "name"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "endpointParams": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "EndpointParams are additional parameters to append to the token URL.",
+                    "type": "object"
+                  },
+                  "proxyUrl": {
+                    "description": "ProxyURL is the HTTP proxy server to use to connect to the targets.\n\n\nEncoded passwords are not supported.",
+                    "type": "string"
+                  },
+                  "scopes": {
+                    "description": "Scopes represents the scopes for the token request.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "tlsConfig": {
+                    "description": "TLS configures the token request's TLS settings.",
+                    "properties": {
+                      "ca": {
+                        "description": "SecretSelector references a secret from a secret provider e.g. Kubernetes Secret. Only one\nprovider can be used at a time.",
+                        "properties": {
+                          "secret": {
+                            "description": "Secret represents reference to a given key from certain Secret in a given namespace.",
+                            "properties": {
+                              "key": {
+                                "description": "Key of the secret to select from. Must be a valid secret key.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the secret to select from.",
+                                "type": "string"
+                              },
+                              "namespace": {
+                                "description": "Namespace of the secret to select from.\nIf empty the parent resource namespace will be chosen.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "key",
+                              "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "cert": {
+                        "description": "Cert uses the secret as the certificate for client authentication to the server.",
+                        "properties": {
+                          "secret": {
+                            "description": "Secret represents reference to a given key from certain Secret in a given namespace.",
+                            "properties": {
+                              "key": {
+                                "description": "Key of the secret to select from. Must be a valid secret key.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the secret to select from.",
+                                "type": "string"
+                              },
+                              "namespace": {
+                                "description": "Namespace of the secret to select from.\nIf empty the parent resource namespace will be chosen.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "key",
+                              "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "insecureSkipVerify": {
+                        "description": "InsecureSkipVerify disables target certificate validation.",
+                        "type": "boolean"
+                      },
+                      "key": {
+                        "description": "Key uses the secret as the private key for client authentication to the server.",
+                        "properties": {
+                          "secret": {
+                            "description": "Secret represents reference to a given key from certain Secret in a given namespace.",
+                            "properties": {
+                              "key": {
+                                "description": "Key of the secret to select from. Must be a valid secret key.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the secret to select from.",
+                                "type": "string"
+                              },
+                              "namespace": {
+                                "description": "Namespace of the secret to select from.\nIf empty the parent resource namespace will be chosen.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "key",
+                              "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "maxVersion": {
+                        "description": "MaxVersion is the maximum TLS version. Accepted values: TLS10 (TLS 1.0), TLS11 (TLS 1.1),\nTLS12 (TLS 1.2), TLS13 (TLS 1.3).\n\n\nIf unset, Prometheus will use Go default minimum version, which is TLS 1.2.\nSee MinVersion in https://pkg.go.dev/crypto/tls#Config.",
+                        "type": "string"
+                      },
+                      "minVersion": {
+                        "description": "MinVersion is the minimum TLS version. Accepted values: TLS10 (TLS 1.0), TLS11 (TLS 1.1),\nTLS12 (TLS 1.2), TLS13 (TLS 1.3).\n\n\nIf unset, Prometheus will use Go default minimum version, which is TLS 1.2.\nSee MinVersion in https://pkg.go.dev/crypto/tls#Config.",
+                        "type": "string"
+                      },
+                      "serverName": {
+                        "description": "ServerName is used to verify the hostname for the targets.",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "tokenURL": {
+                    "description": "TokenURL is the URL to fetch the token from.",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "params": {
+                "additionalProperties": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "description": "HTTP GET params to use when scraping.",
+                "type": "object"
+              },
+              "path": {
+                "description": "HTTP path to scrape metrics from. Defaults to \"/metrics\".",
+                "type": "string"
+              },
+              "port": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ],
+                "description": "Name or number of the port to scrape.\nThe container metadata label is only populated if the port is referenced by name\nbecause port numbers are not unique across containers.",
+                "x-kubernetes-int-or-string": true
+              },
+              "proxyUrl": {
+                "description": "ProxyURL is the HTTP proxy server to use to connect to the targets.\n\n\nEncoded passwords are not supported.",
+                "type": "string"
+              },
+              "scheme": {
+                "description": "Protocol scheme to use to scrape.",
+                "type": "string"
+              },
+              "timeout": {
+                "description": "Timeout for metrics scrapes. Must be a valid Prometheus duration.\nMust not be larger than the scrape interval.",
+                "type": "string"
+              },
+              "tls": {
+                "description": "TLS configures the scrape request's TLS settings.",
+                "properties": {
+                  "ca": {
+                    "description": "SecretSelector references a secret from a secret provider e.g. Kubernetes Secret. Only one\nprovider can be used at a time.",
+                    "properties": {
+                      "secret": {
+                        "description": "Secret represents reference to a given key from certain Secret in a given namespace.",
+                        "properties": {
+                          "key": {
+                            "description": "Key of the secret to select from. Must be a valid secret key.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the secret to select from.",
+                            "type": "string"
+                          },
+                          "namespace": {
+                            "description": "Namespace of the secret to select from.\nIf empty the parent resource namespace will be chosen.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "key",
+                          "name"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "cert": {
+                    "description": "Cert uses the secret as the certificate for client authentication to the server.",
+                    "properties": {
+                      "secret": {
+                        "description": "Secret represents reference to a given key from certain Secret in a given namespace.",
+                        "properties": {
+                          "key": {
+                            "description": "Key of the secret to select from. Must be a valid secret key.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the secret to select from.",
+                            "type": "string"
+                          },
+                          "namespace": {
+                            "description": "Namespace of the secret to select from.\nIf empty the parent resource namespace will be chosen.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "key",
+                          "name"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "insecureSkipVerify": {
+                    "description": "InsecureSkipVerify disables target certificate validation.",
+                    "type": "boolean"
+                  },
+                  "key": {
+                    "description": "Key uses the secret as the private key for client authentication to the server.",
+                    "properties": {
+                      "secret": {
+                        "description": "Secret represents reference to a given key from certain Secret in a given namespace.",
+                        "properties": {
+                          "key": {
+                            "description": "Key of the secret to select from. Must be a valid secret key.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the secret to select from.",
+                            "type": "string"
+                          },
+                          "namespace": {
+                            "description": "Namespace of the secret to select from.\nIf empty the parent resource namespace will be chosen.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "key",
+                          "name"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "maxVersion": {
+                    "description": "MaxVersion is the maximum TLS version. Accepted values: TLS10 (TLS 1.0), TLS11 (TLS 1.1),\nTLS12 (TLS 1.2), TLS13 (TLS 1.3).\n\n\nIf unset, Prometheus will use Go default minimum version, which is TLS 1.2.\nSee MinVersion in https://pkg.go.dev/crypto/tls#Config.",
+                    "type": "string"
+                  },
+                  "minVersion": {
+                    "description": "MinVersion is the minimum TLS version. Accepted values: TLS10 (TLS 1.0), TLS11 (TLS 1.1),\nTLS12 (TLS 1.2), TLS13 (TLS 1.3).\n\n\nIf unset, Prometheus will use Go default minimum version, which is TLS 1.2.\nSee MinVersion in https://pkg.go.dev/crypto/tls#Config.",
+                    "type": "string"
+                  },
+                  "serverName": {
+                    "description": "ServerName is used to verify the hostname for the targets.",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "port"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "filterRunning": {
+          "description": "FilterRunning will drop any pods that are in the \"Failed\" or \"Succeeded\"\npod lifecycle.\nSee: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase\nSpecifically, this prevents scraping Succeeded pods from K8s jobs, which\ncould contribute to noisy logs or irrelevant metrics.\nAdditionally, it can mitigate issues with reusing stale target\nlabels in cases where Pod IPs are reused (e.g. spot containers).\nSee: https://github.com/GoogleCloudPlatform/prometheus-engine/issues/145",
+          "type": "boolean"
+        },
+        "limits": {
+          "description": "Limits to apply at scrape time.",
+          "properties": {
+            "labelNameLength": {
+              "description": "Maximum label name length.\nUses Prometheus default if left unspecified.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "labelValueLength": {
+              "description": "Maximum label value length.\nUses Prometheus default if left unspecified.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "labels": {
+              "description": "Maximum number of labels accepted for a single sample.\nUses Prometheus default if left unspecified.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "samples": {
+              "description": "Maximum number of samples accepted within a single scrape.\nUses Prometheus default if left unspecified.",
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "selector": {
+          "description": "Label selector that specifies which pods are selected for this monitoring\nconfiguration.",
+          "properties": {
+            "matchExpressions": {
+              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+              "items": {
+                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                "properties": {
+                  "key": {
+                    "description": "key is the label key that the selector applies to.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  }
+                },
+                "required": [
+                  "key",
+                  "operator"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            },
+            "matchLabels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
+        "targetLabels": {
+          "description": "Labels to add to the Prometheus target for discovered endpoints.\nThe `instance` label is always set to `<pod_name>:<port>` or `<node_name>:<port>`\nif the scraped pod is controlled by a DaemonSet.",
+          "properties": {
+            "fromPod": {
+              "description": "Labels to transfer from the Kubernetes Pod to Prometheus target labels.\nMappings are applied in order.",
+              "items": {
+                "description": "LabelMapping specifies how to transfer a label from a Kubernetes resource\nonto a Prometheus target.",
+                "properties": {
+                  "from": {
+                    "description": "Kubernetes resource label to remap.",
+                    "type": "string"
+                  },
+                  "to": {
+                    "description": "Remapped Prometheus target label.\nDefaults to the same name as `From`.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "from"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "metadata": {
+              "description": "Pod metadata labels that are set on all scraped targets.\nPermitted keys are `pod`, `container`, and `node` for PodMonitoring and\n`pod`, `container`, `node`, and `namespace` for ClusterPodMonitoring. The `container`\nlabel is only populated if the scrape port is referenced by name.\nDefaults to [pod, container, top_level_controller_name, top_level_controller_type] for\nPodMonitoring and [namespace, pod, container, top_level_controller_name, top_level_controller_type]\nfor ClusterPodMonitoring.\nIf set to null, it will be interpreted as the empty list for PodMonitoring\nand to [namespace] for ClusterPodMonitoring. This is for backwards-compatibility\nonly.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "endpoints",
+        "selector"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "Most recently observed status of the resource.",
+      "properties": {
+        "conditions": {
+          "description": "Represents the latest available observations of a podmonitor's current state.",
+          "items": {
+            "description": "MonitoringCondition describes the condition of a PodMonitoring.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "lastUpdateTime": {
+                "description": "The last time this condition was updated.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human-readable message indicating details about the transition.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "MonitoringConditionType is the type of MonitoringCondition.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "endpointStatuses": {
+          "description": "Represents the latest available observations of target state for each ScrapeEndpoint.",
+          "items": {
+            "properties": {
+              "activeTargets": {
+                "description": "Total number of active targets.",
+                "format": "int64",
+                "type": "integer"
+              },
+              "collectorsFraction": {
+                "description": "Fraction of collectors included in status, bounded [0,1].\nIdeally, this should always be 1. Anything less can\nbe considered a problem and should be investigated.",
+                "type": "string"
+              },
+              "lastUpdateTime": {
+                "description": "Last time this status was updated.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "name": {
+                "description": "The name of the ScrapeEndpoint.",
+                "type": "string"
+              },
+              "sampleGroups": {
+                "description": "A fixed sample of targets grouped by error type.",
+                "items": {
+                  "properties": {
+                    "count": {
+                      "description": "Total count of similar errors.",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "sampleTargets": {
+                      "description": "Targets emitting the error message.",
+                      "items": {
+                        "properties": {
+                          "health": {
+                            "description": "Health status.",
+                            "type": "string"
+                          },
+                          "labels": {
+                            "additionalProperties": {
+                              "description": "A LabelValue is an associated value for a LabelName.",
+                              "type": "string"
+                            },
+                            "description": "The label set, keys and values, of the target.",
+                            "type": "object"
+                          },
+                          "lastError": {
+                            "description": "Error message.",
+                            "type": "string"
+                          },
+                          "lastScrapeDurationSeconds": {
+                            "description": "Scrape duration in seconds.",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "unhealthyTargets": {
+                "description": "Total number of active, unhealthy targets.",
+                "format": "int64",
+                "type": "integer"
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "observedGeneration": {
+          "description": "The generation observed by the controller.",
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "spec"
+  ],
+  "type": "object"
+}

--- a/monitoring.googleapis.com/clusterpodmonitoring_v1alpha1.json
+++ b/monitoring.googleapis.com/clusterpodmonitoring_v1alpha1.json
@@ -1,0 +1,293 @@
+{
+  "description": "ClusterPodMonitoring defines monitoring for a set of pods.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Specification of desired Pod selection for target discovery by\nPrometheus.",
+      "properties": {
+        "endpoints": {
+          "description": "The endpoints to scrape on the selected pods.",
+          "items": {
+            "description": "ScrapeEndpoint specifies a Prometheus metrics endpoint to scrape.",
+            "properties": {
+              "interval": {
+                "description": "Interval at which to scrape metrics. Must be a valid Prometheus duration.",
+                "type": "string"
+              },
+              "metricRelabeling": {
+                "description": "Relabeling rules for metrics scraped from this endpoint. Relabeling rules that\noverride protected target labels (project_id, location, cluster, namespace, job,\ninstance, or __address__) are not permitted. The labelmap action is not permitted\nin general.",
+                "items": {
+                  "description": "RelabelingRule defines a single Prometheus relabeling rule.",
+                  "properties": {
+                    "action": {
+                      "description": "Action to perform based on regex matching. Defaults to 'replace'.",
+                      "type": "string"
+                    },
+                    "modulus": {
+                      "description": "Modulus to take of the hash of the source label values.",
+                      "format": "int64",
+                      "type": "integer"
+                    },
+                    "regex": {
+                      "description": "Regular expression against which the extracted value is matched. Defaults to '(.*)'.",
+                      "type": "string"
+                    },
+                    "replacement": {
+                      "description": "Replacement value against which a regex replace is performed if the\nregular expression matches. Regex capture groups are available. Defaults to '$1'.",
+                      "type": "string"
+                    },
+                    "separator": {
+                      "description": "Separator placed between concatenated source label values. Defaults to ';'.",
+                      "type": "string"
+                    },
+                    "sourceLabels": {
+                      "description": "The source labels select values from existing labels. Their content is concatenated\nusing the configured separator and matched against the configured regular expression\nfor the replace, keep, and drop actions.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "targetLabel": {
+                      "description": "Label to which the resulting value is written in a replace action.\nIt is mandatory for replace actions. Regex capture groups are available.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "params": {
+                "additionalProperties": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "description": "HTTP GET params to use when scraping.",
+                "type": "object"
+              },
+              "path": {
+                "description": "HTTP path to scrape metrics from. Defaults to \"/metrics\".",
+                "type": "string"
+              },
+              "port": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ],
+                "description": "Name or number of the port to scrape.",
+                "x-kubernetes-int-or-string": true
+              },
+              "proxyUrl": {
+                "description": "Proxy URL to scrape through. Encoded passwords are not supported.",
+                "type": "string"
+              },
+              "scheme": {
+                "description": "Protocol scheme to use to scrape.",
+                "type": "string"
+              },
+              "timeout": {
+                "description": "Timeout for metrics scrapes. Must be a valid Prometheus duration.\nMust not be larger then the scrape interval.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "port"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "limits": {
+          "description": "Limits to apply at scrape time.",
+          "properties": {
+            "labelNameLength": {
+              "description": "Maximum label name length.\nUses Prometheus default if left unspecified.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "labelValueLength": {
+              "description": "Maximum label value length.\nUses Prometheus default if left unspecified.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "labels": {
+              "description": "Maximum number of labels accepted for a single sample.\nUses Prometheus default if left unspecified.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "samples": {
+              "description": "Maximum number of samples accepted within a single scrape.\nUses Prometheus default if left unspecified.",
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "selector": {
+          "description": "Label selector that specifies which pods are selected for this monitoring\nconfiguration.",
+          "properties": {
+            "matchExpressions": {
+              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+              "items": {
+                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                "properties": {
+                  "key": {
+                    "description": "key is the label key that the selector applies to.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  }
+                },
+                "required": [
+                  "key",
+                  "operator"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            },
+            "matchLabels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
+        "targetLabels": {
+          "description": "Labels to add to the Prometheus target for discovered endpoints",
+          "properties": {
+            "fromPod": {
+              "description": "Labels to transfer from the Kubernetes Pod to Prometheus target labels.\nMappings are applied in order.",
+              "items": {
+                "description": "LabelMapping specifies how to transfer a label from a Kubernetes resource\nonto a Prometheus target.",
+                "properties": {
+                  "from": {
+                    "description": "Kubenetes resource label to remap.",
+                    "type": "string"
+                  },
+                  "to": {
+                    "description": "Remapped Prometheus target label.\nDefaults to the same name as `From`.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "from"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "metadata": {
+              "description": "Pod metadata labels that are set on all scraped targets.\nPermitted keys are `pod`, `container`, and `node` for PodMonitoring and\n`pod`, `container`, `node`, and `namespace` for ClusterPodMonitoring.\nDefaults to [pod, container] for PodMonitoring and [namespace, pod, container]\nfor ClusterPodMonitoring.\nIf set to null, it will be interpreted as the empty list for PodMonitoring\nand to [namespace] for ClusterPodMonitoring. This is for backwards-compatibility\nonly.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "endpoints",
+        "selector"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "Most recently observed status of the resource.",
+      "properties": {
+        "conditions": {
+          "description": "Represents the latest available observations of a podmonitor's current state.",
+          "items": {
+            "description": "MonitoringCondition describes a condition of a PodMonitoring.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "lastUpdateTime": {
+                "description": "The last time this condition was updated.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human-readable message indicating details about the transition.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "MonitoringConditionType is the type of MonitoringCondition.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "observedGeneration": {
+          "description": "The generation observed by the controller.",
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "spec"
+  ],
+  "type": "object"
+}

--- a/monitoring.googleapis.com/clusterrules_v1.json
+++ b/monitoring.googleapis.com/clusterrules_v1.json
@@ -1,0 +1,151 @@
+{
+  "description": "ClusterRules defines Prometheus alerting and recording rules that are scoped\nto the current cluster. Only metric data from the current cluster is processed\nand all rule results have their project_id and cluster label preserved\nfor query processing.\nIf the location label is not preserved by the rule, it defaults to the cluster's location.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Specification of rules to record and alert on.",
+      "properties": {
+        "groups": {
+          "description": "A list of Prometheus rule groups.",
+          "items": {
+            "description": "RuleGroup declares rules in the Prometheus format:\nhttps://prometheus.io/docs/prometheus/latest/configuration/recording_rules/",
+            "properties": {
+              "interval": {
+                "description": "The interval at which to evaluate the rules. Must be a valid Prometheus duration.",
+                "type": "string"
+              },
+              "name": {
+                "description": "The name of the rule group.",
+                "type": "string"
+              },
+              "rules": {
+                "description": "A list of rules that are executed sequentially as part of this group.",
+                "items": {
+                  "description": "Rule is a single rule in the Prometheus format:\nhttps://prometheus.io/docs/prometheus/latest/configuration/recording_rules/",
+                  "properties": {
+                    "alert": {
+                      "description": "Name of the alert to evaluate the expression as.\nOnly one of `record` and `alert` must be set.",
+                      "type": "string"
+                    },
+                    "annotations": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "A set of annotations to attach to alerts produced by the query expression.\nOnly valid if `alert` is set.",
+                      "type": "object"
+                    },
+                    "expr": {
+                      "description": "The PromQL expression to evaluate.",
+                      "type": "string"
+                    },
+                    "for": {
+                      "description": "The duration to wait before a firing alert produced by this rule is sent to Alertmanager.\nOnly valid if `alert` is set.",
+                      "type": "string"
+                    },
+                    "labels": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "A set of labels to attach to the result of the query expression.",
+                      "type": "object"
+                    },
+                    "record": {
+                      "description": "Record the result of the expression to this metric name.\nOnly one of `record` and `alert` must be set.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "expr"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "interval",
+              "name",
+              "rules"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "groups"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "Most recently observed status of the resource.",
+      "properties": {
+        "conditions": {
+          "description": "Represents the latest available observations of a podmonitor's current state.",
+          "items": {
+            "description": "MonitoringCondition describes the condition of a PodMonitoring.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "lastUpdateTime": {
+                "description": "The last time this condition was updated.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human-readable message indicating details about the transition.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "MonitoringConditionType is the type of MonitoringCondition.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "observedGeneration": {
+          "description": "The generation observed by the controller.",
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "spec"
+  ],
+  "type": "object"
+}

--- a/monitoring.googleapis.com/clusterrules_v1alpha1.json
+++ b/monitoring.googleapis.com/clusterrules_v1alpha1.json
@@ -1,0 +1,102 @@
+{
+  "description": "ClusterRules defines Prometheus alerting and recording rules that are scoped\nto the current cluster. Only metric data from the current cluster is processed\nand all rule results have their project_id and cluster label preserved\nfor query processing.\nIf the location label is not preserved by the rule, it defaults to the cluster's location.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Specification of rules to record and alert on.",
+      "properties": {
+        "groups": {
+          "description": "A list of Prometheus rule groups.",
+          "items": {
+            "description": "RuleGroup declares rules in the Prometheus format:\nhttps://prometheus.io/docs/prometheus/latest/configuration/recording_rules/",
+            "properties": {
+              "interval": {
+                "description": "The interval at which to evaluate the rules. Must be a valid Prometheus duration.",
+                "type": "string"
+              },
+              "name": {
+                "description": "The name of the rule group.",
+                "type": "string"
+              },
+              "rules": {
+                "description": "A list of rules that are executed sequentially as part of this group.",
+                "items": {
+                  "description": "Rule is a single rule in the Prometheus format:\nhttps://prometheus.io/docs/prometheus/latest/configuration/recording_rules/",
+                  "properties": {
+                    "alert": {
+                      "description": "Name of the alert to evaluate the expression as.\nOnly one of `record` and `alert` must be set.",
+                      "type": "string"
+                    },
+                    "annotations": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "A set of annotations to attach to alerts produced by the query expression.\nOnly valid if `alert` is set.",
+                      "type": "object"
+                    },
+                    "expr": {
+                      "description": "The PromQL expression to evaluate.",
+                      "type": "string"
+                    },
+                    "for": {
+                      "description": "The duration to wait before a firing alert produced by this rule is sent to Alertmanager.\nOnly valid if `alert` is set.",
+                      "type": "string"
+                    },
+                    "labels": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "A set of labels to attach to the result of the query expression.",
+                      "type": "object"
+                    },
+                    "record": {
+                      "description": "Record the result of the expression to this metric name.\nOnly one of `record` and `alert` must be set.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "expr"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "interval",
+              "name",
+              "rules"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "groups"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "Most recently observed status of the resource.",
+      "type": "object"
+    }
+  },
+  "required": [
+    "spec"
+  ],
+  "type": "object"
+}

--- a/monitoring.googleapis.com/globalrules_v1.json
+++ b/monitoring.googleapis.com/globalrules_v1.json
@@ -1,0 +1,151 @@
+{
+  "description": "GlobalRules defines Prometheus alerting and recording rules that are scoped\nto all data in the queried project.\nIf the project_id or location labels are not preserved by the rule, they default to\nthe values of the cluster.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Specification of rules to record and alert on.",
+      "properties": {
+        "groups": {
+          "description": "A list of Prometheus rule groups.",
+          "items": {
+            "description": "RuleGroup declares rules in the Prometheus format:\nhttps://prometheus.io/docs/prometheus/latest/configuration/recording_rules/",
+            "properties": {
+              "interval": {
+                "description": "The interval at which to evaluate the rules. Must be a valid Prometheus duration.",
+                "type": "string"
+              },
+              "name": {
+                "description": "The name of the rule group.",
+                "type": "string"
+              },
+              "rules": {
+                "description": "A list of rules that are executed sequentially as part of this group.",
+                "items": {
+                  "description": "Rule is a single rule in the Prometheus format:\nhttps://prometheus.io/docs/prometheus/latest/configuration/recording_rules/",
+                  "properties": {
+                    "alert": {
+                      "description": "Name of the alert to evaluate the expression as.\nOnly one of `record` and `alert` must be set.",
+                      "type": "string"
+                    },
+                    "annotations": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "A set of annotations to attach to alerts produced by the query expression.\nOnly valid if `alert` is set.",
+                      "type": "object"
+                    },
+                    "expr": {
+                      "description": "The PromQL expression to evaluate.",
+                      "type": "string"
+                    },
+                    "for": {
+                      "description": "The duration to wait before a firing alert produced by this rule is sent to Alertmanager.\nOnly valid if `alert` is set.",
+                      "type": "string"
+                    },
+                    "labels": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "A set of labels to attach to the result of the query expression.",
+                      "type": "object"
+                    },
+                    "record": {
+                      "description": "Record the result of the expression to this metric name.\nOnly one of `record` and `alert` must be set.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "expr"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "interval",
+              "name",
+              "rules"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "groups"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "Most recently observed status of the resource.",
+      "properties": {
+        "conditions": {
+          "description": "Represents the latest available observations of a podmonitor's current state.",
+          "items": {
+            "description": "MonitoringCondition describes the condition of a PodMonitoring.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "lastUpdateTime": {
+                "description": "The last time this condition was updated.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human-readable message indicating details about the transition.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "MonitoringConditionType is the type of MonitoringCondition.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "observedGeneration": {
+          "description": "The generation observed by the controller.",
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "spec"
+  ],
+  "type": "object"
+}

--- a/monitoring.googleapis.com/globalrules_v1alpha1.json
+++ b/monitoring.googleapis.com/globalrules_v1alpha1.json
@@ -1,0 +1,102 @@
+{
+  "description": "GlobalRules defines Prometheus alerting and recording rules that are scoped\nto all data in the queried project.\nIf the project_id or location labels are not preserved by the rule, they default to\nthe values of the cluster.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Specification of rules to record and alert on.",
+      "properties": {
+        "groups": {
+          "description": "A list of Prometheus rule groups.",
+          "items": {
+            "description": "RuleGroup declares rules in the Prometheus format:\nhttps://prometheus.io/docs/prometheus/latest/configuration/recording_rules/",
+            "properties": {
+              "interval": {
+                "description": "The interval at which to evaluate the rules. Must be a valid Prometheus duration.",
+                "type": "string"
+              },
+              "name": {
+                "description": "The name of the rule group.",
+                "type": "string"
+              },
+              "rules": {
+                "description": "A list of rules that are executed sequentially as part of this group.",
+                "items": {
+                  "description": "Rule is a single rule in the Prometheus format:\nhttps://prometheus.io/docs/prometheus/latest/configuration/recording_rules/",
+                  "properties": {
+                    "alert": {
+                      "description": "Name of the alert to evaluate the expression as.\nOnly one of `record` and `alert` must be set.",
+                      "type": "string"
+                    },
+                    "annotations": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "A set of annotations to attach to alerts produced by the query expression.\nOnly valid if `alert` is set.",
+                      "type": "object"
+                    },
+                    "expr": {
+                      "description": "The PromQL expression to evaluate.",
+                      "type": "string"
+                    },
+                    "for": {
+                      "description": "The duration to wait before a firing alert produced by this rule is sent to Alertmanager.\nOnly valid if `alert` is set.",
+                      "type": "string"
+                    },
+                    "labels": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "A set of labels to attach to the result of the query expression.",
+                      "type": "object"
+                    },
+                    "record": {
+                      "description": "Record the result of the expression to this metric name.\nOnly one of `record` and `alert` must be set.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "expr"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "interval",
+              "name",
+              "rules"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "groups"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "Most recently observed status of the resource.",
+      "type": "object"
+    }
+  },
+  "required": [
+    "spec"
+  ],
+  "type": "object"
+}

--- a/monitoring.googleapis.com/operatorconfig_v1.json
+++ b/monitoring.googleapis.com/operatorconfig_v1.json
@@ -1,0 +1,492 @@
+{
+  "description": "OperatorConfig defines configuration of the gmp-operator.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "collection": {
+      "description": "Collection specifies how the operator configures collection, including\nscraping and an integrated export to Google Cloud Monitoring.",
+      "properties": {
+        "compression": {
+          "description": "Compression enables compression of metrics collection data",
+          "enum": [
+            "none",
+            "gzip"
+          ],
+          "type": "string"
+        },
+        "credentials": {
+          "description": "A reference to GCP service account credentials with which Prometheus collectors\nare run. It needs to have metric write permissions for all project IDs to which\ndata is written.\nWithin GKE, this can typically be left empty if the compute default\nservice account has the required permissions.",
+          "properties": {
+            "key": {
+              "description": "The key of the secret to select from.  Must be a valid secret key.",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+              "type": "string"
+            },
+            "optional": {
+              "description": "Specify whether the Secret or its key must be defined",
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "key"
+          ],
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
+        "externalLabels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "ExternalLabels specifies external labels that are attached to all scraped\ndata before being written to Google Cloud Monitoring or any other additional exports\nspecified in the OperatorConfig. The precedence behavior matches that of Prometheus.",
+          "type": "object"
+        },
+        "filter": {
+          "description": "Filter limits which metric data is sent to Cloud Monitoring (it doesn't apply to additional exports).",
+          "properties": {
+            "matchOneOf": {
+              "description": "A list of Prometheus time series matchers. Every time series must match at least one\nof the matchers to be exported. This field can be used equivalently to the match[]\nparameter of the Prometheus federation endpoint to selectively export data.\nExample: `[\"{job!='foobar'}\", \"{__name__!~'container_foo.*|container_bar.*'}\"]`",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "kubeletScraping": {
+          "description": "Configuration to scrape the metric endpoints of the Kubelets.",
+          "properties": {
+            "interval": {
+              "description": "The interval at which the metric endpoints are scraped.",
+              "type": "string"
+            },
+            "tlsInsecureSkipVerify": {
+              "description": "TLSInsecureSkipVerify disables verifying the target cert.\nThis can be useful for clusters provisioned with kubeadm.",
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "interval"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "exports": {
+      "description": "Exports is an EXPERIMENTAL feature that specifies additional, optional endpoints to export to,\non top of Google Cloud Monitoring collection.\nNote: To disable integrated export to Google Cloud Monitoring specify a non-matching filter in the \"collection.filter\" field.",
+      "items": {
+        "properties": {
+          "url": {
+            "description": "The URL of the endpoint that supports Prometheus Remote Write to export samples to.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "url"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "type": "array"
+    },
+    "features": {
+      "description": "Features holds configuration for optional managed-collection features.",
+      "properties": {
+        "config": {
+          "description": "Settings for the collector configuration propagation.",
+          "properties": {
+            "compression": {
+              "description": "Compression enables compression of the config data propagated by the operator to collectors\nand the rule-evaluator. It is recommended to use the gzip option when using a large number of\nClusterPodMonitoring, PodMonitoring, GlobalRules, ClusterRules, and/or Rules.",
+              "enum": [
+                "none",
+                "gzip"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "targetStatus": {
+          "description": "Configuration of target status reporting.",
+          "properties": {
+            "enabled": {
+              "description": "Enable target status reporting.",
+              "type": "boolean"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "managedAlertmanager": {
+      "default": {
+        "configSecret": {
+          "key": "alertmanager.yaml",
+          "name": "alertmanager"
+        }
+      },
+      "description": "ManagedAlertmanager holds information for configuring the managed instance of Alertmanager.",
+      "properties": {
+        "configSecret": {
+          "description": "ConfigSecret refers to the name of a single-key Secret in the public namespace that\nholds the managed Alertmanager config file.",
+          "properties": {
+            "key": {
+              "description": "The key of the secret to select from.  Must be a valid secret key.",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+              "type": "string"
+            },
+            "optional": {
+              "description": "Specify whether the Secret or its key must be defined",
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "key"
+          ],
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
+        "externalURL": {
+          "description": "ExternalURL is the URL under which Alertmanager is externally reachable (for example, if\nAlertmanager is served via a reverse proxy). Used for generating relative and absolute\nlinks back to Alertmanager itself. If the URL has a path portion, it will be used to\nprefix all HTTP endpoints served by Alertmanager, otherwise relevant URL components will\nbe derived automatically.\n\n\nIf no URL is provided, Alertmanager will point to the Google Cloud Metric Explorer page.",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "rules": {
+      "description": "Rules specifies how the operator configures and deploys rule-evaluator.",
+      "properties": {
+        "alerting": {
+          "description": "Alerting contains how the rule-evaluator configures alerting.",
+          "properties": {
+            "alertmanagers": {
+              "description": "Alertmanagers contains endpoint configuration for designated Alertmanagers.",
+              "items": {
+                "description": "AlertmanagerEndpoints defines a selection of a single Endpoints object\ncontaining alertmanager IPs to fire alerts against.",
+                "properties": {
+                  "apiVersion": {
+                    "description": "Version of the Alertmanager API that rule-evaluator uses to send alerts. It\ncan be \"v1\" or \"v2\".",
+                    "type": "string"
+                  },
+                  "authorization": {
+                    "description": "Authorization section for this alertmanager endpoint",
+                    "properties": {
+                      "credentials": {
+                        "description": "The secret's key that contains the credentials of the request",
+                        "properties": {
+                          "key": {
+                            "description": "The key of the secret to select from.  Must be a valid secret key.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                            "type": "string"
+                          },
+                          "optional": {
+                            "description": "Specify whether the Secret or its key must be defined",
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "key"
+                        ],
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "type": {
+                        "description": "Set the authentication type. Defaults to Bearer, Basic will cause an\nerror",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "name": {
+                    "description": "Name of Endpoints object in Namespace.",
+                    "type": "string"
+                  },
+                  "namespace": {
+                    "description": "Namespace of Endpoints object.",
+                    "type": "string"
+                  },
+                  "pathPrefix": {
+                    "description": "Prefix for the HTTP path alerts are pushed to.",
+                    "type": "string"
+                  },
+                  "port": {
+                    "anyOf": [
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ],
+                    "description": "Port the Alertmanager API is exposed on.",
+                    "x-kubernetes-int-or-string": true
+                  },
+                  "scheme": {
+                    "description": "Scheme to use when firing alerts.",
+                    "type": "string"
+                  },
+                  "timeout": {
+                    "description": "Timeout is a per-target Alertmanager timeout when pushing alerts.",
+                    "type": "string"
+                  },
+                  "tls": {
+                    "description": "TLS Config to use for alertmanager connection.",
+                    "properties": {
+                      "ca": {
+                        "description": "Struct containing the CA cert to use for the targets.",
+                        "properties": {
+                          "configMap": {
+                            "description": "ConfigMap containing data to use for the targets.",
+                            "properties": {
+                              "key": {
+                                "description": "The key to select.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                "type": "string"
+                              },
+                              "optional": {
+                                "description": "Specify whether the ConfigMap or its key must be defined",
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "secret": {
+                            "description": "Secret containing data to use for the targets.",
+                            "properties": {
+                              "key": {
+                                "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                "type": "string"
+                              },
+                              "optional": {
+                                "description": "Specify whether the Secret or its key must be defined",
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "cert": {
+                        "description": "Struct containing the client cert file for the targets.",
+                        "properties": {
+                          "configMap": {
+                            "description": "ConfigMap containing data to use for the targets.",
+                            "properties": {
+                              "key": {
+                                "description": "The key to select.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                "type": "string"
+                              },
+                              "optional": {
+                                "description": "Specify whether the ConfigMap or its key must be defined",
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "secret": {
+                            "description": "Secret containing data to use for the targets.",
+                            "properties": {
+                              "key": {
+                                "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                "type": "string"
+                              },
+                              "optional": {
+                                "description": "Specify whether the Secret or its key must be defined",
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "insecureSkipVerify": {
+                        "description": "Disable target certificate validation.",
+                        "type": "boolean"
+                      },
+                      "keySecret": {
+                        "description": "Secret containing the client key file for the targets.",
+                        "properties": {
+                          "key": {
+                            "description": "The key of the secret to select from.  Must be a valid secret key.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                            "type": "string"
+                          },
+                          "optional": {
+                            "description": "Specify whether the Secret or its key must be defined",
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "key"
+                        ],
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "maxVersion": {
+                        "description": "Maximum TLS version. Accepted values: TLS10 (TLS 1.0), TLS11 (TLS 1.1), TLS12 (TLS 1.2), TLS13 (TLS 1.3).\nIf unset, Prometheus will use Go default minimum version, which is TLS 1.2.\nSee MinVersion in https://pkg.go.dev/crypto/tls#Config.",
+                        "type": "string"
+                      },
+                      "minVersion": {
+                        "description": "Minimum TLS version. Accepted values: TLS10 (TLS 1.0), TLS11 (TLS 1.1), TLS12 (TLS 1.2), TLS13 (TLS 1.3).\nIf unset, Prometheus will use Go default minimum version, which is TLS 1.2.\nSee MinVersion in https://pkg.go.dev/crypto/tls#Config.",
+                        "type": "string"
+                      },
+                      "serverName": {
+                        "description": "Used to verify the hostname for the targets.",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "required": [
+                  "name",
+                  "namespace",
+                  "port"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "credentials": {
+          "description": "A reference to GCP service account credentials with which the rule\nevaluator container is run. It needs to have metric read permissions\nagainst queryProjectId and metric write permissions against all projects\nto which rule results are written.\nWithin GKE, this can typically be left empty if the compute default\nservice account has the required permissions.",
+          "properties": {
+            "key": {
+              "description": "The key of the secret to select from.  Must be a valid secret key.",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+              "type": "string"
+            },
+            "optional": {
+              "description": "Specify whether the Secret or its key must be defined",
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "key"
+          ],
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
+        "externalLabels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "ExternalLabels specifies external labels that are attached to any rule\nresults and alerts produced by rules. The precedence behavior matches that\nof Prometheus.",
+          "type": "object"
+        },
+        "generatorUrl": {
+          "description": "The base URL used for the generator URL in the alert notification payload.\nShould point to an instance of a query frontend that gives access to queryProjectID.",
+          "type": "string"
+        },
+        "queryProjectID": {
+          "description": "QueryProjectID is the GCP project ID to evaluate rules against.\nIf left blank, the rule-evaluator will try attempt to infer the Project ID\nfrom the environment.",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "scaling": {
+      "description": "Scaling contains configuration options for scaling GMP.",
+      "properties": {
+        "vpa": {
+          "description": "VPASpec defines configuration options for vertical pod autoscaling.",
+          "properties": {
+            "enabled": {
+              "description": "Enabled configures whether the operator configures Vertical Pod Autoscaling for the collector pods.\nIn GKE, installing Vertical Pod Autoscaling requires a cluster restart, and therefore it also results in an operator restart.\nIn other environments, the operator may need to be restarted to enable VPA to run the following check again and watch for the objects.",
+              "type": "boolean"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/monitoring.googleapis.com/operatorconfig_v1alpha1.json
+++ b/monitoring.googleapis.com/operatorconfig_v1alpha1.json
@@ -1,0 +1,346 @@
+{
+  "description": "OperatorConfig defines configuration of the gmp-operator.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "collection": {
+      "description": "Collection specifies how the operator configures collection.",
+      "properties": {
+        "credentials": {
+          "description": "A reference to GCP service account credentials with which Prometheus collectors\nare run. It needs to have metric write permissions for all project IDs to which\ndata is written.\nWithin GKE, this can typically be left empty if the compute default\nservice account has the required permissions.",
+          "properties": {
+            "key": {
+              "description": "The key of the secret to select from.  Must be a valid secret key.",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+              "type": "string"
+            },
+            "optional": {
+              "description": "Specify whether the Secret or its key must be defined",
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "key"
+          ],
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
+        "externalLabels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "ExternalLabels specifies external labels that are attached to all scraped\ndata before being written to Cloud Monitoring. The precedence behavior matches that\nof Prometheus.",
+          "type": "object"
+        },
+        "filter": {
+          "description": "Filter limits which metric data is sent to Cloud Monitoring.",
+          "properties": {
+            "matchOneOf": {
+              "description": "A list Prometheus time series matchers. Every time series must match at least one\nof the matchers to be exported. This field can be used equivalently to the match[]\nparameter of the Prometheus federation endpoint to selectively export data.\nExample: `[\"{job='prometheus'}\", \"{__name__=~'job:.*'}\"]`",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "rules": {
+      "description": "Rules specifies how the operator configures and deployes rule-evaluator.",
+      "properties": {
+        "alerting": {
+          "description": "Alerting contains how the rule-evaluator configures alerting.",
+          "properties": {
+            "alertmanagers": {
+              "description": "Alertmanagers contains endpoint configuration for designated Alertmanagers.",
+              "items": {
+                "description": "AlertmanagerEndpoints defines a selection of a single Endpoints object\ncontaining alertmanager IPs to fire alerts against.",
+                "properties": {
+                  "apiVersion": {
+                    "description": "Version of the Alertmanager API that rule-evaluator uses to send alerts. It\ncan be \"v1\" or \"v2\".",
+                    "type": "string"
+                  },
+                  "authorization": {
+                    "description": "Authorization section for this alertmanager endpoint",
+                    "properties": {
+                      "credentials": {
+                        "description": "The secret's key that contains the credentials of the request",
+                        "properties": {
+                          "key": {
+                            "description": "The key of the secret to select from.  Must be a valid secret key.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                            "type": "string"
+                          },
+                          "optional": {
+                            "description": "Specify whether the Secret or its key must be defined",
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "key"
+                        ],
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "type": {
+                        "description": "Set the authentication type. Defaults to Bearer, Basic will cause an\nerror",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "name": {
+                    "description": "Name of Endpoints object in Namespace.",
+                    "type": "string"
+                  },
+                  "namespace": {
+                    "description": "Namespace of Endpoints object.",
+                    "type": "string"
+                  },
+                  "pathPrefix": {
+                    "description": "Prefix for the HTTP path alerts are pushed to.",
+                    "type": "string"
+                  },
+                  "port": {
+                    "anyOf": [
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ],
+                    "description": "Port the Alertmanager API is exposed on.",
+                    "x-kubernetes-int-or-string": true
+                  },
+                  "scheme": {
+                    "description": "Scheme to use when firing alerts.",
+                    "type": "string"
+                  },
+                  "timeout": {
+                    "description": "Timeout is a per-target Alertmanager timeout when pushing alerts.",
+                    "type": "string"
+                  },
+                  "tls": {
+                    "description": "TLS Config to use for alertmanager connection.",
+                    "properties": {
+                      "ca": {
+                        "description": "Struct containing the CA cert to use for the targets.",
+                        "properties": {
+                          "configMap": {
+                            "description": "ConfigMap containing data to use for the targets.",
+                            "properties": {
+                              "key": {
+                                "description": "The key to select.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                "type": "string"
+                              },
+                              "optional": {
+                                "description": "Specify whether the ConfigMap or its key must be defined",
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "secret": {
+                            "description": "Secret containing data to use for the targets.",
+                            "properties": {
+                              "key": {
+                                "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                "type": "string"
+                              },
+                              "optional": {
+                                "description": "Specify whether the Secret or its key must be defined",
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "cert": {
+                        "description": "Struct containing the client cert file for the targets.",
+                        "properties": {
+                          "configMap": {
+                            "description": "ConfigMap containing data to use for the targets.",
+                            "properties": {
+                              "key": {
+                                "description": "The key to select.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                "type": "string"
+                              },
+                              "optional": {
+                                "description": "Specify whether the ConfigMap or its key must be defined",
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "secret": {
+                            "description": "Secret containing data to use for the targets.",
+                            "properties": {
+                              "key": {
+                                "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                "type": "string"
+                              },
+                              "optional": {
+                                "description": "Specify whether the Secret or its key must be defined",
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "insecureSkipVerify": {
+                        "description": "Disable target certificate validation.",
+                        "type": "boolean"
+                      },
+                      "keySecret": {
+                        "description": "Secret containing the client key file for the targets.",
+                        "properties": {
+                          "key": {
+                            "description": "The key of the secret to select from.  Must be a valid secret key.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                            "type": "string"
+                          },
+                          "optional": {
+                            "description": "Specify whether the Secret or its key must be defined",
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "key"
+                        ],
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "serverName": {
+                        "description": "Used to verify the hostname for the targets.",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "required": [
+                  "name",
+                  "namespace",
+                  "port"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "credentials": {
+          "description": "A reference to GCP service account credentials with which the rule\nevaluator container is run. It needs to have metric read permissions\nagainst queryProjectId and metric write permissions against all projects\nto which rule results are written.\nWithin GKE, this can typically be left empty if the compute default\nservice account has the required permissions.",
+          "properties": {
+            "key": {
+              "description": "The key of the secret to select from.  Must be a valid secret key.",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+              "type": "string"
+            },
+            "optional": {
+              "description": "Specify whether the Secret or its key must be defined",
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "key"
+          ],
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
+        "externalLabels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "ExternalLabels specifies external labels that are attached to any rule\nresults and alerts produced by rules. The precedence behavior matches that\nof Prometheus.",
+          "type": "object"
+        },
+        "queryProjectID": {
+          "description": "QueryProjectID is the GCP project ID to evaluate rules against.\nIf left blank, the rule-evaluator will try attempt to infer the Project ID\nfrom the environment.",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/monitoring.googleapis.com/podmonitoring_v1.json
+++ b/monitoring.googleapis.com/podmonitoring_v1.json
@@ -1,0 +1,715 @@
+{
+  "description": "PodMonitoring defines monitoring for a set of pods, scoped to pods\nwithin the PodMonitoring's namespace.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Specification of desired Pod selection for target discovery by\nPrometheus.",
+      "properties": {
+        "endpoints": {
+          "description": "The endpoints to scrape on the selected pods.",
+          "items": {
+            "description": "ScrapeEndpoint specifies a Prometheus metrics endpoint to scrape.",
+            "properties": {
+              "authorization": {
+                "description": "Authorization is the HTTP authorization credentials for the targets.",
+                "properties": {
+                  "credentials": {
+                    "description": "Credentials uses the secret as the credentials (token) for the authentication header.",
+                    "properties": {
+                      "secret": {
+                        "description": "Secret represents reference to a given key from certain Secret in a given namespace.",
+                        "properties": {
+                          "key": {
+                            "description": "Key of the secret to select from. Must be a valid secret key.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the secret to select from.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "key",
+                          "name"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": {
+                    "description": "Type is the authentication type. Defaults to Bearer.\nBasic will cause an error, as the BasicAuth object should be used instead.",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "basicAuth": {
+                "description": "BasicAuth is the HTTP basic authentication credentials for the targets.",
+                "properties": {
+                  "password": {
+                    "description": "Password uses the secret as the BasicAuth password.",
+                    "properties": {
+                      "secret": {
+                        "description": "Secret represents reference to a given key from certain Secret in a given namespace.",
+                        "properties": {
+                          "key": {
+                            "description": "Key of the secret to select from. Must be a valid secret key.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the secret to select from.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "key",
+                          "name"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "username": {
+                    "description": "Username is the BasicAuth username.",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "interval": {
+                "default": "1m",
+                "description": "Interval at which to scrape metrics. Must be a valid Prometheus duration.",
+                "pattern": "^((([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?|0)$",
+                "type": "string"
+              },
+              "metricRelabeling": {
+                "description": "Relabeling rules for metrics scraped from this endpoint. Relabeling rules that\noverride protected target labels (project_id, location, cluster, namespace, job,\ninstance, top_level_controller, top_level_controller_type, or __address__) are\nnot permitted. The labelmap action is not permitted in general.",
+                "items": {
+                  "description": "RelabelingRule defines a single Prometheus relabeling rule.",
+                  "properties": {
+                    "action": {
+                      "description": "Action to perform based on regex matching. Defaults to 'replace'.",
+                      "type": "string"
+                    },
+                    "modulus": {
+                      "description": "Modulus to take of the hash of the source label values.",
+                      "format": "int64",
+                      "type": "integer"
+                    },
+                    "regex": {
+                      "description": "Regular expression against which the extracted value is matched. Defaults to '(.*)'.",
+                      "type": "string"
+                    },
+                    "replacement": {
+                      "description": "Replacement value against which a regex replace is performed if the\nregular expression matches. Regex capture groups are available. Defaults to '$1'.",
+                      "type": "string"
+                    },
+                    "separator": {
+                      "description": "Separator placed between concatenated source label values. Defaults to ';'.",
+                      "type": "string"
+                    },
+                    "sourceLabels": {
+                      "description": "The source labels select values from existing labels. Their content is concatenated\nusing the configured separator and matched against the configured regular expression\nfor the replace, keep, and drop actions.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "targetLabel": {
+                      "description": "Label to which the resulting value is written in a replace action.\nIt is mandatory for replace actions. Regex capture groups are available.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "oauth2": {
+                "description": "OAuth2 is the OAuth2 client credentials used to fetch a token for the targets.",
+                "properties": {
+                  "clientID": {
+                    "description": "ClientID is the public identifier for the client.",
+                    "type": "string"
+                  },
+                  "clientSecret": {
+                    "description": "ClientSecret uses the secret as the client secret token.",
+                    "properties": {
+                      "secret": {
+                        "description": "Secret represents reference to a given key from certain Secret in a given namespace.",
+                        "properties": {
+                          "key": {
+                            "description": "Key of the secret to select from. Must be a valid secret key.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the secret to select from.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "key",
+                          "name"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "endpointParams": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "EndpointParams are additional parameters to append to the token URL.",
+                    "type": "object"
+                  },
+                  "proxyUrl": {
+                    "description": "ProxyURL is the HTTP proxy server to use to connect to the targets.\n\n\nEncoded passwords are not supported.",
+                    "type": "string"
+                  },
+                  "scopes": {
+                    "description": "Scopes represents the scopes for the token request.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "tlsConfig": {
+                    "description": "TLS configures the token request's TLS settings.",
+                    "properties": {
+                      "ca": {
+                        "description": "SecretSelector references a secret from a secret provider e.g. Kubernetes Secret. Only one\nprovider can be used at a time.",
+                        "properties": {
+                          "secret": {
+                            "description": "Secret represents reference to a given key from certain Secret in a given namespace.",
+                            "properties": {
+                              "key": {
+                                "description": "Key of the secret to select from. Must be a valid secret key.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the secret to select from.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "key",
+                              "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "cert": {
+                        "description": "Cert uses the secret as the certificate for client authentication to the server.",
+                        "properties": {
+                          "secret": {
+                            "description": "Secret represents reference to a given key from certain Secret in a given namespace.",
+                            "properties": {
+                              "key": {
+                                "description": "Key of the secret to select from. Must be a valid secret key.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the secret to select from.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "key",
+                              "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "insecureSkipVerify": {
+                        "description": "InsecureSkipVerify disables target certificate validation.",
+                        "type": "boolean"
+                      },
+                      "key": {
+                        "description": "Key uses the secret as the private key for client authentication to the server.",
+                        "properties": {
+                          "secret": {
+                            "description": "Secret represents reference to a given key from certain Secret in a given namespace.",
+                            "properties": {
+                              "key": {
+                                "description": "Key of the secret to select from. Must be a valid secret key.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the secret to select from.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "key",
+                              "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "maxVersion": {
+                        "description": "MaxVersion is the maximum TLS version. Accepted values: TLS10 (TLS 1.0), TLS11 (TLS 1.1),\nTLS12 (TLS 1.2), TLS13 (TLS 1.3).\n\n\nIf unset, Prometheus will use Go default minimum version, which is TLS 1.2.\nSee MinVersion in https://pkg.go.dev/crypto/tls#Config.",
+                        "type": "string"
+                      },
+                      "minVersion": {
+                        "description": "MinVersion is the minimum TLS version. Accepted values: TLS10 (TLS 1.0), TLS11 (TLS 1.1),\nTLS12 (TLS 1.2), TLS13 (TLS 1.3).\n\n\nIf unset, Prometheus will use Go default minimum version, which is TLS 1.2.\nSee MinVersion in https://pkg.go.dev/crypto/tls#Config.",
+                        "type": "string"
+                      },
+                      "serverName": {
+                        "description": "ServerName is used to verify the hostname for the targets.",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "tokenURL": {
+                    "description": "TokenURL is the URL to fetch the token from.",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "params": {
+                "additionalProperties": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "description": "HTTP GET params to use when scraping.",
+                "type": "object"
+              },
+              "path": {
+                "description": "HTTP path to scrape metrics from. Defaults to \"/metrics\".",
+                "type": "string"
+              },
+              "port": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ],
+                "description": "Name or number of the port to scrape.\nThe container metadata label is only populated if the port is referenced by name\nbecause port numbers are not unique across containers.",
+                "x-kubernetes-int-or-string": true
+              },
+              "proxyUrl": {
+                "description": "ProxyURL is the HTTP proxy server to use to connect to the targets.\n\n\nEncoded passwords are not supported.",
+                "type": "string"
+              },
+              "scheme": {
+                "description": "Protocol scheme to use to scrape.",
+                "type": "string"
+              },
+              "timeout": {
+                "description": "Timeout for metrics scrapes. Must be a valid Prometheus duration.\nMust not be larger than the scrape interval.",
+                "type": "string"
+              },
+              "tls": {
+                "description": "TLS configures the scrape request's TLS settings.",
+                "properties": {
+                  "ca": {
+                    "description": "SecretSelector references a secret from a secret provider e.g. Kubernetes Secret. Only one\nprovider can be used at a time.",
+                    "properties": {
+                      "secret": {
+                        "description": "Secret represents reference to a given key from certain Secret in a given namespace.",
+                        "properties": {
+                          "key": {
+                            "description": "Key of the secret to select from. Must be a valid secret key.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the secret to select from.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "key",
+                          "name"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "cert": {
+                    "description": "Cert uses the secret as the certificate for client authentication to the server.",
+                    "properties": {
+                      "secret": {
+                        "description": "Secret represents reference to a given key from certain Secret in a given namespace.",
+                        "properties": {
+                          "key": {
+                            "description": "Key of the secret to select from. Must be a valid secret key.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the secret to select from.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "key",
+                          "name"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "insecureSkipVerify": {
+                    "description": "InsecureSkipVerify disables target certificate validation.",
+                    "type": "boolean"
+                  },
+                  "key": {
+                    "description": "Key uses the secret as the private key for client authentication to the server.",
+                    "properties": {
+                      "secret": {
+                        "description": "Secret represents reference to a given key from certain Secret in a given namespace.",
+                        "properties": {
+                          "key": {
+                            "description": "Key of the secret to select from. Must be a valid secret key.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the secret to select from.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "key",
+                          "name"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "maxVersion": {
+                    "description": "MaxVersion is the maximum TLS version. Accepted values: TLS10 (TLS 1.0), TLS11 (TLS 1.1),\nTLS12 (TLS 1.2), TLS13 (TLS 1.3).\n\n\nIf unset, Prometheus will use Go default minimum version, which is TLS 1.2.\nSee MinVersion in https://pkg.go.dev/crypto/tls#Config.",
+                    "type": "string"
+                  },
+                  "minVersion": {
+                    "description": "MinVersion is the minimum TLS version. Accepted values: TLS10 (TLS 1.0), TLS11 (TLS 1.1),\nTLS12 (TLS 1.2), TLS13 (TLS 1.3).\n\n\nIf unset, Prometheus will use Go default minimum version, which is TLS 1.2.\nSee MinVersion in https://pkg.go.dev/crypto/tls#Config.",
+                    "type": "string"
+                  },
+                  "serverName": {
+                    "description": "ServerName is used to verify the hostname for the targets.",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "port"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "filterRunning": {
+          "description": "FilterRunning will drop any pods that are in the \"Failed\" or \"Succeeded\"\npod lifecycle.\nSee: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase",
+          "type": "boolean"
+        },
+        "limits": {
+          "description": "Limits to apply at scrape time.",
+          "properties": {
+            "labelNameLength": {
+              "description": "Maximum label name length.\nUses Prometheus default if left unspecified.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "labelValueLength": {
+              "description": "Maximum label value length.\nUses Prometheus default if left unspecified.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "labels": {
+              "description": "Maximum number of labels accepted for a single sample.\nUses Prometheus default if left unspecified.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "samples": {
+              "description": "Maximum number of samples accepted within a single scrape.\nUses Prometheus default if left unspecified.",
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "selector": {
+          "description": "Label selector that specifies which pods are selected for this monitoring\nconfiguration.",
+          "properties": {
+            "matchExpressions": {
+              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+              "items": {
+                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                "properties": {
+                  "key": {
+                    "description": "key is the label key that the selector applies to.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  }
+                },
+                "required": [
+                  "key",
+                  "operator"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            },
+            "matchLabels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
+        "targetLabels": {
+          "description": "Labels to add to the Prometheus target for discovered endpoints.\nThe `instance` label is always set to `<pod_name>:<port>` or `<node_name>:<port>`\nif the scraped pod is controlled by a DaemonSet.",
+          "properties": {
+            "fromPod": {
+              "description": "Labels to transfer from the Kubernetes Pod to Prometheus target labels.\nMappings are applied in order.",
+              "items": {
+                "description": "LabelMapping specifies how to transfer a label from a Kubernetes resource\nonto a Prometheus target.",
+                "properties": {
+                  "from": {
+                    "description": "Kubernetes resource label to remap.",
+                    "type": "string"
+                  },
+                  "to": {
+                    "description": "Remapped Prometheus target label.\nDefaults to the same name as `From`.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "from"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "metadata": {
+              "description": "Pod metadata labels that are set on all scraped targets.\nPermitted keys are `pod`, `container`, and `node` for PodMonitoring and\n`pod`, `container`, `node`, and `namespace` for ClusterPodMonitoring. The `container`\nlabel is only populated if the scrape port is referenced by name.\nDefaults to [pod, container, top_level_controller_name, top_level_controller_type] for\nPodMonitoring and [namespace, pod, container, top_level_controller_name, top_level_controller_type]\nfor ClusterPodMonitoring.\nIf set to null, it will be interpreted as the empty list for PodMonitoring\nand to [namespace] for ClusterPodMonitoring. This is for backwards-compatibility\nonly.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "endpoints",
+        "selector"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "Most recently observed status of the resource.",
+      "properties": {
+        "conditions": {
+          "description": "Represents the latest available observations of a podmonitor's current state.",
+          "items": {
+            "description": "MonitoringCondition describes the condition of a PodMonitoring.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "lastUpdateTime": {
+                "description": "The last time this condition was updated.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human-readable message indicating details about the transition.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "MonitoringConditionType is the type of MonitoringCondition.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "endpointStatuses": {
+          "description": "Represents the latest available observations of target state for each ScrapeEndpoint.",
+          "items": {
+            "properties": {
+              "activeTargets": {
+                "description": "Total number of active targets.",
+                "format": "int64",
+                "type": "integer"
+              },
+              "collectorsFraction": {
+                "description": "Fraction of collectors included in status, bounded [0,1].\nIdeally, this should always be 1. Anything less can\nbe considered a problem and should be investigated.",
+                "type": "string"
+              },
+              "lastUpdateTime": {
+                "description": "Last time this status was updated.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "name": {
+                "description": "The name of the ScrapeEndpoint.",
+                "type": "string"
+              },
+              "sampleGroups": {
+                "description": "A fixed sample of targets grouped by error type.",
+                "items": {
+                  "properties": {
+                    "count": {
+                      "description": "Total count of similar errors.",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "sampleTargets": {
+                      "description": "Targets emitting the error message.",
+                      "items": {
+                        "properties": {
+                          "health": {
+                            "description": "Health status.",
+                            "type": "string"
+                          },
+                          "labels": {
+                            "additionalProperties": {
+                              "description": "A LabelValue is an associated value for a LabelName.",
+                              "type": "string"
+                            },
+                            "description": "The label set, keys and values, of the target.",
+                            "type": "object"
+                          },
+                          "lastError": {
+                            "description": "Error message.",
+                            "type": "string"
+                          },
+                          "lastScrapeDurationSeconds": {
+                            "description": "Scrape duration in seconds.",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "unhealthyTargets": {
+                "description": "Total number of active, unhealthy targets.",
+                "format": "int64",
+                "type": "integer"
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "observedGeneration": {
+          "description": "The generation observed by the controller.",
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "spec"
+  ],
+  "type": "object"
+}

--- a/monitoring.googleapis.com/podmonitoring_v1alpha1.json
+++ b/monitoring.googleapis.com/podmonitoring_v1alpha1.json
@@ -1,0 +1,293 @@
+{
+  "description": "PodMonitoring defines monitoring for a set of pods.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Specification of desired Pod selection for target discovery by\nPrometheus.",
+      "properties": {
+        "endpoints": {
+          "description": "The endpoints to scrape on the selected pods.",
+          "items": {
+            "description": "ScrapeEndpoint specifies a Prometheus metrics endpoint to scrape.",
+            "properties": {
+              "interval": {
+                "description": "Interval at which to scrape metrics. Must be a valid Prometheus duration.",
+                "type": "string"
+              },
+              "metricRelabeling": {
+                "description": "Relabeling rules for metrics scraped from this endpoint. Relabeling rules that\noverride protected target labels (project_id, location, cluster, namespace, job,\ninstance, or __address__) are not permitted. The labelmap action is not permitted\nin general.",
+                "items": {
+                  "description": "RelabelingRule defines a single Prometheus relabeling rule.",
+                  "properties": {
+                    "action": {
+                      "description": "Action to perform based on regex matching. Defaults to 'replace'.",
+                      "type": "string"
+                    },
+                    "modulus": {
+                      "description": "Modulus to take of the hash of the source label values.",
+                      "format": "int64",
+                      "type": "integer"
+                    },
+                    "regex": {
+                      "description": "Regular expression against which the extracted value is matched. Defaults to '(.*)'.",
+                      "type": "string"
+                    },
+                    "replacement": {
+                      "description": "Replacement value against which a regex replace is performed if the\nregular expression matches. Regex capture groups are available. Defaults to '$1'.",
+                      "type": "string"
+                    },
+                    "separator": {
+                      "description": "Separator placed between concatenated source label values. Defaults to ';'.",
+                      "type": "string"
+                    },
+                    "sourceLabels": {
+                      "description": "The source labels select values from existing labels. Their content is concatenated\nusing the configured separator and matched against the configured regular expression\nfor the replace, keep, and drop actions.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "targetLabel": {
+                      "description": "Label to which the resulting value is written in a replace action.\nIt is mandatory for replace actions. Regex capture groups are available.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "params": {
+                "additionalProperties": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "description": "HTTP GET params to use when scraping.",
+                "type": "object"
+              },
+              "path": {
+                "description": "HTTP path to scrape metrics from. Defaults to \"/metrics\".",
+                "type": "string"
+              },
+              "port": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ],
+                "description": "Name or number of the port to scrape.",
+                "x-kubernetes-int-or-string": true
+              },
+              "proxyUrl": {
+                "description": "Proxy URL to scrape through. Encoded passwords are not supported.",
+                "type": "string"
+              },
+              "scheme": {
+                "description": "Protocol scheme to use to scrape.",
+                "type": "string"
+              },
+              "timeout": {
+                "description": "Timeout for metrics scrapes. Must be a valid Prometheus duration.\nMust not be larger then the scrape interval.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "port"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "limits": {
+          "description": "Limits to apply at scrape time.",
+          "properties": {
+            "labelNameLength": {
+              "description": "Maximum label name length.\nUses Prometheus default if left unspecified.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "labelValueLength": {
+              "description": "Maximum label value length.\nUses Prometheus default if left unspecified.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "labels": {
+              "description": "Maximum number of labels accepted for a single sample.\nUses Prometheus default if left unspecified.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "samples": {
+              "description": "Maximum number of samples accepted within a single scrape.\nUses Prometheus default if left unspecified.",
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "selector": {
+          "description": "Label selector that specifies which pods are selected for this monitoring\nconfiguration.",
+          "properties": {
+            "matchExpressions": {
+              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+              "items": {
+                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                "properties": {
+                  "key": {
+                    "description": "key is the label key that the selector applies to.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  }
+                },
+                "required": [
+                  "key",
+                  "operator"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            },
+            "matchLabels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
+        "targetLabels": {
+          "description": "Labels to add to the Prometheus target for discovered endpoints.",
+          "properties": {
+            "fromPod": {
+              "description": "Labels to transfer from the Kubernetes Pod to Prometheus target labels.\nMappings are applied in order.",
+              "items": {
+                "description": "LabelMapping specifies how to transfer a label from a Kubernetes resource\nonto a Prometheus target.",
+                "properties": {
+                  "from": {
+                    "description": "Kubenetes resource label to remap.",
+                    "type": "string"
+                  },
+                  "to": {
+                    "description": "Remapped Prometheus target label.\nDefaults to the same name as `From`.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "from"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "metadata": {
+              "description": "Pod metadata labels that are set on all scraped targets.\nPermitted keys are `pod`, `container`, and `node` for PodMonitoring and\n`pod`, `container`, `node`, and `namespace` for ClusterPodMonitoring.\nDefaults to [pod, container] for PodMonitoring and [namespace, pod, container]\nfor ClusterPodMonitoring.\nIf set to null, it will be interpreted as the empty list for PodMonitoring\nand to [namespace] for ClusterPodMonitoring. This is for backwards-compatibility\nonly.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "endpoints",
+        "selector"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "Most recently observed status of the resource.",
+      "properties": {
+        "conditions": {
+          "description": "Represents the latest available observations of a podmonitor's current state.",
+          "items": {
+            "description": "MonitoringCondition describes a condition of a PodMonitoring.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "lastUpdateTime": {
+                "description": "The last time this condition was updated.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human-readable message indicating details about the transition.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "MonitoringConditionType is the type of MonitoringCondition.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "observedGeneration": {
+          "description": "The generation observed by the controller.",
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "spec"
+  ],
+  "type": "object"
+}

--- a/monitoring.googleapis.com/rules_v1.json
+++ b/monitoring.googleapis.com/rules_v1.json
@@ -1,0 +1,151 @@
+{
+  "description": "Rules defines Prometheus alerting and recording rules that are scoped\nto the namespace of the resource. Only metric data from this namespace is processed\nand all rule results have their project_id, cluster, and namespace label preserved\nfor query processing.\nIf the location label is not preserved by the rule, it defaults to the cluster's location.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Specification of rules to record and alert on.",
+      "properties": {
+        "groups": {
+          "description": "A list of Prometheus rule groups.",
+          "items": {
+            "description": "RuleGroup declares rules in the Prometheus format:\nhttps://prometheus.io/docs/prometheus/latest/configuration/recording_rules/",
+            "properties": {
+              "interval": {
+                "description": "The interval at which to evaluate the rules. Must be a valid Prometheus duration.",
+                "type": "string"
+              },
+              "name": {
+                "description": "The name of the rule group.",
+                "type": "string"
+              },
+              "rules": {
+                "description": "A list of rules that are executed sequentially as part of this group.",
+                "items": {
+                  "description": "Rule is a single rule in the Prometheus format:\nhttps://prometheus.io/docs/prometheus/latest/configuration/recording_rules/",
+                  "properties": {
+                    "alert": {
+                      "description": "Name of the alert to evaluate the expression as.\nOnly one of `record` and `alert` must be set.",
+                      "type": "string"
+                    },
+                    "annotations": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "A set of annotations to attach to alerts produced by the query expression.\nOnly valid if `alert` is set.",
+                      "type": "object"
+                    },
+                    "expr": {
+                      "description": "The PromQL expression to evaluate.",
+                      "type": "string"
+                    },
+                    "for": {
+                      "description": "The duration to wait before a firing alert produced by this rule is sent to Alertmanager.\nOnly valid if `alert` is set.",
+                      "type": "string"
+                    },
+                    "labels": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "A set of labels to attach to the result of the query expression.",
+                      "type": "object"
+                    },
+                    "record": {
+                      "description": "Record the result of the expression to this metric name.\nOnly one of `record` and `alert` must be set.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "expr"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "interval",
+              "name",
+              "rules"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "groups"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "Most recently observed status of the resource.",
+      "properties": {
+        "conditions": {
+          "description": "Represents the latest available observations of a podmonitor's current state.",
+          "items": {
+            "description": "MonitoringCondition describes the condition of a PodMonitoring.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "lastUpdateTime": {
+                "description": "The last time this condition was updated.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human-readable message indicating details about the transition.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "MonitoringConditionType is the type of MonitoringCondition.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "observedGeneration": {
+          "description": "The generation observed by the controller.",
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "spec"
+  ],
+  "type": "object"
+}

--- a/monitoring.googleapis.com/rules_v1alpha1.json
+++ b/monitoring.googleapis.com/rules_v1alpha1.json
@@ -1,0 +1,102 @@
+{
+  "description": "Rules defines Prometheus alerting and recording rules that are scoped\nto the namespace of the resource. Only metric data from this namespace is processed\nand all rule results have their project_id, cluster, and namespace label preserved\nfor query processing.\nIf the location label is not preserved by the rule, it defaults to the cluster's location.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Specification of rules to record and alert on.",
+      "properties": {
+        "groups": {
+          "description": "A list of Prometheus rule groups.",
+          "items": {
+            "description": "RuleGroup declares rules in the Prometheus format:\nhttps://prometheus.io/docs/prometheus/latest/configuration/recording_rules/",
+            "properties": {
+              "interval": {
+                "description": "The interval at which to evaluate the rules. Must be a valid Prometheus duration.",
+                "type": "string"
+              },
+              "name": {
+                "description": "The name of the rule group.",
+                "type": "string"
+              },
+              "rules": {
+                "description": "A list of rules that are executed sequentially as part of this group.",
+                "items": {
+                  "description": "Rule is a single rule in the Prometheus format:\nhttps://prometheus.io/docs/prometheus/latest/configuration/recording_rules/",
+                  "properties": {
+                    "alert": {
+                      "description": "Name of the alert to evaluate the expression as.\nOnly one of `record` and `alert` must be set.",
+                      "type": "string"
+                    },
+                    "annotations": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "A set of annotations to attach to alerts produced by the query expression.\nOnly valid if `alert` is set.",
+                      "type": "object"
+                    },
+                    "expr": {
+                      "description": "The PromQL expression to evaluate.",
+                      "type": "string"
+                    },
+                    "for": {
+                      "description": "The duration to wait before a firing alert produced by this rule is sent to Alertmanager.\nOnly valid if `alert` is set.",
+                      "type": "string"
+                    },
+                    "labels": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "A set of labels to attach to the result of the query expression.",
+                      "type": "object"
+                    },
+                    "record": {
+                      "description": "Record the result of the expression to this metric name.\nOnly one of `record` and `alert` must be set.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "expr"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "interval",
+              "name",
+              "rules"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "groups"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "Most recently observed status of the resource.",
+      "type": "object"
+    }
+  },
+  "required": [
+    "spec"
+  ],
+  "type": "object"
+}


### PR DESCRIPTION
We use Google Managed Prometheus and a variety of these within our Clusters to monitor pods. 

This was generated using the CRD Extractor on a fresh GKE cluster running kubernetes `v1.31.7`

## PR Checklist

- [*] I have used the [CRD Extractor](https://github.com/datreeio/CRDs-catalog?tab=readme-ov-file#crd-extractor) tool to generate these CRDs
