### PR TITLE
feat: add OUTPUT_DIR environment variable support to crd-extractor.sh

### DIFF
--- a/Utilities/crd-extractor.sh
+++ b/Utilities/crd-extractor.sh
@@ -57,7 +57,8 @@ TMP=$(mktemp -d)
 trap 'rm -rf "$TMP"' EXIT
 
 # Create final schemas directory
-SCHEMAS_DIR=$HOME/.datree/crdSchemas
+# Use current directory if OUTPUT_DIR is set, otherwise use default
+SCHEMAS_DIR=${OUTPUT_DIR:-$HOME/.datree/crdSchemas}
 mkdir -p "$SCHEMAS_DIR"
 cd "$SCHEMAS_DIR"
 
@@ -118,9 +119,10 @@ NC='\033[0m' # No Color
 
 if [ $conversionResult == 0 ]; then
     printf "${GREEN}Successfully converted $FETCHED_CRDS CRDs to JSON schema${NC}\n"
+    printf "Schemas saved to: ${CYAN}$SCHEMAS_DIR${NC}\n"
 
     printf "\nTo validate a CR using various tools, run the relevant command:\n"
     printf "\n- ${CYAN}datree:${NC}\n\$ datree test /path/to/file\n"
-    printf "\n- ${CYAN}kubeconform:${NC}\n\$ kubeconform -summary -output json -schema-location default -schema-location '$HOME/.datree/crdSchemas/{{ .Group }}/{{ .ResourceKind }}_{{ .ResourceAPIVersion }}.json' /path/to/file\n"
-    printf "\n- ${CYAN}kubeval:${NC}\n\$ kubeval --additional-schema-locations file:\"$HOME/.datree/crdSchemas\" /path/to/file\n\n"
+    printf "\n- ${CYAN}kubeconform:${NC}\n\$ kubeconform -summary -output json -schema-location default -schema-location '$SCHEMAS_DIR/{{ .Group }}/{{ .ResourceKind }}_{{ .ResourceAPIVersion }}.json' /path/to/file\n"
+    printf "\n- ${CYAN}kubeval:${NC}\n\$ kubeval --additional-schema-locations file:\"$SCHEMAS_DIR\" /path/to/file\n\n"
 fi


### PR DESCRIPTION
Allow specifying a custom output directory for generated CRD schemas by setting the OUTPUT_DIR environment variable. This enables users to generate schemas in their current directory or any specified location instead of the default ~/.datree/crdSchemas.

Also updated the success message to show the actual output directory used and adjusted the example commands to use the correct path.
 