### PR TITLE
feat: add db_operator CRDs

### DIFF
--- a/kinda.rocks/database_v1alpha1.json
+++ b/kinda.rocks/database_v1alpha1.json
@@ -1,0 +1,300 @@
+{
+  "description": "A Database represents the declarative state of a PostgreSQL database.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "A DatabaseSpec defines the desired state of a Database.",
+      "properties": {
+        "deletionPolicy": {
+          "default": "Delete",
+          "description": "DeletionPolicy specifies what will happen to the underlying external\nwhen this managed resource is deleted - either \"Delete\" or \"Orphan\" the\nexternal resource.\nThis field is planned to be deprecated in favor of the ManagementPolicies\nfield in a future release. Currently, both could be set independently and\nnon-default values would be honored if the feature flag is enabled.\nSee the design doc for more information: https://github.com/crossplane/crossplane/blob/499895a25d1a1a0ba1604944ef98ac7a1a71f197/design/design-doc-observe-only-resources.md?plain=1#L223",
+          "enum": [
+            "Orphan",
+            "Delete"
+          ],
+          "type": "string"
+        },
+        "forProvider": {
+          "description": "DatabaseParameters are the configurable fields of a Database.",
+          "properties": {
+            "allowConnections": {
+              "description": "If false then no one can connect to this database. The default is true,\nallowing connections (except as restricted by other mechanisms, such as\nGRANT/REVOKE CONNECT).",
+              "type": "boolean"
+            },
+            "connectionLimit": {
+              "description": "How many concurrent connections can be made to this database. -1 (the\ndefault) means no limit.",
+              "type": "integer"
+            },
+            "encoding": {
+              "description": "Character set encoding to use in the new database. Specify a string\nconstant (e.g., 'SQL_ASCII'), or an integer encoding number, or DEFAULT\nto use the default encoding (namely, the encoding of the template\ndatabase). The character sets supported by the PostgreSQL server are\ndescribed in Section 23.3.1. See below for additional restrictions.",
+              "type": "string"
+            },
+            "isTemplate": {
+              "description": "If true, then this database can be cloned by any user with CREATEDB\nprivileges; if false (the default), then only superusers or the owner of\nthe database can clone it.",
+              "type": "boolean"
+            },
+            "lcCType": {
+              "description": "Character classification (LC_CTYPE) to use in the new database. This\naffects the categorization of characters, e.g. lower, upper and digit.\nThe default is to use the character classification of the template\ndatabase. See below for additional restrictions.",
+              "type": "string"
+            },
+            "lcCollate": {
+              "description": "Collation order (LC_COLLATE) to use in the new database. This affects the\nsort order applied to strings, e.g. in queries with ORDER BY, as well as\nthe order used in indexes on text columns. The default is to use the\ncollation order of the template database. See below for additional\nrestrictions.",
+              "type": "string"
+            },
+            "owner": {
+              "description": "The role name of the user who will own the new database, or DEFAULT to\nuse the default (namely, the user executing the command). To create a\ndatabase owned by another role, you must be a direct or indirect member\nof that role, or be a superuser.",
+              "type": "string"
+            },
+            "tablespace": {
+              "description": "The name of the tablespace that will be associated with the new database,\nor DEFAULT to use the template database's tablespace. This tablespace\nwill be the default tablespace used for objects created in this database.\nSee CREATE TABLESPACE for more information.",
+              "type": "string"
+            },
+            "template": {
+              "description": "The name of the template from which to create the new database, or\nDEFAULT to use the default template (template1).",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "managementPolicies": {
+          "default": [
+            "*"
+          ],
+          "description": "THIS IS A BETA FIELD. It is on by default but can be opted out\nthrough a Crossplane feature flag.\nManagementPolicies specify the array of actions Crossplane is allowed to\ntake on the managed and external resources.\nThis field is planned to replace the DeletionPolicy field in a future\nrelease. Currently, both could be set independently and non-default\nvalues would be honored if the feature flag is enabled. If both are\ncustom, the DeletionPolicy field will be ignored.\nSee the design doc for more information: https://github.com/crossplane/crossplane/blob/499895a25d1a1a0ba1604944ef98ac7a1a71f197/design/design-doc-observe-only-resources.md?plain=1#L223\nand this one: https://github.com/crossplane/crossplane/blob/444267e84783136daa93568b364a5f01228cacbe/design/one-pager-ignore-changes.md",
+          "items": {
+            "description": "A ManagementAction represents an action that the Crossplane controllers\ncan take on an external resource.",
+            "enum": [
+              "Observe",
+              "Create",
+              "Update",
+              "Delete",
+              "LateInitialize",
+              "*"
+            ],
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "providerConfigRef": {
+          "default": {
+            "name": "default"
+          },
+          "description": "ProviderConfigReference specifies how the provider that will be used to\ncreate, observe, update, and delete this managed resource should be\nconfigured.",
+          "properties": {
+            "name": {
+              "description": "Name of the referenced object.",
+              "type": "string"
+            },
+            "policy": {
+              "description": "Policies for referencing.",
+              "properties": {
+                "resolution": {
+                  "default": "Required",
+                  "description": "Resolution specifies whether resolution of this reference is required.\nThe default is 'Required', which means the reconcile will fail if the\nreference cannot be resolved. 'Optional' means this reference will be\na no-op if it cannot be resolved.",
+                  "enum": [
+                    "Required",
+                    "Optional"
+                  ],
+                  "type": "string"
+                },
+                "resolve": {
+                  "description": "Resolve specifies when this reference should be resolved. The default\nis 'IfNotPresent', which will attempt to resolve the reference only when\nthe corresponding field is not present. Use 'Always' to resolve the\nreference on every reconcile.",
+                  "enum": [
+                    "Always",
+                    "IfNotPresent"
+                  ],
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "publishConnectionDetailsTo": {
+          "description": "PublishConnectionDetailsTo specifies the connection secret config which\ncontains a name, metadata and a reference to secret store config to\nwhich any connection details for this managed resource should be written.\nConnection details frequently include the endpoint, username,\nand password required to connect to the managed resource.",
+          "properties": {
+            "configRef": {
+              "default": {
+                "name": "default"
+              },
+              "description": "SecretStoreConfigRef specifies which secret store config should be used\nfor this ConnectionSecret.",
+              "properties": {
+                "name": {
+                  "description": "Name of the referenced object.",
+                  "type": "string"
+                },
+                "policy": {
+                  "description": "Policies for referencing.",
+                  "properties": {
+                    "resolution": {
+                      "default": "Required",
+                      "description": "Resolution specifies whether resolution of this reference is required.\nThe default is 'Required', which means the reconcile will fail if the\nreference cannot be resolved. 'Optional' means this reference will be\na no-op if it cannot be resolved.",
+                      "enum": [
+                        "Required",
+                        "Optional"
+                      ],
+                      "type": "string"
+                    },
+                    "resolve": {
+                      "description": "Resolve specifies when this reference should be resolved. The default\nis 'IfNotPresent', which will attempt to resolve the reference only when\nthe corresponding field is not present. Use 'Always' to resolve the\nreference on every reconcile.",
+                      "enum": [
+                        "Always",
+                        "IfNotPresent"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "required": [
+                "name"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "metadata": {
+              "description": "Metadata is the metadata for connection secret.",
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Annotations are the annotations to be added to connection secret.\n- For Kubernetes secrets, this will be used as \"metadata.annotations\".\n- It is up to Secret Store implementation for others store types.",
+                  "type": "object"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Labels are the labels/tags to be added to connection secret.\n- For Kubernetes secrets, this will be used as \"metadata.labels\".\n- It is up to Secret Store implementation for others store types.",
+                  "type": "object"
+                },
+                "type": {
+                  "description": "Type is the SecretType for the connection secret.\n- Only valid for Kubernetes Secret Stores.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "name": {
+              "description": "Name is the name of the connection secret.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "writeConnectionSecretToRef": {
+          "description": "WriteConnectionSecretToReference specifies the namespace and name of a\nSecret to which any connection details for this managed resource should\nbe written. Connection details frequently include the endpoint, username,\nand password required to connect to the managed resource.\nThis field is planned to be replaced in a future release in favor of\nPublishConnectionDetailsTo. Currently, both could be set independently\nand connection details would be published to both without affecting\neach other.",
+          "properties": {
+            "name": {
+              "description": "Name of the secret.",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "Namespace of the secret.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name",
+            "namespace"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "forProvider"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "A DatabaseStatus represents the observed state of a Database.",
+      "properties": {
+        "conditions": {
+          "description": "Conditions of the resource.",
+          "items": {
+            "description": "A Condition that may apply to a resource.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "LastTransitionTime is the last time this condition transitioned from one\nstatus to another.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A Message containing details about this condition's last transition from\none status to another, if any.",
+                "type": "string"
+              },
+              "observedGeneration": {
+                "description": "ObservedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
+                "format": "int64",
+                "type": "integer"
+              },
+              "reason": {
+                "description": "A Reason for this condition's last transition from one status to another.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of this condition; is it currently True, False, or Unknown?",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of this condition. At most one of each condition type may apply to\na resource at any point in time.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "reason",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "type"
+          ],
+          "x-kubernetes-list-type": "map"
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration is the latest metadata.generation\nwhich resulted in either a ready state, or stalled due to error\nit can not recover from without human intervention.",
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "spec"
+  ],
+  "type": "object"
+}

--- a/kinda.rocks/database_v1beta1.json
+++ b/kinda.rocks/database_v1beta1.json
@@ -1,0 +1,179 @@
+{
+  "description": "Database is the Schema for the databases API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "DatabaseSpec defines the desired state of Database",
+      "properties": {
+        "backup": {
+          "description": "DatabaseBackup defines the desired state of backup and schedule",
+          "properties": {
+            "cron": {
+              "type": "string"
+            },
+            "enable": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "cron",
+            "enable"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "cleanup": {
+          "type": "boolean"
+        },
+        "credentials": {
+          "description": "Credentials should be used to setup everything relates to k8s secrets and configmaps\nTODO(@allanger): Field .spec.secretName should be moved here in the v1beta2 version",
+          "properties": {
+            "templates": {
+              "description": "Templates to add custom entries to ConfigMaps and Secrets",
+              "items": {
+                "description": "Tempaltes to add custom entries to ConfigMaps and Secrets",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "secret": {
+                    "type": "boolean"
+                  },
+                  "template": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name",
+                  "secret",
+                  "template"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "deletionProtected": {
+          "type": "boolean"
+        },
+        "instance": {
+          "type": "string"
+        },
+        "postgres": {
+          "description": "Postgres struct should be used to provide resource that only applicable to postgres",
+          "properties": {
+            "dropPublicSchema": {
+              "description": "If set to true, the public schema will be dropped after the database creation",
+              "type": "boolean"
+            },
+            "extensions": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "schemas": {
+              "description": "Specify schemas to be created. The user created by db-operator will have all access on them.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "template": {
+              "description": "Let user create database from template",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "secretName": {
+          "type": "string"
+        },
+        "secretsTemplates": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        }
+      },
+      "required": [
+        "backup",
+        "deletionProtected",
+        "instance",
+        "secretName"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "DatabaseStatus defines the observed state of Database",
+      "properties": {
+        "database": {
+          "type": "string"
+        },
+        "engine": {
+          "type": "string"
+        },
+        "monitorUserSecret": {
+          "type": "string"
+        },
+        "operatorVersion": {
+          "type": "string"
+        },
+        "proxyStatus": {
+          "description": "DatabaseProxyStatus defines whether proxy for database is enabled or not\nif so, provide information",
+          "properties": {
+            "serviceName": {
+              "type": "string"
+            },
+            "sqlPort": {
+              "format": "int32",
+              "type": "integer"
+            },
+            "status": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "serviceName",
+            "sqlPort",
+            "status"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "status": {
+          "description": "Important: Run \"make generate\" to regenerate code after modifying this file\nAdd custom validation using kubebuilder tags: https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html",
+          "type": "boolean"
+        },
+        "user": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "database",
+        "engine",
+        "status",
+        "user"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/kinda.rocks/dbinstance_v1alpha1.json
+++ b/kinda.rocks/dbinstance_v1alpha1.json
@@ -1,0 +1,198 @@
+{
+  "description": "DbInstance is the Schema for the dbinstances API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "DbInstanceSpec defines the desired state of DbInstance",
+      "properties": {
+        "adminSecretRef": {
+          "description": "NamespacedName is a fork of the kubernetes api type of the same name.\nSadly this is required because CRD structs must have all fields json tagged and the kubernetes type is not tagged.",
+          "properties": {
+            "Name": {
+              "type": "string"
+            },
+            "Namespace": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "Name",
+            "Namespace"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "backup": {
+          "description": "DbInstanceBackup defines name of google bucket to use for storing database dumps for backup when backup is enabled",
+          "properties": {
+            "bucket": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "bucket"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "engine": {
+          "description": "Important: Run \"make generate\" to regenerate code after modifying this file",
+          "type": "string"
+        },
+        "generic": {
+          "description": "GenericInstance is used when instance type is generic\nand describes necessary informations to use instance\ngeneric instance can be any backend, it must be reachable by described address and port",
+          "properties": {
+            "backupHost": {
+              "description": "BackupHost address will be used for dumping database for backup\nUsually secondary address for primary-secondary setup or cluster lb address\nIf it's not defined, above Host will be used as backup host address.",
+              "type": "string"
+            },
+            "host": {
+              "type": "string"
+            },
+            "port": {
+              "type": "integer"
+            },
+            "publicIp": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "host",
+            "port"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "google": {
+          "description": "GoogleInstance is used when instance type is Google Cloud SQL\nand describes necessary informations to use google API to create sql instances",
+          "properties": {
+            "apiEndpoint": {
+              "type": "string"
+            },
+            "clientSecretRef": {
+              "description": "NamespacedName is a fork of the kubernetes api type of the same name.\nSadly this is required because CRD structs must have all fields json tagged and the kubernetes type is not tagged.",
+              "properties": {
+                "Name": {
+                  "type": "string"
+                },
+                "Namespace": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "Name",
+                "Namespace"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "configmapRef": {
+              "description": "NamespacedName is a fork of the kubernetes api type of the same name.\nSadly this is required because CRD structs must have all fields json tagged and the kubernetes type is not tagged.",
+              "properties": {
+                "Name": {
+                  "type": "string"
+                },
+                "Namespace": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "Name",
+                "Namespace"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "instance": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "configmapRef",
+            "instance"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "monitoring": {
+          "description": "DbInstanceMonitoring defines if exporter",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "enabled"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "sslConnection": {
+          "description": "DbInstanceSSLConnection defines weather connection from db-operator to instance has to be ssl or not",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "skip-verify": {
+              "description": "SkipVerity use SSL connection, but don't check against a CA",
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "enabled",
+            "skip-verify"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "adminSecretRef",
+        "engine"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "DbInstanceStatus defines the observed state of DbInstance",
+      "properties": {
+        "checksums": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "info": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "phase": {
+          "description": "Important: Run \"make generate\" to regenerate code after modifying this file",
+          "type": "string"
+        },
+        "status": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "phase",
+        "status"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/kinda.rocks/dbinstance_v1beta1.json
+++ b/kinda.rocks/dbinstance_v1beta1.json
@@ -1,0 +1,273 @@
+{
+  "description": "DbInstance is the Schema for the dbinstances API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "DbInstanceSpec defines the desired state of DbInstance",
+      "properties": {
+        "adminSecretRef": {
+          "description": "NamespacedName is a fork of the kubernetes api type of the same name.\nSadly this is required because CRD structs must have all fields json tagged and the kubernetes type is not tagged.",
+          "properties": {
+            "Name": {
+              "type": "string"
+            },
+            "Namespace": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "Name",
+            "Namespace"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "allowedPrivileges": {
+          "description": "A list of privileges that are allowed to be set as Dbuser's extra privileges",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "backup": {
+          "description": "DbInstanceBackup defines name of google bucket to use for storing database dumps for backup when backup is enabled",
+          "properties": {
+            "bucket": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "bucket"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "engine": {
+          "description": "Important: Run \"make generate\" to regenerate code after modifying this file",
+          "type": "string"
+        },
+        "generic": {
+          "description": "GenericInstance is used when instance type is generic\nand describes necessary informations to use instance\ngeneric instance can be any backend, it must be reachable by described address and port",
+          "properties": {
+            "backupHost": {
+              "description": "BackupHost address will be used for dumping database for backup\nUsually secondary address for primary-secondary setup or cluster lb address\nIf it's not defined, above Host will be used as backup host address.",
+              "type": "string"
+            },
+            "host": {
+              "type": "string"
+            },
+            "hostFrom": {
+              "properties": {
+                "key": {
+                  "type": "string"
+                },
+                "kind": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "namespace": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "key",
+                "kind",
+                "name",
+                "namespace"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "port": {
+              "type": "integer"
+            },
+            "portFrom": {
+              "properties": {
+                "key": {
+                  "type": "string"
+                },
+                "kind": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "namespace": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "key",
+                "kind",
+                "name",
+                "namespace"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "publicIp": {
+              "type": "string"
+            },
+            "publicIpFrom": {
+              "properties": {
+                "key": {
+                  "type": "string"
+                },
+                "kind": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "namespace": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "key",
+                "kind",
+                "name",
+                "namespace"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "google": {
+          "description": "GoogleInstance is used when instance type is Google Cloud SQL\nand describes necessary informations to use google API to create sql instances",
+          "properties": {
+            "apiEndpoint": {
+              "type": "string"
+            },
+            "clientSecretRef": {
+              "description": "NamespacedName is a fork of the kubernetes api type of the same name.\nSadly this is required because CRD structs must have all fields json tagged and the kubernetes type is not tagged.",
+              "properties": {
+                "Name": {
+                  "type": "string"
+                },
+                "Namespace": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "Name",
+                "Namespace"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "configmapRef": {
+              "description": "NamespacedName is a fork of the kubernetes api type of the same name.\nSadly this is required because CRD structs must have all fields json tagged and the kubernetes type is not tagged.",
+              "properties": {
+                "Name": {
+                  "type": "string"
+                },
+                "Namespace": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "Name",
+                "Namespace"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "instance": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "configmapRef",
+            "instance"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "monitoring": {
+          "description": "DbInstanceMonitoring defines if exporter",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "enabled"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "sslConnection": {
+          "description": "DbInstanceSSLConnection defines weather connection from db-operator to instance has to be ssl or not",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "skip-verify": {
+              "description": "SkipVerity use SSL connection, but don't check against a CA",
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "enabled",
+            "skip-verify"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "adminSecretRef",
+        "engine"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "DbInstanceStatus defines the observed state of DbInstance",
+      "properties": {
+        "checksums": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "info": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "phase": {
+          "description": "Important: Run \"make generate\" to regenerate code after modifying this file",
+          "type": "string"
+        },
+        "status": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "phase",
+        "status"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/kinda.rocks/dbuser_v1beta1.json
+++ b/kinda.rocks/dbuser_v1beta1.json
@@ -1,0 +1,113 @@
+{
+  "description": "DbUser is the Schema for the dbusers API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "DbUserSpec defines the desired state of DbUser",
+      "properties": {
+        "accessType": {
+          "description": "AccessType that should be given to a user\nCurrently only readOnly and readWrite are supported by the operator",
+          "type": "string"
+        },
+        "cleanup": {
+          "type": "boolean"
+        },
+        "credentials": {
+          "description": "Credentials should be used to setup everything relates to k8s secrets and configmaps\nTODO(@allanger): Field .spec.secretName should be moved here in the v1beta2 version",
+          "properties": {
+            "templates": {
+              "description": "Templates to add custom entries to ConfigMaps and Secrets",
+              "items": {
+                "description": "Tempaltes to add custom entries to ConfigMaps and Secrets",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "secret": {
+                    "type": "boolean"
+                  },
+                  "template": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name",
+                  "secret",
+                  "template"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "databaseRef": {
+          "description": "DatabaseRef should contain a name of a Database to create a user there\nDatabase should be in the same namespace with the user",
+          "type": "string"
+        },
+        "extraPrivileges": {
+          "description": "A list of additional roles that should be added to the user",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "grantToAdmin": {
+          "default": true,
+          "description": "Should the user be granted to the admin user\nFor example, it should be set to true on Azure instance,\nbecause the admin given by them is not a super user,\nbut should be set to false on AWS, when rds_iam extra\nprivilege is added\nBy default is set to true\nOnly applies to Postgres, doesn't have any effect on Mysql\nTODO: Default should be false, but not to introduce breaking\n      changes it's now set to true. It should be changed in\n      in the next API version",
+          "type": "boolean"
+        },
+        "secretName": {
+          "description": "SecretName name that should be used to save user's credentials",
+          "type": "string"
+        }
+      },
+      "required": [
+        "accessType",
+        "databaseRef",
+        "secretName"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "DbUserStatus defines the observed state of DbUser",
+      "properties": {
+        "created": {
+          "description": "It's required to let the operator update users",
+          "type": "boolean"
+        },
+        "database": {
+          "type": "string"
+        },
+        "operatorVersion": {
+          "type": "string"
+        },
+        "status": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "created",
+        "database",
+        "status"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}


### PR DESCRIPTION
Adding https://github.com/db-operator/db-operator's CRDs to the tree. Source available [here](https://github.com/db-operator/db-operator/tree/main/api).

## PR Checklist

- [x] I have used the [CRD Extractor](https://github.com/datreeio/CRDs-catalog?tab=readme-ov-file#crd-extractor) tool to generate these CRDs
