### PR TITLE
Update Cloudflare Origin CA Issuer CRDs (v0.12.1)

### DIFF
--- a/cert-manager.k8s.cloudflare.com/originissuer_v1.json
+++ b/cert-manager.k8s.cloudflare.com/originissuer_v1.json
@@ -1,12 +1,12 @@
 {
-  "description": "An OriginIssuer represents the Cloudflare Origin CA as an external cert-manager issuer. It is scoped to a single namespace, so it can be used only by resources in the same namespace.",
+  "description": "An OriginIssuer represents the Cloudflare Origin CA as an external cert-manager issuer.\nIt is scoped to a single namespace, so it can be used only by resources in the same\nnamespace.",
   "properties": {
     "apiVersion": {
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
       "type": "string"
     },
     "kind": {
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
       "type": "string"
     },
     "metadata": {
@@ -19,14 +19,33 @@
           "description": "Auth configures how to authenticate with the Cloudflare API.",
           "properties": {
             "serviceKeyRef": {
-              "description": "ServiceKeyRef authenticates with an API Service Key.",
+              "description": "ServiceKeyRef authenticates with an API Service Key (the \"Origin CA Key\").",
               "properties": {
                 "key": {
                   "description": "Key of the secret to select from. Must be a valid secret key.",
                   "type": "string"
                 },
                 "name": {
-                  "description": "Name of the secret in the OriginIssuer's namespace to select from.",
+                  "description": "Name of the secret in the issuer's namespace to select. If a cluster-scoped\nissuer, the secret is selected from the \"cluster resource namespace\" configured\non the controller.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "key",
+                "name"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "tokenRef": {
+              "description": "TokenRef authenticates with an API Token.",
+              "properties": {
+                "key": {
+                  "description": "Key of the secret to select from. Must be a valid secret key.",
+                  "type": "string"
+                },
+                "name": {
+                  "description": "Name of the secret in the issuer's namespace to select. If a cluster-scoped\nissuer, the secret is selected from the \"cluster resource namespace\" configured\non the controller.",
                   "type": "string"
                 }
               },
@@ -61,21 +80,21 @@
       "description": "Status of the OriginIssuer. This is set and managed automatically.",
       "properties": {
         "conditions": {
-          "description": "List of status conditions to indicate the status of an OriginIssuer Known condition types are `Ready`.",
+          "description": "List of status conditions to indicate the status of an OriginIssuer\nKnown condition types are `Ready`.",
           "items": {
             "description": "OriginIssuerCondition contains condition information for the OriginIssuer.",
             "properties": {
               "lastTransitionTime": {
-                "description": "LastTransitionTime is the timestamp corresponding to the last status change of this condition.",
+                "description": "LastTransitionTime is the timestamp corresponding to the last status\nchange of this condition.",
                 "format": "date-time",
                 "type": "string"
               },
               "message": {
-                "description": "Message is a human readable description of the details of the last transition1, complementing reason.",
+                "description": "Message is a human readable description of the details of the last\ntransition1, complementing reason.",
                 "type": "string"
               },
               "reason": {
-                "description": "Reason is a brief machine readable explanation for the condition's last transition.",
+                "description": "Reason is a brief machine readable explanation for the condition's last\ntransition.",
                 "type": "string"
               },
               "status": {


### PR DESCRIPTION
Since the last update (v0.8.0), there are new changes in the CRDs, specially in the tokenRef section.

Generated using the documented script in the original PR for this CRD: 
```
export FILENAME_FORMAT="{fullgroup}__{kind}_{version}"
curl -s https://raw.githubusercontent.com/yannh/kubeconform/master/scripts/openapi2jsonschema.py | \
  python3 /dev/stdin $(
    curl -s https://api.github.com/repos/cloudflare/origin-ca-issuer/git/trees/v0.8.0\?recursive\=1 | \
      jq -r '.tree[] | select(.path | startswith("deploy/crds/")) | "https://raw.githubusercontent.com/cloudflare/origin-ca-issuer/v0.12.1/" + .path' | \
      tr '\n' ' '
  ) | \
  grep 'JSON schema written to' | \
  awk '{ print $(NF) }' | \
  xargs -I {} sh -c 'mkdir -p $(dirname $(echo {} | sed "s|__|/|")) && mv {} $(echo {} | sed "s|__|/|")'
```

## PR Checklist

- [X] I have used the [CRD Extractor](https://github.com/datreeio/CRDs-catalog?tab=readme-ov-file#crd-extractor) tool to generate these CRDs
