### PR TITLE
chore(schemas): update SparkOperator CRD schemas from upstream

### DIFF
--- a/sparkoperator.k8s.io/scheduledsparkapplication_v1beta2.json
+++ b/sparkoperator.k8s.io/scheduledsparkapplication_v1beta2.json
@@ -2860,6 +2860,10 @@
                   "description": "Memory is the amount of memory to request for the pod.",
                   "type": "string"
                 },
+                "memoryLimit": {
+                  "description": "MemoryLimit overrides the memory limit of the pod.",
+                  "type": "string"
+                },
                 "memoryOverhead": {
                   "description": "MemoryOverhead is the amount of off-heap memory to allocate in cluster mode, in MiB unless otherwise specified.",
                   "type": "string"
@@ -4759,6 +4763,10 @@
                   "description": "MinExecutors is the lower bound for the number of executors if dynamic allocation is enabled.",
                   "format": "int32",
                   "type": "integer"
+                },
+                "shuffleTrackingEnabled": {
+                  "description": "ShuffleTrackingEnabled enables shuffle file tracking for executors, which allows dynamic allocation without\nthe need for an external shuffle service. This option will try to keep alive executors that are storing\nshuffle data for active jobs. If external shuffle service is enabled, set ShuffleTrackingEnabled to false.\nShuffleTrackingEnabled is true by default if dynamicAllocation.enabled is true.",
+                  "type": "boolean"
                 },
                 "shuffleTrackingTimeout": {
                   "description": "ShuffleTrackingTimeout controls the timeout in milliseconds for executors that are holding\nshuffle data if shuffle tracking is enabled (true by default if dynamic allocation is enabled).",
@@ -7495,6 +7503,10 @@
                 },
                 "memory": {
                   "description": "Memory is the amount of memory to request for the pod.",
+                  "type": "string"
+                },
+                "memoryLimit": {
+                  "description": "MemoryLimit overrides the memory limit of the pod.",
                   "type": "string"
                 },
                 "memoryOverhead": {
@@ -11078,6 +11090,10 @@
           ],
           "type": "object",
           "additionalProperties": false
+        },
+        "timeZone": {
+          "description": "TimeZone is the time zone in which the cron schedule will be interpreted in.\nThis value is passed to time.LoadLocation, so it must be either \"Local\", \"UTC\",\nor a valid IANA location name e.g. \"America/New_York\".\nDefaults to \"Local\".",
+          "type": "string"
         }
       },
       "required": [

--- a/sparkoperator.k8s.io/sparkapplication_v1beta2.json
+++ b/sparkoperator.k8s.io/sparkapplication_v1beta2.json
@@ -2835,6 +2835,10 @@
               "description": "Memory is the amount of memory to request for the pod.",
               "type": "string"
             },
+            "memoryLimit": {
+              "description": "MemoryLimit overrides the memory limit of the pod.",
+              "type": "string"
+            },
             "memoryOverhead": {
               "description": "MemoryOverhead is the amount of off-heap memory to allocate in cluster mode, in MiB unless otherwise specified.",
               "type": "string"
@@ -4734,6 +4738,10 @@
               "description": "MinExecutors is the lower bound for the number of executors if dynamic allocation is enabled.",
               "format": "int32",
               "type": "integer"
+            },
+            "shuffleTrackingEnabled": {
+              "description": "ShuffleTrackingEnabled enables shuffle file tracking for executors, which allows dynamic allocation without\nthe need for an external shuffle service. This option will try to keep alive executors that are storing\nshuffle data for active jobs. If external shuffle service is enabled, set ShuffleTrackingEnabled to false.\nShuffleTrackingEnabled is true by default if dynamicAllocation.enabled is true.",
+              "type": "boolean"
             },
             "shuffleTrackingTimeout": {
               "description": "ShuffleTrackingTimeout controls the timeout in milliseconds for executors that are holding\nshuffle data if shuffle tracking is enabled (true by default if dynamic allocation is enabled).",
@@ -7470,6 +7478,10 @@
             },
             "memory": {
               "description": "Memory is the amount of memory to request for the pod.",
+              "type": "string"
+            },
+            "memoryLimit": {
+              "description": "MemoryLimit overrides the memory limit of the pod.",
               "type": "string"
             },
             "memoryOverhead": {


### PR DESCRIPTION
### Summary

This PR updates the JSON schemas for SparkApplication and ScheduledSparkApplication using the latest CRD specifications from the [Kubeflow Spark Operator repository](https://github.com/kubeflow/spark-operator/tree/master/config/crd/bases). The schemas were regenerated using the `openapi2jsonschema.py` script to ensure compatibility with the current CRD definitions.

### Details

The following commands were used to generate the updated schemas:

```sh
$ python3 openapi2jsonschema.py https://raw.githubusercontent.com/kubeflow/spark-operator/refs/heads/master/config/crd/bases/sparkoperator.k8s.io_scheduledsparkapplications.yaml 
JSON schema written to scheduledsparkapplication_v1beta2.json

$ python3 openapi2jsonschema.py https://raw.githubusercontent.com/kubeflow/spark-operator/refs/heads/master/config/crd/bases/sparkoperator.k8s.io_sparkapplications.yaml
JSON schema written to sparkapplication_v1beta2.json
```
