### PR TITLE
chore: update Traefik CRDs to v3.5

### DIFF
--- a/traefik.io/ingressroute_v1alpha1.json
+++ b/traefik.io/ingressroute_v1alpha1.json
@@ -16,7 +16,7 @@
       "description": "IngressRouteSpec defines the desired state of IngressRoute.",
       "properties": {
         "entryPoints": {
-          "description": "EntryPoints defines the list of entry point names to bind to.\nEntry points have to be configured in the static configuration.\nMore info: https://doc.traefik.io/traefik/v3.3/routing/entrypoints/\nDefault: all.",
+          "description": "EntryPoints defines the list of entry point names to bind to.\nEntry points have to be configured in the static configuration.\nMore info: https://doc.traefik.io/traefik/v3.5/routing/entrypoints/\nDefault: all.",
           "items": {
             "type": "string"
           },
@@ -35,11 +35,11 @@
                 "type": "string"
               },
               "match": {
-                "description": "Match defines the router's rule.\nMore info: https://doc.traefik.io/traefik/v3.3/routing/routers/#rule",
+                "description": "Match defines the router's rule.\nMore info: https://doc.traefik.io/traefik/v3.5/routing/routers/#rule",
                 "type": "string"
               },
               "middlewares": {
-                "description": "Middlewares defines the list of references to Middleware resources.\nMore info: https://doc.traefik.io/traefik/v3.3/routing/providers/kubernetes-crd/#kind-middleware",
+                "description": "Middlewares defines the list of references to Middleware resources.\nMore info: https://doc.traefik.io/traefik/v3.5/routing/providers/kubernetes-crd/#kind-middleware",
                 "items": {
                   "description": "MiddlewareRef is a reference to a Middleware resource.",
                   "properties": {
@@ -61,15 +61,27 @@
                 "type": "array"
               },
               "observability": {
-                "description": "Observability defines the observability configuration for a router.\nMore info: https://doc.traefik.io/traefik/v3.2/routing/routers/#observability",
+                "description": "Observability defines the observability configuration for a router.\nMore info: https://doc.traefik.io/traefik/v3.5/routing/routers/#observability",
                 "properties": {
                   "accessLogs": {
+                    "description": "AccessLogs enables access logs for this router.",
                     "type": "boolean"
                   },
                   "metrics": {
+                    "description": "Metrics enables metrics for this router.",
                     "type": "boolean"
                   },
+                  "traceVerbosity": {
+                    "default": "minimal",
+                    "description": "TraceVerbosity defines the verbosity level of the tracing for this router.",
+                    "enum": [
+                      "minimal",
+                      "detailed"
+                    ],
+                    "type": "string"
+                  },
                   "tracing": {
+                    "description": "Tracing enables tracing for this router.",
                     "type": "boolean"
                   }
                 },
@@ -77,7 +89,8 @@
                 "additionalProperties": false
               },
               "priority": {
-                "description": "Priority defines the router's priority.\nMore info: https://doc.traefik.io/traefik/v3.3/routing/routers/#priority",
+                "description": "Priority defines the router's priority.\nMore info: https://doc.traefik.io/traefik/v3.5/routing/routers/#priority",
+                "maximum": 9223372036854775000,
                 "type": "integer"
               },
               "services": {
@@ -112,7 +125,7 @@
                               "type": "string"
                             }
                           ],
-                          "description": "Interval defines the frequency of the health check calls.\nDefault: 30s",
+                          "description": "Interval defines the frequency of the health check calls for healthy targets.\nDefault: 30s",
                           "x-kubernetes-int-or-string": true
                         },
                         "method": {
@@ -149,6 +162,18 @@
                             }
                           ],
                           "description": "Timeout defines the maximum duration Traefik will wait for a health check request before considering the server unhealthy.\nDefault: 5s",
+                          "x-kubernetes-int-or-string": true
+                        },
+                        "unhealthyInterval": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "description": "UnhealthyInterval defines the frequency of the health check calls for unhealthy targets.\nWhen UnhealthyInterval is not defined, it defaults to the Interval value.\nDefault: 30s",
                           "x-kubernetes-int-or-string": true
                         }
                       },
@@ -215,11 +240,15 @@
                       "type": "string"
                     },
                     "sticky": {
-                      "description": "Sticky defines the sticky sessions configuration.\nMore info: https://doc.traefik.io/traefik/v3.3/routing/services/#sticky-sessions",
+                      "description": "Sticky defines the sticky sessions configuration.\nMore info: https://doc.traefik.io/traefik/v3.5/routing/services/#sticky-sessions",
                       "properties": {
                         "cookie": {
                           "description": "Cookie defines the sticky cookie configuration.",
                           "properties": {
+                            "domain": {
+                              "description": "Domain defines the host to which the cookie will be sent.\nMore info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#domaindomain-value",
+                              "type": "string"
+                            },
                             "httpOnly": {
                               "description": "HTTPOnly defines whether the cookie can be accessed by client-side APIs, such as JavaScript.",
                               "type": "boolean"
@@ -238,6 +267,11 @@
                             },
                             "sameSite": {
                               "description": "SameSite defines the same site policy.\nMore info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite",
+                              "enum": [
+                                "none",
+                                "lax",
+                                "strict"
+                              ],
                               "type": "string"
                             },
                             "secure": {
@@ -253,11 +287,17 @@
                       "additionalProperties": false
                     },
                     "strategy": {
-                      "description": "Strategy defines the load balancing strategy between the servers.\nRoundRobin is the only supported value at the moment.",
+                      "description": "Strategy defines the load balancing strategy between the servers.\nSupported values are: wrr (Weighed round-robin) and p2c (Power of two choices).\nRoundRobin value is deprecated and supported for backward compatibility.",
+                      "enum": [
+                        "wrr",
+                        "p2c",
+                        "RoundRobin"
+                      ],
                       "type": "string"
                     },
                     "weight": {
                       "description": "Weight defines the weight and should only be specified when Name references a TraefikService object\n(and to be precise, one that embeds a Weighted Round Robin).",
+                      "minimum": 0,
                       "type": "integer"
                     }
                   },
@@ -270,7 +310,7 @@
                 "type": "array"
               },
               "syntax": {
-                "description": "Syntax defines the router's rule syntax.\nMore info: https://doc.traefik.io/traefik/v3.3/routing/routers/#rulesyntax",
+                "description": "Syntax defines the router's rule syntax.\nMore info: https://doc.traefik.io/traefik/v3.5/routing/routers/#rulesyntax\nDeprecated: Please do not use this field and rewrite the router rules to use the v3 syntax.",
                 "type": "string"
               }
             },
@@ -283,14 +323,14 @@
           "type": "array"
         },
         "tls": {
-          "description": "TLS defines the TLS configuration.\nMore info: https://doc.traefik.io/traefik/v3.3/routing/routers/#tls",
+          "description": "TLS defines the TLS configuration.\nMore info: https://doc.traefik.io/traefik/v3.5/routing/routers/#tls",
           "properties": {
             "certResolver": {
-              "description": "CertResolver defines the name of the certificate resolver to use.\nCert resolvers have to be configured in the static configuration.\nMore info: https://doc.traefik.io/traefik/v3.3/https/acme/#certificate-resolvers",
+              "description": "CertResolver defines the name of the certificate resolver to use.\nCert resolvers have to be configured in the static configuration.\nMore info: https://doc.traefik.io/traefik/v3.5/https/acme/#certificate-resolvers",
               "type": "string"
             },
             "domains": {
-              "description": "Domains defines the list of domains that will be used to issue certificates.\nMore info: https://doc.traefik.io/traefik/v3.3/routing/routers/#domains",
+              "description": "Domains defines the list of domains that will be used to issue certificates.\nMore info: https://doc.traefik.io/traefik/v3.5/routing/routers/#domains",
               "items": {
                 "description": "Domain holds a domain name with SANs.",
                 "properties": {
@@ -312,14 +352,14 @@
               "type": "array"
             },
             "options": {
-              "description": "Options defines the reference to a TLSOption, that specifies the parameters of the TLS connection.\nIf not defined, the `default` TLSOption is used.\nMore info: https://doc.traefik.io/traefik/v3.3/https/tls/#tls-options",
+              "description": "Options defines the reference to a TLSOption, that specifies the parameters of the TLS connection.\nIf not defined, the `default` TLSOption is used.\nMore info: https://doc.traefik.io/traefik/v3.5/https/tls/#tls-options",
               "properties": {
                 "name": {
-                  "description": "Name defines the name of the referenced TLSOption.\nMore info: https://doc.traefik.io/traefik/v3.3/routing/providers/kubernetes-crd/#kind-tlsoption",
+                  "description": "Name defines the name of the referenced TLSOption.\nMore info: https://doc.traefik.io/traefik/v3.5/routing/providers/kubernetes-crd/#kind-tlsoption",
                   "type": "string"
                 },
                 "namespace": {
-                  "description": "Namespace defines the namespace of the referenced TLSOption.\nMore info: https://doc.traefik.io/traefik/v3.3/routing/providers/kubernetes-crd/#kind-tlsoption",
+                  "description": "Namespace defines the namespace of the referenced TLSOption.\nMore info: https://doc.traefik.io/traefik/v3.5/routing/providers/kubernetes-crd/#kind-tlsoption",
                   "type": "string"
                 }
               },
@@ -337,11 +377,11 @@
               "description": "Store defines the reference to the TLSStore, that will be used to store certificates.\nPlease note that only `default` TLSStore can be used.",
               "properties": {
                 "name": {
-                  "description": "Name defines the name of the referenced TLSStore.\nMore info: https://doc.traefik.io/traefik/v3.3/routing/providers/kubernetes-crd/#kind-tlsstore",
+                  "description": "Name defines the name of the referenced TLSStore.\nMore info: https://doc.traefik.io/traefik/v3.5/routing/providers/kubernetes-crd/#kind-tlsstore",
                   "type": "string"
                 },
                 "namespace": {
-                  "description": "Namespace defines the namespace of the referenced TLSStore.\nMore info: https://doc.traefik.io/traefik/v3.3/routing/providers/kubernetes-crd/#kind-tlsstore",
+                  "description": "Namespace defines the namespace of the referenced TLSStore.\nMore info: https://doc.traefik.io/traefik/v3.5/routing/providers/kubernetes-crd/#kind-tlsstore",
                   "type": "string"
                 }
               },

--- a/traefik.io/ingressroutetcp_v1alpha1.json
+++ b/traefik.io/ingressroutetcp_v1alpha1.json
@@ -16,7 +16,7 @@
       "description": "IngressRouteTCPSpec defines the desired state of IngressRouteTCP.",
       "properties": {
         "entryPoints": {
-          "description": "EntryPoints defines the list of entry point names to bind to.\nEntry points have to be configured in the static configuration.\nMore info: https://doc.traefik.io/traefik/v3.3/routing/entrypoints/\nDefault: all.",
+          "description": "EntryPoints defines the list of entry point names to bind to.\nEntry points have to be configured in the static configuration.\nMore info: https://doc.traefik.io/traefik/v3.5/routing/entrypoints/\nDefault: all.",
           "items": {
             "type": "string"
           },
@@ -28,7 +28,7 @@
             "description": "RouteTCP holds the TCP route configuration.",
             "properties": {
               "match": {
-                "description": "Match defines the router's rule.\nMore info: https://doc.traefik.io/traefik/v3.3/routing/routers/#rule_1",
+                "description": "Match defines the router's rule.\nMore info: https://doc.traefik.io/traefik/v3.5/routing/routers/#rule_1",
                 "type": "string"
               },
               "middlewares": {
@@ -54,7 +54,8 @@
                 "type": "array"
               },
               "priority": {
-                "description": "Priority defines the router's priority.\nMore info: https://doc.traefik.io/traefik/v3.3/routing/routers/#priority_1",
+                "description": "Priority defines the router's priority.\nMore info: https://doc.traefik.io/traefik/v3.5/routing/routers/#priority_1",
+                "maximum": 9223372036854775000,
                 "type": "integer"
               },
               "services": {
@@ -91,10 +92,12 @@
                       "x-kubernetes-int-or-string": true
                     },
                     "proxyProtocol": {
-                      "description": "ProxyProtocol defines the PROXY protocol configuration.\nMore info: https://doc.traefik.io/traefik/v3.3/routing/services/#proxy-protocol",
+                      "description": "ProxyProtocol defines the PROXY protocol configuration.\nMore info: https://doc.traefik.io/traefik/v3.5/routing/services/#proxy-protocol",
                       "properties": {
                         "version": {
                           "description": "Version defines the PROXY Protocol version to use.",
+                          "maximum": 2,
+                          "minimum": 1,
                           "type": "integer"
                         }
                       },
@@ -115,6 +118,7 @@
                     },
                     "weight": {
                       "description": "Weight defines the weight used when balancing requests between multiple Kubernetes Service.",
+                      "minimum": 0,
                       "type": "integer"
                     }
                   },
@@ -128,7 +132,11 @@
                 "type": "array"
               },
               "syntax": {
-                "description": "Syntax defines the router's rule syntax.\nMore info: https://doc.traefik.io/traefik/v3.3/routing/routers/#rulesyntax_1",
+                "description": "Syntax defines the router's rule syntax.\nMore info: https://doc.traefik.io/traefik/v3.5/routing/routers/#rulesyntax_1\nDeprecated: Please do not use this field and rewrite the router rules to use the v3 syntax.",
+                "enum": [
+                  "v3",
+                  "v2"
+                ],
                 "type": "string"
               }
             },
@@ -141,14 +149,14 @@
           "type": "array"
         },
         "tls": {
-          "description": "TLS defines the TLS configuration on a layer 4 / TCP Route.\nMore info: https://doc.traefik.io/traefik/v3.3/routing/routers/#tls_1",
+          "description": "TLS defines the TLS configuration on a layer 4 / TCP Route.\nMore info: https://doc.traefik.io/traefik/v3.5/routing/routers/#tls_1",
           "properties": {
             "certResolver": {
-              "description": "CertResolver defines the name of the certificate resolver to use.\nCert resolvers have to be configured in the static configuration.\nMore info: https://doc.traefik.io/traefik/v3.3/https/acme/#certificate-resolvers",
+              "description": "CertResolver defines the name of the certificate resolver to use.\nCert resolvers have to be configured in the static configuration.\nMore info: https://doc.traefik.io/traefik/v3.5/https/acme/#certificate-resolvers",
               "type": "string"
             },
             "domains": {
-              "description": "Domains defines the list of domains that will be used to issue certificates.\nMore info: https://doc.traefik.io/traefik/v3.3/routing/routers/#domains",
+              "description": "Domains defines the list of domains that will be used to issue certificates.\nMore info: https://doc.traefik.io/traefik/v3.5/routing/routers/#domains",
               "items": {
                 "description": "Domain holds a domain name with SANs.",
                 "properties": {
@@ -170,7 +178,7 @@
               "type": "array"
             },
             "options": {
-              "description": "Options defines the reference to a TLSOption, that specifies the parameters of the TLS connection.\nIf not defined, the `default` TLSOption is used.\nMore info: https://doc.traefik.io/traefik/v3.3/https/tls/#tls-options",
+              "description": "Options defines the reference to a TLSOption, that specifies the parameters of the TLS connection.\nIf not defined, the `default` TLSOption is used.\nMore info: https://doc.traefik.io/traefik/v3.5/https/tls/#tls-options",
               "properties": {
                 "name": {
                   "description": "Name defines the name of the referenced Traefik resource.",

--- a/traefik.io/ingressrouteudp_v1alpha1.json
+++ b/traefik.io/ingressrouteudp_v1alpha1.json
@@ -16,7 +16,7 @@
       "description": "IngressRouteUDPSpec defines the desired state of a IngressRouteUDP.",
       "properties": {
         "entryPoints": {
-          "description": "EntryPoints defines the list of entry point names to bind to.\nEntry points have to be configured in the static configuration.\nMore info: https://doc.traefik.io/traefik/v3.3/routing/entrypoints/\nDefault: all.",
+          "description": "EntryPoints defines the list of entry point names to bind to.\nEntry points have to be configured in the static configuration.\nMore info: https://doc.traefik.io/traefik/v3.5/routing/entrypoints/\nDefault: all.",
           "items": {
             "type": "string"
           },
@@ -62,6 +62,7 @@
                     },
                     "weight": {
                       "description": "Weight defines the weight used when balancing requests between multiple Kubernetes Service.",
+                      "minimum": 0,
                       "type": "integer"
                     }
                   },

--- a/traefik.io/middleware_v1alpha1.json
+++ b/traefik.io/middleware_v1alpha1.json
@@ -1,5 +1,5 @@
 {
-  "description": "Middleware is the CRD implementation of a Traefik Middleware.\nMore info: https://doc.traefik.io/traefik/v3.3/middlewares/http/overview/",
+  "description": "Middleware is the CRD implementation of a Traefik Middleware.\nMore info: https://doc.traefik.io/traefik/v3.5/middlewares/http/overview/",
   "properties": {
     "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
@@ -16,21 +16,27 @@
       "description": "MiddlewareSpec defines the desired state of a Middleware.",
       "properties": {
         "addPrefix": {
-          "description": "AddPrefix holds the add prefix middleware configuration.\nThis middleware updates the path of a request before forwarding it.\nMore info: https://doc.traefik.io/traefik/v3.3/middlewares/http/addprefix/",
+          "description": "AddPrefix holds the add prefix middleware configuration.\nThis middleware updates the path of a request before forwarding it.\nMore info: https://doc.traefik.io/traefik/v3.5/middlewares/http/addprefix/",
           "properties": {
             "prefix": {
               "description": "Prefix is the string to add before the current path in the requested URL.\nIt should include a leading slash (/).",
-              "type": "string"
+              "type": "string",
+              "x-kubernetes-validations": [
+                {
+                  "message": "must start with a '/'",
+                  "rule": "self.startsWith('/')"
+                }
+              ]
             }
           },
           "type": "object",
           "additionalProperties": false
         },
         "basicAuth": {
-          "description": "BasicAuth holds the basic auth middleware configuration.\nThis middleware restricts access to your services to known users.\nMore info: https://doc.traefik.io/traefik/v3.3/middlewares/http/basicauth/",
+          "description": "BasicAuth holds the basic auth middleware configuration.\nThis middleware restricts access to your services to known users.\nMore info: https://doc.traefik.io/traefik/v3.5/middlewares/http/basicauth/",
           "properties": {
             "headerField": {
-              "description": "HeaderField defines a header field to store the authenticated user.\nMore info: https://doc.traefik.io/traefik/v3.3/middlewares/http/basicauth/#headerfield",
+              "description": "HeaderField defines a header field to store the authenticated user.\nMore info: https://doc.traefik.io/traefik/v3.5/middlewares/http/basicauth/#headerfield",
               "type": "string"
             },
             "realm": {
@@ -50,7 +56,7 @@
           "additionalProperties": false
         },
         "buffering": {
-          "description": "Buffering holds the buffering middleware configuration.\nThis middleware retries or limits the size of requests that can be forwarded to backends.\nMore info: https://doc.traefik.io/traefik/v3.3/middlewares/http/buffering/#maxrequestbodybytes",
+          "description": "Buffering holds the buffering middleware configuration.\nThis middleware retries or limits the size of requests that can be forwarded to backends.\nMore info: https://doc.traefik.io/traefik/v3.5/middlewares/http/buffering/#maxrequestbodybytes",
           "properties": {
             "maxRequestBodyBytes": {
               "description": "MaxRequestBodyBytes defines the maximum allowed body size for the request (in bytes).\nIf the request exceeds the allowed size, it is not forwarded to the service, and the client gets a 413 (Request Entity Too Large) response.\nDefault: 0 (no maximum).",
@@ -73,7 +79,7 @@
               "type": "integer"
             },
             "retryExpression": {
-              "description": "RetryExpression defines the retry conditions.\nIt is a logical combination of functions with operators AND (&&) and OR (||).\nMore info: https://doc.traefik.io/traefik/v3.3/middlewares/http/buffering/#retryexpression",
+              "description": "RetryExpression defines the retry conditions.\nIt is a logical combination of functions with operators AND (&&) and OR (||).\nMore info: https://doc.traefik.io/traefik/v3.5/middlewares/http/buffering/#retryexpression",
               "type": "string"
             }
           },
@@ -81,7 +87,7 @@
           "additionalProperties": false
         },
         "chain": {
-          "description": "Chain holds the configuration of the chain middleware.\nThis middleware enables to define reusable combinations of other pieces of middleware.\nMore info: https://doc.traefik.io/traefik/v3.3/middlewares/http/chain/",
+          "description": "Chain holds the configuration of the chain middleware.\nThis middleware enables to define reusable combinations of other pieces of middleware.\nMore info: https://doc.traefik.io/traefik/v3.5/middlewares/http/chain/",
           "properties": {
             "middlewares": {
               "description": "Middlewares is the list of MiddlewareRef which composes the chain.",
@@ -122,6 +128,7 @@
                 }
               ],
               "description": "CheckPeriod is the interval between successive checks of the circuit breaker condition (when in standby state).",
+              "pattern": "^([0-9]+(ns|us|\u00b5s|ms|s|m|h)?)+$",
               "x-kubernetes-int-or-string": true
             },
             "expression": {
@@ -150,10 +157,13 @@
                 }
               ],
               "description": "RecoveryDuration is the duration for which the circuit breaker will try to recover (as soon as it is in recovering state).",
+              "pattern": "^([0-9]+(ns|us|\u00b5s|ms|s|m|h)?)+$",
               "x-kubernetes-int-or-string": true
             },
             "responseCode": {
               "description": "ResponseCode is the status code that the circuit breaker will return while it is in the open state.",
+              "maximum": 599,
+              "minimum": 100,
               "type": "integer"
             }
           },
@@ -161,7 +171,7 @@
           "additionalProperties": false
         },
         "compress": {
-          "description": "Compress holds the compress middleware configuration.\nThis middleware compresses responses before sending them to the client, using gzip, brotli, or zstd compression.\nMore info: https://doc.traefik.io/traefik/v3.3/middlewares/http/compress/",
+          "description": "Compress holds the compress middleware configuration.\nThis middleware compresses responses before sending them to the client, using gzip, brotli, or zstd compression.\nMore info: https://doc.traefik.io/traefik/v3.5/middlewares/http/compress/",
           "properties": {
             "defaultEncoding": {
               "description": "DefaultEncoding specifies the default encoding if the `Accept-Encoding` header is not in the request or contains a wildcard (`*`).",
@@ -190,6 +200,7 @@
             },
             "minResponseBodyBytes": {
               "description": "MinResponseBodyBytes defines the minimum amount of bytes a response body must have to be compressed.\nDefault: 1024.",
+              "minimum": 0,
               "type": "integer"
             }
           },
@@ -208,10 +219,10 @@
           "additionalProperties": false
         },
         "digestAuth": {
-          "description": "DigestAuth holds the digest auth middleware configuration.\nThis middleware restricts access to your services to known users.\nMore info: https://doc.traefik.io/traefik/v3.3/middlewares/http/digestauth/",
+          "description": "DigestAuth holds the digest auth middleware configuration.\nThis middleware restricts access to your services to known users.\nMore info: https://doc.traefik.io/traefik/v3.5/middlewares/http/digestauth/",
           "properties": {
             "headerField": {
-              "description": "HeaderField defines a header field to store the authenticated user.\nMore info: https://doc.traefik.io/traefik/v3.3/middlewares/http/basicauth/#headerfield",
+              "description": "HeaderField defines a header field to store the authenticated user.\nMore info: https://doc.traefik.io/traefik/v3.5/middlewares/http/basicauth/#headerfield",
               "type": "string"
             },
             "realm": {
@@ -231,14 +242,14 @@
           "additionalProperties": false
         },
         "errors": {
-          "description": "ErrorPage holds the custom error middleware configuration.\nThis middleware returns a custom page in lieu of the default, according to configured ranges of HTTP Status codes.\nMore info: https://doc.traefik.io/traefik/v3.3/middlewares/http/errorpages/",
+          "description": "ErrorPage holds the custom error middleware configuration.\nThis middleware returns a custom page in lieu of the default, according to configured ranges of HTTP Status codes.\nMore info: https://doc.traefik.io/traefik/v3.5/middlewares/http/errorpages/",
           "properties": {
             "query": {
-              "description": "Query defines the URL for the error page (hosted by service).\nThe {status} variable can be used in order to insert the status code in the URL.",
+              "description": "Query defines the URL for the error page (hosted by service).\nThe {status} variable can be used in order to insert the status code in the URL.\nThe {originalStatus} variable can be used in order to insert the upstream status code in the URL.\nThe {url} variable can be used in order to insert the escaped request URL.",
               "type": "string"
             },
             "service": {
-              "description": "Service defines the reference to a Kubernetes Service that will serve the error page.\nMore info: https://doc.traefik.io/traefik/v3.3/middlewares/http/errorpages/#service",
+              "description": "Service defines the reference to a Kubernetes Service that will serve the error page.\nMore info: https://doc.traefik.io/traefik/v3.5/middlewares/http/errorpages/#service",
               "properties": {
                 "healthCheck": {
                   "description": "Healthcheck defines health checks for ExternalName services.",
@@ -267,7 +278,7 @@
                           "type": "string"
                         }
                       ],
-                      "description": "Interval defines the frequency of the health check calls.\nDefault: 30s",
+                      "description": "Interval defines the frequency of the health check calls for healthy targets.\nDefault: 30s",
                       "x-kubernetes-int-or-string": true
                     },
                     "method": {
@@ -304,6 +315,18 @@
                         }
                       ],
                       "description": "Timeout defines the maximum duration Traefik will wait for a health check request before considering the server unhealthy.\nDefault: 5s",
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "unhealthyInterval": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "description": "UnhealthyInterval defines the frequency of the health check calls for unhealthy targets.\nWhen UnhealthyInterval is not defined, it defaults to the Interval value.\nDefault: 30s",
                       "x-kubernetes-int-or-string": true
                     }
                   },
@@ -370,11 +393,15 @@
                   "type": "string"
                 },
                 "sticky": {
-                  "description": "Sticky defines the sticky sessions configuration.\nMore info: https://doc.traefik.io/traefik/v3.3/routing/services/#sticky-sessions",
+                  "description": "Sticky defines the sticky sessions configuration.\nMore info: https://doc.traefik.io/traefik/v3.5/routing/services/#sticky-sessions",
                   "properties": {
                     "cookie": {
                       "description": "Cookie defines the sticky cookie configuration.",
                       "properties": {
+                        "domain": {
+                          "description": "Domain defines the host to which the cookie will be sent.\nMore info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#domaindomain-value",
+                          "type": "string"
+                        },
                         "httpOnly": {
                           "description": "HTTPOnly defines whether the cookie can be accessed by client-side APIs, such as JavaScript.",
                           "type": "boolean"
@@ -393,6 +420,11 @@
                         },
                         "sameSite": {
                           "description": "SameSite defines the same site policy.\nMore info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite",
+                          "enum": [
+                            "none",
+                            "lax",
+                            "strict"
+                          ],
                           "type": "string"
                         },
                         "secure": {
@@ -408,11 +440,17 @@
                   "additionalProperties": false
                 },
                 "strategy": {
-                  "description": "Strategy defines the load balancing strategy between the servers.\nRoundRobin is the only supported value at the moment.",
+                  "description": "Strategy defines the load balancing strategy between the servers.\nSupported values are: wrr (Weighed round-robin) and p2c (Power of two choices).\nRoundRobin value is deprecated and supported for backward compatibility.",
+                  "enum": [
+                    "wrr",
+                    "p2c",
+                    "RoundRobin"
+                  ],
                   "type": "string"
                 },
                 "weight": {
                   "description": "Weight defines the weight and should only be specified when Name references a TraefikService object\n(and to be precise, one that embeds a Weighted Round Robin).",
+                  "minimum": 0,
                   "type": "integer"
                 }
               },
@@ -425,16 +463,24 @@
             "status": {
               "description": "Status defines which status or range of statuses should result in an error page.\nIt can be either a status code as a number (500),\nas multiple comma-separated numbers (500,502),\nas ranges by separating two codes with a dash (500-599),\nor a combination of the two (404,418,500-599).",
               "items": {
+                "pattern": "^([1-5][0-9]{2}[,-]?)+$",
                 "type": "string"
               },
               "type": "array"
+            },
+            "statusRewrites": {
+              "additionalProperties": {
+                "type": "integer"
+              },
+              "description": "StatusRewrites defines a mapping of status codes that should be returned instead of the original error status codes.\nFor example: \"418\": 404 or \"410-418\": 404",
+              "type": "object"
             }
           },
           "type": "object",
           "additionalProperties": false
         },
         "forwardAuth": {
-          "description": "ForwardAuth holds the forward auth middleware configuration.\nThis middleware delegates the request authentication to a Service.\nMore info: https://doc.traefik.io/traefik/v3.3/middlewares/http/forwardauth/",
+          "description": "ForwardAuth holds the forward auth middleware configuration.\nThis middleware delegates the request authentication to a Service.\nMore info: https://doc.traefik.io/traefik/v3.5/middlewares/http/forwardauth/",
           "properties": {
             "addAuthCookiesToResponse": {
               "description": "AddAuthCookiesToResponse defines the list of cookies to copy from the authentication server response to the response.",
@@ -462,7 +508,7 @@
               "type": "array"
             },
             "authResponseHeadersRegex": {
-              "description": "AuthResponseHeadersRegex defines the regex to match headers to copy from the authentication server response and set on forwarded request, after stripping all headers that match the regex.\nMore info: https://doc.traefik.io/traefik/v3.3/middlewares/http/forwardauth/#authresponseheadersregex",
+              "description": "AuthResponseHeadersRegex defines the regex to match headers to copy from the authentication server response and set on forwarded request, after stripping all headers that match the regex.\nMore info: https://doc.traefik.io/traefik/v3.5/middlewares/http/forwardauth/#authresponseheadersregex",
               "type": "string"
             },
             "forwardBody": {
@@ -470,7 +516,7 @@
               "type": "boolean"
             },
             "headerField": {
-              "description": "HeaderField defines a header field to store the authenticated user.\nMore info: https://doc.traefik.io/traefik/v3.3/middlewares/http/forwardauth/#headerfield",
+              "description": "HeaderField defines a header field to store the authenticated user.\nMore info: https://doc.traefik.io/traefik/v3.5/middlewares/http/forwardauth/#headerfield",
               "type": "string"
             },
             "maxBodySize": {
@@ -480,6 +526,10 @@
             },
             "preserveLocationHeader": {
               "description": "PreserveLocationHeader defines whether to forward the Location header to the client as is or prefix it with the domain name of the authentication server.",
+              "type": "boolean"
+            },
+            "preserveRequestMethod": {
+              "description": "PreserveRequestMethod defines whether to preserve the original request method while forwarding the request to the authentication server.",
               "type": "boolean"
             },
             "tls": {
@@ -528,7 +578,7 @@
           "additionalProperties": false
         },
         "headers": {
-          "description": "Headers holds the headers middleware configuration.\nThis middleware manages the requests and responses headers.\nMore info: https://doc.traefik.io/traefik/v3.3/middlewares/http/headers/#customrequestheaders",
+          "description": "Headers holds the headers middleware configuration.\nThis middleware manages the requests and responses headers.\nMore info: https://doc.traefik.io/traefik/v3.5/middlewares/http/headers/#customrequestheaders",
           "properties": {
             "accessControlAllowCredentials": {
               "description": "AccessControlAllowCredentials defines whether the request can include user credentials.",
@@ -692,6 +742,7 @@
             "stsSeconds": {
               "description": "STSSeconds defines the max-age of the Strict-Transport-Security header.\nIf set to 0, the header is not set.",
               "format": "int64",
+              "minimum": 0,
               "type": "integer"
             }
           },
@@ -699,21 +750,23 @@
           "additionalProperties": false
         },
         "inFlightReq": {
-          "description": "InFlightReq holds the in-flight request middleware configuration.\nThis middleware limits the number of requests being processed and served concurrently.\nMore info: https://doc.traefik.io/traefik/v3.3/middlewares/http/inflightreq/",
+          "description": "InFlightReq holds the in-flight request middleware configuration.\nThis middleware limits the number of requests being processed and served concurrently.\nMore info: https://doc.traefik.io/traefik/v3.5/middlewares/http/inflightreq/",
           "properties": {
             "amount": {
               "description": "Amount defines the maximum amount of allowed simultaneous in-flight request.\nThe middleware responds with HTTP 429 Too Many Requests if there are already amount requests in progress (based on the same sourceCriterion strategy).",
               "format": "int64",
+              "minimum": 0,
               "type": "integer"
             },
             "sourceCriterion": {
-              "description": "SourceCriterion defines what criterion is used to group requests as originating from a common source.\nIf several strategies are defined at the same time, an error will be raised.\nIf none are set, the default is to use the requestHost.\nMore info: https://doc.traefik.io/traefik/v3.3/middlewares/http/inflightreq/#sourcecriterion",
+              "description": "SourceCriterion defines what criterion is used to group requests as originating from a common source.\nIf several strategies are defined at the same time, an error will be raised.\nIf none are set, the default is to use the requestHost.\nMore info: https://doc.traefik.io/traefik/v3.5/middlewares/http/inflightreq/#sourcecriterion",
               "properties": {
                 "ipStrategy": {
-                  "description": "IPStrategy holds the IP strategy configuration used by Traefik to determine the client IP.\nMore info: https://doc.traefik.io/traefik/v3.3/middlewares/http/ipallowlist/#ipstrategy",
+                  "description": "IPStrategy holds the IP strategy configuration used by Traefik to determine the client IP.\nMore info: https://doc.traefik.io/traefik/v3.5/middlewares/http/ipallowlist/#ipstrategy",
                   "properties": {
                     "depth": {
                       "description": "Depth tells Traefik to use the X-Forwarded-For header and take the IP located at the depth position (starting from the right).",
+                      "minimum": 0,
                       "type": "integer"
                     },
                     "excludedIPs": {
@@ -748,13 +801,14 @@
           "additionalProperties": false
         },
         "ipAllowList": {
-          "description": "IPAllowList holds the IP allowlist middleware configuration.\nThis middleware limits allowed requests based on the client IP.\nMore info: https://doc.traefik.io/traefik/v3.3/middlewares/http/ipallowlist/",
+          "description": "IPAllowList holds the IP allowlist middleware configuration.\nThis middleware limits allowed requests based on the client IP.\nMore info: https://doc.traefik.io/traefik/v3.5/middlewares/http/ipallowlist/",
           "properties": {
             "ipStrategy": {
-              "description": "IPStrategy holds the IP strategy configuration used by Traefik to determine the client IP.\nMore info: https://doc.traefik.io/traefik/v3.3/middlewares/http/ipallowlist/#ipstrategy",
+              "description": "IPStrategy holds the IP strategy configuration used by Traefik to determine the client IP.\nMore info: https://doc.traefik.io/traefik/v3.5/middlewares/http/ipallowlist/#ipstrategy",
               "properties": {
                 "depth": {
                   "description": "Depth tells Traefik to use the X-Forwarded-For header and take the IP located at the depth position (starting from the right).",
+                  "minimum": 0,
                   "type": "integer"
                 },
                 "excludedIPs": {
@@ -791,10 +845,11 @@
           "description": "Deprecated: please use IPAllowList instead.",
           "properties": {
             "ipStrategy": {
-              "description": "IPStrategy holds the IP strategy configuration used by Traefik to determine the client IP.\nMore info: https://doc.traefik.io/traefik/v3.3/middlewares/http/ipallowlist/#ipstrategy",
+              "description": "IPStrategy holds the IP strategy configuration used by Traefik to determine the client IP.\nMore info: https://doc.traefik.io/traefik/v3.5/middlewares/http/ipallowlist/#ipstrategy",
               "properties": {
                 "depth": {
                   "description": "Depth tells Traefik to use the X-Forwarded-For header and take the IP located at the depth position (starting from the right).",
+                  "minimum": 0,
                   "type": "integer"
                 },
                 "excludedIPs": {
@@ -824,7 +879,7 @@
           "additionalProperties": false
         },
         "passTLSClientCert": {
-          "description": "PassTLSClientCert holds the pass TLS client cert middleware configuration.\nThis middleware adds the selected data from the passed client TLS certificate to a header.\nMore info: https://doc.traefik.io/traefik/v3.3/middlewares/http/passtlsclientcert/",
+          "description": "PassTLSClientCert holds the pass TLS client cert middleware configuration.\nThis middleware adds the selected data from the passed client TLS certificate to a header.\nMore info: https://doc.traefik.io/traefik/v3.5/middlewares/http/passtlsclientcert/",
           "properties": {
             "info": {
               "description": "Info selects the specific client certificate details you want to add to the X-Forwarded-Tls-Client-Cert-Info header.",
@@ -939,16 +994,18 @@
           "type": "object"
         },
         "rateLimit": {
-          "description": "RateLimit holds the rate limit configuration.\nThis middleware ensures that services will receive a fair amount of requests, and allows one to define what fair is.\nMore info: https://doc.traefik.io/traefik/v3.3/middlewares/http/ratelimit/",
+          "description": "RateLimit holds the rate limit configuration.\nThis middleware ensures that services will receive a fair amount of requests, and allows one to define what fair is.\nMore info: https://doc.traefik.io/traefik/v3.5/middlewares/http/ratelimit/",
           "properties": {
             "average": {
               "description": "Average is the maximum rate, by default in requests/s, allowed for the given source.\nIt defaults to 0, which means no rate limiting.\nThe rate is actually defined by dividing Average by Period. So for a rate below 1req/s,\none needs to define a Period larger than a second.",
               "format": "int64",
+              "minimum": 0,
               "type": "integer"
             },
             "burst": {
               "description": "Burst is the maximum number of requests allowed to arrive in the same arbitrarily small period of time.\nIt defaults to 1.",
               "format": "int64",
+              "minimum": 0,
               "type": "integer"
             },
             "period": {
@@ -963,14 +1020,107 @@
               "description": "Period, in combination with Average, defines the actual maximum rate, such as:\nr = Average / Period. It defaults to a second.",
               "x-kubernetes-int-or-string": true
             },
+            "redis": {
+              "description": "Redis hold the configs of Redis as bucket in rate limiter.",
+              "properties": {
+                "db": {
+                  "description": "DB defines the Redis database that will be selected after connecting to the server.",
+                  "type": "integer"
+                },
+                "dialTimeout": {
+                  "anyOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "description": "DialTimeout sets the timeout for establishing new connections.\nDefault value is 5 seconds.",
+                  "pattern": "^([0-9]+(ns|us|\u00b5s|ms|s|m|h)?)+$",
+                  "x-kubernetes-int-or-string": true
+                },
+                "endpoints": {
+                  "description": "Endpoints contains either a single address or a seed list of host:port addresses.\nDefault value is [\"localhost:6379\"].",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "maxActiveConns": {
+                  "description": "MaxActiveConns defines the maximum number of connections allocated by the pool at a given time.\nDefault value is 0, meaning there is no limit.",
+                  "type": "integer"
+                },
+                "minIdleConns": {
+                  "description": "MinIdleConns defines the minimum number of idle connections.\nDefault value is 0, and idle connections are not closed by default.",
+                  "type": "integer"
+                },
+                "poolSize": {
+                  "description": "PoolSize defines the initial number of socket connections.\nIf the pool runs out of available connections, additional ones will be created beyond PoolSize.\nThis can be limited using MaxActiveConns.\n// Default value is 0, meaning 10 connections per every available CPU as reported by runtime.GOMAXPROCS.",
+                  "type": "integer"
+                },
+                "readTimeout": {
+                  "anyOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "description": "ReadTimeout defines the timeout for socket read operations.\nDefault value is 3 seconds.",
+                  "pattern": "^([0-9]+(ns|us|\u00b5s|ms|s|m|h)?)+$",
+                  "x-kubernetes-int-or-string": true
+                },
+                "secret": {
+                  "description": "Secret defines the name of the referenced Kubernetes Secret containing Redis credentials.",
+                  "type": "string"
+                },
+                "tls": {
+                  "description": "TLS defines TLS-specific configurations, including the CA, certificate, and key,\nwhich can be provided as a file path or file content.",
+                  "properties": {
+                    "caSecret": {
+                      "description": "CASecret is the name of the referenced Kubernetes Secret containing the CA to validate the server certificate.\nThe CA certificate is extracted from key `tls.ca` or `ca.crt`.",
+                      "type": "string"
+                    },
+                    "certSecret": {
+                      "description": "CertSecret is the name of the referenced Kubernetes Secret containing the client certificate.\nThe client certificate is extracted from the keys `tls.crt` and `tls.key`.",
+                      "type": "string"
+                    },
+                    "insecureSkipVerify": {
+                      "description": "InsecureSkipVerify defines whether the server certificates should be validated.",
+                      "type": "boolean"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "writeTimeout": {
+                  "anyOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "description": "WriteTimeout defines the timeout for socket write operations.\nDefault value is 3 seconds.",
+                  "pattern": "^([0-9]+(ns|us|\u00b5s|ms|s|m|h)?)+$",
+                  "x-kubernetes-int-or-string": true
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
             "sourceCriterion": {
               "description": "SourceCriterion defines what criterion is used to group requests as originating from a common source.\nIf several strategies are defined at the same time, an error will be raised.\nIf none are set, the default is to use the request's remote address field (as an ipStrategy).",
               "properties": {
                 "ipStrategy": {
-                  "description": "IPStrategy holds the IP strategy configuration used by Traefik to determine the client IP.\nMore info: https://doc.traefik.io/traefik/v3.3/middlewares/http/ipallowlist/#ipstrategy",
+                  "description": "IPStrategy holds the IP strategy configuration used by Traefik to determine the client IP.\nMore info: https://doc.traefik.io/traefik/v3.5/middlewares/http/ipallowlist/#ipstrategy",
                   "properties": {
                     "depth": {
                       "description": "Depth tells Traefik to use the X-Forwarded-For header and take the IP located at the depth position (starting from the right).",
+                      "minimum": 0,
                       "type": "integer"
                     },
                     "excludedIPs": {
@@ -1005,10 +1155,10 @@
           "additionalProperties": false
         },
         "redirectRegex": {
-          "description": "RedirectRegex holds the redirect regex middleware configuration.\nThis middleware redirects a request using regex matching and replacement.\nMore info: https://doc.traefik.io/traefik/v3.3/middlewares/http/redirectregex/#regex",
+          "description": "RedirectRegex holds the redirect regex middleware configuration.\nThis middleware redirects a request using regex matching and replacement.\nMore info: https://doc.traefik.io/traefik/v3.5/middlewares/http/redirectregex/#regex",
           "properties": {
             "permanent": {
-              "description": "Permanent defines whether the redirection is permanent (301).",
+              "description": "Permanent defines whether the redirection is permanent (308).",
               "type": "boolean"
             },
             "regex": {
@@ -1024,10 +1174,10 @@
           "additionalProperties": false
         },
         "redirectScheme": {
-          "description": "RedirectScheme holds the redirect scheme middleware configuration.\nThis middleware redirects requests from a scheme/port to another.\nMore info: https://doc.traefik.io/traefik/v3.3/middlewares/http/redirectscheme/",
+          "description": "RedirectScheme holds the redirect scheme middleware configuration.\nThis middleware redirects requests from a scheme/port to another.\nMore info: https://doc.traefik.io/traefik/v3.5/middlewares/http/redirectscheme/",
           "properties": {
             "permanent": {
-              "description": "Permanent defines whether the redirection is permanent (301).",
+              "description": "Permanent defines whether the redirection is permanent (308).",
               "type": "boolean"
             },
             "port": {
@@ -1043,7 +1193,7 @@
           "additionalProperties": false
         },
         "replacePath": {
-          "description": "ReplacePath holds the replace path middleware configuration.\nThis middleware replaces the path of the request URL and store the original path in an X-Replaced-Path header.\nMore info: https://doc.traefik.io/traefik/v3.3/middlewares/http/replacepath/",
+          "description": "ReplacePath holds the replace path middleware configuration.\nThis middleware replaces the path of the request URL and store the original path in an X-Replaced-Path header.\nMore info: https://doc.traefik.io/traefik/v3.5/middlewares/http/replacepath/",
           "properties": {
             "path": {
               "description": "Path defines the path to use as replacement in the request URL.",
@@ -1054,7 +1204,7 @@
           "additionalProperties": false
         },
         "replacePathRegex": {
-          "description": "ReplacePathRegex holds the replace path regex middleware configuration.\nThis middleware replaces the path of a URL using regex matching and replacement.\nMore info: https://doc.traefik.io/traefik/v3.3/middlewares/http/replacepathregex/",
+          "description": "ReplacePathRegex holds the replace path regex middleware configuration.\nThis middleware replaces the path of a URL using regex matching and replacement.\nMore info: https://doc.traefik.io/traefik/v3.5/middlewares/http/replacepathregex/",
           "properties": {
             "regex": {
               "description": "Regex defines the regular expression used to match and capture the path from the request URL.",
@@ -1069,10 +1219,11 @@
           "additionalProperties": false
         },
         "retry": {
-          "description": "Retry holds the retry middleware configuration.\nThis middleware reissues requests a given number of times to a backend server if that server does not reply.\nAs soon as the server answers, the middleware stops retrying, regardless of the response status.\nMore info: https://doc.traefik.io/traefik/v3.3/middlewares/http/retry/",
+          "description": "Retry holds the retry middleware configuration.\nThis middleware reissues requests a given number of times to a backend server if that server does not reply.\nAs soon as the server answers, the middleware stops retrying, regardless of the response status.\nMore info: https://doc.traefik.io/traefik/v3.5/middlewares/http/retry/",
           "properties": {
             "attempts": {
               "description": "Attempts defines how many times the request should be retried.",
+              "minimum": 0,
               "type": "integer"
             },
             "initialInterval": {
@@ -1085,6 +1236,7 @@
                 }
               ],
               "description": "InitialInterval defines the first wait time in the exponential backoff series.\nThe maximum interval is calculated as twice the initialInterval.\nIf unspecified, requests will be retried immediately.\nThe value of initialInterval should be provided in seconds or as a valid duration format,\nsee https://pkg.go.dev/time#ParseDuration.",
+              "pattern": "^([0-9]+(ns|us|\u00b5s|ms|s|m|h)?)+$",
               "x-kubernetes-int-or-string": true
             }
           },
@@ -1092,7 +1244,7 @@
           "additionalProperties": false
         },
         "stripPrefix": {
-          "description": "StripPrefix holds the strip prefix middleware configuration.\nThis middleware removes the specified prefixes from the URL path.\nMore info: https://doc.traefik.io/traefik/v3.3/middlewares/http/stripprefix/",
+          "description": "StripPrefix holds the strip prefix middleware configuration.\nThis middleware removes the specified prefixes from the URL path.\nMore info: https://doc.traefik.io/traefik/v3.5/middlewares/http/stripprefix/",
           "properties": {
             "forceSlash": {
               "description": "Deprecated: ForceSlash option is deprecated, please remove any usage of this option.\nForceSlash ensures that the resulting stripped path is not the empty string, by replacing it with / when necessary.\nDefault: true.",
@@ -1110,7 +1262,7 @@
           "additionalProperties": false
         },
         "stripPrefixRegex": {
-          "description": "StripPrefixRegex holds the strip prefix regex middleware configuration.\nThis middleware removes the matching prefixes from the URL path.\nMore info: https://doc.traefik.io/traefik/v3.3/middlewares/http/stripprefixregex/",
+          "description": "StripPrefixRegex holds the strip prefix regex middleware configuration.\nThis middleware removes the matching prefixes from the URL path.\nMore info: https://doc.traefik.io/traefik/v3.5/middlewares/http/stripprefixregex/",
           "properties": {
             "regex": {
               "description": "Regex defines the regular expression to match the path prefix from the request URL.",

--- a/traefik.io/middlewaretcp_v1alpha1.json
+++ b/traefik.io/middlewaretcp_v1alpha1.json
@@ -1,5 +1,5 @@
 {
-  "description": "MiddlewareTCP is the CRD implementation of a Traefik TCP middleware.\nMore info: https://doc.traefik.io/traefik/v3.3/middlewares/overview/",
+  "description": "MiddlewareTCP is the CRD implementation of a Traefik TCP middleware.\nMore info: https://doc.traefik.io/traefik/v3.5/middlewares/overview/",
   "properties": {
     "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
@@ -21,6 +21,7 @@
             "amount": {
               "description": "Amount defines the maximum amount of allowed simultaneous connections.\nThe middleware closes the connection if there are already amount connections opened.",
               "format": "int64",
+              "minimum": 0,
               "type": "integer"
             }
           },
@@ -28,7 +29,7 @@
           "additionalProperties": false
         },
         "ipAllowList": {
-          "description": "IPAllowList defines the IPAllowList middleware configuration.\nThis middleware accepts/refuses connections based on the client IP.\nMore info: https://doc.traefik.io/traefik/v3.3/middlewares/tcp/ipallowlist/",
+          "description": "IPAllowList defines the IPAllowList middleware configuration.\nThis middleware accepts/refuses connections based on the client IP.\nMore info: https://doc.traefik.io/traefik/v3.5/middlewares/tcp/ipallowlist/",
           "properties": {
             "sourceRange": {
               "description": "SourceRange defines the allowed IPs (or ranges of allowed IPs by using CIDR notation).",
@@ -42,7 +43,7 @@
           "additionalProperties": false
         },
         "ipWhiteList": {
-          "description": "IPWhiteList defines the IPWhiteList middleware configuration.\nThis middleware accepts/refuses connections based on the client IP.\nDeprecated: please use IPAllowList instead.\nMore info: https://doc.traefik.io/traefik/v3.3/middlewares/tcp/ipwhitelist/",
+          "description": "IPWhiteList defines the IPWhiteList middleware configuration.\nThis middleware accepts/refuses connections based on the client IP.\nDeprecated: please use IPAllowList instead.\nMore info: https://doc.traefik.io/traefik/v3.5/middlewares/tcp/ipwhitelist/",
           "properties": {
             "sourceRange": {
               "description": "SourceRange defines the allowed IPs (or ranges of allowed IPs by using CIDR notation).",

--- a/traefik.io/serverstransport_v1alpha1.json
+++ b/traefik.io/serverstransport_v1alpha1.json
@@ -1,5 +1,5 @@
 {
-  "description": "ServersTransport is the CRD implementation of a ServersTransport.\nIf no serversTransport is specified, the default@internal will be used.\nThe default@internal serversTransport is created from the static configuration.\nMore info: https://doc.traefik.io/traefik/v3.3/routing/services/#serverstransport_1",
+  "description": "ServersTransport is the CRD implementation of a ServersTransport.\nIf no serversTransport is specified, the default@internal will be used.\nThe default@internal serversTransport is created from the static configuration.\nMore info: https://doc.traefik.io/traefik/v3.5/routing/services/#serverstransport_1",
   "properties": {
     "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
@@ -39,6 +39,7 @@
                 }
               ],
               "description": "DialTimeout is the amount of time to wait until a connection to a backend server can be established.",
+              "pattern": "^([0-9]+(ns|us|\u00b5s|ms|s|m|h)?)+$",
               "x-kubernetes-int-or-string": true
             },
             "idleConnTimeout": {
@@ -51,6 +52,7 @@
                 }
               ],
               "description": "IdleConnTimeout is the maximum period for which an idle HTTP keep-alive connection will remain open before closing itself.",
+              "pattern": "^([0-9]+(ns|us|\u00b5s|ms|s|m|h)?)+$",
               "x-kubernetes-int-or-string": true
             },
             "pingTimeout": {
@@ -63,6 +65,7 @@
                 }
               ],
               "description": "PingTimeout is the timeout after which the HTTP/2 connection will be closed if a response to ping is not received.",
+              "pattern": "^([0-9]+(ns|us|\u00b5s|ms|s|m|h)?)+$",
               "x-kubernetes-int-or-string": true
             },
             "readIdleTimeout": {
@@ -75,6 +78,7 @@
                 }
               ],
               "description": "ReadIdleTimeout is the timeout after which a health check using ping frame will be carried out if no frame is received on the HTTP/2 connection.",
+              "pattern": "^([0-9]+(ns|us|\u00b5s|ms|s|m|h)?)+$",
               "x-kubernetes-int-or-string": true
             },
             "responseHeaderTimeout": {
@@ -87,6 +91,7 @@
                 }
               ],
               "description": "ResponseHeaderTimeout is the amount of time to wait for a server's response headers after fully writing the request (including its body, if any).",
+              "pattern": "^([0-9]+(ns|us|\u00b5s|ms|s|m|h)?)+$",
               "x-kubernetes-int-or-string": true
             }
           },
@@ -99,14 +104,40 @@
         },
         "maxIdleConnsPerHost": {
           "description": "MaxIdleConnsPerHost controls the maximum idle (keep-alive) to keep per-host.",
+          "minimum": 0,
           "type": "integer"
         },
         "peerCertURI": {
           "description": "PeerCertURI defines the peer cert URI used to match against SAN URI during the peer certificate verification.",
           "type": "string"
         },
+        "rootCAs": {
+          "description": "RootCAs defines a list of CA certificate Secrets or ConfigMaps used to validate server certificates.",
+          "items": {
+            "description": "RootCA defines a reference to a Secret or a ConfigMap that holds a CA certificate.\nIf both a Secret and a ConfigMap reference are defined, the Secret reference takes precedence.",
+            "properties": {
+              "configMap": {
+                "description": "ConfigMap defines the name of a ConfigMap that holds a CA certificate.\nThe referenced ConfigMap must contain a certificate under either a tls.ca or a ca.crt key.",
+                "type": "string"
+              },
+              "secret": {
+                "description": "Secret defines the name of a Secret that holds a CA certificate.\nThe referenced Secret must contain a certificate under either a tls.ca or a ca.crt key.",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "x-kubernetes-validations": [
+              {
+                "message": "RootCA cannot have both Secret and ConfigMap defined.",
+                "rule": "!has(self.secret) || !has(self.configMap)"
+              }
+            ],
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
         "rootCAsSecrets": {
-          "description": "RootCAsSecrets defines a list of CA secret used to validate self-signed certificate.",
+          "description": "RootCAsSecrets defines a list of CA secret used to validate self-signed certificate.\nDeprecated: RootCAsSecrets is deprecated, please use the RootCAs option instead.",
           "items": {
             "type": "string"
           },

--- a/traefik.io/serverstransporttcp_v1alpha1.json
+++ b/traefik.io/serverstransporttcp_v1alpha1.json
@@ -1,5 +1,5 @@
 {
-  "description": "ServersTransportTCP is the CRD implementation of a TCPServersTransport.\nIf no tcpServersTransport is specified, a default one named default@internal will be used.\nThe default@internal tcpServersTransport can be configured in the static configuration.\nMore info: https://doc.traefik.io/traefik/v3.3/routing/services/#serverstransport_3",
+  "description": "ServersTransportTCP is the CRD implementation of a TCPServersTransport.\nIf no tcpServersTransport is specified, a default one named default@internal will be used.\nThe default@internal tcpServersTransport can be configured in the static configuration.\nMore info: https://doc.traefik.io/traefik/v3.5/routing/services/#serverstransport_3",
   "properties": {
     "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
@@ -25,6 +25,7 @@
             }
           ],
           "description": "DialKeepAlive is the interval between keep-alive probes for an active network connection. If zero, keep-alive probes are sent with a default value (currently 15 seconds), if supported by the protocol and operating system. Network protocols or operating systems that do not support keep-alives ignore this field. If negative, keep-alive probes are disabled.",
+          "pattern": "^([0-9]+(ns|us|\u00b5s|ms|s|m|h)?)+$",
           "x-kubernetes-int-or-string": true
         },
         "dialTimeout": {
@@ -37,6 +38,7 @@
             }
           ],
           "description": "DialTimeout is the amount of time to wait until a connection to a backend server can be established.",
+          "pattern": "^([0-9]+(ns|us|\u00b5s|ms|s|m|h)?)+$",
           "x-kubernetes-int-or-string": true
         },
         "terminationDelay": {
@@ -49,6 +51,7 @@
             }
           ],
           "description": "TerminationDelay defines the delay to wait before fully terminating the connection, after one connected peer has closed its writing capability.",
+          "pattern": "^([0-9]+(ns|us|\u00b5s|ms|s|m|h)?)+$",
           "x-kubernetes-int-or-string": true
         },
         "tls": {
@@ -69,8 +72,33 @@
               "description": "MaxIdleConnsPerHost controls the maximum idle (keep-alive) to keep per-host.\nPeerCertURI defines the peer cert URI used to match against SAN URI during the peer certificate verification.",
               "type": "string"
             },
+            "rootCAs": {
+              "description": "RootCAs defines a list of CA certificate Secrets or ConfigMaps used to validate server certificates.",
+              "items": {
+                "description": "RootCA defines a reference to a Secret or a ConfigMap that holds a CA certificate.\nIf both a Secret and a ConfigMap reference are defined, the Secret reference takes precedence.",
+                "properties": {
+                  "configMap": {
+                    "description": "ConfigMap defines the name of a ConfigMap that holds a CA certificate.\nThe referenced ConfigMap must contain a certificate under either a tls.ca or a ca.crt key.",
+                    "type": "string"
+                  },
+                  "secret": {
+                    "description": "Secret defines the name of a Secret that holds a CA certificate.\nThe referenced Secret must contain a certificate under either a tls.ca or a ca.crt key.",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "x-kubernetes-validations": [
+                  {
+                    "message": "RootCA cannot have both Secret and ConfigMap defined.",
+                    "rule": "!has(self.secret) || !has(self.configMap)"
+                  }
+                ],
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
             "rootCAsSecrets": {
-              "description": "RootCAsSecrets defines a list of CA secret used to validate self-signed certificates.",
+              "description": "RootCAsSecrets defines a list of CA secret used to validate self-signed certificate.\nDeprecated: RootCAsSecrets is deprecated, please use the RootCAs option instead.",
               "items": {
                 "type": "string"
               },

--- a/traefik.io/tlsoption_v1alpha1.json
+++ b/traefik.io/tlsoption_v1alpha1.json
@@ -1,5 +1,5 @@
 {
-  "description": "TLSOption is the CRD implementation of a Traefik TLS Option, allowing to configure some parameters of the TLS connection.\nMore info: https://doc.traefik.io/traefik/v3.3/https/tls/#tls-options",
+  "description": "TLSOption is the CRD implementation of a Traefik TLS Option, allowing to configure some parameters of the TLS connection.\nMore info: https://doc.traefik.io/traefik/v3.5/https/tls/#tls-options",
   "properties": {
     "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
@@ -16,14 +16,14 @@
       "description": "TLSOptionSpec defines the desired state of a TLSOption.",
       "properties": {
         "alpnProtocols": {
-          "description": "ALPNProtocols defines the list of supported application level protocols for the TLS handshake, in order of preference.\nMore info: https://doc.traefik.io/traefik/v3.3/https/tls/#alpn-protocols",
+          "description": "ALPNProtocols defines the list of supported application level protocols for the TLS handshake, in order of preference.\nMore info: https://doc.traefik.io/traefik/v3.5/https/tls/#alpn-protocols",
           "items": {
             "type": "string"
           },
           "type": "array"
         },
         "cipherSuites": {
-          "description": "CipherSuites defines the list of supported cipher suites for TLS versions up to TLS 1.2.\nMore info: https://doc.traefik.io/traefik/v3.3/https/tls/#cipher-suites",
+          "description": "CipherSuites defines the list of supported cipher suites for TLS versions up to TLS 1.2.\nMore info: https://doc.traefik.io/traefik/v3.5/https/tls/#cipher-suites",
           "items": {
             "type": "string"
           },
@@ -55,11 +55,15 @@
           "additionalProperties": false
         },
         "curvePreferences": {
-          "description": "CurvePreferences defines the preferred elliptic curves in a specific order.\nMore info: https://doc.traefik.io/traefik/v3.3/https/tls/#curve-preferences",
+          "description": "CurvePreferences defines the preferred elliptic curves.\nMore info: https://doc.traefik.io/traefik/v3.5/https/tls/#curve-preferences",
           "items": {
             "type": "string"
           },
           "type": "array"
+        },
+        "disableSessionTickets": {
+          "description": "DisableSessionTickets disables TLS session resumption via session tickets.",
+          "type": "boolean"
         },
         "maxVersion": {
           "description": "MaxVersion defines the maximum TLS version that Traefik will accept.\nPossible values: VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13.\nDefault: None.",

--- a/traefik.io/tlsstore_v1alpha1.json
+++ b/traefik.io/tlsstore_v1alpha1.json
@@ -1,5 +1,5 @@
 {
-  "description": "TLSStore is the CRD implementation of a Traefik TLS Store.\nFor the time being, only the TLSStore named default is supported.\nThis means that you cannot have two stores that are named default in different Kubernetes namespaces.\nMore info: https://doc.traefik.io/traefik/v3.3/https/tls/#certificates-stores",
+  "description": "TLSStore is the CRD implementation of a Traefik TLS Store.\nFor the time being, only the TLSStore named default is supported.\nThis means that you cannot have two stores that are named default in different Kubernetes namespaces.\nMore info: https://doc.traefik.io/traefik/v3.5/https/tls/#certificates-stores",
   "properties": {
     "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",

--- a/traefik.io/traefikservice_v1alpha1.json
+++ b/traefik.io/traefikservice_v1alpha1.json
@@ -1,5 +1,5 @@
 {
-  "description": "TraefikService is the CRD implementation of a Traefik Service.\nTraefikService object allows to:\n- Apply weight to Services on load-balancing\n- Mirror traffic on services\nMore info: https://doc.traefik.io/traefik/v3.3/routing/providers/kubernetes-crd/#kind-traefikservice",
+  "description": "TraefikService is the CRD implementation of a Traefik Service.\nTraefikService object allows to:\n- Apply weight to Services on load-balancing\n- Mirror traffic on services\nMore info: https://doc.traefik.io/traefik/v3.5/routing/providers/kubernetes-crd/#kind-traefikservice",
   "properties": {
     "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
@@ -45,7 +45,7 @@
                       "type": "string"
                     }
                   ],
-                  "description": "Interval defines the frequency of the health check calls.\nDefault: 30s",
+                  "description": "Interval defines the frequency of the health check calls for healthy targets.\nDefault: 30s",
                   "x-kubernetes-int-or-string": true
                 },
                 "method": {
@@ -82,6 +82,18 @@
                     }
                   ],
                   "description": "Timeout defines the maximum duration Traefik will wait for a health check request before considering the server unhealthy.\nDefault: 5s",
+                  "x-kubernetes-int-or-string": true
+                },
+                "unhealthyInterval": {
+                  "anyOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "description": "UnhealthyInterval defines the frequency of the health check calls for unhealthy targets.\nWhen UnhealthyInterval is not defined, it defaults to the Interval value.\nDefault: 30s",
                   "x-kubernetes-int-or-string": true
                 }
               },
@@ -137,7 +149,7 @@
                             "type": "string"
                           }
                         ],
-                        "description": "Interval defines the frequency of the health check calls.\nDefault: 30s",
+                        "description": "Interval defines the frequency of the health check calls for healthy targets.\nDefault: 30s",
                         "x-kubernetes-int-or-string": true
                       },
                       "method": {
@@ -174,6 +186,18 @@
                           }
                         ],
                         "description": "Timeout defines the maximum duration Traefik will wait for a health check request before considering the server unhealthy.\nDefault: 5s",
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "unhealthyInterval": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "description": "UnhealthyInterval defines the frequency of the health check calls for unhealthy targets.\nWhen UnhealthyInterval is not defined, it defaults to the Interval value.\nDefault: 30s",
                         "x-kubernetes-int-or-string": true
                       }
                     },
@@ -244,11 +268,15 @@
                     "type": "string"
                   },
                   "sticky": {
-                    "description": "Sticky defines the sticky sessions configuration.\nMore info: https://doc.traefik.io/traefik/v3.3/routing/services/#sticky-sessions",
+                    "description": "Sticky defines the sticky sessions configuration.\nMore info: https://doc.traefik.io/traefik/v3.5/routing/services/#sticky-sessions",
                     "properties": {
                       "cookie": {
                         "description": "Cookie defines the sticky cookie configuration.",
                         "properties": {
+                          "domain": {
+                            "description": "Domain defines the host to which the cookie will be sent.\nMore info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#domaindomain-value",
+                            "type": "string"
+                          },
                           "httpOnly": {
                             "description": "HTTPOnly defines whether the cookie can be accessed by client-side APIs, such as JavaScript.",
                             "type": "boolean"
@@ -267,6 +295,11 @@
                           },
                           "sameSite": {
                             "description": "SameSite defines the same site policy.\nMore info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite",
+                            "enum": [
+                              "none",
+                              "lax",
+                              "strict"
+                            ],
                             "type": "string"
                           },
                           "secure": {
@@ -282,11 +315,17 @@
                     "additionalProperties": false
                   },
                   "strategy": {
-                    "description": "Strategy defines the load balancing strategy between the servers.\nRoundRobin is the only supported value at the moment.",
+                    "description": "Strategy defines the load balancing strategy between the servers.\nSupported values are: wrr (Weighed round-robin) and p2c (Power of two choices).\nRoundRobin value is deprecated and supported for backward compatibility.",
+                    "enum": [
+                      "wrr",
+                      "p2c",
+                      "RoundRobin"
+                    ],
                     "type": "string"
                   },
                   "weight": {
                     "description": "Weight defines the weight and should only be specified when Name references a TraefikService object\n(and to be precise, one that embeds a Weighted Round Robin).",
+                    "minimum": 0,
                     "type": "integer"
                   }
                 },
@@ -350,11 +389,15 @@
               "type": "string"
             },
             "sticky": {
-              "description": "Sticky defines the sticky sessions configuration.\nMore info: https://doc.traefik.io/traefik/v3.3/routing/services/#sticky-sessions",
+              "description": "Sticky defines the sticky sessions configuration.\nMore info: https://doc.traefik.io/traefik/v3.5/routing/services/#sticky-sessions",
               "properties": {
                 "cookie": {
                   "description": "Cookie defines the sticky cookie configuration.",
                   "properties": {
+                    "domain": {
+                      "description": "Domain defines the host to which the cookie will be sent.\nMore info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#domaindomain-value",
+                      "type": "string"
+                    },
                     "httpOnly": {
                       "description": "HTTPOnly defines whether the cookie can be accessed by client-side APIs, such as JavaScript.",
                       "type": "boolean"
@@ -373,6 +416,11 @@
                     },
                     "sameSite": {
                       "description": "SameSite defines the same site policy.\nMore info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite",
+                      "enum": [
+                        "none",
+                        "lax",
+                        "strict"
+                      ],
                       "type": "string"
                     },
                     "secure": {
@@ -388,11 +436,17 @@
               "additionalProperties": false
             },
             "strategy": {
-              "description": "Strategy defines the load balancing strategy between the servers.\nRoundRobin is the only supported value at the moment.",
+              "description": "Strategy defines the load balancing strategy between the servers.\nSupported values are: wrr (Weighed round-robin) and p2c (Power of two choices).\nRoundRobin value is deprecated and supported for backward compatibility.",
+              "enum": [
+                "wrr",
+                "p2c",
+                "RoundRobin"
+              ],
               "type": "string"
             },
             "weight": {
               "description": "Weight defines the weight and should only be specified when Name references a TraefikService object\n(and to be precise, one that embeds a Weighted Round Robin).",
+              "minimum": 0,
               "type": "integer"
             }
           },
@@ -437,7 +491,7 @@
                             "type": "string"
                           }
                         ],
-                        "description": "Interval defines the frequency of the health check calls.\nDefault: 30s",
+                        "description": "Interval defines the frequency of the health check calls for healthy targets.\nDefault: 30s",
                         "x-kubernetes-int-or-string": true
                       },
                       "method": {
@@ -474,6 +528,18 @@
                           }
                         ],
                         "description": "Timeout defines the maximum duration Traefik will wait for a health check request before considering the server unhealthy.\nDefault: 5s",
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "unhealthyInterval": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "description": "UnhealthyInterval defines the frequency of the health check calls for unhealthy targets.\nWhen UnhealthyInterval is not defined, it defaults to the Interval value.\nDefault: 30s",
                         "x-kubernetes-int-or-string": true
                       }
                     },
@@ -540,11 +606,15 @@
                     "type": "string"
                   },
                   "sticky": {
-                    "description": "Sticky defines the sticky sessions configuration.\nMore info: https://doc.traefik.io/traefik/v3.3/routing/services/#sticky-sessions",
+                    "description": "Sticky defines the sticky sessions configuration.\nMore info: https://doc.traefik.io/traefik/v3.5/routing/services/#sticky-sessions",
                     "properties": {
                       "cookie": {
                         "description": "Cookie defines the sticky cookie configuration.",
                         "properties": {
+                          "domain": {
+                            "description": "Domain defines the host to which the cookie will be sent.\nMore info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#domaindomain-value",
+                            "type": "string"
+                          },
                           "httpOnly": {
                             "description": "HTTPOnly defines whether the cookie can be accessed by client-side APIs, such as JavaScript.",
                             "type": "boolean"
@@ -563,6 +633,11 @@
                           },
                           "sameSite": {
                             "description": "SameSite defines the same site policy.\nMore info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite",
+                            "enum": [
+                              "none",
+                              "lax",
+                              "strict"
+                            ],
                             "type": "string"
                           },
                           "secure": {
@@ -578,11 +653,17 @@
                     "additionalProperties": false
                   },
                   "strategy": {
-                    "description": "Strategy defines the load balancing strategy between the servers.\nRoundRobin is the only supported value at the moment.",
+                    "description": "Strategy defines the load balancing strategy between the servers.\nSupported values are: wrr (Weighed round-robin) and p2c (Power of two choices).\nRoundRobin value is deprecated and supported for backward compatibility.",
+                    "enum": [
+                      "wrr",
+                      "p2c",
+                      "RoundRobin"
+                    ],
                     "type": "string"
                   },
                   "weight": {
                     "description": "Weight defines the weight and should only be specified when Name references a TraefikService object\n(and to be precise, one that embeds a Weighted Round Robin).",
+                    "minimum": 0,
                     "type": "integer"
                   }
                 },
@@ -595,11 +676,15 @@
               "type": "array"
             },
             "sticky": {
-              "description": "Sticky defines whether sticky sessions are enabled.\nMore info: https://doc.traefik.io/traefik/v3.3/routing/providers/kubernetes-crd/#stickiness-and-load-balancing",
+              "description": "Sticky defines whether sticky sessions are enabled.\nMore info: https://doc.traefik.io/traefik/v3.5/routing/providers/kubernetes-crd/#stickiness-and-load-balancing",
               "properties": {
                 "cookie": {
                   "description": "Cookie defines the sticky cookie configuration.",
                   "properties": {
+                    "domain": {
+                      "description": "Domain defines the host to which the cookie will be sent.\nMore info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#domaindomain-value",
+                      "type": "string"
+                    },
                     "httpOnly": {
                       "description": "HTTPOnly defines whether the cookie can be accessed by client-side APIs, such as JavaScript.",
                       "type": "boolean"
@@ -618,6 +703,11 @@
                     },
                     "sameSite": {
                       "description": "SameSite defines the same site policy.\nMore info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite",
+                      "enum": [
+                        "none",
+                        "lax",
+                        "strict"
+                      ],
                       "type": "string"
                     },
                     "secure": {


### PR DESCRIPTION
Updating the traefik.io CRDs to 3.5 from https://github.com/traefik/traefik-helm-chart/tree/master/traefik-crds/crds-files/traefik

## PR Checklist

- [x] I have used the [CRD Extractor](https://github.com/datreeio/CRDs-catalog?tab=readme-ov-file#crd-extractor) tool to generate these CRDs
