### PR TITLE
Adding Twingate Kubernetes Operator's CRDs

### DIFF
--- a/twingate.com/twingateconnector_v1beta.json
+++ b/twingate.com/twingateconnector_v1beta.json
@@ -1,0 +1,144 @@
+{
+  "type": "object",
+  "description": "TwingateConnector represents a Connector in Twingate.",
+  "required": [
+    "spec"
+  ],
+  "properties": {
+    "spec": {
+      "type": "object",
+      "description": "TwingateConnectorSpec defines the desired state of TwingateConnector",
+      "x-kubernetes-validations": [
+        {
+          "rule": "(!has(oldSelf.id) || self.id == oldSelf.id)",
+          "message": "id is immutable once set"
+        },
+        {
+          "rule": "(has(self.image) && !has(self.imagePolicy)) || (!has(self.image) && has(self.imagePolicy)) || (!has(self.image) && !has(self.imagePolicy))",
+          "message": "Can define either `image` or `imagePolicy`, not both."
+        }
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "nullable": true
+        },
+        "name": {
+          "type": "string",
+          "maxLength": 30,
+          "description": "Name of the Connector (optional, if not specified Twingate will give a random name)"
+        },
+        "logLevel": {
+          "type": "integer",
+          "default": 3,
+          "minimum": -1,
+          "maximum": 7,
+          "description": "Log level for the Connector (-1 to 7: -1 for no logs, 0 - least verbose, 7 - most verbose, default: 3)."
+        },
+        "logAnalytics": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable real-time connection logs."
+        },
+        "hasStatusNotificationsEnabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable status notifications for the Connector."
+        },
+        "image": {
+          "type": "object",
+          "description": "Image defines the image to use for the Connector.",
+          "properties": {
+            "repository": {
+              "type": "string",
+              "default": "twingate/connector",
+              "description": "Repository to use for the Connector."
+            },
+            "tag": {
+              "type": "string",
+              "default": "1",
+              "description": "Tag to use for the Connector."
+            }
+          },
+          "additionalProperties": false
+        },
+        "imagePolicy": {
+          "type": "object",
+          "description": "ImagePolicy defines the image to use for the Connector and a schedule to keep it up to date.",
+          "required": [
+            "provider"
+          ],
+          "x-kubernetes-validations": [
+            {
+              "rule": "self.provider != \"google\" || (self.provider == \"google\" && !has(self.repository))",
+              "message": "Google provider requires specifying repository."
+            }
+          ],
+          "properties": {
+            "provider": {
+              "type": "string",
+              "description": "Provider determines how the operator looks for a new connector version.\n  * dockerhub: Check Twingate's official DockerHub repository (`twingate/connector`) for new tags.\n  * google: Check Google Container Registry specified by the `repository` value for new tags.\n",
+              "enum": [
+                "dockerhub",
+                "google"
+              ],
+              "default": "dockerhub"
+            },
+            "repository": {
+              "type": "string",
+              "default": "twingate/connector",
+              "description": "Repository to use for pod's image."
+            },
+            "schedule": {
+              "type": "string",
+              "description": "Cron schedule to check for new versions."
+            },
+            "version": {
+              "type": "string",
+              "description": "Semver version specifier (ex: '^1.0.0'). Uses NPM spec: https://github.com/npm/node-semver#ranges"
+            },
+            "allowPrerelease": {
+              "type": "boolean",
+              "default": false,
+              "description": "Allow pre-release versions."
+            }
+          },
+          "additionalProperties": false
+        },
+        "containerExtra": {
+          "type": "object",
+          "description": "Extra container configuration for the Connector Deployment's pod template at `.spec.template.spec.containers`.",
+          "x-kubernetes-preserve-unknown-fields": true
+        },
+        "podExtra": {
+          "type": "object",
+          "description": "Extra pod configuration to be added to the Connector Deployment's pod template at `.spec.template.spec`",
+          "x-kubernetes-preserve-unknown-fields": true
+        },
+        "podAnnotations": {
+          "type": "object",
+          "description": "Extra annotations to add to the Connector Deployment's pod template at `.spec.template.metadata.annotations`.",
+          "x-kubernetes-preserve-unknown-fields": true
+        },
+        "podLabels": {
+          "type": "object",
+          "description": "Extra labels to add to the Connector Deployment's pod template at `.spec.template.metadata.labels`.",
+          "x-kubernetes-preserve-unknown-fields": true
+        },
+        "sidecarContainers": {
+          "type": "array",
+          "description": "SidecarContainers allows injecting additional containers to the Connector Pod.",
+          "items": {
+            "type": "object",
+            "x-kubernetes-preserve-unknown-fields": true
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "status": {
+      "type": "object",
+      "x-kubernetes-preserve-unknown-fields": true
+    }
+  }
+}

--- a/twingate.com/twingategroup_v1beta.json
+++ b/twingate.com/twingategroup_v1beta.json
@@ -1,0 +1,31 @@
+{
+  "type": "object",
+  "description": "TwingateGroup represents a Group in Twingate.",
+  "required": [
+    "spec"
+  ],
+  "properties": {
+    "spec": {
+      "type": "object",
+      "description": "TwingateGroupSpec defines the desired state of TwingateGroup",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "nullable": true
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the group."
+        }
+      },
+      "additionalProperties": false
+    },
+    "status": {
+      "type": "object",
+      "x-kubernetes-preserve-unknown-fields": true
+    }
+  }
+}

--- a/twingate.com/twingateresource_v1beta.json
+++ b/twingate.com/twingateresource_v1beta.json
@@ -1,0 +1,217 @@
+{
+  "type": "object",
+  "description": "TwingateResource represents a resource in Twingate.",
+  "required": [
+    "spec"
+  ],
+  "properties": {
+    "spec": {
+      "type": "object",
+      "description": "TwingateResourceSpec defines the desired state of TwingateResource",
+      "x-kubernetes-validations": [
+        {
+          "rule": "(self.isBrowserShortcutEnabled && !(self.address.contains('*') || self.address.contains('?'))) || (self.isBrowserShortcutEnabled == false)",
+          "message": "if isBrowserShortcutEnabled is set to true, then address can't be wildcard"
+        },
+        {
+          "rule": "(self.type == \"Network\" && !has(self.proxy)) || (self.type == \"Kubernetes\" && has(self.proxy))",
+          "message": "proxy should be set for Kubernetes Resource"
+        },
+        {
+          "rule": "(self.isBrowserShortcutEnabled && self.type == \"Network\") || (self.isBrowserShortcutEnabled == false)",
+          "message": "isBrowserShortcutEnabled cannot be set to true for Kubernetes Resource"
+        }
+      ],
+      "required": [
+        "name",
+        "address"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "nullable": true
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the resource."
+        },
+        "address": {
+          "type": "string",
+          "description": "Address of the resource."
+        },
+        "alias": {
+          "type": "string",
+          "nullable": true,
+          "description": "Alias of the resource."
+        },
+        "isBrowserShortcutEnabled": {
+          "type": "boolean",
+          "default": false,
+          "description": "isBrowserShortcutEnabled specifies whether the resource will display a browser shortcut in the Twingate client."
+        },
+        "securityPolicyId": {
+          "type": "string",
+          "nullable": true,
+          "pattern": "^[-A-Za-z0-9+/]*={0,3}$"
+        },
+        "isVisible": {
+          "type": "boolean",
+          "default": true,
+          "description": "isVisible specifies whether the resource will display in the main resources list in the Twingate client."
+        },
+        "protocols": {
+          "type": "object",
+          "nullable": true,
+          "description": "protocols specifies the resource's protocol policies.",
+          "properties": {
+            "allowIcmp": {
+              "type": "boolean",
+              "nullable": true,
+              "description": "allowIcmp specifies whether the resource will allow ICMP traffic."
+            },
+            "tcp": {
+              "type": "object",
+              "nullable": true,
+              "description": "tcp specifies the resource's TCP protocol policy.",
+              "x-kubernetes-validations": [
+                {
+                  "rule": "(self.policy == \"ALLOW_ALL\" && size(self.ports) == 0) || (self.policy == \"RESTRICTED\")",
+                  "message": "Can't specify port ranges for ALLOW_ALL policy."
+                }
+              ],
+              "properties": {
+                "policy": {
+                  "type": "string",
+                  "nullable": true,
+                  "enum": [
+                    "ALLOW_ALL",
+                    "RESTRICTED"
+                  ]
+                },
+                "ports": {
+                  "type": "array",
+                  "default": [],
+                  "items": {
+                    "type": "object",
+                    "x-kubernetes-validations": [
+                      {
+                        "rule": "(self.start <= self.end)",
+                        "message": "Start port value must be less or equal to end port value"
+                      }
+                    ],
+                    "properties": {
+                      "start": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 65535
+                      },
+                      "end": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 65535
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                }
+              },
+              "additionalProperties": false
+            },
+            "udp": {
+              "type": "object",
+              "nullable": true,
+              "description": "udp specifies the resource's UDP protocol policy.",
+              "x-kubernetes-validations": [
+                {
+                  "rule": "(self.policy == \"ALLOW_ALL\" && size(self.ports) == 0) || (self.policy == \"RESTRICTED\")",
+                  "message": "Can't specify port ranges for ALLOW_ALL policy."
+                }
+              ],
+              "properties": {
+                "policy": {
+                  "type": "string",
+                  "nullable": true,
+                  "enum": [
+                    "ALLOW_ALL",
+                    "RESTRICTED"
+                  ]
+                },
+                "ports": {
+                  "type": "array",
+                  "default": [],
+                  "items": {
+                    "type": "object",
+                    "x-kubernetes-validations": [
+                      {
+                        "rule": "(self.start <= self.end)",
+                        "message": "Start port value must be less or equal to end port value"
+                      }
+                    ],
+                    "properties": {
+                      "start": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 65535
+                      },
+                      "end": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 65535
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        "syncLabels": {
+          "type": "boolean",
+          "default": true,
+          "description": "syncLabels specifies whether the resource should sync the metadata labels as resource tags in the Twingate client."
+        },
+        "type": {
+          "type": "string",
+          "description": "The resource type",
+          "default": "Network",
+          "enum": [
+            "Network",
+            "Kubernetes"
+          ],
+          "x-kubernetes-validations": [
+            {
+              "rule": "self == oldSelf",
+              "message": "Resource type is immutable"
+            }
+          ]
+        },
+        "proxy": {
+          "type": "object",
+          "required": [
+            "address",
+            "certificateAuthorityCert"
+          ],
+          "properties": {
+            "address": {
+              "type": "string",
+              "description": "Address of the proxy."
+            },
+            "certificateAuthorityCert": {
+              "type": "string",
+              "description": "Base64-encoded certificate of the Certificate Authority issuing the proxy's TLS certificate."
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "status": {
+      "type": "object",
+      "x-kubernetes-preserve-unknown-fields": true
+    }
+  }
+}

--- a/twingate.com/twingateresourceaccess_v1beta.json
+++ b/twingate.com/twingateresourceaccess_v1beta.json
@@ -1,0 +1,138 @@
+{
+  "type": "object",
+  "description": "TwingateResourceAccess represents a resource access policy in Twingate. It allows to configure an access between a Resource and a Principal which is either a Group or a ServiceAccount.",
+  "required": [
+    "spec"
+  ],
+  "properties": {
+    "spec": {
+      "type": "object",
+      "description": "TwingateResourceAccessSpec defines the desired state of TwingateResourceAccess",
+      "oneOf": [
+        {
+          "properties": null,
+          "required": [
+            "resourceRef",
+            "principalId"
+          ]
+        },
+        {
+          "properties": null,
+          "required": [
+            "resourceRef",
+            "principalExternalRef"
+          ]
+        },
+        {
+          "properties": null,
+          "required": [
+            "resourceRef",
+            "groupRef"
+          ]
+        }
+      ],
+      "properties": {
+        "principalId": {
+          "type": "string",
+          "pattern": "^[-A-Za-z0-9+/]*={0,3}$",
+          "description": "principalId is the ID of the principal (Group/ServiceAccount) to provide access to the resource.",
+          "x-kubernetes-validations": [
+            {
+              "rule": "self == oldSelf",
+              "message": "principalId is immutable"
+            }
+          ]
+        },
+        "groupRef": {
+          "type": "object",
+          "description": "groupRef specifies the TwingateGroup kubernetes object reference to provide access to.",
+          "x-kubernetes-validations": [
+            {
+              "rule": "self == oldSelf",
+              "message": "groupRef is immutable."
+            }
+          ],
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "Name of the TwingateGroup object."
+            },
+            "namespace": {
+              "type": "string",
+              "default": "default",
+              "description": "Namespace of TwingateGroup object."
+            }
+          },
+          "additionalProperties": false
+        },
+        "principalExternalRef": {
+          "type": "object",
+          "required": [
+            "type",
+            "name"
+          ],
+          "description": "principalExternalRef allows referencing a Principal (Group/ServiceAccount) by name.",
+          "properties": {
+            "type": {
+              "type": "string",
+              "description": "Type of the external reference.",
+              "enum": [
+                "group",
+                "serviceAccount"
+              ],
+              "x-kubernetes-validations": [
+                {
+                  "rule": "self == oldSelf",
+                  "message": "principalExternalRef.type is immutable"
+                }
+              ]
+            },
+            "name": {
+              "type": "string",
+              "description": "Name of the external reference to match. (Note: name uniqueness is not enforce, if 2 entities match the same name, the first will be used)",
+              "x-kubernetes-validations": [
+                {
+                  "rule": "self == oldSelf",
+                  "message": "principalExternalRef.name is immutable"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        "securityPolicyId": {
+          "type": "string",
+          "nullable": true,
+          "pattern": "^[-A-Za-z0-9+/]*={0,3}$"
+        },
+        "resourceRef": {
+          "type": "object",
+          "description": "resourceRef specifies the TwingateResource reference to provide access to.",
+          "x-kubernetes-validations": [
+            {
+              "rule": "self == oldSelf",
+              "message": "resourceRef is immutable."
+            }
+          ],
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "Name of the resource."
+            },
+            "namespace": {
+              "type": "string",
+              "nullable": true,
+              "description": "Namespace of the resource."
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "status": {
+      "type": "object",
+      "x-kubernetes-preserve-unknown-fields": true
+    }
+  }
+}


### PR DESCRIPTION
Generated with:
```
export FILENAME_FORMAT="{fullgroup}__{kind}_{version}"
curl -s https://raw.githubusercontent.com/yannh/kubeconform/master/scripts/openapi2jsonschema.py | \
  python3 /dev/stdin [link-to-CRDs] | \
  grep 'JSON schema written to' | \
  awk '{ print $(NF) }' | \
  xargs -I {} sh -c 'f=$0; mkdir -p $(dirname $(echo $f | sed "s|__|/|")) && mv $f $(echo $f | sed "s|__|/|")' '{}'
```

I was following a colleague's instructions to generate these, but let me know if it's necessary to use the CRD Extractor instead.

List of CRDs:
- https://raw.githubusercontent.com/Twingate/kubernetes-operator/refs/heads/main/deploy/twingate-operator/crds/twingate.com.twingateconnector.yaml
- https://raw.githubusercontent.com/Twingate/kubernetes-operator/refs/heads/main/deploy/twingate-operator/crds/twingate.com.twingategroup.yaml
- https://raw.githubusercontent.com/Twingate/kubernetes-operator/refs/heads/main/deploy/twingate-operator/crds/twingate.com.twingateresourceaccesses.yaml
- https://raw.githubusercontent.com/Twingate/kubernetes-operator/refs/heads/main/deploy/twingate-operator/crds/twingate.com.twingateresources.yaml