### PR TITLE
Fixing twingateresourceaccess's invalid json

### DIFF
--- a/twingate.com/twingateresourceaccess_v1beta.json
+++ b/twingate.com/twingateresourceaccess_v1beta.json
@@ -10,21 +10,18 @@
       "description": "TwingateResourceAccessSpec defines the desired state of TwingateResourceAccess",
       "oneOf": [
         {
-          "properties": null,
           "required": [
             "resourceRef",
             "principalId"
           ]
         },
         {
-          "properties": null,
           "required": [
             "resourceRef",
             "principalExternalRef"
           ]
         },
         {
-          "properties": null,
           "required": [
             "resourceRef",
             "groupRef"


### PR DESCRIPTION
## PR Checklist

- [x] I have used the [CRD Extractor](https://github.com/datreeio/CRDs-catalog?tab=readme-ov-file#crd-extractor) tool to generate these CRDs

I believe the presence of empty `properties` in the oneOf clauses is causing failures