### PR TITLE
feat: upgrade cnpg to 1.29.0

### DIFF
--- a/postgresql.cnpg.io/backup_v1.json
+++ b/postgresql.cnpg.io/backup_v1.json
@@ -186,6 +186,10 @@
               ],
               "type": "object",
               "additionalProperties": false
+            },
+            "useDefaultAzureCredentials": {
+              "description": "Use the default Azure authentication flow, which includes DefaultAzureCredential.\nThis allows authentication using environment variables and managed identities.",
+              "type": "boolean"
             }
           },
           "type": "object",
@@ -303,6 +307,10 @@
             "podName": {
               "description": "The pod name",
               "type": "string"
+            },
+            "sessionID": {
+              "description": "The instance manager session ID. This is a unique identifier generated at instance manager\nstartup and changes on every restart (including container reboots). Used to detect if\nthe instance manager was restarted during long-running operations like backups, which\nwould terminate any running backup process.",
+              "type": "string"
             }
           },
           "type": "object",
@@ -330,6 +338,16 @@
           },
           "description": "A map containing the plugin metadata",
           "type": "object"
+        },
+        "reconciliationStartedAt": {
+          "description": "When the backup process was started by the operator",
+          "format": "date-time",
+          "type": "string"
+        },
+        "reconciliationTerminatedAt": {
+          "description": "When the reconciliation was terminated by the operator (either successfully or not)",
+          "format": "date-time",
+          "type": "string"
         },
         "s3Credentials": {
           "description": "The credentials to use to upload data to S3",
@@ -457,12 +475,12 @@
           "additionalProperties": false
         },
         "startedAt": {
-          "description": "When the backup was started",
+          "description": "When the backup execution was started by the backup tool",
           "format": "date-time",
           "type": "string"
         },
         "stoppedAt": {
-          "description": "When the backup was terminated",
+          "description": "When the backup execution was terminated by the backup tool",
           "format": "date-time",
           "type": "string"
         },

--- a/postgresql.cnpg.io/cluster_v1.json
+++ b/postgresql.cnpg.io/cluster_v1.json
@@ -829,7 +829,7 @@
                     "type": "string"
                   },
                   "operator": {
-                    "description": "Operator represents a key's relationship to the value.\nValid operators are Exists and Equal. Defaults to Equal.\nExists is equivalent to wildcard for value, so that a pod can\ntolerate all taints of a particular category.",
+                    "description": "Operator represents a key's relationship to the value.\nValid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.\nExists is equivalent to wildcard for value, so that a pod can\ntolerate all taints of a particular category.\nLt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).",
                     "type": "string"
                   },
                   "tolerationSeconds": {
@@ -943,6 +943,10 @@
                       ],
                       "type": "object",
                       "additionalProperties": false
+                    },
+                    "useDefaultAzureCredentials": {
+                      "description": "Use the default Azure authentication flow, which includes DefaultAzureCredential.\nThis allows authentication using environment variables and managed identities.",
+                      "type": "boolean"
                     }
                   },
                   "type": "object",
@@ -1772,7 +1776,7 @@
                       "type": "string"
                     },
                     "targetTime": {
-                      "description": "The target time as a timestamp in the RFC3339 standard",
+                      "description": "The target time as a timestamp in RFC3339 format or PostgreSQL timestamp format.\nTimestamps without an explicit timezone are interpreted as UTC.",
                       "type": "string"
                     },
                     "targetXID": {
@@ -2219,7 +2223,7 @@
                       "additionalProperties": false
                     },
                     "resources": {
-                      "description": "resources represents the minimum resources the volume should have.\nIf RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements\nthat are lower than previous value but must still be higher than capacity recorded in the\nstatus field of the claim.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources",
+                      "description": "resources represents the minimum resources the volume should have.\nUsers are allowed to specify resource requirements\nthat are lower than previous value but must still be higher than capacity recorded in the\nstatus field of the claim.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources",
                       "properties": {
                         "limits": {
                           "additionalProperties": {
@@ -2458,6 +2462,10 @@
                         ],
                         "type": "object",
                         "additionalProperties": false
+                      },
+                      "useDefaultAzureCredentials": {
+                        "description": "Use the default Azure authentication flow, which includes DefaultAzureCredential.\nThis allows authentication using environment variables and managed identities.",
+                        "type": "boolean"
                       }
                     },
                     "type": "object",
@@ -3776,6 +3784,78 @@
           "type": "object",
           "additionalProperties": false
         },
+        "podSelectorRefs": {
+          "description": "PodSelectorRefs defines named pod label selectors that can be referenced\nin pg_hba rules using the ${podselector:NAME} syntax in the address field.\nThe operator resolves matching pod IPs and the instance manager expands\npg_hba lines accordingly. Only pods in the Cluster's own namespace are considered.",
+          "items": {
+            "description": "PodSelectorRef defines a named pod label selector for use in pg_hba rules.\nPods matching the selector in the Cluster's namespace will have their IPs\nresolved and made available for pg_hba address expansion via the\n`${podselector:NAME}` syntax.",
+            "properties": {
+              "name": {
+                "description": "Name is the identifier used to reference this selector in pg_hba rules\nvia the ${podselector:NAME} syntax in the address field.",
+                "minLength": 1,
+                "pattern": "^[a-z]([a-z0-9_-]*[a-z0-9])?$",
+                "type": "string"
+              },
+              "selector": {
+                "description": "Selector is a label selector that identifies the pods whose IPs\nshould be resolved. Only pods in the Cluster's namespace are considered.",
+                "properties": {
+                  "matchExpressions": {
+                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                    "items": {
+                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                      "properties": {
+                        "key": {
+                          "description": "key is the label key that the selector applies to.",
+                          "type": "string"
+                        },
+                        "operator": {
+                          "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                          "type": "string"
+                        },
+                        "values": {
+                          "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array",
+                          "x-kubernetes-list-type": "atomic"
+                        }
+                      },
+                      "required": [
+                        "key",
+                        "operator"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  },
+                  "matchLabels": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                    "type": "object"
+                  }
+                },
+                "type": "object",
+                "x-kubernetes-map-type": "atomic",
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "name",
+              "selector"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "name"
+          ],
+          "x-kubernetes-list-type": "map"
+        },
         "postgresGID": {
           "default": 26,
           "description": "The GID of the `postgres` user inside the image, defaults to `26`",
@@ -3800,12 +3880,49 @@
               "items": {
                 "description": "ExtensionConfiguration is the configuration used to add\nPostgreSQL extensions to the Cluster.",
                 "properties": {
+                  "bin_path": {
+                    "description": "A list of directories within the image to be appended to the\nPostgreSQL process's `PATH` environment variable.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
                   "dynamic_library_path": {
                     "description": "The list of directories inside the image which should be added to dynamic_library_path.\nIf not defined, defaults to \"/lib\".",
                     "items": {
                       "type": "string"
                     },
                     "type": "array"
+                  },
+                  "env": {
+                    "description": "Env is a list of custom environment variables to be set in the\nPostgreSQL process for this extension. It is the responsibility of the\ncluster administrator to ensure the variables are correct for the\nspecific extension. Note that changes to these variables require\na manual cluster restart to take effect.",
+                    "items": {
+                      "description": "ExtensionEnvVar defines an environment variable for a specific extension\nimage volume.",
+                      "properties": {
+                        "name": {
+                          "description": "Name of the environment variable to be injected into the\nPostgreSQL process.",
+                          "minLength": 1,
+                          "pattern": "^[a-zA-Z_][a-zA-Z0-9_]*$",
+                          "type": "string"
+                        },
+                        "value": {
+                          "description": "Value of the environment variable. CloudNativePG performs a direct\nreplacement of this value, with support for placeholder expansion.\nThe ${`image_root`} placeholder resolves to the absolute mount path\nof the extension's volume (e.g., `/extensions/my-extension`). This\nis particularly useful for allowing applications or libraries to\nlocate specific directories within the mounted image.\nUnrecognized placeholders are rejected. To include a literal ${...}\nin the value, escape it as $${...}.",
+                          "minLength": 1,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name",
+                        "value"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-map-keys": [
+                      "name"
+                    ],
+                    "x-kubernetes-list-type": "map"
                   },
                   "extension_control_path": {
                     "description": "The list of directories inside the image which should be added to extension_control_path.\nIf not defined, defaults to \"/share\".",
@@ -3815,7 +3932,7 @@
                     "type": "array"
                   },
                   "image": {
-                    "description": "The image containing the extension, required",
+                    "description": "The image containing the extension.",
                     "properties": {
                       "pullPolicy": {
                         "description": "Policy for pulling OCI objects. Possible values are:\nAlways: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.\nNever: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.\nIfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.\nDefaults to Always if :latest tag is specified, or IfNotPresent otherwise.",
@@ -3827,12 +3944,6 @@
                       }
                     },
                     "type": "object",
-                    "x-kubernetes-validations": [
-                      {
-                        "message": "An image reference is required",
-                        "rule": "has(self.reference)"
-                      }
-                    ],
                     "additionalProperties": false
                   },
                   "ld_library_path": {
@@ -3845,18 +3956,21 @@
                   "name": {
                     "description": "The name of the extension, required",
                     "minLength": 1,
-                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                    "pattern": "^[a-z0-9]([-a-z0-9_]*[a-z0-9])?$",
                     "type": "string"
                   }
                 },
                 "required": [
-                  "image",
                   "name"
                 ],
                 "type": "object",
                 "additionalProperties": false
               },
-              "type": "array"
+              "type": "array",
+              "x-kubernetes-list-map-keys": [
+                "name"
+              ],
+              "x-kubernetes-list-type": "map"
             },
             "ldap": {
               "description": "Options to specify LDAP configuration",
@@ -3955,7 +4069,7 @@
               "type": "object"
             },
             "pg_hba": {
-              "description": "PostgreSQL Host Based Authentication rules (lines to be appended\nto the pg_hba.conf file)",
+              "description": "PostgreSQL Host Based Authentication rules (lines to be appended\nto the pg_hba.conf file).\nUse the ${podselector:NAME} syntax to reference a pod selector;\nthe rule will be expanded for each Pod IP matching that selector.",
               "items": {
                 "type": "string"
               },
@@ -4517,6 +4631,13 @@
                       "signerName": {
                         "description": "Kubelet's generated CSRs will be addressed to this signer.",
                         "type": "string"
+                      },
+                      "userAnnotations": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "description": "userAnnotations allow pod authors to pass additional information to\nthe signer implementation.  Kubernetes does not restrict or validate this\nmetadata in any way.\n\nThese values are copied verbatim into the `spec.unverifiedUserAnnotations` field of\nthe PodCertificateRequest objects that Kubelet creates.\n\nEntries are subject to the same validation as object metadata annotations,\nwith the addition that all keys must be domain-prefixed. No restrictions\nare placed on values, except an overall size limitation on the entire field.\n\nSigners should document the keys and values they support. Signers should\ndeny requests that contain keys they do not recognize.",
+                        "type": "object"
                       }
                     },
                     "required": [
@@ -4937,6 +5058,18 @@
           "type": "object",
           "additionalProperties": false
         },
+        "serviceAccountName": {
+          "description": "Name of an existing ServiceAccount in the same namespace to use for the cluster.\nWhen specified, the operator will not create a new ServiceAccount\nbut will use the provided one. This is useful for sharing a single\nServiceAccount across multiple clusters (e.g., for cloud IAM configurations).\nIf not specified, a ServiceAccount will be created with the cluster name.\nMutually exclusive with ServiceAccountTemplate.",
+          "maxLength": 253,
+          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+          "type": "string",
+          "x-kubernetes-validations": [
+            {
+              "message": "serviceAccountName is immutable",
+              "rule": "self == oldSelf"
+            }
+          ]
+        },
         "serviceAccountTemplate": {
           "description": "Configure the generation of the service account",
           "properties": {
@@ -5056,7 +5189,7 @@
                   "additionalProperties": false
                 },
                 "resources": {
-                  "description": "resources represents the minimum resources the volume should have.\nIf RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements\nthat are lower than previous value but must still be higher than capacity recorded in the\nstatus field of the claim.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources",
+                  "description": "resources represents the minimum resources the volume should have.\nUsers are allowed to specify resource requirements\nthat are lower than previous value but must still be higher than capacity recorded in the\nstatus field of the claim.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources",
                   "properties": {
                     "limits": {
                       "additionalProperties": {
@@ -5283,7 +5416,7 @@
                         "additionalProperties": false
                       },
                       "resources": {
-                        "description": "resources represents the minimum resources the volume should have.\nIf RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements\nthat are lower than previous value but must still be higher than capacity recorded in the\nstatus field of the claim.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources",
+                        "description": "resources represents the minimum resources the volume should have.\nUsers are allowed to specify resource requirements\nthat are lower than previous value but must still be higher than capacity recorded in the\nstatus field of the claim.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources",
                         "properties": {
                           "limits": {
                             "additionalProperties": {
@@ -5583,7 +5716,7 @@
                   "additionalProperties": false
                 },
                 "resources": {
-                  "description": "resources represents the minimum resources the volume should have.\nIf RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements\nthat are lower than previous value but must still be higher than capacity recorded in the\nstatus field of the claim.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources",
+                  "description": "resources represents the minimum resources the volume should have.\nUsers are allowed to specify resource requirements\nthat are lower than previous value but must still be higher than capacity recorded in the\nstatus field of the claim.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources",
                   "properties": {
                     "limits": {
                       "additionalProperties": {
@@ -6042,6 +6175,99 @@
         "pgDataImageInfo": {
           "description": "PGDataImageInfo contains the details of the latest image that has run on the current data directory.",
           "properties": {
+            "extensions": {
+              "description": "Extensions contains the container image extensions available for the current Image",
+              "items": {
+                "description": "ExtensionConfiguration is the configuration used to add\nPostgreSQL extensions to the Cluster.",
+                "properties": {
+                  "bin_path": {
+                    "description": "A list of directories within the image to be appended to the\nPostgreSQL process's `PATH` environment variable.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "dynamic_library_path": {
+                    "description": "The list of directories inside the image which should be added to dynamic_library_path.\nIf not defined, defaults to \"/lib\".",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "env": {
+                    "description": "Env is a list of custom environment variables to be set in the\nPostgreSQL process for this extension. It is the responsibility of the\ncluster administrator to ensure the variables are correct for the\nspecific extension. Note that changes to these variables require\na manual cluster restart to take effect.",
+                    "items": {
+                      "description": "ExtensionEnvVar defines an environment variable for a specific extension\nimage volume.",
+                      "properties": {
+                        "name": {
+                          "description": "Name of the environment variable to be injected into the\nPostgreSQL process.",
+                          "minLength": 1,
+                          "pattern": "^[a-zA-Z_][a-zA-Z0-9_]*$",
+                          "type": "string"
+                        },
+                        "value": {
+                          "description": "Value of the environment variable. CloudNativePG performs a direct\nreplacement of this value, with support for placeholder expansion.\nThe ${`image_root`} placeholder resolves to the absolute mount path\nof the extension's volume (e.g., `/extensions/my-extension`). This\nis particularly useful for allowing applications or libraries to\nlocate specific directories within the mounted image.\nUnrecognized placeholders are rejected. To include a literal ${...}\nin the value, escape it as $${...}.",
+                          "minLength": 1,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name",
+                        "value"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-map-keys": [
+                      "name"
+                    ],
+                    "x-kubernetes-list-type": "map"
+                  },
+                  "extension_control_path": {
+                    "description": "The list of directories inside the image which should be added to extension_control_path.\nIf not defined, defaults to \"/share\".",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "image": {
+                    "description": "The image containing the extension.",
+                    "properties": {
+                      "pullPolicy": {
+                        "description": "Policy for pulling OCI objects. Possible values are:\nAlways: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.\nNever: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.\nIfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.\nDefaults to Always if :latest tag is specified, or IfNotPresent otherwise.",
+                        "type": "string"
+                      },
+                      "reference": {
+                        "description": "Required: Image or artifact reference to be used.\nBehaves in the same way as pod.spec.containers[*].image.\nPull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.\nMore info: https://kubernetes.io/docs/concepts/containers/images\nThis field is optional to allow higher level config management to default or override\ncontainer images in workload controllers like Deployments and StatefulSets.",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "ld_library_path": {
+                    "description": "The list of directories inside the image which should be added to ld_library_path.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "name": {
+                    "description": "The name of the extension, required",
+                    "minLength": 1,
+                    "pattern": "^[a-z0-9]([-a-z0-9_]*[a-z0-9])?$",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
             "image": {
               "description": "Image is the image name",
               "type": "string"
@@ -6127,6 +6353,35 @@
             "additionalProperties": false
           },
           "type": "array"
+        },
+        "podSelectorRefs": {
+          "description": "PodSelectorRefs contains the resolved pod IPs for each named selector\ndefined in spec.podSelectorRefs.",
+          "items": {
+            "description": "PodSelectorRefStatus contains the resolved pod IPs for a named selector.",
+            "properties": {
+              "ips": {
+                "description": "IPs is the list of pod IPs matching the selector.\nEach IP is a single address (no CIDR notation).",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "name": {
+                "description": "Name corresponds to the name in the spec's PodSelectorRef.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "name"
+          ],
+          "x-kubernetes-list-type": "map"
         },
         "poolerIntegrations": {
           "description": "The integration needed by poolers referencing the cluster",

--- a/postgresql.cnpg.io/clusterimagecatalog_v1.json
+++ b/postgresql.cnpg.io/clusterimagecatalog_v1.json
@@ -20,6 +20,103 @@
           "items": {
             "description": "CatalogImage defines the image and major version",
             "properties": {
+              "extensions": {
+                "description": "The configuration of the extensions to be added",
+                "items": {
+                  "description": "ExtensionConfiguration is the configuration used to add\nPostgreSQL extensions to the Cluster.",
+                  "properties": {
+                    "bin_path": {
+                      "description": "A list of directories within the image to be appended to the\nPostgreSQL process's `PATH` environment variable.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "dynamic_library_path": {
+                      "description": "The list of directories inside the image which should be added to dynamic_library_path.\nIf not defined, defaults to \"/lib\".",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "env": {
+                      "description": "Env is a list of custom environment variables to be set in the\nPostgreSQL process for this extension. It is the responsibility of the\ncluster administrator to ensure the variables are correct for the\nspecific extension. Note that changes to these variables require\na manual cluster restart to take effect.",
+                      "items": {
+                        "description": "ExtensionEnvVar defines an environment variable for a specific extension\nimage volume.",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the environment variable to be injected into the\nPostgreSQL process.",
+                            "minLength": 1,
+                            "pattern": "^[a-zA-Z_][a-zA-Z0-9_]*$",
+                            "type": "string"
+                          },
+                          "value": {
+                            "description": "Value of the environment variable. CloudNativePG performs a direct\nreplacement of this value, with support for placeholder expansion.\nThe ${`image_root`} placeholder resolves to the absolute mount path\nof the extension's volume (e.g., `/extensions/my-extension`). This\nis particularly useful for allowing applications or libraries to\nlocate specific directories within the mounted image.\nUnrecognized placeholders are rejected. To include a literal ${...}\nin the value, escape it as $${...}.",
+                            "minLength": 1,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "value"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array",
+                      "x-kubernetes-list-map-keys": [
+                        "name"
+                      ],
+                      "x-kubernetes-list-type": "map"
+                    },
+                    "extension_control_path": {
+                      "description": "The list of directories inside the image which should be added to extension_control_path.\nIf not defined, defaults to \"/share\".",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "image": {
+                      "description": "The image containing the extension.",
+                      "properties": {
+                        "pullPolicy": {
+                          "description": "Policy for pulling OCI objects. Possible values are:\nAlways: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.\nNever: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.\nIfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.\nDefaults to Always if :latest tag is specified, or IfNotPresent otherwise.",
+                          "type": "string"
+                        },
+                        "reference": {
+                          "description": "Required: Image or artifact reference to be used.\nBehaves in the same way as pod.spec.containers[*].image.\nPull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.\nMore info: https://kubernetes.io/docs/concepts/containers/images\nThis field is optional to allow higher level config management to default or override\ncontainer images in workload controllers like Deployments and StatefulSets.",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "ld_library_path": {
+                      "description": "The list of directories inside the image which should be added to ld_library_path.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "name": {
+                      "description": "The name of the extension, required",
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9_]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array",
+                "x-kubernetes-list-map-keys": [
+                  "name"
+                ],
+                "x-kubernetes-list-type": "map"
+              },
               "image": {
                 "description": "The image reference",
                 "type": "string"

--- a/postgresql.cnpg.io/imagecatalog_v1.json
+++ b/postgresql.cnpg.io/imagecatalog_v1.json
@@ -20,6 +20,103 @@
           "items": {
             "description": "CatalogImage defines the image and major version",
             "properties": {
+              "extensions": {
+                "description": "The configuration of the extensions to be added",
+                "items": {
+                  "description": "ExtensionConfiguration is the configuration used to add\nPostgreSQL extensions to the Cluster.",
+                  "properties": {
+                    "bin_path": {
+                      "description": "A list of directories within the image to be appended to the\nPostgreSQL process's `PATH` environment variable.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "dynamic_library_path": {
+                      "description": "The list of directories inside the image which should be added to dynamic_library_path.\nIf not defined, defaults to \"/lib\".",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "env": {
+                      "description": "Env is a list of custom environment variables to be set in the\nPostgreSQL process for this extension. It is the responsibility of the\ncluster administrator to ensure the variables are correct for the\nspecific extension. Note that changes to these variables require\na manual cluster restart to take effect.",
+                      "items": {
+                        "description": "ExtensionEnvVar defines an environment variable for a specific extension\nimage volume.",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the environment variable to be injected into the\nPostgreSQL process.",
+                            "minLength": 1,
+                            "pattern": "^[a-zA-Z_][a-zA-Z0-9_]*$",
+                            "type": "string"
+                          },
+                          "value": {
+                            "description": "Value of the environment variable. CloudNativePG performs a direct\nreplacement of this value, with support for placeholder expansion.\nThe ${`image_root`} placeholder resolves to the absolute mount path\nof the extension's volume (e.g., `/extensions/my-extension`). This\nis particularly useful for allowing applications or libraries to\nlocate specific directories within the mounted image.\nUnrecognized placeholders are rejected. To include a literal ${...}\nin the value, escape it as $${...}.",
+                            "minLength": 1,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "value"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array",
+                      "x-kubernetes-list-map-keys": [
+                        "name"
+                      ],
+                      "x-kubernetes-list-type": "map"
+                    },
+                    "extension_control_path": {
+                      "description": "The list of directories inside the image which should be added to extension_control_path.\nIf not defined, defaults to \"/share\".",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "image": {
+                      "description": "The image containing the extension.",
+                      "properties": {
+                        "pullPolicy": {
+                          "description": "Policy for pulling OCI objects. Possible values are:\nAlways: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.\nNever: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.\nIfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.\nDefaults to Always if :latest tag is specified, or IfNotPresent otherwise.",
+                          "type": "string"
+                        },
+                        "reference": {
+                          "description": "Required: Image or artifact reference to be used.\nBehaves in the same way as pod.spec.containers[*].image.\nPull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.\nMore info: https://kubernetes.io/docs/concepts/containers/images\nThis field is optional to allow higher level config management to default or override\ncontainer images in workload controllers like Deployments and StatefulSets.",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "ld_library_path": {
+                      "description": "The list of directories inside the image which should be added to ld_library_path.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "name": {
+                      "description": "The name of the extension, required",
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9_]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array",
+                "x-kubernetes-list-map-keys": [
+                  "name"
+                ],
+                "x-kubernetes-list-type": "map"
+              },
               "image": {
                 "description": "The image reference",
                 "type": "string"

--- a/postgresql.cnpg.io/pooler_v1.json
+++ b/postgresql.cnpg.io/pooler_v1.json
@@ -336,6 +336,18 @@
           "type": "object",
           "additionalProperties": false
         },
+        "serviceAccountName": {
+          "description": "Name of an existing ServiceAccount in the same namespace to use for the pooler.\nWhen specified, the operator will not create a new ServiceAccount\nbut will use the provided one. This is useful for sharing a single\nServiceAccount across multiple poolers (e.g., for cloud IAM configurations).\nIf not specified, a ServiceAccount will be created with the pooler name.",
+          "maxLength": 253,
+          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+          "type": "string",
+          "x-kubernetes-validations": [
+            {
+              "message": "serviceAccountName is immutable",
+              "rule": "self == oldSelf"
+            }
+          ]
+        },
         "serviceTemplate": {
           "description": "Template for the Service to be created",
           "properties": {
@@ -2224,7 +2236,7 @@
                         "additionalProperties": false
                       },
                       "resizePolicy": {
-                        "description": "Resources resize policy for the container.",
+                        "description": "Resources resize policy for the container.\nThis field cannot be set on ephemeral containers.",
                         "items": {
                           "description": "ContainerResizePolicy represents resource resize policy for the container.",
                           "properties": {
@@ -5150,7 +5162,7 @@
                         "additionalProperties": false
                       },
                       "resizePolicy": {
-                        "description": "Resources resize policy for the container.",
+                        "description": "Resources resize policy for the container.\nThis field cannot be set on ephemeral containers.",
                         "items": {
                           "description": "ContainerResizePolicy represents resource resize policy for the container.",
                           "properties": {
@@ -5770,7 +5782,7 @@
                   "x-kubernetes-list-type": "atomic"
                 },
                 "resourceClaims": {
-                  "description": "ResourceClaims defines which ResourceClaims must be allocated\nand reserved before the Pod is allowed to start. The resources\nwill be made available to those containers which consume them\nby name.\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable.",
+                  "description": "ResourceClaims defines which ResourceClaims must be allocated\nand reserved before the Pod is allowed to start. The resources\nwill be made available to those containers which consume them\nby name.\n\nThis is a stable field but requires that the\nDynamicResourceAllocation feature gate is enabled.\n\nThis field is immutable.",
                   "items": {
                     "description": "PodResourceClaim references exactly one ResourceClaim, either directly\nor by naming a ResourceClaimTemplate which is then turned into a ResourceClaim\nfor the pod.\n\nIt adds a name to it that uniquely identifies the ResourceClaim inside the Pod.\nContainers that need access to the ResourceClaim reference it with this name.",
                     "properties": {
@@ -6090,7 +6102,7 @@
                         "type": "string"
                       },
                       "operator": {
-                        "description": "Operator represents a key's relationship to the value.\nValid operators are Exists and Equal. Defaults to Equal.\nExists is equivalent to wildcard for value, so that a pod can\ntolerate all taints of a particular category.",
+                        "description": "Operator represents a key's relationship to the value.\nValid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.\nExists is equivalent to wildcard for value, so that a pod can\ntolerate all taints of a particular category.\nLt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).",
                         "type": "string"
                       },
                       "tolerationSeconds": {
@@ -6662,7 +6674,7 @@
                                     "additionalProperties": false
                                   },
                                   "resources": {
-                                    "description": "resources represents the minimum resources the volume should have.\nIf RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements\nthat are lower than previous value but must still be higher than capacity recorded in the\nstatus field of the claim.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources",
+                                    "description": "resources represents the minimum resources the volume should have.\nUsers are allowed to specify resource requirements\nthat are lower than previous value but must still be higher than capacity recorded in the\nstatus field of the claim.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources",
                                     "properties": {
                                       "limits": {
                                         "additionalProperties": {
@@ -7373,6 +7385,13 @@
                                     "signerName": {
                                       "description": "Kubelet's generated CSRs will be addressed to this signer.",
                                       "type": "string"
+                                    },
+                                    "userAnnotations": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "description": "userAnnotations allow pod authors to pass additional information to\nthe signer implementation.  Kubernetes does not restrict or validate this\nmetadata in any way.\n\nThese values are copied verbatim into the `spec.unverifiedUserAnnotations` field of\nthe PodCertificateRequest objects that Kubelet creates.\n\nEntries are subject to the same validation as object metadata annotations,\nwith the addition that all keys must be domain-prefixed. No restrictions\nare placed on values, except an overall size limitation on the entire field.\n\nSigners should document the keys and values they support. Signers should\ndeny requests that contain keys they do not recognize.",
+                                      "type": "object"
                                     }
                                   },
                                   "required": [
@@ -7742,6 +7761,29 @@
                     "name"
                   ],
                   "x-kubernetes-list-type": "map"
+                },
+                "workloadRef": {
+                  "description": "WorkloadRef provides a reference to the Workload object that this Pod belongs to.\nThis field is used by the scheduler to identify the PodGroup and apply the\ncorrect group scheduling policies. The Workload object referenced\nby this field may not exist at the time the Pod is created.\nThis field is immutable, but a Workload object with the same name\nmay be recreated with different policies. Doing this during pod scheduling\nmay result in the placement not conforming to the expected policies.",
+                  "properties": {
+                    "name": {
+                      "description": "Name defines the name of the Workload object this Pod belongs to.\nWorkload must be in the same namespace as the Pod.\nIf it doesn't match any existing Workload, the Pod will remain unschedulable\nuntil a Workload object is created and observed by the kube-scheduler.\nIt must be a DNS subdomain.",
+                      "type": "string"
+                    },
+                    "podGroup": {
+                      "description": "PodGroup is the name of the PodGroup within the Workload that this Pod\nbelongs to. If it doesn't match any existing PodGroup within the Workload,\nthe Pod will remain unschedulable until the Workload object is recreated\nand observed by the kube-scheduler. It must be a DNS label.",
+                      "type": "string"
+                    },
+                    "podGroupReplicaKey": {
+                      "description": "PodGroupReplicaKey specifies the replica key of the PodGroup to which this\nPod belongs. It is used to distinguish pods belonging to different replicas\nof the same pod group. The pod group policy is applied separately to each replica.\nWhen set, it must be a DNS label.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "podGroup"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
                 }
               },
               "required": [


### PR DESCRIPTION
## PR Checklist

- [x] I generated these CRs using the [CRD Extractor tool](https://github.com/datreeio/CRDs-catalog?tab=readme-ov-file#crd-extractor). If I used a different method, I have described the method in this PR.
- [x] I am updating existing schemas and have specified the updated schema version.
- [ ] I am adding new schemas and included a link to the GitHub repository that contains the source of these schemas.

CNPG release: https://github.com/cloudnative-pg/cloudnative-pg/releases/tag/v1.29.0

I have helm chart 0.28.0 installed: https://github.com/cloudnative-pg/charts/releases/tag/cloudnative-pg-v0.28.0

I know their versioning is confusing, but chart version 0.28.0 is for application version 1.29.0. The previous PR updating these resources here seems to have mentioned the chart version incorrectly in it's commit message: https://github.com/datreeio/CRDs-catalog/pull/766/commits
