### PR TITLE
Update k6.io CRDs definition

### DIFF
--- a/k6.io/privateloadzone_v1alpha1.json
+++ b/k6.io/privateloadzone_v1alpha1.json
@@ -1,0 +1,208 @@
+{
+  "properties": {
+    "apiVersion": {
+      "type": "string"
+    },
+    "kind": {
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "properties": {
+        "config": {
+          "properties": {
+            "secrets": {
+              "items": {
+                "properties": {
+                  "configMapRef": {
+                    "properties": {
+                      "name": {
+                        "default": "",
+                        "type": "string"
+                      },
+                      "optional": {
+                        "type": "boolean"
+                      }
+                    },
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  },
+                  "secretRef": {
+                    "properties": {
+                      "name": {
+                        "default": "",
+                        "type": "string"
+                      },
+                      "optional": {
+                        "type": "boolean"
+                      }
+                    },
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "image": {
+          "type": "string"
+        },
+        "imagePullSecrets": {
+          "items": {
+            "properties": {
+              "name": {
+                "default": "",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "x-kubernetes-map-type": "atomic",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "nodeSelector": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "resources": {
+          "properties": {
+            "claims": {
+              "items": {
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "request": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array",
+              "x-kubernetes-list-map-keys": [
+                "name"
+              ],
+              "x-kubernetes-list-type": "map"
+            },
+            "limits": {
+              "additionalProperties": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ],
+                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                "x-kubernetes-int-or-string": true
+              },
+              "type": "object"
+            },
+            "requests": {
+              "additionalProperties": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ],
+                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                "x-kubernetes-int-or-string": true
+              },
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "serviceAccountName": {
+          "type": "string"
+        },
+        "token": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "resources",
+        "token"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "properties": {
+        "conditions": {
+          "items": {
+            "properties": {
+              "lastTransitionTime": {
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "maxLength": 32768,
+                "type": "string"
+              },
+              "observedGeneration": {
+                "format": "int64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "reason": {
+                "maxLength": 1024,
+                "minLength": 1,
+                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
+                "type": "string"
+              },
+              "status": {
+                "enum": [
+                  "True",
+                  "False",
+                  "Unknown"
+                ],
+                "type": "string"
+              },
+              "type": {
+                "maxLength": 316,
+                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "message",
+              "reason",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/k6.io/testrun_v1alpha1.json
+++ b/k6.io/testrun_v1alpha1.json
@@ -44,7 +44,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -54,7 +55,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchFields": {
                                 "items": {
@@ -69,7 +71,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -79,7 +82,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               }
                             },
                             "type": "object",
@@ -98,7 +102,8 @@
                         "type": "object",
                         "additionalProperties": false
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     },
                     "requiredDuringSchedulingIgnoredDuringExecution": {
                       "properties": {
@@ -118,7 +123,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -128,7 +134,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchFields": {
                                 "items": {
@@ -143,7 +150,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -153,14 +161,16 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               }
                             },
                             "type": "object",
                             "x-kubernetes-map-type": "atomic",
                             "additionalProperties": false
                           },
-                          "type": "array"
+                          "type": "array",
+                          "x-kubernetes-list-type": "atomic"
                         }
                       },
                       "required": [
@@ -196,7 +206,8 @@
                                           "items": {
                                             "type": "string"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       },
                                       "required": [
@@ -206,7 +217,8 @@
                                       "type": "object",
                                       "additionalProperties": false
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "matchLabels": {
                                     "additionalProperties": {
@@ -218,6 +230,20 @@
                                 "type": "object",
                                 "x-kubernetes-map-type": "atomic",
                                 "additionalProperties": false
+                              },
+                              "matchLabelKeys": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "mismatchLabelKeys": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "namespaceSelector": {
                                 "properties": {
@@ -234,7 +260,8 @@
                                           "items": {
                                             "type": "string"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       },
                                       "required": [
@@ -244,7 +271,8 @@
                                       "type": "object",
                                       "additionalProperties": false
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "matchLabels": {
                                     "additionalProperties": {
@@ -261,7 +289,8 @@
                                 "items": {
                                   "type": "string"
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "topologyKey": {
                                 "type": "string"
@@ -285,7 +314,8 @@
                         "type": "object",
                         "additionalProperties": false
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     },
                     "requiredDuringSchedulingIgnoredDuringExecution": {
                       "items": {
@@ -305,7 +335,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -315,7 +346,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchLabels": {
                                 "additionalProperties": {
@@ -327,6 +359,20 @@
                             "type": "object",
                             "x-kubernetes-map-type": "atomic",
                             "additionalProperties": false
+                          },
+                          "matchLabelKeys": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "mismatchLabelKeys": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "namespaceSelector": {
                             "properties": {
@@ -343,7 +389,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -353,7 +400,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchLabels": {
                                 "additionalProperties": {
@@ -370,7 +418,8 @@
                             "items": {
                               "type": "string"
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "topologyKey": {
                             "type": "string"
@@ -382,7 +431,8 @@
                         "type": "object",
                         "additionalProperties": false
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     }
                   },
                   "type": "object",
@@ -410,7 +460,8 @@
                                           "items": {
                                             "type": "string"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       },
                                       "required": [
@@ -420,7 +471,8 @@
                                       "type": "object",
                                       "additionalProperties": false
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "matchLabels": {
                                     "additionalProperties": {
@@ -432,6 +484,20 @@
                                 "type": "object",
                                 "x-kubernetes-map-type": "atomic",
                                 "additionalProperties": false
+                              },
+                              "matchLabelKeys": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "mismatchLabelKeys": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "namespaceSelector": {
                                 "properties": {
@@ -448,7 +514,8 @@
                                           "items": {
                                             "type": "string"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       },
                                       "required": [
@@ -458,7 +525,8 @@
                                       "type": "object",
                                       "additionalProperties": false
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "matchLabels": {
                                     "additionalProperties": {
@@ -475,7 +543,8 @@
                                 "items": {
                                   "type": "string"
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "topologyKey": {
                                 "type": "string"
@@ -499,7 +568,8 @@
                         "type": "object",
                         "additionalProperties": false
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     },
                     "requiredDuringSchedulingIgnoredDuringExecution": {
                       "items": {
@@ -519,7 +589,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -529,7 +600,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchLabels": {
                                 "additionalProperties": {
@@ -541,6 +613,20 @@
                             "type": "object",
                             "x-kubernetes-map-type": "atomic",
                             "additionalProperties": false
+                          },
+                          "matchLabelKeys": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "mismatchLabelKeys": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "namespaceSelector": {
                             "properties": {
@@ -557,7 +643,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -567,7 +654,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchLabels": {
                                 "additionalProperties": {
@@ -584,7 +672,8 @@
                             "items": {
                               "type": "string"
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "topologyKey": {
                             "type": "string"
@@ -596,7 +685,8 @@
                         "type": "object",
                         "additionalProperties": false
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     }
                   },
                   "type": "object",
@@ -608,6 +698,121 @@
             },
             "automountServiceAccountToken": {
               "type": "string"
+            },
+            "containerSecurityContext": {
+              "properties": {
+                "allowPrivilegeEscalation": {
+                  "type": "boolean"
+                },
+                "appArmorProfile": {
+                  "properties": {
+                    "localhostProfile": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "capabilities": {
+                  "properties": {
+                    "add": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
+                    },
+                    "drop": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "privileged": {
+                  "type": "boolean"
+                },
+                "procMount": {
+                  "type": "string"
+                },
+                "readOnlyRootFilesystem": {
+                  "type": "boolean"
+                },
+                "runAsGroup": {
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "runAsNonRoot": {
+                  "type": "boolean"
+                },
+                "runAsUser": {
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "seLinuxOptions": {
+                  "properties": {
+                    "level": {
+                      "type": "string"
+                    },
+                    "role": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string"
+                    },
+                    "user": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "seccompProfile": {
+                  "properties": {
+                    "localhostProfile": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "windowsOptions": {
+                  "properties": {
+                    "gmsaCredentialSpec": {
+                      "type": "string"
+                    },
+                    "gmsaCredentialSpecName": {
+                      "type": "string"
+                    },
+                    "hostProcess": {
+                      "type": "boolean"
+                    },
+                    "runAsUserName": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
             },
             "env": {
               "items": {
@@ -626,6 +831,7 @@
                             "type": "string"
                           },
                           "name": {
+                            "default": "",
                             "type": "string"
                           },
                           "optional": {
@@ -689,6 +895,7 @@
                             "type": "string"
                           },
                           "name": {
+                            "default": "",
                             "type": "string"
                           },
                           "optional": {
@@ -721,6 +928,7 @@
                   "configMapRef": {
                     "properties": {
                       "name": {
+                        "default": "",
                         "type": "string"
                       },
                       "optional": {
@@ -737,6 +945,7 @@
                   "secretRef": {
                     "properties": {
                       "name": {
+                        "default": "",
                         "type": "string"
                       },
                       "optional": {
@@ -763,6 +972,7 @@
               "items": {
                 "properties": {
                   "name": {
+                    "default": "",
                     "type": "string"
                   }
                 },
@@ -804,6 +1014,7 @@
                                   "type": "string"
                                 },
                                 "name": {
+                                  "default": "",
                                   "type": "string"
                                 },
                                 "optional": {
@@ -867,6 +1078,7 @@
                                   "type": "string"
                                 },
                                 "name": {
+                                  "default": "",
                                   "type": "string"
                                 },
                                 "optional": {
@@ -899,6 +1111,7 @@
                         "configMapRef": {
                           "properties": {
                             "name": {
+                              "default": "",
                               "type": "string"
                             },
                             "optional": {
@@ -915,6 +1128,7 @@
                         "secretRef": {
                           "properties": {
                             "name": {
+                              "default": "",
                               "type": "string"
                             },
                             "optional": {
@@ -937,6 +1151,9 @@
                   "name": {
                     "type": "string"
                   },
+                  "restartPolicy": {
+                    "type": "string"
+                  },
                   "volumeMounts": {
                     "items": {
                       "properties": {
@@ -951,6 +1168,9 @@
                         },
                         "readOnly": {
                           "type": "boolean"
+                        },
+                        "recursiveReadOnly": {
+                          "type": "string"
                         },
                         "subPath": {
                           "type": "string"
@@ -985,7 +1205,8 @@
                       "items": {
                         "type": "string"
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     }
                   },
                   "type": "object",
@@ -1002,6 +1223,7 @@
                       "type": "integer"
                     },
                     "service": {
+                      "default": "",
                       "type": "string"
                     }
                   },
@@ -1033,7 +1255,8 @@
                         "type": "object",
                         "additionalProperties": false
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     },
                     "path": {
                       "type": "string"
@@ -1138,7 +1361,8 @@
                       "items": {
                         "type": "string"
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     }
                   },
                   "type": "object",
@@ -1155,6 +1379,7 @@
                       "type": "integer"
                     },
                     "service": {
+                      "default": "",
                       "type": "string"
                     }
                   },
@@ -1186,7 +1411,8 @@
                         "type": "object",
                         "additionalProperties": false
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     },
                     "path": {
                       "type": "string"
@@ -1266,6 +1492,9 @@
                     "properties": {
                       "name": {
                         "type": "string"
+                      },
+                      "request": {
+                        "type": "string"
                       }
                     },
                     "required": [
@@ -1316,6 +1545,21 @@
             },
             "securityContext": {
               "properties": {
+                "appArmorProfile": {
+                  "properties": {
+                    "localhostProfile": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
                 "fsGroup": {
                   "format": "int64",
                   "type": "integer"
@@ -1333,6 +1577,9 @@
                 "runAsUser": {
                   "format": "int64",
                   "type": "integer"
+                },
+                "seLinuxChangePolicy": {
+                  "type": "string"
                 },
                 "seLinuxOptions": {
                   "properties": {
@@ -1372,7 +1619,11 @@
                     "format": "int64",
                     "type": "integer"
                   },
-                  "type": "array"
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                },
+                "supplementalGroupsPolicy": {
+                  "type": "string"
                 },
                 "sysctls": {
                   "items": {
@@ -1391,7 +1642,8 @@
                     "type": "object",
                     "additionalProperties": false
                   },
-                  "type": "array"
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
                 },
                 "windowsOptions": {
                   "properties": {
@@ -1443,6 +1695,87 @@
               },
               "type": "array"
             },
+            "topologySpreadConstraints": {
+              "items": {
+                "properties": {
+                  "labelSelector": {
+                    "properties": {
+                      "matchExpressions": {
+                        "items": {
+                          "properties": {
+                            "key": {
+                              "type": "string"
+                            },
+                            "operator": {
+                              "type": "string"
+                            },
+                            "values": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
+                            }
+                          },
+                          "required": [
+                            "key",
+                            "operator"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
+                      },
+                      "matchLabels": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "type": "object"
+                      }
+                    },
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  },
+                  "matchLabelKeys": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  },
+                  "maxSkew": {
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "minDomains": {
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "nodeAffinityPolicy": {
+                    "type": "string"
+                  },
+                  "nodeTaintsPolicy": {
+                    "type": "string"
+                  },
+                  "topologyKey": {
+                    "type": "string"
+                  },
+                  "whenUnsatisfiable": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "maxSkew",
+                  "topologyKey",
+                  "whenUnsatisfiable"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
             "volumeMounts": {
               "items": {
                 "properties": {
@@ -1457,6 +1790,9 @@
                   },
                   "readOnly": {
                     "type": "boolean"
+                  },
+                  "recursiveReadOnly": {
+                    "type": "string"
                   },
                   "subPath": {
                     "type": "string"
@@ -1511,12 +1847,14 @@
                         "type": "string"
                       },
                       "fsType": {
+                        "default": "ext4",
                         "type": "string"
                       },
                       "kind": {
                         "type": "string"
                       },
                       "readOnly": {
+                        "default": false,
                         "type": "boolean"
                       }
                     },
@@ -1552,7 +1890,8 @@
                         "items": {
                           "type": "string"
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "path": {
                         "type": "string"
@@ -1566,6 +1905,7 @@
                       "secretRef": {
                         "properties": {
                           "name": {
+                            "default": "",
                             "type": "string"
                           }
                         },
@@ -1594,6 +1934,7 @@
                       "secretRef": {
                         "properties": {
                           "name": {
+                            "default": "",
                             "type": "string"
                           }
                         },
@@ -1638,9 +1979,11 @@
                           "type": "object",
                           "additionalProperties": false
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "name": {
+                        "default": "",
                         "type": "string"
                       },
                       "optional": {
@@ -1662,6 +2005,7 @@
                       "nodePublishSecretRef": {
                         "properties": {
                           "name": {
+                            "default": "",
                             "type": "string"
                           }
                         },
@@ -1752,7 +2096,8 @@
                           "type": "object",
                           "additionalProperties": false
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       }
                     },
                     "type": "object",
@@ -1792,7 +2137,8 @@
                                 "items": {
                                   "type": "string"
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "dataSource": {
                                 "properties": {
@@ -1838,25 +2184,6 @@
                               },
                               "resources": {
                                 "properties": {
-                                  "claims": {
-                                    "items": {
-                                      "properties": {
-                                        "name": {
-                                          "type": "string"
-                                        }
-                                      },
-                                      "required": [
-                                        "name"
-                                      ],
-                                      "type": "object",
-                                      "additionalProperties": false
-                                    },
-                                    "type": "array",
-                                    "x-kubernetes-list-map-keys": [
-                                      "name"
-                                    ],
-                                    "x-kubernetes-list-type": "map"
-                                  },
                                   "limits": {
                                     "additionalProperties": {
                                       "anyOf": [
@@ -1906,7 +2233,8 @@
                                           "items": {
                                             "type": "string"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       },
                                       "required": [
@@ -1916,7 +2244,8 @@
                                       "type": "object",
                                       "additionalProperties": false
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "matchLabels": {
                                     "additionalProperties": {
@@ -1930,6 +2259,9 @@
                                 "additionalProperties": false
                               },
                               "storageClassName": {
+                                "type": "string"
+                              },
+                              "volumeAttributesClassName": {
                                 "type": "string"
                               },
                               "volumeMode": {
@@ -1969,13 +2301,15 @@
                         "items": {
                           "type": "string"
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "wwids": {
                         "items": {
                           "type": "string"
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       }
                     },
                     "type": "object",
@@ -2001,6 +2335,7 @@
                       "secretRef": {
                         "properties": {
                           "name": {
+                            "default": "",
                             "type": "string"
                           }
                         },
@@ -2101,6 +2436,18 @@
                     "type": "object",
                     "additionalProperties": false
                   },
+                  "image": {
+                    "properties": {
+                      "pullPolicy": {
+                        "type": "string"
+                      },
+                      "reference": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
                   "iscsi": {
                     "properties": {
                       "chapAuthDiscovery": {
@@ -2119,6 +2466,7 @@
                         "type": "string"
                       },
                       "iscsiInterface": {
+                        "default": "default",
                         "type": "string"
                       },
                       "lun": {
@@ -2129,7 +2477,8 @@
                         "items": {
                           "type": "string"
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "readOnly": {
                         "type": "boolean"
@@ -2137,6 +2486,7 @@
                       "secretRef": {
                         "properties": {
                           "name": {
+                            "default": "",
                             "type": "string"
                           }
                         },
@@ -2235,6 +2585,67 @@
                       "sources": {
                         "items": {
                           "properties": {
+                            "clusterTrustBundle": {
+                              "properties": {
+                                "labelSelector": {
+                                  "properties": {
+                                    "matchExpressions": {
+                                      "items": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "operator": {
+                                            "type": "string"
+                                          },
+                                          "values": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
+                                          }
+                                        },
+                                        "required": [
+                                          "key",
+                                          "operator"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    },
+                                    "matchLabels": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                },
+                                "path": {
+                                  "type": "string"
+                                },
+                                "signerName": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "path"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
                             "configMap": {
                               "properties": {
                                 "items": {
@@ -2258,9 +2669,11 @@
                                     "type": "object",
                                     "additionalProperties": false
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "name": {
+                                  "default": "",
                                   "type": "string"
                                 },
                                 "optional": {
@@ -2334,7 +2747,8 @@
                                     "type": "object",
                                     "additionalProperties": false
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               },
                               "type": "object",
@@ -2363,9 +2777,11 @@
                                     "type": "object",
                                     "additionalProperties": false
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "name": {
+                                  "default": "",
                                   "type": "string"
                                 },
                                 "optional": {
@@ -2399,7 +2815,8 @@
                           "type": "object",
                           "additionalProperties": false
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       }
                     },
                     "type": "object",
@@ -2442,15 +2859,18 @@
                         "type": "string"
                       },
                       "keyring": {
+                        "default": "/etc/ceph/keyring",
                         "type": "string"
                       },
                       "monitors": {
                         "items": {
                           "type": "string"
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "pool": {
+                        "default": "rbd",
                         "type": "string"
                       },
                       "readOnly": {
@@ -2459,6 +2879,7 @@
                       "secretRef": {
                         "properties": {
                           "name": {
+                            "default": "",
                             "type": "string"
                           }
                         },
@@ -2467,6 +2888,7 @@
                         "additionalProperties": false
                       },
                       "user": {
+                        "default": "admin",
                         "type": "string"
                       }
                     },
@@ -2480,6 +2902,7 @@
                   "scaleIO": {
                     "properties": {
                       "fsType": {
+                        "default": "xfs",
                         "type": "string"
                       },
                       "gateway": {
@@ -2494,6 +2917,7 @@
                       "secretRef": {
                         "properties": {
                           "name": {
+                            "default": "",
                             "type": "string"
                           }
                         },
@@ -2505,6 +2929,7 @@
                         "type": "boolean"
                       },
                       "storageMode": {
+                        "default": "ThinProvisioned",
                         "type": "string"
                       },
                       "storagePool": {
@@ -2552,7 +2977,8 @@
                           "type": "object",
                           "additionalProperties": false
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "optional": {
                         "type": "boolean"
@@ -2575,6 +3001,7 @@
                       "secretRef": {
                         "properties": {
                           "name": {
+                            "default": "",
                             "type": "string"
                           }
                         },
@@ -2631,6 +3058,7 @@
           "type": "integer"
         },
         "paused": {
+          "default": "true",
           "type": "string"
         },
         "ports": {
@@ -2664,6 +3092,7 @@
           "type": "array"
         },
         "quiet": {
+          "default": "true",
           "type": "string"
         },
         "runner": {
@@ -2690,7 +3119,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -2700,7 +3130,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchFields": {
                                 "items": {
@@ -2715,7 +3146,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -2725,7 +3157,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               }
                             },
                             "type": "object",
@@ -2744,7 +3177,8 @@
                         "type": "object",
                         "additionalProperties": false
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     },
                     "requiredDuringSchedulingIgnoredDuringExecution": {
                       "properties": {
@@ -2764,7 +3198,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -2774,7 +3209,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchFields": {
                                 "items": {
@@ -2789,7 +3225,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -2799,14 +3236,16 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               }
                             },
                             "type": "object",
                             "x-kubernetes-map-type": "atomic",
                             "additionalProperties": false
                           },
-                          "type": "array"
+                          "type": "array",
+                          "x-kubernetes-list-type": "atomic"
                         }
                       },
                       "required": [
@@ -2842,7 +3281,8 @@
                                           "items": {
                                             "type": "string"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       },
                                       "required": [
@@ -2852,7 +3292,8 @@
                                       "type": "object",
                                       "additionalProperties": false
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "matchLabels": {
                                     "additionalProperties": {
@@ -2864,6 +3305,20 @@
                                 "type": "object",
                                 "x-kubernetes-map-type": "atomic",
                                 "additionalProperties": false
+                              },
+                              "matchLabelKeys": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "mismatchLabelKeys": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "namespaceSelector": {
                                 "properties": {
@@ -2880,7 +3335,8 @@
                                           "items": {
                                             "type": "string"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       },
                                       "required": [
@@ -2890,7 +3346,8 @@
                                       "type": "object",
                                       "additionalProperties": false
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "matchLabels": {
                                     "additionalProperties": {
@@ -2907,7 +3364,8 @@
                                 "items": {
                                   "type": "string"
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "topologyKey": {
                                 "type": "string"
@@ -2931,7 +3389,8 @@
                         "type": "object",
                         "additionalProperties": false
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     },
                     "requiredDuringSchedulingIgnoredDuringExecution": {
                       "items": {
@@ -2951,7 +3410,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -2961,7 +3421,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchLabels": {
                                 "additionalProperties": {
@@ -2973,6 +3434,20 @@
                             "type": "object",
                             "x-kubernetes-map-type": "atomic",
                             "additionalProperties": false
+                          },
+                          "matchLabelKeys": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "mismatchLabelKeys": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "namespaceSelector": {
                             "properties": {
@@ -2989,7 +3464,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -2999,7 +3475,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchLabels": {
                                 "additionalProperties": {
@@ -3016,7 +3493,8 @@
                             "items": {
                               "type": "string"
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "topologyKey": {
                             "type": "string"
@@ -3028,7 +3506,8 @@
                         "type": "object",
                         "additionalProperties": false
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     }
                   },
                   "type": "object",
@@ -3056,7 +3535,8 @@
                                           "items": {
                                             "type": "string"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       },
                                       "required": [
@@ -3066,7 +3546,8 @@
                                       "type": "object",
                                       "additionalProperties": false
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "matchLabels": {
                                     "additionalProperties": {
@@ -3078,6 +3559,20 @@
                                 "type": "object",
                                 "x-kubernetes-map-type": "atomic",
                                 "additionalProperties": false
+                              },
+                              "matchLabelKeys": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "mismatchLabelKeys": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "namespaceSelector": {
                                 "properties": {
@@ -3094,7 +3589,8 @@
                                           "items": {
                                             "type": "string"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       },
                                       "required": [
@@ -3104,7 +3600,8 @@
                                       "type": "object",
                                       "additionalProperties": false
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "matchLabels": {
                                     "additionalProperties": {
@@ -3121,7 +3618,8 @@
                                 "items": {
                                   "type": "string"
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "topologyKey": {
                                 "type": "string"
@@ -3145,7 +3643,8 @@
                         "type": "object",
                         "additionalProperties": false
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     },
                     "requiredDuringSchedulingIgnoredDuringExecution": {
                       "items": {
@@ -3165,7 +3664,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -3175,7 +3675,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchLabels": {
                                 "additionalProperties": {
@@ -3187,6 +3688,20 @@
                             "type": "object",
                             "x-kubernetes-map-type": "atomic",
                             "additionalProperties": false
+                          },
+                          "matchLabelKeys": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "mismatchLabelKeys": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "namespaceSelector": {
                             "properties": {
@@ -3203,7 +3718,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -3213,7 +3729,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchLabels": {
                                 "additionalProperties": {
@@ -3230,7 +3747,8 @@
                             "items": {
                               "type": "string"
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "topologyKey": {
                             "type": "string"
@@ -3242,7 +3760,8 @@
                         "type": "object",
                         "additionalProperties": false
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     }
                   },
                   "type": "object",
@@ -3254,6 +3773,121 @@
             },
             "automountServiceAccountToken": {
               "type": "string"
+            },
+            "containerSecurityContext": {
+              "properties": {
+                "allowPrivilegeEscalation": {
+                  "type": "boolean"
+                },
+                "appArmorProfile": {
+                  "properties": {
+                    "localhostProfile": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "capabilities": {
+                  "properties": {
+                    "add": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
+                    },
+                    "drop": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "privileged": {
+                  "type": "boolean"
+                },
+                "procMount": {
+                  "type": "string"
+                },
+                "readOnlyRootFilesystem": {
+                  "type": "boolean"
+                },
+                "runAsGroup": {
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "runAsNonRoot": {
+                  "type": "boolean"
+                },
+                "runAsUser": {
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "seLinuxOptions": {
+                  "properties": {
+                    "level": {
+                      "type": "string"
+                    },
+                    "role": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string"
+                    },
+                    "user": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "seccompProfile": {
+                  "properties": {
+                    "localhostProfile": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "windowsOptions": {
+                  "properties": {
+                    "gmsaCredentialSpec": {
+                      "type": "string"
+                    },
+                    "gmsaCredentialSpecName": {
+                      "type": "string"
+                    },
+                    "hostProcess": {
+                      "type": "boolean"
+                    },
+                    "runAsUserName": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
             },
             "env": {
               "items": {
@@ -3272,6 +3906,7 @@
                             "type": "string"
                           },
                           "name": {
+                            "default": "",
                             "type": "string"
                           },
                           "optional": {
@@ -3335,6 +3970,7 @@
                             "type": "string"
                           },
                           "name": {
+                            "default": "",
                             "type": "string"
                           },
                           "optional": {
@@ -3367,6 +4003,7 @@
                   "configMapRef": {
                     "properties": {
                       "name": {
+                        "default": "",
                         "type": "string"
                       },
                       "optional": {
@@ -3383,6 +4020,7 @@
                   "secretRef": {
                     "properties": {
                       "name": {
+                        "default": "",
                         "type": "string"
                       },
                       "optional": {
@@ -3409,6 +4047,7 @@
               "items": {
                 "properties": {
                   "name": {
+                    "default": "",
                     "type": "string"
                   }
                 },
@@ -3450,6 +4089,7 @@
                                   "type": "string"
                                 },
                                 "name": {
+                                  "default": "",
                                   "type": "string"
                                 },
                                 "optional": {
@@ -3513,6 +4153,7 @@
                                   "type": "string"
                                 },
                                 "name": {
+                                  "default": "",
                                   "type": "string"
                                 },
                                 "optional": {
@@ -3545,6 +4186,7 @@
                         "configMapRef": {
                           "properties": {
                             "name": {
+                              "default": "",
                               "type": "string"
                             },
                             "optional": {
@@ -3561,6 +4203,7 @@
                         "secretRef": {
                           "properties": {
                             "name": {
+                              "default": "",
                               "type": "string"
                             },
                             "optional": {
@@ -3583,6 +4226,9 @@
                   "name": {
                     "type": "string"
                   },
+                  "restartPolicy": {
+                    "type": "string"
+                  },
                   "volumeMounts": {
                     "items": {
                       "properties": {
@@ -3597,6 +4243,9 @@
                         },
                         "readOnly": {
                           "type": "boolean"
+                        },
+                        "recursiveReadOnly": {
+                          "type": "string"
                         },
                         "subPath": {
                           "type": "string"
@@ -3631,7 +4280,8 @@
                       "items": {
                         "type": "string"
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     }
                   },
                   "type": "object",
@@ -3648,6 +4298,7 @@
                       "type": "integer"
                     },
                     "service": {
+                      "default": "",
                       "type": "string"
                     }
                   },
@@ -3679,7 +4330,8 @@
                         "type": "object",
                         "additionalProperties": false
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     },
                     "path": {
                       "type": "string"
@@ -3784,7 +4436,8 @@
                       "items": {
                         "type": "string"
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     }
                   },
                   "type": "object",
@@ -3801,6 +4454,7 @@
                       "type": "integer"
                     },
                     "service": {
+                      "default": "",
                       "type": "string"
                     }
                   },
@@ -3832,7 +4486,8 @@
                         "type": "object",
                         "additionalProperties": false
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     },
                     "path": {
                       "type": "string"
@@ -3912,6 +4567,9 @@
                     "properties": {
                       "name": {
                         "type": "string"
+                      },
+                      "request": {
+                        "type": "string"
                       }
                     },
                     "required": [
@@ -3962,6 +4620,21 @@
             },
             "securityContext": {
               "properties": {
+                "appArmorProfile": {
+                  "properties": {
+                    "localhostProfile": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
                 "fsGroup": {
                   "format": "int64",
                   "type": "integer"
@@ -3979,6 +4652,9 @@
                 "runAsUser": {
                   "format": "int64",
                   "type": "integer"
+                },
+                "seLinuxChangePolicy": {
+                  "type": "string"
                 },
                 "seLinuxOptions": {
                   "properties": {
@@ -4018,7 +4694,11 @@
                     "format": "int64",
                     "type": "integer"
                   },
-                  "type": "array"
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                },
+                "supplementalGroupsPolicy": {
+                  "type": "string"
                 },
                 "sysctls": {
                   "items": {
@@ -4037,7 +4717,8 @@
                     "type": "object",
                     "additionalProperties": false
                   },
-                  "type": "array"
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
                 },
                 "windowsOptions": {
                   "properties": {
@@ -4089,6 +4770,87 @@
               },
               "type": "array"
             },
+            "topologySpreadConstraints": {
+              "items": {
+                "properties": {
+                  "labelSelector": {
+                    "properties": {
+                      "matchExpressions": {
+                        "items": {
+                          "properties": {
+                            "key": {
+                              "type": "string"
+                            },
+                            "operator": {
+                              "type": "string"
+                            },
+                            "values": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
+                            }
+                          },
+                          "required": [
+                            "key",
+                            "operator"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
+                      },
+                      "matchLabels": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "type": "object"
+                      }
+                    },
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  },
+                  "matchLabelKeys": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  },
+                  "maxSkew": {
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "minDomains": {
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "nodeAffinityPolicy": {
+                    "type": "string"
+                  },
+                  "nodeTaintsPolicy": {
+                    "type": "string"
+                  },
+                  "topologyKey": {
+                    "type": "string"
+                  },
+                  "whenUnsatisfiable": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "maxSkew",
+                  "topologyKey",
+                  "whenUnsatisfiable"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
             "volumeMounts": {
               "items": {
                 "properties": {
@@ -4103,6 +4865,9 @@
                   },
                   "readOnly": {
                     "type": "boolean"
+                  },
+                  "recursiveReadOnly": {
+                    "type": "string"
                   },
                   "subPath": {
                     "type": "string"
@@ -4157,12 +4922,14 @@
                         "type": "string"
                       },
                       "fsType": {
+                        "default": "ext4",
                         "type": "string"
                       },
                       "kind": {
                         "type": "string"
                       },
                       "readOnly": {
+                        "default": false,
                         "type": "boolean"
                       }
                     },
@@ -4198,7 +4965,8 @@
                         "items": {
                           "type": "string"
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "path": {
                         "type": "string"
@@ -4212,6 +4980,7 @@
                       "secretRef": {
                         "properties": {
                           "name": {
+                            "default": "",
                             "type": "string"
                           }
                         },
@@ -4240,6 +5009,7 @@
                       "secretRef": {
                         "properties": {
                           "name": {
+                            "default": "",
                             "type": "string"
                           }
                         },
@@ -4284,9 +5054,11 @@
                           "type": "object",
                           "additionalProperties": false
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "name": {
+                        "default": "",
                         "type": "string"
                       },
                       "optional": {
@@ -4308,6 +5080,7 @@
                       "nodePublishSecretRef": {
                         "properties": {
                           "name": {
+                            "default": "",
                             "type": "string"
                           }
                         },
@@ -4398,7 +5171,8 @@
                           "type": "object",
                           "additionalProperties": false
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       }
                     },
                     "type": "object",
@@ -4438,7 +5212,8 @@
                                 "items": {
                                   "type": "string"
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "dataSource": {
                                 "properties": {
@@ -4484,25 +5259,6 @@
                               },
                               "resources": {
                                 "properties": {
-                                  "claims": {
-                                    "items": {
-                                      "properties": {
-                                        "name": {
-                                          "type": "string"
-                                        }
-                                      },
-                                      "required": [
-                                        "name"
-                                      ],
-                                      "type": "object",
-                                      "additionalProperties": false
-                                    },
-                                    "type": "array",
-                                    "x-kubernetes-list-map-keys": [
-                                      "name"
-                                    ],
-                                    "x-kubernetes-list-type": "map"
-                                  },
                                   "limits": {
                                     "additionalProperties": {
                                       "anyOf": [
@@ -4552,7 +5308,8 @@
                                           "items": {
                                             "type": "string"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       },
                                       "required": [
@@ -4562,7 +5319,8 @@
                                       "type": "object",
                                       "additionalProperties": false
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "matchLabels": {
                                     "additionalProperties": {
@@ -4576,6 +5334,9 @@
                                 "additionalProperties": false
                               },
                               "storageClassName": {
+                                "type": "string"
+                              },
+                              "volumeAttributesClassName": {
                                 "type": "string"
                               },
                               "volumeMode": {
@@ -4615,13 +5376,15 @@
                         "items": {
                           "type": "string"
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "wwids": {
                         "items": {
                           "type": "string"
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       }
                     },
                     "type": "object",
@@ -4647,6 +5410,7 @@
                       "secretRef": {
                         "properties": {
                           "name": {
+                            "default": "",
                             "type": "string"
                           }
                         },
@@ -4747,6 +5511,18 @@
                     "type": "object",
                     "additionalProperties": false
                   },
+                  "image": {
+                    "properties": {
+                      "pullPolicy": {
+                        "type": "string"
+                      },
+                      "reference": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
                   "iscsi": {
                     "properties": {
                       "chapAuthDiscovery": {
@@ -4765,6 +5541,7 @@
                         "type": "string"
                       },
                       "iscsiInterface": {
+                        "default": "default",
                         "type": "string"
                       },
                       "lun": {
@@ -4775,7 +5552,8 @@
                         "items": {
                           "type": "string"
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "readOnly": {
                         "type": "boolean"
@@ -4783,6 +5561,7 @@
                       "secretRef": {
                         "properties": {
                           "name": {
+                            "default": "",
                             "type": "string"
                           }
                         },
@@ -4881,6 +5660,67 @@
                       "sources": {
                         "items": {
                           "properties": {
+                            "clusterTrustBundle": {
+                              "properties": {
+                                "labelSelector": {
+                                  "properties": {
+                                    "matchExpressions": {
+                                      "items": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "operator": {
+                                            "type": "string"
+                                          },
+                                          "values": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
+                                          }
+                                        },
+                                        "required": [
+                                          "key",
+                                          "operator"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    },
+                                    "matchLabels": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                },
+                                "path": {
+                                  "type": "string"
+                                },
+                                "signerName": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "path"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
                             "configMap": {
                               "properties": {
                                 "items": {
@@ -4904,9 +5744,11 @@
                                     "type": "object",
                                     "additionalProperties": false
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "name": {
+                                  "default": "",
                                   "type": "string"
                                 },
                                 "optional": {
@@ -4980,7 +5822,8 @@
                                     "type": "object",
                                     "additionalProperties": false
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               },
                               "type": "object",
@@ -5009,9 +5852,11 @@
                                     "type": "object",
                                     "additionalProperties": false
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "name": {
+                                  "default": "",
                                   "type": "string"
                                 },
                                 "optional": {
@@ -5045,7 +5890,8 @@
                           "type": "object",
                           "additionalProperties": false
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       }
                     },
                     "type": "object",
@@ -5088,15 +5934,18 @@
                         "type": "string"
                       },
                       "keyring": {
+                        "default": "/etc/ceph/keyring",
                         "type": "string"
                       },
                       "monitors": {
                         "items": {
                           "type": "string"
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "pool": {
+                        "default": "rbd",
                         "type": "string"
                       },
                       "readOnly": {
@@ -5105,6 +5954,7 @@
                       "secretRef": {
                         "properties": {
                           "name": {
+                            "default": "",
                             "type": "string"
                           }
                         },
@@ -5113,6 +5963,7 @@
                         "additionalProperties": false
                       },
                       "user": {
+                        "default": "admin",
                         "type": "string"
                       }
                     },
@@ -5126,6 +5977,7 @@
                   "scaleIO": {
                     "properties": {
                       "fsType": {
+                        "default": "xfs",
                         "type": "string"
                       },
                       "gateway": {
@@ -5140,6 +5992,7 @@
                       "secretRef": {
                         "properties": {
                           "name": {
+                            "default": "",
                             "type": "string"
                           }
                         },
@@ -5151,6 +6004,7 @@
                         "type": "boolean"
                       },
                       "storageMode": {
+                        "default": "ThinProvisioned",
                         "type": "string"
                       },
                       "storagePool": {
@@ -5198,7 +6052,8 @@
                           "type": "object",
                           "additionalProperties": false
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "optional": {
                         "type": "boolean"
@@ -5221,6 +6076,7 @@
                       "secretRef": {
                         "properties": {
                           "name": {
+                            "default": "",
                             "type": "string"
                           }
                         },
@@ -5299,6 +6155,9 @@
                 },
                 "name": {
                   "type": "string"
+                },
+                "readOnly": {
+                  "type": "boolean"
                 }
               },
               "required": [
@@ -5374,7 +6233,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -5384,7 +6244,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchFields": {
                                 "items": {
@@ -5399,7 +6260,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -5409,7 +6271,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               }
                             },
                             "type": "object",
@@ -5428,7 +6291,8 @@
                         "type": "object",
                         "additionalProperties": false
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     },
                     "requiredDuringSchedulingIgnoredDuringExecution": {
                       "properties": {
@@ -5448,7 +6312,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -5458,7 +6323,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchFields": {
                                 "items": {
@@ -5473,7 +6339,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -5483,14 +6350,16 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               }
                             },
                             "type": "object",
                             "x-kubernetes-map-type": "atomic",
                             "additionalProperties": false
                           },
-                          "type": "array"
+                          "type": "array",
+                          "x-kubernetes-list-type": "atomic"
                         }
                       },
                       "required": [
@@ -5526,7 +6395,8 @@
                                           "items": {
                                             "type": "string"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       },
                                       "required": [
@@ -5536,7 +6406,8 @@
                                       "type": "object",
                                       "additionalProperties": false
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "matchLabels": {
                                     "additionalProperties": {
@@ -5548,6 +6419,20 @@
                                 "type": "object",
                                 "x-kubernetes-map-type": "atomic",
                                 "additionalProperties": false
+                              },
+                              "matchLabelKeys": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "mismatchLabelKeys": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "namespaceSelector": {
                                 "properties": {
@@ -5564,7 +6449,8 @@
                                           "items": {
                                             "type": "string"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       },
                                       "required": [
@@ -5574,7 +6460,8 @@
                                       "type": "object",
                                       "additionalProperties": false
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "matchLabels": {
                                     "additionalProperties": {
@@ -5591,7 +6478,8 @@
                                 "items": {
                                   "type": "string"
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "topologyKey": {
                                 "type": "string"
@@ -5615,7 +6503,8 @@
                         "type": "object",
                         "additionalProperties": false
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     },
                     "requiredDuringSchedulingIgnoredDuringExecution": {
                       "items": {
@@ -5635,7 +6524,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -5645,7 +6535,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchLabels": {
                                 "additionalProperties": {
@@ -5657,6 +6548,20 @@
                             "type": "object",
                             "x-kubernetes-map-type": "atomic",
                             "additionalProperties": false
+                          },
+                          "matchLabelKeys": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "mismatchLabelKeys": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "namespaceSelector": {
                             "properties": {
@@ -5673,7 +6578,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -5683,7 +6589,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchLabels": {
                                 "additionalProperties": {
@@ -5700,7 +6607,8 @@
                             "items": {
                               "type": "string"
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "topologyKey": {
                             "type": "string"
@@ -5712,7 +6620,8 @@
                         "type": "object",
                         "additionalProperties": false
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     }
                   },
                   "type": "object",
@@ -5740,7 +6649,8 @@
                                           "items": {
                                             "type": "string"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       },
                                       "required": [
@@ -5750,7 +6660,8 @@
                                       "type": "object",
                                       "additionalProperties": false
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "matchLabels": {
                                     "additionalProperties": {
@@ -5762,6 +6673,20 @@
                                 "type": "object",
                                 "x-kubernetes-map-type": "atomic",
                                 "additionalProperties": false
+                              },
+                              "matchLabelKeys": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "mismatchLabelKeys": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "namespaceSelector": {
                                 "properties": {
@@ -5778,7 +6703,8 @@
                                           "items": {
                                             "type": "string"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       },
                                       "required": [
@@ -5788,7 +6714,8 @@
                                       "type": "object",
                                       "additionalProperties": false
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "matchLabels": {
                                     "additionalProperties": {
@@ -5805,7 +6732,8 @@
                                 "items": {
                                   "type": "string"
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "topologyKey": {
                                 "type": "string"
@@ -5829,7 +6757,8 @@
                         "type": "object",
                         "additionalProperties": false
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     },
                     "requiredDuringSchedulingIgnoredDuringExecution": {
                       "items": {
@@ -5849,7 +6778,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -5859,7 +6789,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchLabels": {
                                 "additionalProperties": {
@@ -5871,6 +6802,20 @@
                             "type": "object",
                             "x-kubernetes-map-type": "atomic",
                             "additionalProperties": false
+                          },
+                          "matchLabelKeys": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "mismatchLabelKeys": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "namespaceSelector": {
                             "properties": {
@@ -5887,7 +6832,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
@@ -5897,7 +6843,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchLabels": {
                                 "additionalProperties": {
@@ -5914,7 +6861,8 @@
                             "items": {
                               "type": "string"
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "topologyKey": {
                             "type": "string"
@@ -5926,7 +6874,8 @@
                         "type": "object",
                         "additionalProperties": false
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     }
                   },
                   "type": "object",
@@ -5938,6 +6887,121 @@
             },
             "automountServiceAccountToken": {
               "type": "string"
+            },
+            "containerSecurityContext": {
+              "properties": {
+                "allowPrivilegeEscalation": {
+                  "type": "boolean"
+                },
+                "appArmorProfile": {
+                  "properties": {
+                    "localhostProfile": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "capabilities": {
+                  "properties": {
+                    "add": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
+                    },
+                    "drop": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "privileged": {
+                  "type": "boolean"
+                },
+                "procMount": {
+                  "type": "string"
+                },
+                "readOnlyRootFilesystem": {
+                  "type": "boolean"
+                },
+                "runAsGroup": {
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "runAsNonRoot": {
+                  "type": "boolean"
+                },
+                "runAsUser": {
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "seLinuxOptions": {
+                  "properties": {
+                    "level": {
+                      "type": "string"
+                    },
+                    "role": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string"
+                    },
+                    "user": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "seccompProfile": {
+                  "properties": {
+                    "localhostProfile": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "windowsOptions": {
+                  "properties": {
+                    "gmsaCredentialSpec": {
+                      "type": "string"
+                    },
+                    "gmsaCredentialSpecName": {
+                      "type": "string"
+                    },
+                    "hostProcess": {
+                      "type": "boolean"
+                    },
+                    "runAsUserName": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
             },
             "env": {
               "items": {
@@ -5956,6 +7020,7 @@
                             "type": "string"
                           },
                           "name": {
+                            "default": "",
                             "type": "string"
                           },
                           "optional": {
@@ -6019,6 +7084,7 @@
                             "type": "string"
                           },
                           "name": {
+                            "default": "",
                             "type": "string"
                           },
                           "optional": {
@@ -6051,6 +7117,7 @@
                   "configMapRef": {
                     "properties": {
                       "name": {
+                        "default": "",
                         "type": "string"
                       },
                       "optional": {
@@ -6067,6 +7134,7 @@
                   "secretRef": {
                     "properties": {
                       "name": {
+                        "default": "",
                         "type": "string"
                       },
                       "optional": {
@@ -6093,6 +7161,7 @@
               "items": {
                 "properties": {
                   "name": {
+                    "default": "",
                     "type": "string"
                   }
                 },
@@ -6134,6 +7203,7 @@
                                   "type": "string"
                                 },
                                 "name": {
+                                  "default": "",
                                   "type": "string"
                                 },
                                 "optional": {
@@ -6197,6 +7267,7 @@
                                   "type": "string"
                                 },
                                 "name": {
+                                  "default": "",
                                   "type": "string"
                                 },
                                 "optional": {
@@ -6229,6 +7300,7 @@
                         "configMapRef": {
                           "properties": {
                             "name": {
+                              "default": "",
                               "type": "string"
                             },
                             "optional": {
@@ -6245,6 +7317,7 @@
                         "secretRef": {
                           "properties": {
                             "name": {
+                              "default": "",
                               "type": "string"
                             },
                             "optional": {
@@ -6267,6 +7340,9 @@
                   "name": {
                     "type": "string"
                   },
+                  "restartPolicy": {
+                    "type": "string"
+                  },
                   "volumeMounts": {
                     "items": {
                       "properties": {
@@ -6281,6 +7357,9 @@
                         },
                         "readOnly": {
                           "type": "boolean"
+                        },
+                        "recursiveReadOnly": {
+                          "type": "string"
                         },
                         "subPath": {
                           "type": "string"
@@ -6315,7 +7394,8 @@
                       "items": {
                         "type": "string"
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     }
                   },
                   "type": "object",
@@ -6332,6 +7412,7 @@
                       "type": "integer"
                     },
                     "service": {
+                      "default": "",
                       "type": "string"
                     }
                   },
@@ -6363,7 +7444,8 @@
                         "type": "object",
                         "additionalProperties": false
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     },
                     "path": {
                       "type": "string"
@@ -6468,7 +7550,8 @@
                       "items": {
                         "type": "string"
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     }
                   },
                   "type": "object",
@@ -6485,6 +7568,7 @@
                       "type": "integer"
                     },
                     "service": {
+                      "default": "",
                       "type": "string"
                     }
                   },
@@ -6516,7 +7600,8 @@
                         "type": "object",
                         "additionalProperties": false
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     },
                     "path": {
                       "type": "string"
@@ -6596,6 +7681,9 @@
                     "properties": {
                       "name": {
                         "type": "string"
+                      },
+                      "request": {
+                        "type": "string"
                       }
                     },
                     "required": [
@@ -6646,6 +7734,21 @@
             },
             "securityContext": {
               "properties": {
+                "appArmorProfile": {
+                  "properties": {
+                    "localhostProfile": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
                 "fsGroup": {
                   "format": "int64",
                   "type": "integer"
@@ -6663,6 +7766,9 @@
                 "runAsUser": {
                   "format": "int64",
                   "type": "integer"
+                },
+                "seLinuxChangePolicy": {
+                  "type": "string"
                 },
                 "seLinuxOptions": {
                   "properties": {
@@ -6702,7 +7808,11 @@
                     "format": "int64",
                     "type": "integer"
                   },
-                  "type": "array"
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                },
+                "supplementalGroupsPolicy": {
+                  "type": "string"
                 },
                 "sysctls": {
                   "items": {
@@ -6721,7 +7831,8 @@
                     "type": "object",
                     "additionalProperties": false
                   },
-                  "type": "array"
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
                 },
                 "windowsOptions": {
                   "properties": {
@@ -6773,6 +7884,87 @@
               },
               "type": "array"
             },
+            "topologySpreadConstraints": {
+              "items": {
+                "properties": {
+                  "labelSelector": {
+                    "properties": {
+                      "matchExpressions": {
+                        "items": {
+                          "properties": {
+                            "key": {
+                              "type": "string"
+                            },
+                            "operator": {
+                              "type": "string"
+                            },
+                            "values": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
+                            }
+                          },
+                          "required": [
+                            "key",
+                            "operator"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
+                      },
+                      "matchLabels": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "type": "object"
+                      }
+                    },
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  },
+                  "matchLabelKeys": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  },
+                  "maxSkew": {
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "minDomains": {
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "nodeAffinityPolicy": {
+                    "type": "string"
+                  },
+                  "nodeTaintsPolicy": {
+                    "type": "string"
+                  },
+                  "topologyKey": {
+                    "type": "string"
+                  },
+                  "whenUnsatisfiable": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "maxSkew",
+                  "topologyKey",
+                  "whenUnsatisfiable"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
             "volumeMounts": {
               "items": {
                 "properties": {
@@ -6787,6 +7979,9 @@
                   },
                   "readOnly": {
                     "type": "boolean"
+                  },
+                  "recursiveReadOnly": {
+                    "type": "string"
                   },
                   "subPath": {
                     "type": "string"
@@ -6841,12 +8036,14 @@
                         "type": "string"
                       },
                       "fsType": {
+                        "default": "ext4",
                         "type": "string"
                       },
                       "kind": {
                         "type": "string"
                       },
                       "readOnly": {
+                        "default": false,
                         "type": "boolean"
                       }
                     },
@@ -6882,7 +8079,8 @@
                         "items": {
                           "type": "string"
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "path": {
                         "type": "string"
@@ -6896,6 +8094,7 @@
                       "secretRef": {
                         "properties": {
                           "name": {
+                            "default": "",
                             "type": "string"
                           }
                         },
@@ -6924,6 +8123,7 @@
                       "secretRef": {
                         "properties": {
                           "name": {
+                            "default": "",
                             "type": "string"
                           }
                         },
@@ -6968,9 +8168,11 @@
                           "type": "object",
                           "additionalProperties": false
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "name": {
+                        "default": "",
                         "type": "string"
                       },
                       "optional": {
@@ -6992,6 +8194,7 @@
                       "nodePublishSecretRef": {
                         "properties": {
                           "name": {
+                            "default": "",
                             "type": "string"
                           }
                         },
@@ -7082,7 +8285,8 @@
                           "type": "object",
                           "additionalProperties": false
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       }
                     },
                     "type": "object",
@@ -7122,7 +8326,8 @@
                                 "items": {
                                   "type": "string"
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "dataSource": {
                                 "properties": {
@@ -7168,25 +8373,6 @@
                               },
                               "resources": {
                                 "properties": {
-                                  "claims": {
-                                    "items": {
-                                      "properties": {
-                                        "name": {
-                                          "type": "string"
-                                        }
-                                      },
-                                      "required": [
-                                        "name"
-                                      ],
-                                      "type": "object",
-                                      "additionalProperties": false
-                                    },
-                                    "type": "array",
-                                    "x-kubernetes-list-map-keys": [
-                                      "name"
-                                    ],
-                                    "x-kubernetes-list-type": "map"
-                                  },
                                   "limits": {
                                     "additionalProperties": {
                                       "anyOf": [
@@ -7236,7 +8422,8 @@
                                           "items": {
                                             "type": "string"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       },
                                       "required": [
@@ -7246,7 +8433,8 @@
                                       "type": "object",
                                       "additionalProperties": false
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "matchLabels": {
                                     "additionalProperties": {
@@ -7260,6 +8448,9 @@
                                 "additionalProperties": false
                               },
                               "storageClassName": {
+                                "type": "string"
+                              },
+                              "volumeAttributesClassName": {
                                 "type": "string"
                               },
                               "volumeMode": {
@@ -7299,13 +8490,15 @@
                         "items": {
                           "type": "string"
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "wwids": {
                         "items": {
                           "type": "string"
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       }
                     },
                     "type": "object",
@@ -7331,6 +8524,7 @@
                       "secretRef": {
                         "properties": {
                           "name": {
+                            "default": "",
                             "type": "string"
                           }
                         },
@@ -7431,6 +8625,18 @@
                     "type": "object",
                     "additionalProperties": false
                   },
+                  "image": {
+                    "properties": {
+                      "pullPolicy": {
+                        "type": "string"
+                      },
+                      "reference": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
                   "iscsi": {
                     "properties": {
                       "chapAuthDiscovery": {
@@ -7449,6 +8655,7 @@
                         "type": "string"
                       },
                       "iscsiInterface": {
+                        "default": "default",
                         "type": "string"
                       },
                       "lun": {
@@ -7459,7 +8666,8 @@
                         "items": {
                           "type": "string"
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "readOnly": {
                         "type": "boolean"
@@ -7467,6 +8675,7 @@
                       "secretRef": {
                         "properties": {
                           "name": {
+                            "default": "",
                             "type": "string"
                           }
                         },
@@ -7565,6 +8774,67 @@
                       "sources": {
                         "items": {
                           "properties": {
+                            "clusterTrustBundle": {
+                              "properties": {
+                                "labelSelector": {
+                                  "properties": {
+                                    "matchExpressions": {
+                                      "items": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "operator": {
+                                            "type": "string"
+                                          },
+                                          "values": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
+                                          }
+                                        },
+                                        "required": [
+                                          "key",
+                                          "operator"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    },
+                                    "matchLabels": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                },
+                                "path": {
+                                  "type": "string"
+                                },
+                                "signerName": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "path"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
                             "configMap": {
                               "properties": {
                                 "items": {
@@ -7588,9 +8858,11 @@
                                     "type": "object",
                                     "additionalProperties": false
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "name": {
+                                  "default": "",
                                   "type": "string"
                                 },
                                 "optional": {
@@ -7664,7 +8936,8 @@
                                     "type": "object",
                                     "additionalProperties": false
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               },
                               "type": "object",
@@ -7693,9 +8966,11 @@
                                     "type": "object",
                                     "additionalProperties": false
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "name": {
+                                  "default": "",
                                   "type": "string"
                                 },
                                 "optional": {
@@ -7729,7 +9004,8 @@
                           "type": "object",
                           "additionalProperties": false
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       }
                     },
                     "type": "object",
@@ -7772,15 +9048,18 @@
                         "type": "string"
                       },
                       "keyring": {
+                        "default": "/etc/ceph/keyring",
                         "type": "string"
                       },
                       "monitors": {
                         "items": {
                           "type": "string"
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "pool": {
+                        "default": "rbd",
                         "type": "string"
                       },
                       "readOnly": {
@@ -7789,6 +9068,7 @@
                       "secretRef": {
                         "properties": {
                           "name": {
+                            "default": "",
                             "type": "string"
                           }
                         },
@@ -7797,6 +9077,7 @@
                         "additionalProperties": false
                       },
                       "user": {
+                        "default": "admin",
                         "type": "string"
                       }
                     },
@@ -7810,6 +9091,7 @@
                   "scaleIO": {
                     "properties": {
                       "fsType": {
+                        "default": "xfs",
                         "type": "string"
                       },
                       "gateway": {
@@ -7824,6 +9106,7 @@
                       "secretRef": {
                         "properties": {
                           "name": {
+                            "default": "",
                             "type": "string"
                           }
                         },
@@ -7835,6 +9118,7 @@
                         "type": "boolean"
                       },
                       "storageMode": {
+                        "default": "ThinProvisioned",
                         "type": "string"
                       },
                       "storagePool": {
@@ -7882,7 +9166,8 @@
                           "type": "object",
                           "additionalProperties": false
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "optional": {
                         "type": "boolean"
@@ -7905,6 +9190,7 @@
                       "secretRef": {
                         "properties": {
                           "name": {
+                            "default": "",
                             "type": "string"
                           }
                         },


### PR DESCRIPTION
Update the CRD schemas of `k6.io` to the latest version. The CRD for `k6` itself seems to have been remove, I decided to leave it for backward compatibility.

The new schemas have been generated with:
```sh
./Utilities/openapi2jsonschema.py https://raw.githubusercontent.com/grafana/k6-operator/refs/heads/main/config/crd/bases/k6.io_privateloadzones.yaml
./Utilities/openapi2jsonschema.py https://raw.githubusercontent.com/grafana/k6-operator/refs/heads/main/config/crd/bases/k6.io_testruns.yaml
```

## PR Checklist

- [ ] I have used the [CRD Extractor](https://github.com/datreeio/CRDs-catalog?tab=readme-ov-file#crd-extractor) tool to generate these CRDs
