### PR TITLE
add crossplane azure providerconfig.

### DIFF
--- a/azure.upbound.io/providerconfig_v1beta1.json
+++ b/azure.upbound.io/providerconfig_v1beta1.json
@@ -1,0 +1,188 @@
+{
+  "description": "A ProviderConfig configures the Azure provider.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "A ProviderConfigSpec defines the desired state of a ProviderConfig.",
+      "properties": {
+        "clientID": {
+          "description": "ClientID is the user-assigned managed identity's ID\nwhen Credentials.Source is `InjectedIdentity`. If unset and\nCredentials.Source is `InjectedIdentity`, then a system-assigned\nmanaged identity is used.",
+          "type": "string"
+        },
+        "credentials": {
+          "description": "Credentials required to authenticate to this provider.",
+          "properties": {
+            "env": {
+              "description": "Env is a reference to an environment variable that contains credentials\nthat must be used to connect to the provider.",
+              "properties": {
+                "name": {
+                  "description": "Name is the name of an environment variable.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "fs": {
+              "description": "Fs is a reference to a filesystem location that contains credentials that\nmust be used to connect to the provider.",
+              "properties": {
+                "path": {
+                  "description": "Path is a filesystem path.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "path"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "secretRef": {
+              "description": "A SecretRef is a reference to a secret key that contains the credentials\nthat must be used to connect to the provider.",
+              "properties": {
+                "key": {
+                  "description": "The key to select.",
+                  "type": "string"
+                },
+                "name": {
+                  "description": "Name of the secret.",
+                  "type": "string"
+                },
+                "namespace": {
+                  "description": "Namespace of the secret.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "key",
+                "name",
+                "namespace"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "source": {
+              "description": "Source of the provider credentials.",
+              "enum": [
+                "None",
+                "Secret",
+                "UserAssignedManagedIdentity",
+                "SystemAssignedManagedIdentity",
+                "OIDCTokenFile",
+                "Upbound",
+                "Filesystem"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "source"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "environment": {
+          "description": "The Cloud Environment which should be used. Possible values are \"public\",\n\"usgovernment\", \"german\", and \"china\". Defaults to \"public\".",
+          "type": "string"
+        },
+        "msiEndpoint": {
+          "description": "MSIEndpoint is the optional path to a custom endpoint for\nManaged Service Identity.",
+          "type": "string"
+        },
+        "oidcTokenFilePath": {
+          "description": "OIDCTokenFilePath is the optional path to a token file\nthat allows to access a managed identity.",
+          "type": "string"
+        },
+        "subscriptionID": {
+          "description": "SubscriptionID is the Azure subscription ID to be used.\nIf unset, subscription ID from Credentials will be used.\nRequired if Credentials.Source is InjectedIdentity.",
+          "type": "string"
+        },
+        "tenantID": {
+          "description": "TenantID is the Azure AD tenant ID to be used.\nIf unset, tenant ID from Credentials will be used.\nRequired if Credentials.Source is InjectedIdentity.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "credentials"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "A ProviderConfigStatus reflects the observed state of a ProviderConfig.",
+      "properties": {
+        "conditions": {
+          "description": "Conditions of the resource.",
+          "items": {
+            "description": "A Condition that may apply to a resource.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "LastTransitionTime is the last time this condition transitioned from one\nstatus to another.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A Message containing details about this condition's last transition from\none status to another, if any.",
+                "type": "string"
+              },
+              "observedGeneration": {
+                "description": "ObservedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
+                "format": "int64",
+                "type": "integer"
+              },
+              "reason": {
+                "description": "A Reason for this condition's last transition from one status to another.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of this condition; is it currently True, False, or Unknown?",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of this condition. At most one of each condition type may apply to\na resource at any point in time.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "reason",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "type"
+          ],
+          "x-kubernetes-list-type": "map"
+        },
+        "users": {
+          "description": "Users of this provider configuration.",
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "spec"
+  ],
+  "type": "object"
+}


### PR DESCRIPTION
## PR Checklist

- [ ] I have used the [CRD Extractor](https://github.com/datreeio/CRDs-catalog?tab=readme-ov-file#crd-extractor) tool to generate these CRDs

Not exactly the CRD Extractor. I ran the following for only extracting the providerconfig - taken from the CRD Extractor script:

```shell
export FILENAME_FORMAT="{fullgroup}_{kind}_{version}"
SCHEMAS_DIR=$(pwd)

python3 ./Utilities/openapi2jsonschema.py https://raw.githubusercontent.com/crossplane-contrib/provider-upjet-azure/refs/heads/main/package/crds/azure.upbound.io_providerconfigs.yaml

for schema in "$SCHEMAS_DIR"/*.json; do             
    crdFileName=$(basename "$schema")
    crdGroup=$(echo "$crdFileName" | cut -d"_" -f1)
    outName=$(echo "$crdFileName" | cut -d"_" -f2-)
    mkdir -p "$crdGroup"
    mv "$schema" "./$crdGroup/$outName"
done
```