### PR TITLE
Update argo-rollouts to v1.9.0

### DIFF
--- a/argoproj.io/analysisrun_v1alpha1.json
+++ b/argoproj.io/analysisrun_v1alpha1.json
@@ -31,8 +31,7 @@
                     "required": [
                       "fieldPath"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "secretKeyRef": {
                     "properties": {
@@ -47,19 +46,16 @@
                       "key",
                       "name"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   }
                 },
-                "type": "object",
-                "additionalProperties": false
+                "type": "object"
               }
             },
             "required": [
               "name"
             ],
-            "type": "object",
-            "additionalProperties": false
+            "type": "object"
           },
           "type": "array"
         },
@@ -73,8 +69,7 @@
             "required": [
               "metricName"
             ],
-            "type": "object",
-            "additionalProperties": false
+            "type": "object"
           },
           "type": "array"
         },
@@ -93,8 +88,7 @@
               "limit",
               "metricName"
             ],
-            "type": "object",
-            "additionalProperties": false
+            "type": "object"
           },
           "type": "array"
         },
@@ -201,8 +195,7 @@
                                             "type": "string"
                                           }
                                         },
-                                        "type": "object",
-                                        "additionalProperties": false
+                                        "type": "object"
                                       },
                                       "type": "array"
                                     },
@@ -213,8 +206,7 @@
                                       "type": "string"
                                     }
                                   },
-                                  "type": "object",
-                                  "additionalProperties": false
+                                  "type": "object"
                                 },
                                 "period": {
                                   "anyOf": [
@@ -234,8 +226,7 @@
                                   "type": "string"
                                 }
                               },
-                              "type": "object",
-                              "additionalProperties": false
+                              "type": "object"
                             },
                             "period": {
                               "anyOf": [
@@ -252,8 +243,7 @@
                               "type": "boolean"
                             }
                           },
-                          "type": "object",
-                          "additionalProperties": false
+                          "type": "object"
                         },
                         "type": "array"
                       }
@@ -261,8 +251,7 @@
                     "required": [
                       "metricDataQueries"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "datadog": {
                     "properties": {
@@ -313,12 +302,10 @@
                             "type": "boolean"
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "graphite": {
                     "properties": {
@@ -329,8 +316,7 @@
                         "type": "string"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "influxdb": {
                     "properties": {
@@ -341,8 +327,7 @@
                         "type": "string"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "job": {
                     "properties": {
@@ -361,8 +346,7 @@
                             "type": "object"
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "spec": {
                         "properties": {
@@ -384,6 +368,9 @@
                           "completions": {
                             "format": "int32",
                             "type": "integer"
+                          },
+                          "managedBy": {
+                            "type": "string"
                           },
                           "manualSelector": {
                             "type": "boolean"
@@ -425,8 +412,7 @@
                                         "operator",
                                         "values"
                                       ],
-                                      "type": "object",
-                                      "additionalProperties": false
+                                      "type": "object"
                                     },
                                     "onPodConditions": {
                                       "items": {
@@ -442,8 +428,7 @@
                                           "status",
                                           "type"
                                         ],
-                                        "type": "object",
-                                        "additionalProperties": false
+                                        "type": "object"
                                       },
                                       "type": "array",
                                       "x-kubernetes-list-type": "atomic"
@@ -452,8 +437,7 @@
                                   "required": [
                                     "action"
                                   ],
-                                  "type": "object",
-                                  "additionalProperties": false
+                                  "type": "object"
                                 },
                                 "type": "array",
                                 "x-kubernetes-list-type": "atomic"
@@ -462,8 +446,7 @@
                             "required": [
                               "rules"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "podReplacementPolicy": {
                             "type": "string"
@@ -483,17 +466,18 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
                                     "key",
                                     "operator"
                                   ],
-                                  "type": "object",
-                                  "additionalProperties": false
+                                  "type": "object"
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchLabels": {
                                 "additionalProperties": {
@@ -503,8 +487,31 @@
                               }
                             },
                             "type": "object",
-                            "x-kubernetes-map-type": "atomic",
-                            "additionalProperties": false
+                            "x-kubernetes-map-type": "atomic"
+                          },
+                          "successPolicy": {
+                            "properties": {
+                              "rules": {
+                                "items": {
+                                  "properties": {
+                                    "succeededCount": {
+                                      "format": "int32",
+                                      "type": "integer"
+                                    },
+                                    "succeededIndexes": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              }
+                            },
+                            "required": [
+                              "rules"
+                            ],
+                            "type": "object"
                           },
                           "suspend": {
                             "type": "boolean"
@@ -526,8 +533,7 @@
                                     "type": "object"
                                   }
                                 },
-                                "type": "object",
-                                "additionalProperties": false
+                                "type": "object"
                               },
                               "spec": {
                                 "properties": {
@@ -557,17 +563,18 @@
                                                             "items": {
                                                               "type": "string"
                                                             },
-                                                            "type": "array"
+                                                            "type": "array",
+                                                            "x-kubernetes-list-type": "atomic"
                                                           }
                                                         },
                                                         "required": [
                                                           "key",
                                                           "operator"
                                                         ],
-                                                        "type": "object",
-                                                        "additionalProperties": false
+                                                        "type": "object"
                                                       },
-                                                      "type": "array"
+                                                      "type": "array",
+                                                      "x-kubernetes-list-type": "atomic"
                                                     },
                                                     "matchFields": {
                                                       "items": {
@@ -582,22 +589,22 @@
                                                             "items": {
                                                               "type": "string"
                                                             },
-                                                            "type": "array"
+                                                            "type": "array",
+                                                            "x-kubernetes-list-type": "atomic"
                                                           }
                                                         },
                                                         "required": [
                                                           "key",
                                                           "operator"
                                                         ],
-                                                        "type": "object",
-                                                        "additionalProperties": false
+                                                        "type": "object"
                                                       },
-                                                      "type": "array"
+                                                      "type": "array",
+                                                      "x-kubernetes-list-type": "atomic"
                                                     }
                                                   },
                                                   "type": "object",
-                                                  "x-kubernetes-map-type": "atomic",
-                                                  "additionalProperties": false
+                                                  "x-kubernetes-map-type": "atomic"
                                                 },
                                                 "weight": {
                                                   "format": "int32",
@@ -608,10 +615,10 @@
                                                 "preference",
                                                 "weight"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
-                                            "type": "array"
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
                                           },
                                           "requiredDuringSchedulingIgnoredDuringExecution": {
                                             "properties": {
@@ -631,17 +638,18 @@
                                                             "items": {
                                                               "type": "string"
                                                             },
-                                                            "type": "array"
+                                                            "type": "array",
+                                                            "x-kubernetes-list-type": "atomic"
                                                           }
                                                         },
                                                         "required": [
                                                           "key",
                                                           "operator"
                                                         ],
-                                                        "type": "object",
-                                                        "additionalProperties": false
+                                                        "type": "object"
                                                       },
-                                                      "type": "array"
+                                                      "type": "array",
+                                                      "x-kubernetes-list-type": "atomic"
                                                     },
                                                     "matchFields": {
                                                       "items": {
@@ -656,36 +664,35 @@
                                                             "items": {
                                                               "type": "string"
                                                             },
-                                                            "type": "array"
+                                                            "type": "array",
+                                                            "x-kubernetes-list-type": "atomic"
                                                           }
                                                         },
                                                         "required": [
                                                           "key",
                                                           "operator"
                                                         ],
-                                                        "type": "object",
-                                                        "additionalProperties": false
+                                                        "type": "object"
                                                       },
-                                                      "type": "array"
+                                                      "type": "array",
+                                                      "x-kubernetes-list-type": "atomic"
                                                     }
                                                   },
                                                   "type": "object",
-                                                  "x-kubernetes-map-type": "atomic",
-                                                  "additionalProperties": false
+                                                  "x-kubernetes-map-type": "atomic"
                                                 },
-                                                "type": "array"
+                                                "type": "array",
+                                                "x-kubernetes-list-type": "atomic"
                                               }
                                             },
                                             "required": [
                                               "nodeSelectorTerms"
                                             ],
                                             "type": "object",
-                                            "x-kubernetes-map-type": "atomic",
-                                            "additionalProperties": false
+                                            "x-kubernetes-map-type": "atomic"
                                           }
                                         },
-                                        "type": "object",
-                                        "additionalProperties": false
+                                        "type": "object"
                                       },
                                       "podAffinity": {
                                         "properties": {
@@ -709,17 +716,18 @@
                                                                 "items": {
                                                                   "type": "string"
                                                                 },
-                                                                "type": "array"
+                                                                "type": "array",
+                                                                "x-kubernetes-list-type": "atomic"
                                                               }
                                                             },
                                                             "required": [
                                                               "key",
                                                               "operator"
                                                             ],
-                                                            "type": "object",
-                                                            "additionalProperties": false
+                                                            "type": "object"
                                                           },
-                                                          "type": "array"
+                                                          "type": "array",
+                                                          "x-kubernetes-list-type": "atomic"
                                                         },
                                                         "matchLabels": {
                                                           "additionalProperties": {
@@ -729,8 +737,7 @@
                                                         }
                                                       },
                                                       "type": "object",
-                                                      "x-kubernetes-map-type": "atomic",
-                                                      "additionalProperties": false
+                                                      "x-kubernetes-map-type": "atomic"
                                                     },
                                                     "matchLabelKeys": {
                                                       "items": {
@@ -761,17 +768,18 @@
                                                                 "items": {
                                                                   "type": "string"
                                                                 },
-                                                                "type": "array"
+                                                                "type": "array",
+                                                                "x-kubernetes-list-type": "atomic"
                                                               }
                                                             },
                                                             "required": [
                                                               "key",
                                                               "operator"
                                                             ],
-                                                            "type": "object",
-                                                            "additionalProperties": false
+                                                            "type": "object"
                                                           },
-                                                          "type": "array"
+                                                          "type": "array",
+                                                          "x-kubernetes-list-type": "atomic"
                                                         },
                                                         "matchLabels": {
                                                           "additionalProperties": {
@@ -781,14 +789,14 @@
                                                         }
                                                       },
                                                       "type": "object",
-                                                      "x-kubernetes-map-type": "atomic",
-                                                      "additionalProperties": false
+                                                      "x-kubernetes-map-type": "atomic"
                                                     },
                                                     "namespaces": {
                                                       "items": {
                                                         "type": "string"
                                                       },
-                                                      "type": "array"
+                                                      "type": "array",
+                                                      "x-kubernetes-list-type": "atomic"
                                                     },
                                                     "topologyKey": {
                                                       "type": "string"
@@ -797,8 +805,7 @@
                                                   "required": [
                                                     "topologyKey"
                                                   ],
-                                                  "type": "object",
-                                                  "additionalProperties": false
+                                                  "type": "object"
                                                 },
                                                 "weight": {
                                                   "format": "int32",
@@ -809,10 +816,10 @@
                                                 "podAffinityTerm",
                                                 "weight"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
-                                            "type": "array"
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
                                           },
                                           "requiredDuringSchedulingIgnoredDuringExecution": {
                                             "items": {
@@ -832,17 +839,18 @@
                                                             "items": {
                                                               "type": "string"
                                                             },
-                                                            "type": "array"
+                                                            "type": "array",
+                                                            "x-kubernetes-list-type": "atomic"
                                                           }
                                                         },
                                                         "required": [
                                                           "key",
                                                           "operator"
                                                         ],
-                                                        "type": "object",
-                                                        "additionalProperties": false
+                                                        "type": "object"
                                                       },
-                                                      "type": "array"
+                                                      "type": "array",
+                                                      "x-kubernetes-list-type": "atomic"
                                                     },
                                                     "matchLabels": {
                                                       "additionalProperties": {
@@ -852,8 +860,7 @@
                                                     }
                                                   },
                                                   "type": "object",
-                                                  "x-kubernetes-map-type": "atomic",
-                                                  "additionalProperties": false
+                                                  "x-kubernetes-map-type": "atomic"
                                                 },
                                                 "matchLabelKeys": {
                                                   "items": {
@@ -884,17 +891,18 @@
                                                             "items": {
                                                               "type": "string"
                                                             },
-                                                            "type": "array"
+                                                            "type": "array",
+                                                            "x-kubernetes-list-type": "atomic"
                                                           }
                                                         },
                                                         "required": [
                                                           "key",
                                                           "operator"
                                                         ],
-                                                        "type": "object",
-                                                        "additionalProperties": false
+                                                        "type": "object"
                                                       },
-                                                      "type": "array"
+                                                      "type": "array",
+                                                      "x-kubernetes-list-type": "atomic"
                                                     },
                                                     "matchLabels": {
                                                       "additionalProperties": {
@@ -904,14 +912,14 @@
                                                     }
                                                   },
                                                   "type": "object",
-                                                  "x-kubernetes-map-type": "atomic",
-                                                  "additionalProperties": false
+                                                  "x-kubernetes-map-type": "atomic"
                                                 },
                                                 "namespaces": {
                                                   "items": {
                                                     "type": "string"
                                                   },
-                                                  "type": "array"
+                                                  "type": "array",
+                                                  "x-kubernetes-list-type": "atomic"
                                                 },
                                                 "topologyKey": {
                                                   "type": "string"
@@ -920,14 +928,13 @@
                                               "required": [
                                                 "topologyKey"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
-                                            "type": "array"
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
                                           }
                                         },
-                                        "type": "object",
-                                        "additionalProperties": false
+                                        "type": "object"
                                       },
                                       "podAntiAffinity": {
                                         "properties": {
@@ -951,17 +958,18 @@
                                                                 "items": {
                                                                   "type": "string"
                                                                 },
-                                                                "type": "array"
+                                                                "type": "array",
+                                                                "x-kubernetes-list-type": "atomic"
                                                               }
                                                             },
                                                             "required": [
                                                               "key",
                                                               "operator"
                                                             ],
-                                                            "type": "object",
-                                                            "additionalProperties": false
+                                                            "type": "object"
                                                           },
-                                                          "type": "array"
+                                                          "type": "array",
+                                                          "x-kubernetes-list-type": "atomic"
                                                         },
                                                         "matchLabels": {
                                                           "additionalProperties": {
@@ -971,8 +979,7 @@
                                                         }
                                                       },
                                                       "type": "object",
-                                                      "x-kubernetes-map-type": "atomic",
-                                                      "additionalProperties": false
+                                                      "x-kubernetes-map-type": "atomic"
                                                     },
                                                     "matchLabelKeys": {
                                                       "items": {
@@ -1003,17 +1010,18 @@
                                                                 "items": {
                                                                   "type": "string"
                                                                 },
-                                                                "type": "array"
+                                                                "type": "array",
+                                                                "x-kubernetes-list-type": "atomic"
                                                               }
                                                             },
                                                             "required": [
                                                               "key",
                                                               "operator"
                                                             ],
-                                                            "type": "object",
-                                                            "additionalProperties": false
+                                                            "type": "object"
                                                           },
-                                                          "type": "array"
+                                                          "type": "array",
+                                                          "x-kubernetes-list-type": "atomic"
                                                         },
                                                         "matchLabels": {
                                                           "additionalProperties": {
@@ -1023,14 +1031,14 @@
                                                         }
                                                       },
                                                       "type": "object",
-                                                      "x-kubernetes-map-type": "atomic",
-                                                      "additionalProperties": false
+                                                      "x-kubernetes-map-type": "atomic"
                                                     },
                                                     "namespaces": {
                                                       "items": {
                                                         "type": "string"
                                                       },
-                                                      "type": "array"
+                                                      "type": "array",
+                                                      "x-kubernetes-list-type": "atomic"
                                                     },
                                                     "topologyKey": {
                                                       "type": "string"
@@ -1039,8 +1047,7 @@
                                                   "required": [
                                                     "topologyKey"
                                                   ],
-                                                  "type": "object",
-                                                  "additionalProperties": false
+                                                  "type": "object"
                                                 },
                                                 "weight": {
                                                   "format": "int32",
@@ -1051,10 +1058,10 @@
                                                 "podAffinityTerm",
                                                 "weight"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
-                                            "type": "array"
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
                                           },
                                           "requiredDuringSchedulingIgnoredDuringExecution": {
                                             "items": {
@@ -1074,17 +1081,18 @@
                                                             "items": {
                                                               "type": "string"
                                                             },
-                                                            "type": "array"
+                                                            "type": "array",
+                                                            "x-kubernetes-list-type": "atomic"
                                                           }
                                                         },
                                                         "required": [
                                                           "key",
                                                           "operator"
                                                         ],
-                                                        "type": "object",
-                                                        "additionalProperties": false
+                                                        "type": "object"
                                                       },
-                                                      "type": "array"
+                                                      "type": "array",
+                                                      "x-kubernetes-list-type": "atomic"
                                                     },
                                                     "matchLabels": {
                                                       "additionalProperties": {
@@ -1094,8 +1102,7 @@
                                                     }
                                                   },
                                                   "type": "object",
-                                                  "x-kubernetes-map-type": "atomic",
-                                                  "additionalProperties": false
+                                                  "x-kubernetes-map-type": "atomic"
                                                 },
                                                 "matchLabelKeys": {
                                                   "items": {
@@ -1126,17 +1133,18 @@
                                                             "items": {
                                                               "type": "string"
                                                             },
-                                                            "type": "array"
+                                                            "type": "array",
+                                                            "x-kubernetes-list-type": "atomic"
                                                           }
                                                         },
                                                         "required": [
                                                           "key",
                                                           "operator"
                                                         ],
-                                                        "type": "object",
-                                                        "additionalProperties": false
+                                                        "type": "object"
                                                       },
-                                                      "type": "array"
+                                                      "type": "array",
+                                                      "x-kubernetes-list-type": "atomic"
                                                     },
                                                     "matchLabels": {
                                                       "additionalProperties": {
@@ -1146,14 +1154,14 @@
                                                     }
                                                   },
                                                   "type": "object",
-                                                  "x-kubernetes-map-type": "atomic",
-                                                  "additionalProperties": false
+                                                  "x-kubernetes-map-type": "atomic"
                                                 },
                                                 "namespaces": {
                                                   "items": {
                                                     "type": "string"
                                                   },
-                                                  "type": "array"
+                                                  "type": "array",
+                                                  "x-kubernetes-list-type": "atomic"
                                                 },
                                                 "topologyKey": {
                                                   "type": "string"
@@ -1162,18 +1170,16 @@
                                               "required": [
                                                 "topologyKey"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
-                                            "type": "array"
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
                                           }
                                         },
-                                        "type": "object",
-                                        "additionalProperties": false
+                                        "type": "object"
                                       }
                                     },
-                                    "type": "object",
-                                    "additionalProperties": false
+                                    "type": "object"
                                   },
                                   "automountServiceAccountToken": {
                                     "type": "boolean"
@@ -1185,13 +1191,15 @@
                                           "items": {
                                             "type": "string"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "command": {
                                           "items": {
                                             "type": "string"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "env": {
                                           "items": {
@@ -1210,6 +1218,7 @@
                                                         "type": "string"
                                                       },
                                                       "name": {
+                                                        "default": "",
                                                         "type": "string"
                                                       },
                                                       "optional": {
@@ -1220,8 +1229,7 @@
                                                       "key"
                                                     ],
                                                     "type": "object",
-                                                    "x-kubernetes-map-type": "atomic",
-                                                    "additionalProperties": false
+                                                    "x-kubernetes-map-type": "atomic"
                                                   },
                                                   "fieldRef": {
                                                     "properties": {
@@ -1236,8 +1244,31 @@
                                                       "fieldPath"
                                                     ],
                                                     "type": "object",
-                                                    "x-kubernetes-map-type": "atomic",
-                                                    "additionalProperties": false
+                                                    "x-kubernetes-map-type": "atomic"
+                                                  },
+                                                  "fileKeyRef": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "optional": {
+                                                        "default": false,
+                                                        "type": "boolean"
+                                                      },
+                                                      "path": {
+                                                        "type": "string"
+                                                      },
+                                                      "volumeName": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key",
+                                                      "path",
+                                                      "volumeName"
+                                                    ],
+                                                    "type": "object",
+                                                    "x-kubernetes-map-type": "atomic"
                                                   },
                                                   "resourceFieldRef": {
                                                     "properties": {
@@ -1264,8 +1295,7 @@
                                                       "resource"
                                                     ],
                                                     "type": "object",
-                                                    "x-kubernetes-map-type": "atomic",
-                                                    "additionalProperties": false
+                                                    "x-kubernetes-map-type": "atomic"
                                                   },
                                                   "secretKeyRef": {
                                                     "properties": {
@@ -1273,6 +1303,7 @@
                                                         "type": "string"
                                                       },
                                                       "name": {
+                                                        "default": "",
                                                         "type": "string"
                                                       },
                                                       "optional": {
@@ -1283,21 +1314,22 @@
                                                       "key"
                                                     ],
                                                     "type": "object",
-                                                    "x-kubernetes-map-type": "atomic",
-                                                    "additionalProperties": false
+                                                    "x-kubernetes-map-type": "atomic"
                                                   }
                                                 },
-                                                "type": "object",
-                                                "additionalProperties": false
+                                                "type": "object"
                                               }
                                             },
                                             "required": [
                                               "name"
                                             ],
-                                            "type": "object",
-                                            "additionalProperties": false
+                                            "type": "object"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-map-keys": [
+                                            "name"
+                                          ],
+                                          "x-kubernetes-list-type": "map"
                                         },
                                         "envFrom": {
                                           "items": {
@@ -1305,6 +1337,7 @@
                                               "configMapRef": {
                                                 "properties": {
                                                   "name": {
+                                                    "default": "",
                                                     "type": "string"
                                                   },
                                                   "optional": {
@@ -1312,8 +1345,7 @@
                                                   }
                                                 },
                                                 "type": "object",
-                                                "x-kubernetes-map-type": "atomic",
-                                                "additionalProperties": false
+                                                "x-kubernetes-map-type": "atomic"
                                               },
                                               "prefix": {
                                                 "type": "string"
@@ -1321,6 +1353,7 @@
                                               "secretRef": {
                                                 "properties": {
                                                   "name": {
+                                                    "default": "",
                                                     "type": "string"
                                                   },
                                                   "optional": {
@@ -1328,14 +1361,13 @@
                                                   }
                                                 },
                                                 "type": "object",
-                                                "x-kubernetes-map-type": "atomic",
-                                                "additionalProperties": false
+                                                "x-kubernetes-map-type": "atomic"
                                               }
                                             },
-                                            "type": "object",
-                                            "additionalProperties": false
+                                            "type": "object"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "image": {
                                           "type": "string"
@@ -1353,11 +1385,11 @@
                                                       "items": {
                                                         "type": "string"
                                                       },
-                                                      "type": "array"
+                                                      "type": "array",
+                                                      "x-kubernetes-list-type": "atomic"
                                                     }
                                                   },
-                                                  "type": "object",
-                                                  "additionalProperties": false
+                                                  "type": "object"
                                                 },
                                                 "httpGet": {
                                                   "properties": {
@@ -1378,10 +1410,10 @@
                                                           "name",
                                                           "value"
                                                         ],
-                                                        "type": "object",
-                                                        "additionalProperties": false
+                                                        "type": "object"
                                                       },
-                                                      "type": "array"
+                                                      "type": "array",
+                                                      "x-kubernetes-list-type": "atomic"
                                                     },
                                                     "path": {
                                                       "type": "string"
@@ -1404,8 +1436,7 @@
                                                   "required": [
                                                     "port"
                                                   ],
-                                                  "type": "object",
-                                                  "additionalProperties": false
+                                                  "type": "object"
                                                 },
                                                 "sleep": {
                                                   "properties": {
@@ -1417,8 +1448,7 @@
                                                   "required": [
                                                     "seconds"
                                                   ],
-                                                  "type": "object",
-                                                  "additionalProperties": false
+                                                  "type": "object"
                                                 },
                                                 "tcpSocket": {
                                                   "properties": {
@@ -1440,12 +1470,10 @@
                                                   "required": [
                                                     "port"
                                                   ],
-                                                  "type": "object",
-                                                  "additionalProperties": false
+                                                  "type": "object"
                                                 }
                                               },
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "preStop": {
                                               "properties": {
@@ -1455,11 +1483,11 @@
                                                       "items": {
                                                         "type": "string"
                                                       },
-                                                      "type": "array"
+                                                      "type": "array",
+                                                      "x-kubernetes-list-type": "atomic"
                                                     }
                                                   },
-                                                  "type": "object",
-                                                  "additionalProperties": false
+                                                  "type": "object"
                                                 },
                                                 "httpGet": {
                                                   "properties": {
@@ -1480,10 +1508,10 @@
                                                           "name",
                                                           "value"
                                                         ],
-                                                        "type": "object",
-                                                        "additionalProperties": false
+                                                        "type": "object"
                                                       },
-                                                      "type": "array"
+                                                      "type": "array",
+                                                      "x-kubernetes-list-type": "atomic"
                                                     },
                                                     "path": {
                                                       "type": "string"
@@ -1506,8 +1534,7 @@
                                                   "required": [
                                                     "port"
                                                   ],
-                                                  "type": "object",
-                                                  "additionalProperties": false
+                                                  "type": "object"
                                                 },
                                                 "sleep": {
                                                   "properties": {
@@ -1519,8 +1546,7 @@
                                                   "required": [
                                                     "seconds"
                                                   ],
-                                                  "type": "object",
-                                                  "additionalProperties": false
+                                                  "type": "object"
                                                 },
                                                 "tcpSocket": {
                                                   "properties": {
@@ -1542,16 +1568,16 @@
                                                   "required": [
                                                     "port"
                                                   ],
-                                                  "type": "object",
-                                                  "additionalProperties": false
+                                                  "type": "object"
                                                 }
                                               },
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
+                                            },
+                                            "stopSignal": {
+                                              "type": "string"
                                             }
                                           },
-                                          "type": "object",
-                                          "additionalProperties": false
+                                          "type": "object"
                                         },
                                         "livenessProbe": {
                                           "properties": {
@@ -1561,11 +1587,11 @@
                                                   "items": {
                                                     "type": "string"
                                                   },
-                                                  "type": "array"
+                                                  "type": "array",
+                                                  "x-kubernetes-list-type": "atomic"
                                                 }
                                               },
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "failureThreshold": {
                                               "format": "int32",
@@ -1578,14 +1604,14 @@
                                                   "type": "integer"
                                                 },
                                                 "service": {
+                                                  "default": "",
                                                   "type": "string"
                                                 }
                                               },
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "httpGet": {
                                               "properties": {
@@ -1606,10 +1632,10 @@
                                                       "name",
                                                       "value"
                                                     ],
-                                                    "type": "object",
-                                                    "additionalProperties": false
+                                                    "type": "object"
                                                   },
-                                                  "type": "array"
+                                                  "type": "array",
+                                                  "x-kubernetes-list-type": "atomic"
                                                 },
                                                 "path": {
                                                   "type": "string"
@@ -1632,8 +1658,7 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "initialDelaySeconds": {
                                               "format": "int32",
@@ -1667,8 +1692,7 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "terminationGracePeriodSeconds": {
                                               "format": "int64",
@@ -1679,8 +1703,7 @@
                                               "type": "integer"
                                             }
                                           },
-                                          "type": "object",
-                                          "additionalProperties": false
+                                          "type": "object"
                                         },
                                         "name": {
                                           "type": "string"
@@ -1710,8 +1733,7 @@
                                             "required": [
                                               "containerPort"
                                             ],
-                                            "type": "object",
-                                            "additionalProperties": false
+                                            "type": "object"
                                           },
                                           "type": "array",
                                           "x-kubernetes-list-map-keys": [
@@ -1728,11 +1750,11 @@
                                                   "items": {
                                                     "type": "string"
                                                   },
-                                                  "type": "array"
+                                                  "type": "array",
+                                                  "x-kubernetes-list-type": "atomic"
                                                 }
                                               },
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "failureThreshold": {
                                               "format": "int32",
@@ -1745,14 +1767,14 @@
                                                   "type": "integer"
                                                 },
                                                 "service": {
+                                                  "default": "",
                                                   "type": "string"
                                                 }
                                               },
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "httpGet": {
                                               "properties": {
@@ -1773,10 +1795,10 @@
                                                       "name",
                                                       "value"
                                                     ],
-                                                    "type": "object",
-                                                    "additionalProperties": false
+                                                    "type": "object"
                                                   },
-                                                  "type": "array"
+                                                  "type": "array",
+                                                  "x-kubernetes-list-type": "atomic"
                                                 },
                                                 "path": {
                                                   "type": "string"
@@ -1799,8 +1821,7 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "initialDelaySeconds": {
                                               "format": "int32",
@@ -1834,8 +1855,7 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "terminationGracePeriodSeconds": {
                                               "format": "int64",
@@ -1846,8 +1866,7 @@
                                               "type": "integer"
                                             }
                                           },
-                                          "type": "object",
-                                          "additionalProperties": false
+                                          "type": "object"
                                         },
                                         "resizePolicy": {
                                           "items": {
@@ -1863,8 +1882,7 @@
                                               "resourceName",
                                               "restartPolicy"
                                             ],
-                                            "type": "object",
-                                            "additionalProperties": false
+                                            "type": "object"
                                           },
                                           "type": "array",
                                           "x-kubernetes-list-type": "atomic"
@@ -1876,13 +1894,15 @@
                                                 "properties": {
                                                   "name": {
                                                     "type": "string"
+                                                  },
+                                                  "request": {
+                                                    "type": "string"
                                                   }
                                                 },
                                                 "required": [
                                                   "name"
                                                 ],
-                                                "type": "object",
-                                                "additionalProperties": false
+                                                "type": "object"
                                               },
                                               "type": "array",
                                               "x-kubernetes-list-map-keys": [
@@ -1897,16 +1917,63 @@
                                               "x-kubernetes-preserve-unknown-fields": true
                                             }
                                           },
-                                          "type": "object",
-                                          "additionalProperties": false
+                                          "type": "object"
                                         },
                                         "restartPolicy": {
                                           "type": "string"
+                                        },
+                                        "restartPolicyRules": {
+                                          "items": {
+                                            "properties": {
+                                              "action": {
+                                                "type": "string"
+                                              },
+                                              "exitCodes": {
+                                                "properties": {
+                                                  "operator": {
+                                                    "type": "string"
+                                                  },
+                                                  "values": {
+                                                    "items": {
+                                                      "format": "int32",
+                                                      "type": "integer"
+                                                    },
+                                                    "type": "array",
+                                                    "x-kubernetes-list-type": "set"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "operator"
+                                                ],
+                                                "type": "object"
+                                              }
+                                            },
+                                            "required": [
+                                              "action"
+                                            ],
+                                            "type": "object"
+                                          },
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "securityContext": {
                                           "properties": {
                                             "allowPrivilegeEscalation": {
                                               "type": "boolean"
+                                            },
+                                            "appArmorProfile": {
+                                              "properties": {
+                                                "localhostProfile": {
+                                                  "type": "string"
+                                                },
+                                                "type": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "type"
+                                              ],
+                                              "type": "object"
                                             },
                                             "capabilities": {
                                               "properties": {
@@ -1914,17 +1981,18 @@
                                                   "items": {
                                                     "type": "string"
                                                   },
-                                                  "type": "array"
+                                                  "type": "array",
+                                                  "x-kubernetes-list-type": "atomic"
                                                 },
                                                 "drop": {
                                                   "items": {
                                                     "type": "string"
                                                   },
-                                                  "type": "array"
+                                                  "type": "array",
+                                                  "x-kubernetes-list-type": "atomic"
                                                 }
                                               },
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "privileged": {
                                               "type": "boolean"
@@ -1961,8 +2029,7 @@
                                                   "type": "string"
                                                 }
                                               },
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "seccompProfile": {
                                               "properties": {
@@ -1976,8 +2043,7 @@
                                               "required": [
                                                 "type"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "windowsOptions": {
                                               "properties": {
@@ -1994,12 +2060,10 @@
                                                   "type": "string"
                                                 }
                                               },
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             }
                                           },
-                                          "type": "object",
-                                          "additionalProperties": false
+                                          "type": "object"
                                         },
                                         "startupProbe": {
                                           "properties": {
@@ -2009,11 +2073,11 @@
                                                   "items": {
                                                     "type": "string"
                                                   },
-                                                  "type": "array"
+                                                  "type": "array",
+                                                  "x-kubernetes-list-type": "atomic"
                                                 }
                                               },
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "failureThreshold": {
                                               "format": "int32",
@@ -2026,14 +2090,14 @@
                                                   "type": "integer"
                                                 },
                                                 "service": {
+                                                  "default": "",
                                                   "type": "string"
                                                 }
                                               },
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "httpGet": {
                                               "properties": {
@@ -2054,10 +2118,10 @@
                                                       "name",
                                                       "value"
                                                     ],
-                                                    "type": "object",
-                                                    "additionalProperties": false
+                                                    "type": "object"
                                                   },
-                                                  "type": "array"
+                                                  "type": "array",
+                                                  "x-kubernetes-list-type": "atomic"
                                                 },
                                                 "path": {
                                                   "type": "string"
@@ -2080,8 +2144,7 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "initialDelaySeconds": {
                                               "format": "int32",
@@ -2115,8 +2178,7 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "terminationGracePeriodSeconds": {
                                               "format": "int64",
@@ -2127,8 +2189,7 @@
                                               "type": "integer"
                                             }
                                           },
-                                          "type": "object",
-                                          "additionalProperties": false
+                                          "type": "object"
                                         },
                                         "stdin": {
                                           "type": "boolean"
@@ -2159,10 +2220,13 @@
                                               "devicePath",
                                               "name"
                                             ],
-                                            "type": "object",
-                                            "additionalProperties": false
+                                            "type": "object"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-map-keys": [
+                                            "devicePath"
+                                          ],
+                                          "x-kubernetes-list-type": "map"
                                         },
                                         "volumeMounts": {
                                           "items": {
@@ -2179,6 +2243,9 @@
                                               "readOnly": {
                                                 "type": "boolean"
                                               },
+                                              "recursiveReadOnly": {
+                                                "type": "string"
+                                              },
                                               "subPath": {
                                                 "type": "string"
                                               },
@@ -2190,10 +2257,13 @@
                                               "mountPath",
                                               "name"
                                             ],
-                                            "type": "object",
-                                            "additionalProperties": false
+                                            "type": "object"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-map-keys": [
+                                            "mountPath"
+                                          ],
+                                          "x-kubernetes-list-type": "map"
                                         },
                                         "workingDir": {
                                           "type": "string"
@@ -2202,10 +2272,13 @@
                                       "required": [
                                         "name"
                                       ],
-                                      "type": "object",
-                                      "additionalProperties": false
+                                      "type": "object"
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-map-keys": [
+                                      "name"
+                                    ],
+                                    "x-kubernetes-list-type": "map"
                                   },
                                   "dnsConfig": {
                                     "properties": {
@@ -2213,7 +2286,8 @@
                                         "items": {
                                           "type": "string"
                                         },
-                                        "type": "array"
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
                                       },
                                       "options": {
                                         "items": {
@@ -2225,20 +2299,20 @@
                                               "type": "string"
                                             }
                                           },
-                                          "type": "object",
-                                          "additionalProperties": false
+                                          "type": "object"
                                         },
-                                        "type": "array"
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
                                       },
                                       "searches": {
                                         "items": {
                                           "type": "string"
                                         },
-                                        "type": "array"
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
                                       }
                                     },
-                                    "type": "object",
-                                    "additionalProperties": false
+                                    "type": "object"
                                   },
                                   "dnsPolicy": {
                                     "type": "string"
@@ -2253,13 +2327,15 @@
                                           "items": {
                                             "type": "string"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "command": {
                                           "items": {
                                             "type": "string"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "env": {
                                           "items": {
@@ -2278,6 +2354,7 @@
                                                         "type": "string"
                                                       },
                                                       "name": {
+                                                        "default": "",
                                                         "type": "string"
                                                       },
                                                       "optional": {
@@ -2288,8 +2365,7 @@
                                                       "key"
                                                     ],
                                                     "type": "object",
-                                                    "x-kubernetes-map-type": "atomic",
-                                                    "additionalProperties": false
+                                                    "x-kubernetes-map-type": "atomic"
                                                   },
                                                   "fieldRef": {
                                                     "properties": {
@@ -2304,8 +2380,31 @@
                                                       "fieldPath"
                                                     ],
                                                     "type": "object",
-                                                    "x-kubernetes-map-type": "atomic",
-                                                    "additionalProperties": false
+                                                    "x-kubernetes-map-type": "atomic"
+                                                  },
+                                                  "fileKeyRef": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "optional": {
+                                                        "default": false,
+                                                        "type": "boolean"
+                                                      },
+                                                      "path": {
+                                                        "type": "string"
+                                                      },
+                                                      "volumeName": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key",
+                                                      "path",
+                                                      "volumeName"
+                                                    ],
+                                                    "type": "object",
+                                                    "x-kubernetes-map-type": "atomic"
                                                   },
                                                   "resourceFieldRef": {
                                                     "properties": {
@@ -2332,8 +2431,7 @@
                                                       "resource"
                                                     ],
                                                     "type": "object",
-                                                    "x-kubernetes-map-type": "atomic",
-                                                    "additionalProperties": false
+                                                    "x-kubernetes-map-type": "atomic"
                                                   },
                                                   "secretKeyRef": {
                                                     "properties": {
@@ -2341,6 +2439,7 @@
                                                         "type": "string"
                                                       },
                                                       "name": {
+                                                        "default": "",
                                                         "type": "string"
                                                       },
                                                       "optional": {
@@ -2351,21 +2450,22 @@
                                                       "key"
                                                     ],
                                                     "type": "object",
-                                                    "x-kubernetes-map-type": "atomic",
-                                                    "additionalProperties": false
+                                                    "x-kubernetes-map-type": "atomic"
                                                   }
                                                 },
-                                                "type": "object",
-                                                "additionalProperties": false
+                                                "type": "object"
                                               }
                                             },
                                             "required": [
                                               "name"
                                             ],
-                                            "type": "object",
-                                            "additionalProperties": false
+                                            "type": "object"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-map-keys": [
+                                            "name"
+                                          ],
+                                          "x-kubernetes-list-type": "map"
                                         },
                                         "envFrom": {
                                           "items": {
@@ -2373,6 +2473,7 @@
                                               "configMapRef": {
                                                 "properties": {
                                                   "name": {
+                                                    "default": "",
                                                     "type": "string"
                                                   },
                                                   "optional": {
@@ -2380,8 +2481,7 @@
                                                   }
                                                 },
                                                 "type": "object",
-                                                "x-kubernetes-map-type": "atomic",
-                                                "additionalProperties": false
+                                                "x-kubernetes-map-type": "atomic"
                                               },
                                               "prefix": {
                                                 "type": "string"
@@ -2389,6 +2489,7 @@
                                               "secretRef": {
                                                 "properties": {
                                                   "name": {
+                                                    "default": "",
                                                     "type": "string"
                                                   },
                                                   "optional": {
@@ -2396,14 +2497,13 @@
                                                   }
                                                 },
                                                 "type": "object",
-                                                "x-kubernetes-map-type": "atomic",
-                                                "additionalProperties": false
+                                                "x-kubernetes-map-type": "atomic"
                                               }
                                             },
-                                            "type": "object",
-                                            "additionalProperties": false
+                                            "type": "object"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "image": {
                                           "type": "string"
@@ -2421,11 +2521,11 @@
                                                       "items": {
                                                         "type": "string"
                                                       },
-                                                      "type": "array"
+                                                      "type": "array",
+                                                      "x-kubernetes-list-type": "atomic"
                                                     }
                                                   },
-                                                  "type": "object",
-                                                  "additionalProperties": false
+                                                  "type": "object"
                                                 },
                                                 "httpGet": {
                                                   "properties": {
@@ -2446,10 +2546,10 @@
                                                           "name",
                                                           "value"
                                                         ],
-                                                        "type": "object",
-                                                        "additionalProperties": false
+                                                        "type": "object"
                                                       },
-                                                      "type": "array"
+                                                      "type": "array",
+                                                      "x-kubernetes-list-type": "atomic"
                                                     },
                                                     "path": {
                                                       "type": "string"
@@ -2472,8 +2572,7 @@
                                                   "required": [
                                                     "port"
                                                   ],
-                                                  "type": "object",
-                                                  "additionalProperties": false
+                                                  "type": "object"
                                                 },
                                                 "sleep": {
                                                   "properties": {
@@ -2485,8 +2584,7 @@
                                                   "required": [
                                                     "seconds"
                                                   ],
-                                                  "type": "object",
-                                                  "additionalProperties": false
+                                                  "type": "object"
                                                 },
                                                 "tcpSocket": {
                                                   "properties": {
@@ -2508,12 +2606,10 @@
                                                   "required": [
                                                     "port"
                                                   ],
-                                                  "type": "object",
-                                                  "additionalProperties": false
+                                                  "type": "object"
                                                 }
                                               },
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "preStop": {
                                               "properties": {
@@ -2523,11 +2619,11 @@
                                                       "items": {
                                                         "type": "string"
                                                       },
-                                                      "type": "array"
+                                                      "type": "array",
+                                                      "x-kubernetes-list-type": "atomic"
                                                     }
                                                   },
-                                                  "type": "object",
-                                                  "additionalProperties": false
+                                                  "type": "object"
                                                 },
                                                 "httpGet": {
                                                   "properties": {
@@ -2548,10 +2644,10 @@
                                                           "name",
                                                           "value"
                                                         ],
-                                                        "type": "object",
-                                                        "additionalProperties": false
+                                                        "type": "object"
                                                       },
-                                                      "type": "array"
+                                                      "type": "array",
+                                                      "x-kubernetes-list-type": "atomic"
                                                     },
                                                     "path": {
                                                       "type": "string"
@@ -2574,8 +2670,7 @@
                                                   "required": [
                                                     "port"
                                                   ],
-                                                  "type": "object",
-                                                  "additionalProperties": false
+                                                  "type": "object"
                                                 },
                                                 "sleep": {
                                                   "properties": {
@@ -2587,8 +2682,7 @@
                                                   "required": [
                                                     "seconds"
                                                   ],
-                                                  "type": "object",
-                                                  "additionalProperties": false
+                                                  "type": "object"
                                                 },
                                                 "tcpSocket": {
                                                   "properties": {
@@ -2610,16 +2704,16 @@
                                                   "required": [
                                                     "port"
                                                   ],
-                                                  "type": "object",
-                                                  "additionalProperties": false
+                                                  "type": "object"
                                                 }
                                               },
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
+                                            },
+                                            "stopSignal": {
+                                              "type": "string"
                                             }
                                           },
-                                          "type": "object",
-                                          "additionalProperties": false
+                                          "type": "object"
                                         },
                                         "livenessProbe": {
                                           "properties": {
@@ -2629,11 +2723,11 @@
                                                   "items": {
                                                     "type": "string"
                                                   },
-                                                  "type": "array"
+                                                  "type": "array",
+                                                  "x-kubernetes-list-type": "atomic"
                                                 }
                                               },
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "failureThreshold": {
                                               "format": "int32",
@@ -2646,14 +2740,14 @@
                                                   "type": "integer"
                                                 },
                                                 "service": {
+                                                  "default": "",
                                                   "type": "string"
                                                 }
                                               },
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "httpGet": {
                                               "properties": {
@@ -2674,10 +2768,10 @@
                                                       "name",
                                                       "value"
                                                     ],
-                                                    "type": "object",
-                                                    "additionalProperties": false
+                                                    "type": "object"
                                                   },
-                                                  "type": "array"
+                                                  "type": "array",
+                                                  "x-kubernetes-list-type": "atomic"
                                                 },
                                                 "path": {
                                                   "type": "string"
@@ -2700,8 +2794,7 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "initialDelaySeconds": {
                                               "format": "int32",
@@ -2735,8 +2828,7 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "terminationGracePeriodSeconds": {
                                               "format": "int64",
@@ -2747,8 +2839,7 @@
                                               "type": "integer"
                                             }
                                           },
-                                          "type": "object",
-                                          "additionalProperties": false
+                                          "type": "object"
                                         },
                                         "name": {
                                           "type": "string"
@@ -2778,8 +2869,7 @@
                                             "required": [
                                               "containerPort"
                                             ],
-                                            "type": "object",
-                                            "additionalProperties": false
+                                            "type": "object"
                                           },
                                           "type": "array",
                                           "x-kubernetes-list-map-keys": [
@@ -2796,11 +2886,11 @@
                                                   "items": {
                                                     "type": "string"
                                                   },
-                                                  "type": "array"
+                                                  "type": "array",
+                                                  "x-kubernetes-list-type": "atomic"
                                                 }
                                               },
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "failureThreshold": {
                                               "format": "int32",
@@ -2813,14 +2903,14 @@
                                                   "type": "integer"
                                                 },
                                                 "service": {
+                                                  "default": "",
                                                   "type": "string"
                                                 }
                                               },
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "httpGet": {
                                               "properties": {
@@ -2841,10 +2931,10 @@
                                                       "name",
                                                       "value"
                                                     ],
-                                                    "type": "object",
-                                                    "additionalProperties": false
+                                                    "type": "object"
                                                   },
-                                                  "type": "array"
+                                                  "type": "array",
+                                                  "x-kubernetes-list-type": "atomic"
                                                 },
                                                 "path": {
                                                   "type": "string"
@@ -2867,8 +2957,7 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "initialDelaySeconds": {
                                               "format": "int32",
@@ -2902,8 +2991,7 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "terminationGracePeriodSeconds": {
                                               "format": "int64",
@@ -2914,8 +3002,7 @@
                                               "type": "integer"
                                             }
                                           },
-                                          "type": "object",
-                                          "additionalProperties": false
+                                          "type": "object"
                                         },
                                         "resizePolicy": {
                                           "items": {
@@ -2931,8 +3018,7 @@
                                               "resourceName",
                                               "restartPolicy"
                                             ],
-                                            "type": "object",
-                                            "additionalProperties": false
+                                            "type": "object"
                                           },
                                           "type": "array",
                                           "x-kubernetes-list-type": "atomic"
@@ -2944,13 +3030,15 @@
                                                 "properties": {
                                                   "name": {
                                                     "type": "string"
+                                                  },
+                                                  "request": {
+                                                    "type": "string"
                                                   }
                                                 },
                                                 "required": [
                                                   "name"
                                                 ],
-                                                "type": "object",
-                                                "additionalProperties": false
+                                                "type": "object"
                                               },
                                               "type": "array",
                                               "x-kubernetes-list-map-keys": [
@@ -2965,16 +3053,63 @@
                                               "x-kubernetes-preserve-unknown-fields": true
                                             }
                                           },
-                                          "type": "object",
-                                          "additionalProperties": false
+                                          "type": "object"
                                         },
                                         "restartPolicy": {
                                           "type": "string"
+                                        },
+                                        "restartPolicyRules": {
+                                          "items": {
+                                            "properties": {
+                                              "action": {
+                                                "type": "string"
+                                              },
+                                              "exitCodes": {
+                                                "properties": {
+                                                  "operator": {
+                                                    "type": "string"
+                                                  },
+                                                  "values": {
+                                                    "items": {
+                                                      "format": "int32",
+                                                      "type": "integer"
+                                                    },
+                                                    "type": "array",
+                                                    "x-kubernetes-list-type": "set"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "operator"
+                                                ],
+                                                "type": "object"
+                                              }
+                                            },
+                                            "required": [
+                                              "action"
+                                            ],
+                                            "type": "object"
+                                          },
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "securityContext": {
                                           "properties": {
                                             "allowPrivilegeEscalation": {
                                               "type": "boolean"
+                                            },
+                                            "appArmorProfile": {
+                                              "properties": {
+                                                "localhostProfile": {
+                                                  "type": "string"
+                                                },
+                                                "type": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "type"
+                                              ],
+                                              "type": "object"
                                             },
                                             "capabilities": {
                                               "properties": {
@@ -2982,17 +3117,18 @@
                                                   "items": {
                                                     "type": "string"
                                                   },
-                                                  "type": "array"
+                                                  "type": "array",
+                                                  "x-kubernetes-list-type": "atomic"
                                                 },
                                                 "drop": {
                                                   "items": {
                                                     "type": "string"
                                                   },
-                                                  "type": "array"
+                                                  "type": "array",
+                                                  "x-kubernetes-list-type": "atomic"
                                                 }
                                               },
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "privileged": {
                                               "type": "boolean"
@@ -3029,8 +3165,7 @@
                                                   "type": "string"
                                                 }
                                               },
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "seccompProfile": {
                                               "properties": {
@@ -3044,8 +3179,7 @@
                                               "required": [
                                                 "type"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "windowsOptions": {
                                               "properties": {
@@ -3062,12 +3196,10 @@
                                                   "type": "string"
                                                 }
                                               },
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             }
                                           },
-                                          "type": "object",
-                                          "additionalProperties": false
+                                          "type": "object"
                                         },
                                         "startupProbe": {
                                           "properties": {
@@ -3077,11 +3209,11 @@
                                                   "items": {
                                                     "type": "string"
                                                   },
-                                                  "type": "array"
+                                                  "type": "array",
+                                                  "x-kubernetes-list-type": "atomic"
                                                 }
                                               },
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "failureThreshold": {
                                               "format": "int32",
@@ -3094,14 +3226,14 @@
                                                   "type": "integer"
                                                 },
                                                 "service": {
+                                                  "default": "",
                                                   "type": "string"
                                                 }
                                               },
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "httpGet": {
                                               "properties": {
@@ -3122,10 +3254,10 @@
                                                       "name",
                                                       "value"
                                                     ],
-                                                    "type": "object",
-                                                    "additionalProperties": false
+                                                    "type": "object"
                                                   },
-                                                  "type": "array"
+                                                  "type": "array",
+                                                  "x-kubernetes-list-type": "atomic"
                                                 },
                                                 "path": {
                                                   "type": "string"
@@ -3148,8 +3280,7 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "initialDelaySeconds": {
                                               "format": "int32",
@@ -3183,8 +3314,7 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "terminationGracePeriodSeconds": {
                                               "format": "int64",
@@ -3195,8 +3325,7 @@
                                               "type": "integer"
                                             }
                                           },
-                                          "type": "object",
-                                          "additionalProperties": false
+                                          "type": "object"
                                         },
                                         "stdin": {
                                           "type": "boolean"
@@ -3230,10 +3359,13 @@
                                               "devicePath",
                                               "name"
                                             ],
-                                            "type": "object",
-                                            "additionalProperties": false
+                                            "type": "object"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-map-keys": [
+                                            "devicePath"
+                                          ],
+                                          "x-kubernetes-list-type": "map"
                                         },
                                         "volumeMounts": {
                                           "items": {
@@ -3250,6 +3382,9 @@
                                               "readOnly": {
                                                 "type": "boolean"
                                               },
+                                              "recursiveReadOnly": {
+                                                "type": "string"
+                                              },
                                               "subPath": {
                                                 "type": "string"
                                               },
@@ -3261,10 +3396,13 @@
                                               "mountPath",
                                               "name"
                                             ],
-                                            "type": "object",
-                                            "additionalProperties": false
+                                            "type": "object"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-map-keys": [
+                                            "mountPath"
+                                          ],
+                                          "x-kubernetes-list-type": "map"
                                         },
                                         "workingDir": {
                                           "type": "string"
@@ -3273,10 +3411,13 @@
                                       "required": [
                                         "name"
                                       ],
-                                      "type": "object",
-                                      "additionalProperties": false
+                                      "type": "object"
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-map-keys": [
+                                      "name"
+                                    ],
+                                    "x-kubernetes-list-type": "map"
                                   },
                                   "hostAliases": {
                                     "items": {
@@ -3285,16 +3426,23 @@
                                           "items": {
                                             "type": "string"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "ip": {
                                           "type": "string"
                                         }
                                       },
-                                      "type": "object",
-                                      "additionalProperties": false
+                                      "required": [
+                                        "ip"
+                                      ],
+                                      "type": "object"
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-map-keys": [
+                                      "ip"
+                                    ],
+                                    "x-kubernetes-list-type": "map"
                                   },
                                   "hostIPC": {
                                     "type": "boolean"
@@ -3311,18 +3459,25 @@
                                   "hostname": {
                                     "type": "string"
                                   },
+                                  "hostnameOverride": {
+                                    "type": "string"
+                                  },
                                   "imagePullSecrets": {
                                     "items": {
                                       "properties": {
                                         "name": {
+                                          "default": "",
                                           "type": "string"
                                         }
                                       },
                                       "type": "object",
-                                      "x-kubernetes-map-type": "atomic",
-                                      "additionalProperties": false
+                                      "x-kubernetes-map-type": "atomic"
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-map-keys": [
+                                      "name"
+                                    ],
+                                    "x-kubernetes-list-type": "map"
                                   },
                                   "initContainers": {
                                     "items": {
@@ -3331,13 +3486,15 @@
                                           "items": {
                                             "type": "string"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "command": {
                                           "items": {
                                             "type": "string"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "env": {
                                           "items": {
@@ -3356,6 +3513,7 @@
                                                         "type": "string"
                                                       },
                                                       "name": {
+                                                        "default": "",
                                                         "type": "string"
                                                       },
                                                       "optional": {
@@ -3366,8 +3524,7 @@
                                                       "key"
                                                     ],
                                                     "type": "object",
-                                                    "x-kubernetes-map-type": "atomic",
-                                                    "additionalProperties": false
+                                                    "x-kubernetes-map-type": "atomic"
                                                   },
                                                   "fieldRef": {
                                                     "properties": {
@@ -3382,8 +3539,31 @@
                                                       "fieldPath"
                                                     ],
                                                     "type": "object",
-                                                    "x-kubernetes-map-type": "atomic",
-                                                    "additionalProperties": false
+                                                    "x-kubernetes-map-type": "atomic"
+                                                  },
+                                                  "fileKeyRef": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "optional": {
+                                                        "default": false,
+                                                        "type": "boolean"
+                                                      },
+                                                      "path": {
+                                                        "type": "string"
+                                                      },
+                                                      "volumeName": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key",
+                                                      "path",
+                                                      "volumeName"
+                                                    ],
+                                                    "type": "object",
+                                                    "x-kubernetes-map-type": "atomic"
                                                   },
                                                   "resourceFieldRef": {
                                                     "properties": {
@@ -3410,8 +3590,7 @@
                                                       "resource"
                                                     ],
                                                     "type": "object",
-                                                    "x-kubernetes-map-type": "atomic",
-                                                    "additionalProperties": false
+                                                    "x-kubernetes-map-type": "atomic"
                                                   },
                                                   "secretKeyRef": {
                                                     "properties": {
@@ -3419,6 +3598,7 @@
                                                         "type": "string"
                                                       },
                                                       "name": {
+                                                        "default": "",
                                                         "type": "string"
                                                       },
                                                       "optional": {
@@ -3429,21 +3609,22 @@
                                                       "key"
                                                     ],
                                                     "type": "object",
-                                                    "x-kubernetes-map-type": "atomic",
-                                                    "additionalProperties": false
+                                                    "x-kubernetes-map-type": "atomic"
                                                   }
                                                 },
-                                                "type": "object",
-                                                "additionalProperties": false
+                                                "type": "object"
                                               }
                                             },
                                             "required": [
                                               "name"
                                             ],
-                                            "type": "object",
-                                            "additionalProperties": false
+                                            "type": "object"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-map-keys": [
+                                            "name"
+                                          ],
+                                          "x-kubernetes-list-type": "map"
                                         },
                                         "envFrom": {
                                           "items": {
@@ -3451,6 +3632,7 @@
                                               "configMapRef": {
                                                 "properties": {
                                                   "name": {
+                                                    "default": "",
                                                     "type": "string"
                                                   },
                                                   "optional": {
@@ -3458,8 +3640,7 @@
                                                   }
                                                 },
                                                 "type": "object",
-                                                "x-kubernetes-map-type": "atomic",
-                                                "additionalProperties": false
+                                                "x-kubernetes-map-type": "atomic"
                                               },
                                               "prefix": {
                                                 "type": "string"
@@ -3467,6 +3648,7 @@
                                               "secretRef": {
                                                 "properties": {
                                                   "name": {
+                                                    "default": "",
                                                     "type": "string"
                                                   },
                                                   "optional": {
@@ -3474,14 +3656,13 @@
                                                   }
                                                 },
                                                 "type": "object",
-                                                "x-kubernetes-map-type": "atomic",
-                                                "additionalProperties": false
+                                                "x-kubernetes-map-type": "atomic"
                                               }
                                             },
-                                            "type": "object",
-                                            "additionalProperties": false
+                                            "type": "object"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "image": {
                                           "type": "string"
@@ -3499,11 +3680,11 @@
                                                       "items": {
                                                         "type": "string"
                                                       },
-                                                      "type": "array"
+                                                      "type": "array",
+                                                      "x-kubernetes-list-type": "atomic"
                                                     }
                                                   },
-                                                  "type": "object",
-                                                  "additionalProperties": false
+                                                  "type": "object"
                                                 },
                                                 "httpGet": {
                                                   "properties": {
@@ -3524,10 +3705,10 @@
                                                           "name",
                                                           "value"
                                                         ],
-                                                        "type": "object",
-                                                        "additionalProperties": false
+                                                        "type": "object"
                                                       },
-                                                      "type": "array"
+                                                      "type": "array",
+                                                      "x-kubernetes-list-type": "atomic"
                                                     },
                                                     "path": {
                                                       "type": "string"
@@ -3550,8 +3731,7 @@
                                                   "required": [
                                                     "port"
                                                   ],
-                                                  "type": "object",
-                                                  "additionalProperties": false
+                                                  "type": "object"
                                                 },
                                                 "sleep": {
                                                   "properties": {
@@ -3563,8 +3743,7 @@
                                                   "required": [
                                                     "seconds"
                                                   ],
-                                                  "type": "object",
-                                                  "additionalProperties": false
+                                                  "type": "object"
                                                 },
                                                 "tcpSocket": {
                                                   "properties": {
@@ -3586,12 +3765,10 @@
                                                   "required": [
                                                     "port"
                                                   ],
-                                                  "type": "object",
-                                                  "additionalProperties": false
+                                                  "type": "object"
                                                 }
                                               },
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "preStop": {
                                               "properties": {
@@ -3601,11 +3778,11 @@
                                                       "items": {
                                                         "type": "string"
                                                       },
-                                                      "type": "array"
+                                                      "type": "array",
+                                                      "x-kubernetes-list-type": "atomic"
                                                     }
                                                   },
-                                                  "type": "object",
-                                                  "additionalProperties": false
+                                                  "type": "object"
                                                 },
                                                 "httpGet": {
                                                   "properties": {
@@ -3626,10 +3803,10 @@
                                                           "name",
                                                           "value"
                                                         ],
-                                                        "type": "object",
-                                                        "additionalProperties": false
+                                                        "type": "object"
                                                       },
-                                                      "type": "array"
+                                                      "type": "array",
+                                                      "x-kubernetes-list-type": "atomic"
                                                     },
                                                     "path": {
                                                       "type": "string"
@@ -3652,8 +3829,7 @@
                                                   "required": [
                                                     "port"
                                                   ],
-                                                  "type": "object",
-                                                  "additionalProperties": false
+                                                  "type": "object"
                                                 },
                                                 "sleep": {
                                                   "properties": {
@@ -3665,8 +3841,7 @@
                                                   "required": [
                                                     "seconds"
                                                   ],
-                                                  "type": "object",
-                                                  "additionalProperties": false
+                                                  "type": "object"
                                                 },
                                                 "tcpSocket": {
                                                   "properties": {
@@ -3688,16 +3863,16 @@
                                                   "required": [
                                                     "port"
                                                   ],
-                                                  "type": "object",
-                                                  "additionalProperties": false
+                                                  "type": "object"
                                                 }
                                               },
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
+                                            },
+                                            "stopSignal": {
+                                              "type": "string"
                                             }
                                           },
-                                          "type": "object",
-                                          "additionalProperties": false
+                                          "type": "object"
                                         },
                                         "livenessProbe": {
                                           "properties": {
@@ -3707,11 +3882,11 @@
                                                   "items": {
                                                     "type": "string"
                                                   },
-                                                  "type": "array"
+                                                  "type": "array",
+                                                  "x-kubernetes-list-type": "atomic"
                                                 }
                                               },
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "failureThreshold": {
                                               "format": "int32",
@@ -3724,14 +3899,14 @@
                                                   "type": "integer"
                                                 },
                                                 "service": {
+                                                  "default": "",
                                                   "type": "string"
                                                 }
                                               },
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "httpGet": {
                                               "properties": {
@@ -3752,10 +3927,10 @@
                                                       "name",
                                                       "value"
                                                     ],
-                                                    "type": "object",
-                                                    "additionalProperties": false
+                                                    "type": "object"
                                                   },
-                                                  "type": "array"
+                                                  "type": "array",
+                                                  "x-kubernetes-list-type": "atomic"
                                                 },
                                                 "path": {
                                                   "type": "string"
@@ -3778,8 +3953,7 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "initialDelaySeconds": {
                                               "format": "int32",
@@ -3813,8 +3987,7 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "terminationGracePeriodSeconds": {
                                               "format": "int64",
@@ -3825,8 +3998,7 @@
                                               "type": "integer"
                                             }
                                           },
-                                          "type": "object",
-                                          "additionalProperties": false
+                                          "type": "object"
                                         },
                                         "name": {
                                           "type": "string"
@@ -3856,8 +4028,7 @@
                                             "required": [
                                               "containerPort"
                                             ],
-                                            "type": "object",
-                                            "additionalProperties": false
+                                            "type": "object"
                                           },
                                           "type": "array",
                                           "x-kubernetes-list-map-keys": [
@@ -3874,11 +4045,11 @@
                                                   "items": {
                                                     "type": "string"
                                                   },
-                                                  "type": "array"
+                                                  "type": "array",
+                                                  "x-kubernetes-list-type": "atomic"
                                                 }
                                               },
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "failureThreshold": {
                                               "format": "int32",
@@ -3891,14 +4062,14 @@
                                                   "type": "integer"
                                                 },
                                                 "service": {
+                                                  "default": "",
                                                   "type": "string"
                                                 }
                                               },
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "httpGet": {
                                               "properties": {
@@ -3919,10 +4090,10 @@
                                                       "name",
                                                       "value"
                                                     ],
-                                                    "type": "object",
-                                                    "additionalProperties": false
+                                                    "type": "object"
                                                   },
-                                                  "type": "array"
+                                                  "type": "array",
+                                                  "x-kubernetes-list-type": "atomic"
                                                 },
                                                 "path": {
                                                   "type": "string"
@@ -3945,8 +4116,7 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "initialDelaySeconds": {
                                               "format": "int32",
@@ -3980,8 +4150,7 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "terminationGracePeriodSeconds": {
                                               "format": "int64",
@@ -3992,8 +4161,7 @@
                                               "type": "integer"
                                             }
                                           },
-                                          "type": "object",
-                                          "additionalProperties": false
+                                          "type": "object"
                                         },
                                         "resizePolicy": {
                                           "items": {
@@ -4009,8 +4177,7 @@
                                               "resourceName",
                                               "restartPolicy"
                                             ],
-                                            "type": "object",
-                                            "additionalProperties": false
+                                            "type": "object"
                                           },
                                           "type": "array",
                                           "x-kubernetes-list-type": "atomic"
@@ -4022,13 +4189,15 @@
                                                 "properties": {
                                                   "name": {
                                                     "type": "string"
+                                                  },
+                                                  "request": {
+                                                    "type": "string"
                                                   }
                                                 },
                                                 "required": [
                                                   "name"
                                                 ],
-                                                "type": "object",
-                                                "additionalProperties": false
+                                                "type": "object"
                                               },
                                               "type": "array",
                                               "x-kubernetes-list-map-keys": [
@@ -4043,16 +4212,63 @@
                                               "x-kubernetes-preserve-unknown-fields": true
                                             }
                                           },
-                                          "type": "object",
-                                          "additionalProperties": false
+                                          "type": "object"
                                         },
                                         "restartPolicy": {
                                           "type": "string"
+                                        },
+                                        "restartPolicyRules": {
+                                          "items": {
+                                            "properties": {
+                                              "action": {
+                                                "type": "string"
+                                              },
+                                              "exitCodes": {
+                                                "properties": {
+                                                  "operator": {
+                                                    "type": "string"
+                                                  },
+                                                  "values": {
+                                                    "items": {
+                                                      "format": "int32",
+                                                      "type": "integer"
+                                                    },
+                                                    "type": "array",
+                                                    "x-kubernetes-list-type": "set"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "operator"
+                                                ],
+                                                "type": "object"
+                                              }
+                                            },
+                                            "required": [
+                                              "action"
+                                            ],
+                                            "type": "object"
+                                          },
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "securityContext": {
                                           "properties": {
                                             "allowPrivilegeEscalation": {
                                               "type": "boolean"
+                                            },
+                                            "appArmorProfile": {
+                                              "properties": {
+                                                "localhostProfile": {
+                                                  "type": "string"
+                                                },
+                                                "type": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "type"
+                                              ],
+                                              "type": "object"
                                             },
                                             "capabilities": {
                                               "properties": {
@@ -4060,17 +4276,18 @@
                                                   "items": {
                                                     "type": "string"
                                                   },
-                                                  "type": "array"
+                                                  "type": "array",
+                                                  "x-kubernetes-list-type": "atomic"
                                                 },
                                                 "drop": {
                                                   "items": {
                                                     "type": "string"
                                                   },
-                                                  "type": "array"
+                                                  "type": "array",
+                                                  "x-kubernetes-list-type": "atomic"
                                                 }
                                               },
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "privileged": {
                                               "type": "boolean"
@@ -4107,8 +4324,7 @@
                                                   "type": "string"
                                                 }
                                               },
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "seccompProfile": {
                                               "properties": {
@@ -4122,8 +4338,7 @@
                                               "required": [
                                                 "type"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "windowsOptions": {
                                               "properties": {
@@ -4140,12 +4355,10 @@
                                                   "type": "string"
                                                 }
                                               },
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             }
                                           },
-                                          "type": "object",
-                                          "additionalProperties": false
+                                          "type": "object"
                                         },
                                         "startupProbe": {
                                           "properties": {
@@ -4155,11 +4368,11 @@
                                                   "items": {
                                                     "type": "string"
                                                   },
-                                                  "type": "array"
+                                                  "type": "array",
+                                                  "x-kubernetes-list-type": "atomic"
                                                 }
                                               },
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "failureThreshold": {
                                               "format": "int32",
@@ -4172,14 +4385,14 @@
                                                   "type": "integer"
                                                 },
                                                 "service": {
+                                                  "default": "",
                                                   "type": "string"
                                                 }
                                               },
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "httpGet": {
                                               "properties": {
@@ -4200,10 +4413,10 @@
                                                       "name",
                                                       "value"
                                                     ],
-                                                    "type": "object",
-                                                    "additionalProperties": false
+                                                    "type": "object"
                                                   },
-                                                  "type": "array"
+                                                  "type": "array",
+                                                  "x-kubernetes-list-type": "atomic"
                                                 },
                                                 "path": {
                                                   "type": "string"
@@ -4226,8 +4439,7 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "initialDelaySeconds": {
                                               "format": "int32",
@@ -4261,8 +4473,7 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "terminationGracePeriodSeconds": {
                                               "format": "int64",
@@ -4273,8 +4484,7 @@
                                               "type": "integer"
                                             }
                                           },
-                                          "type": "object",
-                                          "additionalProperties": false
+                                          "type": "object"
                                         },
                                         "stdin": {
                                           "type": "boolean"
@@ -4305,10 +4515,13 @@
                                               "devicePath",
                                               "name"
                                             ],
-                                            "type": "object",
-                                            "additionalProperties": false
+                                            "type": "object"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-map-keys": [
+                                            "devicePath"
+                                          ],
+                                          "x-kubernetes-list-type": "map"
                                         },
                                         "volumeMounts": {
                                           "items": {
@@ -4325,6 +4538,9 @@
                                               "readOnly": {
                                                 "type": "boolean"
                                               },
+                                              "recursiveReadOnly": {
+                                                "type": "string"
+                                              },
                                               "subPath": {
                                                 "type": "string"
                                               },
@@ -4336,10 +4552,13 @@
                                               "mountPath",
                                               "name"
                                             ],
-                                            "type": "object",
-                                            "additionalProperties": false
+                                            "type": "object"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-map-keys": [
+                                            "mountPath"
+                                          ],
+                                          "x-kubernetes-list-type": "map"
                                         },
                                         "workingDir": {
                                           "type": "string"
@@ -4348,10 +4567,13 @@
                                       "required": [
                                         "name"
                                       ],
-                                      "type": "object",
-                                      "additionalProperties": false
+                                      "type": "object"
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-map-keys": [
+                                      "name"
+                                    ],
+                                    "x-kubernetes-list-type": "map"
                                   },
                                   "nodeName": {
                                     "type": "string"
@@ -4372,8 +4594,7 @@
                                     "required": [
                                       "name"
                                     ],
-                                    "type": "object",
-                                    "additionalProperties": false
+                                    "type": "object"
                                   },
                                   "overhead": {
                                     "additionalProperties": {
@@ -4410,10 +4631,10 @@
                                       "required": [
                                         "conditionType"
                                       ],
-                                      "type": "object",
-                                      "additionalProperties": false
+                                      "type": "object"
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "resourceClaims": {
                                     "items": {
@@ -4421,30 +4642,79 @@
                                         "name": {
                                           "type": "string"
                                         },
-                                        "source": {
-                                          "properties": {
-                                            "resourceClaimName": {
-                                              "type": "string"
-                                            },
-                                            "resourceClaimTemplateName": {
-                                              "type": "string"
-                                            }
-                                          },
-                                          "type": "object",
-                                          "additionalProperties": false
+                                        "resourceClaimName": {
+                                          "type": "string"
+                                        },
+                                        "resourceClaimTemplateName": {
+                                          "type": "string"
                                         }
                                       },
                                       "required": [
                                         "name"
                                       ],
-                                      "type": "object",
-                                      "additionalProperties": false
+                                      "type": "object"
                                     },
                                     "type": "array",
                                     "x-kubernetes-list-map-keys": [
                                       "name"
                                     ],
                                     "x-kubernetes-list-type": "map"
+                                  },
+                                  "resources": {
+                                    "properties": {
+                                      "claims": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "request": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name"
+                                          ],
+                                          "type": "object"
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-map-keys": [
+                                          "name"
+                                        ],
+                                        "x-kubernetes-list-type": "map"
+                                      },
+                                      "limits": {
+                                        "additionalProperties": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "type": "object"
+                                      },
+                                      "requests": {
+                                        "additionalProperties": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object"
                                   },
                                   "restartPolicy": {
                                     "type": "string"
@@ -4465,8 +4735,7 @@
                                       "required": [
                                         "name"
                                       ],
-                                      "type": "object",
-                                      "additionalProperties": false
+                                      "type": "object"
                                     },
                                     "type": "array",
                                     "x-kubernetes-list-map-keys": [
@@ -4476,6 +4745,20 @@
                                   },
                                   "securityContext": {
                                     "properties": {
+                                      "appArmorProfile": {
+                                        "properties": {
+                                          "localhostProfile": {
+                                            "type": "string"
+                                          },
+                                          "type": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "type"
+                                        ],
+                                        "type": "object"
+                                      },
                                       "fsGroup": {
                                         "format": "int64",
                                         "type": "integer"
@@ -4494,6 +4777,9 @@
                                         "format": "int64",
                                         "type": "integer"
                                       },
+                                      "seLinuxChangePolicy": {
+                                        "type": "string"
+                                      },
                                       "seLinuxOptions": {
                                         "properties": {
                                           "level": {
@@ -4509,8 +4795,7 @@
                                             "type": "string"
                                           }
                                         },
-                                        "type": "object",
-                                        "additionalProperties": false
+                                        "type": "object"
                                       },
                                       "seccompProfile": {
                                         "properties": {
@@ -4524,15 +4809,18 @@
                                         "required": [
                                           "type"
                                         ],
-                                        "type": "object",
-                                        "additionalProperties": false
+                                        "type": "object"
                                       },
                                       "supplementalGroups": {
                                         "items": {
                                           "format": "int64",
                                           "type": "integer"
                                         },
-                                        "type": "array"
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "supplementalGroupsPolicy": {
+                                        "type": "string"
                                       },
                                       "sysctls": {
                                         "items": {
@@ -4548,10 +4836,10 @@
                                             "name",
                                             "value"
                                           ],
-                                          "type": "object",
-                                          "additionalProperties": false
+                                          "type": "object"
                                         },
-                                        "type": "array"
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
                                       },
                                       "windowsOptions": {
                                         "properties": {
@@ -4568,12 +4856,10 @@
                                             "type": "string"
                                           }
                                         },
-                                        "type": "object",
-                                        "additionalProperties": false
+                                        "type": "object"
                                       }
                                     },
-                                    "type": "object",
-                                    "additionalProperties": false
+                                    "type": "object"
                                   },
                                   "serviceAccount": {
                                     "type": "string"
@@ -4614,10 +4900,10 @@
                                           "type": "string"
                                         }
                                       },
-                                      "type": "object",
-                                      "additionalProperties": false
+                                      "type": "object"
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "topologySpreadConstraints": {
                                     "items": {
@@ -4637,17 +4923,18 @@
                                                     "items": {
                                                       "type": "string"
                                                     },
-                                                    "type": "array"
+                                                    "type": "array",
+                                                    "x-kubernetes-list-type": "atomic"
                                                   }
                                                 },
                                                 "required": [
                                                   "key",
                                                   "operator"
                                                 ],
-                                                "type": "object",
-                                                "additionalProperties": false
+                                                "type": "object"
                                               },
-                                              "type": "array"
+                                              "type": "array",
+                                              "x-kubernetes-list-type": "atomic"
                                             },
                                             "matchLabels": {
                                               "additionalProperties": {
@@ -4657,8 +4944,7 @@
                                             }
                                           },
                                           "type": "object",
-                                          "x-kubernetes-map-type": "atomic",
-                                          "additionalProperties": false
+                                          "x-kubernetes-map-type": "atomic"
                                         },
                                         "matchLabelKeys": {
                                           "items": {
@@ -4693,8 +4979,7 @@
                                         "topologyKey",
                                         "whenUnsatisfiable"
                                       ],
-                                      "type": "object",
-                                      "additionalProperties": false
+                                      "type": "object"
                                     },
                                     "type": "array",
                                     "x-kubernetes-list-map-keys": [
@@ -4710,12 +4995,10 @@
                                 "required": [
                                   "containers"
                                 ],
-                                "type": "object",
-                                "additionalProperties": false
+                                "type": "object"
                               }
                             },
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "ttlSecondsAfterFinished": {
                             "format": "int32",
@@ -4725,15 +5008,13 @@
                         "required": [
                           "template"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       }
                     },
                     "required": [
                       "spec"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "kayenta": {
                     "properties": {
@@ -4748,6 +5029,9 @@
                       },
                       "configurationAccountName": {
                         "type": "string"
+                      },
+                      "lookback": {
+                        "type": "boolean"
                       },
                       "metricsAccountName": {
                         "type": "string"
@@ -4775,14 +5059,11 @@
                                 }
                               },
                               "required": [
-                                "end",
                                 "region",
                                 "scope",
-                                "start",
                                 "step"
                               ],
-                              "type": "object",
-                              "additionalProperties": false
+                              "type": "object"
                             },
                             "experimentScope": {
                               "properties": {
@@ -4804,14 +5085,11 @@
                                 }
                               },
                               "required": [
-                                "end",
                                 "region",
                                 "scope",
-                                "start",
                                 "step"
                               ],
-                              "type": "object",
-                              "additionalProperties": false
+                              "type": "object"
                             },
                             "name": {
                               "type": "string"
@@ -4822,8 +5100,7 @@
                             "experimentScope",
                             "name"
                           ],
-                          "type": "object",
-                          "additionalProperties": false
+                          "type": "object"
                         },
                         "type": "array"
                       },
@@ -4845,8 +5122,7 @@
                           "marginal",
                           "pass"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       }
                     },
                     "required": [
@@ -4859,8 +5135,7 @@
                       "storageAccountName",
                       "threshold"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "newRelic": {
                     "properties": {
@@ -4878,8 +5153,7 @@
                     "required": [
                       "query"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "plugin": {
                     "type": "object",
@@ -4910,8 +5184,7 @@
                                 "type": "string"
                               }
                             },
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "sigv4": {
                             "properties": {
@@ -4925,12 +5198,10 @@
                                 "type": "string"
                               }
                             },
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "headers": {
                         "items": {
@@ -4946,8 +5217,7 @@
                             "key",
                             "value"
                           ],
-                          "type": "object",
-                          "additionalProperties": false
+                          "type": "object"
                         },
                         "type": "array"
                       },
@@ -4969,16 +5239,14 @@
                             "type": "string"
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "timeout": {
                         "format": "int64",
                         "type": "integer"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "skywalking": {
                     "properties": {
@@ -4992,8 +5260,7 @@
                         "type": "string"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "wavefront": {
                     "properties": {
@@ -5004,8 +5271,7 @@
                         "type": "string"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "web": {
                     "properties": {
@@ -5029,8 +5295,7 @@
                                 "type": "string"
                               }
                             },
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "sigv4": {
                             "properties": {
@@ -5044,12 +5309,10 @@
                                 "type": "string"
                               }
                             },
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "body": {
                         "type": "string"
@@ -5068,8 +5331,7 @@
                             "key",
                             "value"
                           ],
-                          "type": "object",
-                          "additionalProperties": false
+                          "type": "object"
                         },
                         "type": "array"
                       },
@@ -5097,12 +5359,10 @@
                     "required": [
                       "url"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   }
                 },
-                "type": "object",
-                "additionalProperties": false
+                "type": "object"
               },
               "successCondition": {
                 "type": "string"
@@ -5112,8 +5372,7 @@
               "name",
               "provider"
             ],
-            "type": "object",
-            "additionalProperties": false
+            "type": "object"
           },
           "type": "array"
         },
@@ -5135,15 +5394,13 @@
               "type": "integer"
             }
           },
-          "type": "object",
-          "additionalProperties": false
+          "type": "object"
         }
       },
       "required": [
         "metrics"
       ],
-      "type": "object",
-      "additionalProperties": false
+      "type": "object"
     },
     "status": {
       "properties": {
@@ -5174,8 +5431,7 @@
               "type": "integer"
             }
           },
-          "type": "object",
-          "additionalProperties": false
+          "type": "object"
         },
         "message": {
           "type": "string"
@@ -5244,8 +5500,7 @@
                   "required": [
                     "phase"
                   ],
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 },
                 "type": "array"
               },
@@ -5273,8 +5528,7 @@
               "name",
               "phase"
             ],
-            "type": "object",
-            "additionalProperties": false
+            "type": "object"
           },
           "type": "array"
         },
@@ -5304,8 +5558,7 @@
               "type": "integer"
             }
           },
-          "type": "object",
-          "additionalProperties": false
+          "type": "object"
         },
         "startedAt": {
           "format": "date-time",
@@ -5315,8 +5568,7 @@
       "required": [
         "phase"
       ],
-      "type": "object",
-      "additionalProperties": false
+      "type": "object"
     }
   },
   "required": [

--- a/argoproj.io/analysisrun_v1alpha1.json
+++ b/argoproj.io/analysisrun_v1alpha1.json
@@ -31,7 +31,8 @@
                     "required": [
                       "fieldPath"
                     ],
-                    "type": "object"
+                    "type": "object",
+                    "additionalProperties": false
                   },
                   "secretKeyRef": {
                     "properties": {
@@ -46,16 +47,19 @@
                       "key",
                       "name"
                     ],
-                    "type": "object"
+                    "type": "object",
+                    "additionalProperties": false
                   }
                 },
-                "type": "object"
+                "type": "object",
+                "additionalProperties": false
               }
             },
             "required": [
               "name"
             ],
-            "type": "object"
+            "type": "object",
+            "additionalProperties": false
           },
           "type": "array"
         },
@@ -69,7 +73,8 @@
             "required": [
               "metricName"
             ],
-            "type": "object"
+            "type": "object",
+            "additionalProperties": false
           },
           "type": "array"
         },
@@ -88,7 +93,8 @@
               "limit",
               "metricName"
             ],
-            "type": "object"
+            "type": "object",
+            "additionalProperties": false
           },
           "type": "array"
         },
@@ -195,7 +201,8 @@
                                             "type": "string"
                                           }
                                         },
-                                        "type": "object"
+                                        "type": "object",
+                                        "additionalProperties": false
                                       },
                                       "type": "array"
                                     },
@@ -206,7 +213,8 @@
                                       "type": "string"
                                     }
                                   },
-                                  "type": "object"
+                                  "type": "object",
+                                  "additionalProperties": false
                                 },
                                 "period": {
                                   "anyOf": [
@@ -226,7 +234,8 @@
                                   "type": "string"
                                 }
                               },
-                              "type": "object"
+                              "type": "object",
+                              "additionalProperties": false
                             },
                             "period": {
                               "anyOf": [
@@ -243,7 +252,8 @@
                               "type": "boolean"
                             }
                           },
-                          "type": "object"
+                          "type": "object",
+                          "additionalProperties": false
                         },
                         "type": "array"
                       }
@@ -251,7 +261,8 @@
                     "required": [
                       "metricDataQueries"
                     ],
-                    "type": "object"
+                    "type": "object",
+                    "additionalProperties": false
                   },
                   "datadog": {
                     "properties": {
@@ -302,10 +313,12 @@
                             "type": "boolean"
                           }
                         },
-                        "type": "object"
+                        "type": "object",
+                        "additionalProperties": false
                       }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "additionalProperties": false
                   },
                   "graphite": {
                     "properties": {
@@ -316,7 +329,8 @@
                         "type": "string"
                       }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "additionalProperties": false
                   },
                   "influxdb": {
                     "properties": {
@@ -327,7 +341,8 @@
                         "type": "string"
                       }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "additionalProperties": false
                   },
                   "job": {
                     "properties": {
@@ -346,7 +361,8 @@
                             "type": "object"
                           }
                         },
-                        "type": "object"
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "spec": {
                         "properties": {
@@ -412,7 +428,8 @@
                                         "operator",
                                         "values"
                                       ],
-                                      "type": "object"
+                                      "type": "object",
+                                      "additionalProperties": false
                                     },
                                     "onPodConditions": {
                                       "items": {
@@ -428,7 +445,8 @@
                                           "status",
                                           "type"
                                         ],
-                                        "type": "object"
+                                        "type": "object",
+                                        "additionalProperties": false
                                       },
                                       "type": "array",
                                       "x-kubernetes-list-type": "atomic"
@@ -437,7 +455,8 @@
                                   "required": [
                                     "action"
                                   ],
-                                  "type": "object"
+                                  "type": "object",
+                                  "additionalProperties": false
                                 },
                                 "type": "array",
                                 "x-kubernetes-list-type": "atomic"
@@ -446,7 +465,8 @@
                             "required": [
                               "rules"
                             ],
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "podReplacementPolicy": {
                             "type": "string"
@@ -474,7 +494,8 @@
                                     "key",
                                     "operator"
                                   ],
-                                  "type": "object"
+                                  "type": "object",
+                                  "additionalProperties": false
                                 },
                                 "type": "array",
                                 "x-kubernetes-list-type": "atomic"
@@ -487,7 +508,8 @@
                               }
                             },
                             "type": "object",
-                            "x-kubernetes-map-type": "atomic"
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
                           },
                           "successPolicy": {
                             "properties": {
@@ -502,7 +524,8 @@
                                       "type": "string"
                                     }
                                   },
-                                  "type": "object"
+                                  "type": "object",
+                                  "additionalProperties": false
                                 },
                                 "type": "array",
                                 "x-kubernetes-list-type": "atomic"
@@ -511,7 +534,8 @@
                             "required": [
                               "rules"
                             ],
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "suspend": {
                             "type": "boolean"
@@ -533,7 +557,8 @@
                                     "type": "object"
                                   }
                                 },
-                                "type": "object"
+                                "type": "object",
+                                "additionalProperties": false
                               },
                               "spec": {
                                 "properties": {
@@ -571,7 +596,8 @@
                                                           "key",
                                                           "operator"
                                                         ],
-                                                        "type": "object"
+                                                        "type": "object",
+                                                        "additionalProperties": false
                                                       },
                                                       "type": "array",
                                                       "x-kubernetes-list-type": "atomic"
@@ -597,14 +623,16 @@
                                                           "key",
                                                           "operator"
                                                         ],
-                                                        "type": "object"
+                                                        "type": "object",
+                                                        "additionalProperties": false
                                                       },
                                                       "type": "array",
                                                       "x-kubernetes-list-type": "atomic"
                                                     }
                                                   },
                                                   "type": "object",
-                                                  "x-kubernetes-map-type": "atomic"
+                                                  "x-kubernetes-map-type": "atomic",
+                                                  "additionalProperties": false
                                                 },
                                                 "weight": {
                                                   "format": "int32",
@@ -615,7 +643,8 @@
                                                 "preference",
                                                 "weight"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "type": "array",
                                             "x-kubernetes-list-type": "atomic"
@@ -646,7 +675,8 @@
                                                           "key",
                                                           "operator"
                                                         ],
-                                                        "type": "object"
+                                                        "type": "object",
+                                                        "additionalProperties": false
                                                       },
                                                       "type": "array",
                                                       "x-kubernetes-list-type": "atomic"
@@ -672,14 +702,16 @@
                                                           "key",
                                                           "operator"
                                                         ],
-                                                        "type": "object"
+                                                        "type": "object",
+                                                        "additionalProperties": false
                                                       },
                                                       "type": "array",
                                                       "x-kubernetes-list-type": "atomic"
                                                     }
                                                   },
                                                   "type": "object",
-                                                  "x-kubernetes-map-type": "atomic"
+                                                  "x-kubernetes-map-type": "atomic",
+                                                  "additionalProperties": false
                                                 },
                                                 "type": "array",
                                                 "x-kubernetes-list-type": "atomic"
@@ -689,10 +721,12 @@
                                               "nodeSelectorTerms"
                                             ],
                                             "type": "object",
-                                            "x-kubernetes-map-type": "atomic"
+                                            "x-kubernetes-map-type": "atomic",
+                                            "additionalProperties": false
                                           }
                                         },
-                                        "type": "object"
+                                        "type": "object",
+                                        "additionalProperties": false
                                       },
                                       "podAffinity": {
                                         "properties": {
@@ -724,7 +758,8 @@
                                                               "key",
                                                               "operator"
                                                             ],
-                                                            "type": "object"
+                                                            "type": "object",
+                                                            "additionalProperties": false
                                                           },
                                                           "type": "array",
                                                           "x-kubernetes-list-type": "atomic"
@@ -737,7 +772,8 @@
                                                         }
                                                       },
                                                       "type": "object",
-                                                      "x-kubernetes-map-type": "atomic"
+                                                      "x-kubernetes-map-type": "atomic",
+                                                      "additionalProperties": false
                                                     },
                                                     "matchLabelKeys": {
                                                       "items": {
@@ -776,7 +812,8 @@
                                                               "key",
                                                               "operator"
                                                             ],
-                                                            "type": "object"
+                                                            "type": "object",
+                                                            "additionalProperties": false
                                                           },
                                                           "type": "array",
                                                           "x-kubernetes-list-type": "atomic"
@@ -789,7 +826,8 @@
                                                         }
                                                       },
                                                       "type": "object",
-                                                      "x-kubernetes-map-type": "atomic"
+                                                      "x-kubernetes-map-type": "atomic",
+                                                      "additionalProperties": false
                                                     },
                                                     "namespaces": {
                                                       "items": {
@@ -805,7 +843,8 @@
                                                   "required": [
                                                     "topologyKey"
                                                   ],
-                                                  "type": "object"
+                                                  "type": "object",
+                                                  "additionalProperties": false
                                                 },
                                                 "weight": {
                                                   "format": "int32",
@@ -816,7 +855,8 @@
                                                 "podAffinityTerm",
                                                 "weight"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "type": "array",
                                             "x-kubernetes-list-type": "atomic"
@@ -847,7 +887,8 @@
                                                           "key",
                                                           "operator"
                                                         ],
-                                                        "type": "object"
+                                                        "type": "object",
+                                                        "additionalProperties": false
                                                       },
                                                       "type": "array",
                                                       "x-kubernetes-list-type": "atomic"
@@ -860,7 +901,8 @@
                                                     }
                                                   },
                                                   "type": "object",
-                                                  "x-kubernetes-map-type": "atomic"
+                                                  "x-kubernetes-map-type": "atomic",
+                                                  "additionalProperties": false
                                                 },
                                                 "matchLabelKeys": {
                                                   "items": {
@@ -899,7 +941,8 @@
                                                           "key",
                                                           "operator"
                                                         ],
-                                                        "type": "object"
+                                                        "type": "object",
+                                                        "additionalProperties": false
                                                       },
                                                       "type": "array",
                                                       "x-kubernetes-list-type": "atomic"
@@ -912,7 +955,8 @@
                                                     }
                                                   },
                                                   "type": "object",
-                                                  "x-kubernetes-map-type": "atomic"
+                                                  "x-kubernetes-map-type": "atomic",
+                                                  "additionalProperties": false
                                                 },
                                                 "namespaces": {
                                                   "items": {
@@ -928,13 +972,15 @@
                                               "required": [
                                                 "topologyKey"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "type": "array",
                                             "x-kubernetes-list-type": "atomic"
                                           }
                                         },
-                                        "type": "object"
+                                        "type": "object",
+                                        "additionalProperties": false
                                       },
                                       "podAntiAffinity": {
                                         "properties": {
@@ -966,7 +1012,8 @@
                                                               "key",
                                                               "operator"
                                                             ],
-                                                            "type": "object"
+                                                            "type": "object",
+                                                            "additionalProperties": false
                                                           },
                                                           "type": "array",
                                                           "x-kubernetes-list-type": "atomic"
@@ -979,7 +1026,8 @@
                                                         }
                                                       },
                                                       "type": "object",
-                                                      "x-kubernetes-map-type": "atomic"
+                                                      "x-kubernetes-map-type": "atomic",
+                                                      "additionalProperties": false
                                                     },
                                                     "matchLabelKeys": {
                                                       "items": {
@@ -1018,7 +1066,8 @@
                                                               "key",
                                                               "operator"
                                                             ],
-                                                            "type": "object"
+                                                            "type": "object",
+                                                            "additionalProperties": false
                                                           },
                                                           "type": "array",
                                                           "x-kubernetes-list-type": "atomic"
@@ -1031,7 +1080,8 @@
                                                         }
                                                       },
                                                       "type": "object",
-                                                      "x-kubernetes-map-type": "atomic"
+                                                      "x-kubernetes-map-type": "atomic",
+                                                      "additionalProperties": false
                                                     },
                                                     "namespaces": {
                                                       "items": {
@@ -1047,7 +1097,8 @@
                                                   "required": [
                                                     "topologyKey"
                                                   ],
-                                                  "type": "object"
+                                                  "type": "object",
+                                                  "additionalProperties": false
                                                 },
                                                 "weight": {
                                                   "format": "int32",
@@ -1058,7 +1109,8 @@
                                                 "podAffinityTerm",
                                                 "weight"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "type": "array",
                                             "x-kubernetes-list-type": "atomic"
@@ -1089,7 +1141,8 @@
                                                           "key",
                                                           "operator"
                                                         ],
-                                                        "type": "object"
+                                                        "type": "object",
+                                                        "additionalProperties": false
                                                       },
                                                       "type": "array",
                                                       "x-kubernetes-list-type": "atomic"
@@ -1102,7 +1155,8 @@
                                                     }
                                                   },
                                                   "type": "object",
-                                                  "x-kubernetes-map-type": "atomic"
+                                                  "x-kubernetes-map-type": "atomic",
+                                                  "additionalProperties": false
                                                 },
                                                 "matchLabelKeys": {
                                                   "items": {
@@ -1141,7 +1195,8 @@
                                                           "key",
                                                           "operator"
                                                         ],
-                                                        "type": "object"
+                                                        "type": "object",
+                                                        "additionalProperties": false
                                                       },
                                                       "type": "array",
                                                       "x-kubernetes-list-type": "atomic"
@@ -1154,7 +1209,8 @@
                                                     }
                                                   },
                                                   "type": "object",
-                                                  "x-kubernetes-map-type": "atomic"
+                                                  "x-kubernetes-map-type": "atomic",
+                                                  "additionalProperties": false
                                                 },
                                                 "namespaces": {
                                                   "items": {
@@ -1170,16 +1226,19 @@
                                               "required": [
                                                 "topologyKey"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "type": "array",
                                             "x-kubernetes-list-type": "atomic"
                                           }
                                         },
-                                        "type": "object"
+                                        "type": "object",
+                                        "additionalProperties": false
                                       }
                                     },
-                                    "type": "object"
+                                    "type": "object",
+                                    "additionalProperties": false
                                   },
                                   "automountServiceAccountToken": {
                                     "type": "boolean"
@@ -1229,7 +1288,8 @@
                                                       "key"
                                                     ],
                                                     "type": "object",
-                                                    "x-kubernetes-map-type": "atomic"
+                                                    "x-kubernetes-map-type": "atomic",
+                                                    "additionalProperties": false
                                                   },
                                                   "fieldRef": {
                                                     "properties": {
@@ -1244,7 +1304,8 @@
                                                       "fieldPath"
                                                     ],
                                                     "type": "object",
-                                                    "x-kubernetes-map-type": "atomic"
+                                                    "x-kubernetes-map-type": "atomic",
+                                                    "additionalProperties": false
                                                   },
                                                   "fileKeyRef": {
                                                     "properties": {
@@ -1268,7 +1329,8 @@
                                                       "volumeName"
                                                     ],
                                                     "type": "object",
-                                                    "x-kubernetes-map-type": "atomic"
+                                                    "x-kubernetes-map-type": "atomic",
+                                                    "additionalProperties": false
                                                   },
                                                   "resourceFieldRef": {
                                                     "properties": {
@@ -1295,7 +1357,8 @@
                                                       "resource"
                                                     ],
                                                     "type": "object",
-                                                    "x-kubernetes-map-type": "atomic"
+                                                    "x-kubernetes-map-type": "atomic",
+                                                    "additionalProperties": false
                                                   },
                                                   "secretKeyRef": {
                                                     "properties": {
@@ -1314,16 +1377,19 @@
                                                       "key"
                                                     ],
                                                     "type": "object",
-                                                    "x-kubernetes-map-type": "atomic"
+                                                    "x-kubernetes-map-type": "atomic",
+                                                    "additionalProperties": false
                                                   }
                                                 },
-                                                "type": "object"
+                                                "type": "object",
+                                                "additionalProperties": false
                                               }
                                             },
                                             "required": [
                                               "name"
                                             ],
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           },
                                           "type": "array",
                                           "x-kubernetes-list-map-keys": [
@@ -1345,7 +1411,8 @@
                                                   }
                                                 },
                                                 "type": "object",
-                                                "x-kubernetes-map-type": "atomic"
+                                                "x-kubernetes-map-type": "atomic",
+                                                "additionalProperties": false
                                               },
                                               "prefix": {
                                                 "type": "string"
@@ -1361,10 +1428,12 @@
                                                   }
                                                 },
                                                 "type": "object",
-                                                "x-kubernetes-map-type": "atomic"
+                                                "x-kubernetes-map-type": "atomic",
+                                                "additionalProperties": false
                                               }
                                             },
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           },
                                           "type": "array",
                                           "x-kubernetes-list-type": "atomic"
@@ -1389,7 +1458,8 @@
                                                       "x-kubernetes-list-type": "atomic"
                                                     }
                                                   },
-                                                  "type": "object"
+                                                  "type": "object",
+                                                  "additionalProperties": false
                                                 },
                                                 "httpGet": {
                                                   "properties": {
@@ -1410,7 +1480,8 @@
                                                           "name",
                                                           "value"
                                                         ],
-                                                        "type": "object"
+                                                        "type": "object",
+                                                        "additionalProperties": false
                                                       },
                                                       "type": "array",
                                                       "x-kubernetes-list-type": "atomic"
@@ -1436,7 +1507,8 @@
                                                   "required": [
                                                     "port"
                                                   ],
-                                                  "type": "object"
+                                                  "type": "object",
+                                                  "additionalProperties": false
                                                 },
                                                 "sleep": {
                                                   "properties": {
@@ -1448,7 +1520,8 @@
                                                   "required": [
                                                     "seconds"
                                                   ],
-                                                  "type": "object"
+                                                  "type": "object",
+                                                  "additionalProperties": false
                                                 },
                                                 "tcpSocket": {
                                                   "properties": {
@@ -1470,10 +1543,12 @@
                                                   "required": [
                                                     "port"
                                                   ],
-                                                  "type": "object"
+                                                  "type": "object",
+                                                  "additionalProperties": false
                                                 }
                                               },
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "preStop": {
                                               "properties": {
@@ -1487,7 +1562,8 @@
                                                       "x-kubernetes-list-type": "atomic"
                                                     }
                                                   },
-                                                  "type": "object"
+                                                  "type": "object",
+                                                  "additionalProperties": false
                                                 },
                                                 "httpGet": {
                                                   "properties": {
@@ -1508,7 +1584,8 @@
                                                           "name",
                                                           "value"
                                                         ],
-                                                        "type": "object"
+                                                        "type": "object",
+                                                        "additionalProperties": false
                                                       },
                                                       "type": "array",
                                                       "x-kubernetes-list-type": "atomic"
@@ -1534,7 +1611,8 @@
                                                   "required": [
                                                     "port"
                                                   ],
-                                                  "type": "object"
+                                                  "type": "object",
+                                                  "additionalProperties": false
                                                 },
                                                 "sleep": {
                                                   "properties": {
@@ -1546,7 +1624,8 @@
                                                   "required": [
                                                     "seconds"
                                                   ],
-                                                  "type": "object"
+                                                  "type": "object",
+                                                  "additionalProperties": false
                                                 },
                                                 "tcpSocket": {
                                                   "properties": {
@@ -1568,16 +1647,19 @@
                                                   "required": [
                                                     "port"
                                                   ],
-                                                  "type": "object"
+                                                  "type": "object",
+                                                  "additionalProperties": false
                                                 }
                                               },
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "stopSignal": {
                                               "type": "string"
                                             }
                                           },
-                                          "type": "object"
+                                          "type": "object",
+                                          "additionalProperties": false
                                         },
                                         "livenessProbe": {
                                           "properties": {
@@ -1591,7 +1673,8 @@
                                                   "x-kubernetes-list-type": "atomic"
                                                 }
                                               },
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "failureThreshold": {
                                               "format": "int32",
@@ -1611,7 +1694,8 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "httpGet": {
                                               "properties": {
@@ -1632,7 +1716,8 @@
                                                       "name",
                                                       "value"
                                                     ],
-                                                    "type": "object"
+                                                    "type": "object",
+                                                    "additionalProperties": false
                                                   },
                                                   "type": "array",
                                                   "x-kubernetes-list-type": "atomic"
@@ -1658,7 +1743,8 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "initialDelaySeconds": {
                                               "format": "int32",
@@ -1692,7 +1778,8 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "terminationGracePeriodSeconds": {
                                               "format": "int64",
@@ -1703,7 +1790,8 @@
                                               "type": "integer"
                                             }
                                           },
-                                          "type": "object"
+                                          "type": "object",
+                                          "additionalProperties": false
                                         },
                                         "name": {
                                           "type": "string"
@@ -1733,7 +1821,8 @@
                                             "required": [
                                               "containerPort"
                                             ],
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           },
                                           "type": "array",
                                           "x-kubernetes-list-map-keys": [
@@ -1754,7 +1843,8 @@
                                                   "x-kubernetes-list-type": "atomic"
                                                 }
                                               },
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "failureThreshold": {
                                               "format": "int32",
@@ -1774,7 +1864,8 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "httpGet": {
                                               "properties": {
@@ -1795,7 +1886,8 @@
                                                       "name",
                                                       "value"
                                                     ],
-                                                    "type": "object"
+                                                    "type": "object",
+                                                    "additionalProperties": false
                                                   },
                                                   "type": "array",
                                                   "x-kubernetes-list-type": "atomic"
@@ -1821,7 +1913,8 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "initialDelaySeconds": {
                                               "format": "int32",
@@ -1855,7 +1948,8 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "terminationGracePeriodSeconds": {
                                               "format": "int64",
@@ -1866,7 +1960,8 @@
                                               "type": "integer"
                                             }
                                           },
-                                          "type": "object"
+                                          "type": "object",
+                                          "additionalProperties": false
                                         },
                                         "resizePolicy": {
                                           "items": {
@@ -1882,7 +1977,8 @@
                                               "resourceName",
                                               "restartPolicy"
                                             ],
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           },
                                           "type": "array",
                                           "x-kubernetes-list-type": "atomic"
@@ -1902,7 +1998,8 @@
                                                 "required": [
                                                   "name"
                                                 ],
-                                                "type": "object"
+                                                "type": "object",
+                                                "additionalProperties": false
                                               },
                                               "type": "array",
                                               "x-kubernetes-list-map-keys": [
@@ -1917,7 +2014,8 @@
                                               "x-kubernetes-preserve-unknown-fields": true
                                             }
                                           },
-                                          "type": "object"
+                                          "type": "object",
+                                          "additionalProperties": false
                                         },
                                         "restartPolicy": {
                                           "type": "string"
@@ -1945,13 +2043,15 @@
                                                 "required": [
                                                   "operator"
                                                 ],
-                                                "type": "object"
+                                                "type": "object",
+                                                "additionalProperties": false
                                               }
                                             },
                                             "required": [
                                               "action"
                                             ],
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           },
                                           "type": "array",
                                           "x-kubernetes-list-type": "atomic"
@@ -1973,7 +2073,8 @@
                                               "required": [
                                                 "type"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "capabilities": {
                                               "properties": {
@@ -1992,7 +2093,8 @@
                                                   "x-kubernetes-list-type": "atomic"
                                                 }
                                               },
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "privileged": {
                                               "type": "boolean"
@@ -2029,7 +2131,8 @@
                                                   "type": "string"
                                                 }
                                               },
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "seccompProfile": {
                                               "properties": {
@@ -2043,7 +2146,8 @@
                                               "required": [
                                                 "type"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "windowsOptions": {
                                               "properties": {
@@ -2060,10 +2164,12 @@
                                                   "type": "string"
                                                 }
                                               },
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             }
                                           },
-                                          "type": "object"
+                                          "type": "object",
+                                          "additionalProperties": false
                                         },
                                         "startupProbe": {
                                           "properties": {
@@ -2077,7 +2183,8 @@
                                                   "x-kubernetes-list-type": "atomic"
                                                 }
                                               },
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "failureThreshold": {
                                               "format": "int32",
@@ -2097,7 +2204,8 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "httpGet": {
                                               "properties": {
@@ -2118,7 +2226,8 @@
                                                       "name",
                                                       "value"
                                                     ],
-                                                    "type": "object"
+                                                    "type": "object",
+                                                    "additionalProperties": false
                                                   },
                                                   "type": "array",
                                                   "x-kubernetes-list-type": "atomic"
@@ -2144,7 +2253,8 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "initialDelaySeconds": {
                                               "format": "int32",
@@ -2178,7 +2288,8 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "terminationGracePeriodSeconds": {
                                               "format": "int64",
@@ -2189,7 +2300,8 @@
                                               "type": "integer"
                                             }
                                           },
-                                          "type": "object"
+                                          "type": "object",
+                                          "additionalProperties": false
                                         },
                                         "stdin": {
                                           "type": "boolean"
@@ -2220,7 +2332,8 @@
                                               "devicePath",
                                               "name"
                                             ],
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           },
                                           "type": "array",
                                           "x-kubernetes-list-map-keys": [
@@ -2257,7 +2370,8 @@
                                               "mountPath",
                                               "name"
                                             ],
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           },
                                           "type": "array",
                                           "x-kubernetes-list-map-keys": [
@@ -2272,7 +2386,8 @@
                                       "required": [
                                         "name"
                                       ],
-                                      "type": "object"
+                                      "type": "object",
+                                      "additionalProperties": false
                                     },
                                     "type": "array",
                                     "x-kubernetes-list-map-keys": [
@@ -2299,7 +2414,8 @@
                                               "type": "string"
                                             }
                                           },
-                                          "type": "object"
+                                          "type": "object",
+                                          "additionalProperties": false
                                         },
                                         "type": "array",
                                         "x-kubernetes-list-type": "atomic"
@@ -2312,7 +2428,8 @@
                                         "x-kubernetes-list-type": "atomic"
                                       }
                                     },
-                                    "type": "object"
+                                    "type": "object",
+                                    "additionalProperties": false
                                   },
                                   "dnsPolicy": {
                                     "type": "string"
@@ -2365,7 +2482,8 @@
                                                       "key"
                                                     ],
                                                     "type": "object",
-                                                    "x-kubernetes-map-type": "atomic"
+                                                    "x-kubernetes-map-type": "atomic",
+                                                    "additionalProperties": false
                                                   },
                                                   "fieldRef": {
                                                     "properties": {
@@ -2380,7 +2498,8 @@
                                                       "fieldPath"
                                                     ],
                                                     "type": "object",
-                                                    "x-kubernetes-map-type": "atomic"
+                                                    "x-kubernetes-map-type": "atomic",
+                                                    "additionalProperties": false
                                                   },
                                                   "fileKeyRef": {
                                                     "properties": {
@@ -2404,7 +2523,8 @@
                                                       "volumeName"
                                                     ],
                                                     "type": "object",
-                                                    "x-kubernetes-map-type": "atomic"
+                                                    "x-kubernetes-map-type": "atomic",
+                                                    "additionalProperties": false
                                                   },
                                                   "resourceFieldRef": {
                                                     "properties": {
@@ -2431,7 +2551,8 @@
                                                       "resource"
                                                     ],
                                                     "type": "object",
-                                                    "x-kubernetes-map-type": "atomic"
+                                                    "x-kubernetes-map-type": "atomic",
+                                                    "additionalProperties": false
                                                   },
                                                   "secretKeyRef": {
                                                     "properties": {
@@ -2450,16 +2571,19 @@
                                                       "key"
                                                     ],
                                                     "type": "object",
-                                                    "x-kubernetes-map-type": "atomic"
+                                                    "x-kubernetes-map-type": "atomic",
+                                                    "additionalProperties": false
                                                   }
                                                 },
-                                                "type": "object"
+                                                "type": "object",
+                                                "additionalProperties": false
                                               }
                                             },
                                             "required": [
                                               "name"
                                             ],
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           },
                                           "type": "array",
                                           "x-kubernetes-list-map-keys": [
@@ -2481,7 +2605,8 @@
                                                   }
                                                 },
                                                 "type": "object",
-                                                "x-kubernetes-map-type": "atomic"
+                                                "x-kubernetes-map-type": "atomic",
+                                                "additionalProperties": false
                                               },
                                               "prefix": {
                                                 "type": "string"
@@ -2497,10 +2622,12 @@
                                                   }
                                                 },
                                                 "type": "object",
-                                                "x-kubernetes-map-type": "atomic"
+                                                "x-kubernetes-map-type": "atomic",
+                                                "additionalProperties": false
                                               }
                                             },
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           },
                                           "type": "array",
                                           "x-kubernetes-list-type": "atomic"
@@ -2525,7 +2652,8 @@
                                                       "x-kubernetes-list-type": "atomic"
                                                     }
                                                   },
-                                                  "type": "object"
+                                                  "type": "object",
+                                                  "additionalProperties": false
                                                 },
                                                 "httpGet": {
                                                   "properties": {
@@ -2546,7 +2674,8 @@
                                                           "name",
                                                           "value"
                                                         ],
-                                                        "type": "object"
+                                                        "type": "object",
+                                                        "additionalProperties": false
                                                       },
                                                       "type": "array",
                                                       "x-kubernetes-list-type": "atomic"
@@ -2572,7 +2701,8 @@
                                                   "required": [
                                                     "port"
                                                   ],
-                                                  "type": "object"
+                                                  "type": "object",
+                                                  "additionalProperties": false
                                                 },
                                                 "sleep": {
                                                   "properties": {
@@ -2584,7 +2714,8 @@
                                                   "required": [
                                                     "seconds"
                                                   ],
-                                                  "type": "object"
+                                                  "type": "object",
+                                                  "additionalProperties": false
                                                 },
                                                 "tcpSocket": {
                                                   "properties": {
@@ -2606,10 +2737,12 @@
                                                   "required": [
                                                     "port"
                                                   ],
-                                                  "type": "object"
+                                                  "type": "object",
+                                                  "additionalProperties": false
                                                 }
                                               },
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "preStop": {
                                               "properties": {
@@ -2623,7 +2756,8 @@
                                                       "x-kubernetes-list-type": "atomic"
                                                     }
                                                   },
-                                                  "type": "object"
+                                                  "type": "object",
+                                                  "additionalProperties": false
                                                 },
                                                 "httpGet": {
                                                   "properties": {
@@ -2644,7 +2778,8 @@
                                                           "name",
                                                           "value"
                                                         ],
-                                                        "type": "object"
+                                                        "type": "object",
+                                                        "additionalProperties": false
                                                       },
                                                       "type": "array",
                                                       "x-kubernetes-list-type": "atomic"
@@ -2670,7 +2805,8 @@
                                                   "required": [
                                                     "port"
                                                   ],
-                                                  "type": "object"
+                                                  "type": "object",
+                                                  "additionalProperties": false
                                                 },
                                                 "sleep": {
                                                   "properties": {
@@ -2682,7 +2818,8 @@
                                                   "required": [
                                                     "seconds"
                                                   ],
-                                                  "type": "object"
+                                                  "type": "object",
+                                                  "additionalProperties": false
                                                 },
                                                 "tcpSocket": {
                                                   "properties": {
@@ -2704,16 +2841,19 @@
                                                   "required": [
                                                     "port"
                                                   ],
-                                                  "type": "object"
+                                                  "type": "object",
+                                                  "additionalProperties": false
                                                 }
                                               },
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "stopSignal": {
                                               "type": "string"
                                             }
                                           },
-                                          "type": "object"
+                                          "type": "object",
+                                          "additionalProperties": false
                                         },
                                         "livenessProbe": {
                                           "properties": {
@@ -2727,7 +2867,8 @@
                                                   "x-kubernetes-list-type": "atomic"
                                                 }
                                               },
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "failureThreshold": {
                                               "format": "int32",
@@ -2747,7 +2888,8 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "httpGet": {
                                               "properties": {
@@ -2768,7 +2910,8 @@
                                                       "name",
                                                       "value"
                                                     ],
-                                                    "type": "object"
+                                                    "type": "object",
+                                                    "additionalProperties": false
                                                   },
                                                   "type": "array",
                                                   "x-kubernetes-list-type": "atomic"
@@ -2794,7 +2937,8 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "initialDelaySeconds": {
                                               "format": "int32",
@@ -2828,7 +2972,8 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "terminationGracePeriodSeconds": {
                                               "format": "int64",
@@ -2839,7 +2984,8 @@
                                               "type": "integer"
                                             }
                                           },
-                                          "type": "object"
+                                          "type": "object",
+                                          "additionalProperties": false
                                         },
                                         "name": {
                                           "type": "string"
@@ -2869,7 +3015,8 @@
                                             "required": [
                                               "containerPort"
                                             ],
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           },
                                           "type": "array",
                                           "x-kubernetes-list-map-keys": [
@@ -2890,7 +3037,8 @@
                                                   "x-kubernetes-list-type": "atomic"
                                                 }
                                               },
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "failureThreshold": {
                                               "format": "int32",
@@ -2910,7 +3058,8 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "httpGet": {
                                               "properties": {
@@ -2931,7 +3080,8 @@
                                                       "name",
                                                       "value"
                                                     ],
-                                                    "type": "object"
+                                                    "type": "object",
+                                                    "additionalProperties": false
                                                   },
                                                   "type": "array",
                                                   "x-kubernetes-list-type": "atomic"
@@ -2957,7 +3107,8 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "initialDelaySeconds": {
                                               "format": "int32",
@@ -2991,7 +3142,8 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "terminationGracePeriodSeconds": {
                                               "format": "int64",
@@ -3002,7 +3154,8 @@
                                               "type": "integer"
                                             }
                                           },
-                                          "type": "object"
+                                          "type": "object",
+                                          "additionalProperties": false
                                         },
                                         "resizePolicy": {
                                           "items": {
@@ -3018,7 +3171,8 @@
                                               "resourceName",
                                               "restartPolicy"
                                             ],
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           },
                                           "type": "array",
                                           "x-kubernetes-list-type": "atomic"
@@ -3038,7 +3192,8 @@
                                                 "required": [
                                                   "name"
                                                 ],
-                                                "type": "object"
+                                                "type": "object",
+                                                "additionalProperties": false
                                               },
                                               "type": "array",
                                               "x-kubernetes-list-map-keys": [
@@ -3053,7 +3208,8 @@
                                               "x-kubernetes-preserve-unknown-fields": true
                                             }
                                           },
-                                          "type": "object"
+                                          "type": "object",
+                                          "additionalProperties": false
                                         },
                                         "restartPolicy": {
                                           "type": "string"
@@ -3081,13 +3237,15 @@
                                                 "required": [
                                                   "operator"
                                                 ],
-                                                "type": "object"
+                                                "type": "object",
+                                                "additionalProperties": false
                                               }
                                             },
                                             "required": [
                                               "action"
                                             ],
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           },
                                           "type": "array",
                                           "x-kubernetes-list-type": "atomic"
@@ -3109,7 +3267,8 @@
                                               "required": [
                                                 "type"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "capabilities": {
                                               "properties": {
@@ -3128,7 +3287,8 @@
                                                   "x-kubernetes-list-type": "atomic"
                                                 }
                                               },
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "privileged": {
                                               "type": "boolean"
@@ -3165,7 +3325,8 @@
                                                   "type": "string"
                                                 }
                                               },
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "seccompProfile": {
                                               "properties": {
@@ -3179,7 +3340,8 @@
                                               "required": [
                                                 "type"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "windowsOptions": {
                                               "properties": {
@@ -3196,10 +3358,12 @@
                                                   "type": "string"
                                                 }
                                               },
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             }
                                           },
-                                          "type": "object"
+                                          "type": "object",
+                                          "additionalProperties": false
                                         },
                                         "startupProbe": {
                                           "properties": {
@@ -3213,7 +3377,8 @@
                                                   "x-kubernetes-list-type": "atomic"
                                                 }
                                               },
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "failureThreshold": {
                                               "format": "int32",
@@ -3233,7 +3398,8 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "httpGet": {
                                               "properties": {
@@ -3254,7 +3420,8 @@
                                                       "name",
                                                       "value"
                                                     ],
-                                                    "type": "object"
+                                                    "type": "object",
+                                                    "additionalProperties": false
                                                   },
                                                   "type": "array",
                                                   "x-kubernetes-list-type": "atomic"
@@ -3280,7 +3447,8 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "initialDelaySeconds": {
                                               "format": "int32",
@@ -3314,7 +3482,8 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "terminationGracePeriodSeconds": {
                                               "format": "int64",
@@ -3325,7 +3494,8 @@
                                               "type": "integer"
                                             }
                                           },
-                                          "type": "object"
+                                          "type": "object",
+                                          "additionalProperties": false
                                         },
                                         "stdin": {
                                           "type": "boolean"
@@ -3359,7 +3529,8 @@
                                               "devicePath",
                                               "name"
                                             ],
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           },
                                           "type": "array",
                                           "x-kubernetes-list-map-keys": [
@@ -3396,7 +3567,8 @@
                                               "mountPath",
                                               "name"
                                             ],
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           },
                                           "type": "array",
                                           "x-kubernetes-list-map-keys": [
@@ -3411,7 +3583,8 @@
                                       "required": [
                                         "name"
                                       ],
-                                      "type": "object"
+                                      "type": "object",
+                                      "additionalProperties": false
                                     },
                                     "type": "array",
                                     "x-kubernetes-list-map-keys": [
@@ -3436,7 +3609,8 @@
                                       "required": [
                                         "ip"
                                       ],
-                                      "type": "object"
+                                      "type": "object",
+                                      "additionalProperties": false
                                     },
                                     "type": "array",
                                     "x-kubernetes-list-map-keys": [
@@ -3471,7 +3645,8 @@
                                         }
                                       },
                                       "type": "object",
-                                      "x-kubernetes-map-type": "atomic"
+                                      "x-kubernetes-map-type": "atomic",
+                                      "additionalProperties": false
                                     },
                                     "type": "array",
                                     "x-kubernetes-list-map-keys": [
@@ -3524,7 +3699,8 @@
                                                       "key"
                                                     ],
                                                     "type": "object",
-                                                    "x-kubernetes-map-type": "atomic"
+                                                    "x-kubernetes-map-type": "atomic",
+                                                    "additionalProperties": false
                                                   },
                                                   "fieldRef": {
                                                     "properties": {
@@ -3539,7 +3715,8 @@
                                                       "fieldPath"
                                                     ],
                                                     "type": "object",
-                                                    "x-kubernetes-map-type": "atomic"
+                                                    "x-kubernetes-map-type": "atomic",
+                                                    "additionalProperties": false
                                                   },
                                                   "fileKeyRef": {
                                                     "properties": {
@@ -3563,7 +3740,8 @@
                                                       "volumeName"
                                                     ],
                                                     "type": "object",
-                                                    "x-kubernetes-map-type": "atomic"
+                                                    "x-kubernetes-map-type": "atomic",
+                                                    "additionalProperties": false
                                                   },
                                                   "resourceFieldRef": {
                                                     "properties": {
@@ -3590,7 +3768,8 @@
                                                       "resource"
                                                     ],
                                                     "type": "object",
-                                                    "x-kubernetes-map-type": "atomic"
+                                                    "x-kubernetes-map-type": "atomic",
+                                                    "additionalProperties": false
                                                   },
                                                   "secretKeyRef": {
                                                     "properties": {
@@ -3609,16 +3788,19 @@
                                                       "key"
                                                     ],
                                                     "type": "object",
-                                                    "x-kubernetes-map-type": "atomic"
+                                                    "x-kubernetes-map-type": "atomic",
+                                                    "additionalProperties": false
                                                   }
                                                 },
-                                                "type": "object"
+                                                "type": "object",
+                                                "additionalProperties": false
                                               }
                                             },
                                             "required": [
                                               "name"
                                             ],
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           },
                                           "type": "array",
                                           "x-kubernetes-list-map-keys": [
@@ -3640,7 +3822,8 @@
                                                   }
                                                 },
                                                 "type": "object",
-                                                "x-kubernetes-map-type": "atomic"
+                                                "x-kubernetes-map-type": "atomic",
+                                                "additionalProperties": false
                                               },
                                               "prefix": {
                                                 "type": "string"
@@ -3656,10 +3839,12 @@
                                                   }
                                                 },
                                                 "type": "object",
-                                                "x-kubernetes-map-type": "atomic"
+                                                "x-kubernetes-map-type": "atomic",
+                                                "additionalProperties": false
                                               }
                                             },
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           },
                                           "type": "array",
                                           "x-kubernetes-list-type": "atomic"
@@ -3684,7 +3869,8 @@
                                                       "x-kubernetes-list-type": "atomic"
                                                     }
                                                   },
-                                                  "type": "object"
+                                                  "type": "object",
+                                                  "additionalProperties": false
                                                 },
                                                 "httpGet": {
                                                   "properties": {
@@ -3705,7 +3891,8 @@
                                                           "name",
                                                           "value"
                                                         ],
-                                                        "type": "object"
+                                                        "type": "object",
+                                                        "additionalProperties": false
                                                       },
                                                       "type": "array",
                                                       "x-kubernetes-list-type": "atomic"
@@ -3731,7 +3918,8 @@
                                                   "required": [
                                                     "port"
                                                   ],
-                                                  "type": "object"
+                                                  "type": "object",
+                                                  "additionalProperties": false
                                                 },
                                                 "sleep": {
                                                   "properties": {
@@ -3743,7 +3931,8 @@
                                                   "required": [
                                                     "seconds"
                                                   ],
-                                                  "type": "object"
+                                                  "type": "object",
+                                                  "additionalProperties": false
                                                 },
                                                 "tcpSocket": {
                                                   "properties": {
@@ -3765,10 +3954,12 @@
                                                   "required": [
                                                     "port"
                                                   ],
-                                                  "type": "object"
+                                                  "type": "object",
+                                                  "additionalProperties": false
                                                 }
                                               },
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "preStop": {
                                               "properties": {
@@ -3782,7 +3973,8 @@
                                                       "x-kubernetes-list-type": "atomic"
                                                     }
                                                   },
-                                                  "type": "object"
+                                                  "type": "object",
+                                                  "additionalProperties": false
                                                 },
                                                 "httpGet": {
                                                   "properties": {
@@ -3803,7 +3995,8 @@
                                                           "name",
                                                           "value"
                                                         ],
-                                                        "type": "object"
+                                                        "type": "object",
+                                                        "additionalProperties": false
                                                       },
                                                       "type": "array",
                                                       "x-kubernetes-list-type": "atomic"
@@ -3829,7 +4022,8 @@
                                                   "required": [
                                                     "port"
                                                   ],
-                                                  "type": "object"
+                                                  "type": "object",
+                                                  "additionalProperties": false
                                                 },
                                                 "sleep": {
                                                   "properties": {
@@ -3841,7 +4035,8 @@
                                                   "required": [
                                                     "seconds"
                                                   ],
-                                                  "type": "object"
+                                                  "type": "object",
+                                                  "additionalProperties": false
                                                 },
                                                 "tcpSocket": {
                                                   "properties": {
@@ -3863,16 +4058,19 @@
                                                   "required": [
                                                     "port"
                                                   ],
-                                                  "type": "object"
+                                                  "type": "object",
+                                                  "additionalProperties": false
                                                 }
                                               },
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "stopSignal": {
                                               "type": "string"
                                             }
                                           },
-                                          "type": "object"
+                                          "type": "object",
+                                          "additionalProperties": false
                                         },
                                         "livenessProbe": {
                                           "properties": {
@@ -3886,7 +4084,8 @@
                                                   "x-kubernetes-list-type": "atomic"
                                                 }
                                               },
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "failureThreshold": {
                                               "format": "int32",
@@ -3906,7 +4105,8 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "httpGet": {
                                               "properties": {
@@ -3927,7 +4127,8 @@
                                                       "name",
                                                       "value"
                                                     ],
-                                                    "type": "object"
+                                                    "type": "object",
+                                                    "additionalProperties": false
                                                   },
                                                   "type": "array",
                                                   "x-kubernetes-list-type": "atomic"
@@ -3953,7 +4154,8 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "initialDelaySeconds": {
                                               "format": "int32",
@@ -3987,7 +4189,8 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "terminationGracePeriodSeconds": {
                                               "format": "int64",
@@ -3998,7 +4201,8 @@
                                               "type": "integer"
                                             }
                                           },
-                                          "type": "object"
+                                          "type": "object",
+                                          "additionalProperties": false
                                         },
                                         "name": {
                                           "type": "string"
@@ -4028,7 +4232,8 @@
                                             "required": [
                                               "containerPort"
                                             ],
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           },
                                           "type": "array",
                                           "x-kubernetes-list-map-keys": [
@@ -4049,7 +4254,8 @@
                                                   "x-kubernetes-list-type": "atomic"
                                                 }
                                               },
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "failureThreshold": {
                                               "format": "int32",
@@ -4069,7 +4275,8 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "httpGet": {
                                               "properties": {
@@ -4090,7 +4297,8 @@
                                                       "name",
                                                       "value"
                                                     ],
-                                                    "type": "object"
+                                                    "type": "object",
+                                                    "additionalProperties": false
                                                   },
                                                   "type": "array",
                                                   "x-kubernetes-list-type": "atomic"
@@ -4116,7 +4324,8 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "initialDelaySeconds": {
                                               "format": "int32",
@@ -4150,7 +4359,8 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "terminationGracePeriodSeconds": {
                                               "format": "int64",
@@ -4161,7 +4371,8 @@
                                               "type": "integer"
                                             }
                                           },
-                                          "type": "object"
+                                          "type": "object",
+                                          "additionalProperties": false
                                         },
                                         "resizePolicy": {
                                           "items": {
@@ -4177,7 +4388,8 @@
                                               "resourceName",
                                               "restartPolicy"
                                             ],
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           },
                                           "type": "array",
                                           "x-kubernetes-list-type": "atomic"
@@ -4197,7 +4409,8 @@
                                                 "required": [
                                                   "name"
                                                 ],
-                                                "type": "object"
+                                                "type": "object",
+                                                "additionalProperties": false
                                               },
                                               "type": "array",
                                               "x-kubernetes-list-map-keys": [
@@ -4212,7 +4425,8 @@
                                               "x-kubernetes-preserve-unknown-fields": true
                                             }
                                           },
-                                          "type": "object"
+                                          "type": "object",
+                                          "additionalProperties": false
                                         },
                                         "restartPolicy": {
                                           "type": "string"
@@ -4240,13 +4454,15 @@
                                                 "required": [
                                                   "operator"
                                                 ],
-                                                "type": "object"
+                                                "type": "object",
+                                                "additionalProperties": false
                                               }
                                             },
                                             "required": [
                                               "action"
                                             ],
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           },
                                           "type": "array",
                                           "x-kubernetes-list-type": "atomic"
@@ -4268,7 +4484,8 @@
                                               "required": [
                                                 "type"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "capabilities": {
                                               "properties": {
@@ -4287,7 +4504,8 @@
                                                   "x-kubernetes-list-type": "atomic"
                                                 }
                                               },
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "privileged": {
                                               "type": "boolean"
@@ -4324,7 +4542,8 @@
                                                   "type": "string"
                                                 }
                                               },
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "seccompProfile": {
                                               "properties": {
@@ -4338,7 +4557,8 @@
                                               "required": [
                                                 "type"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "windowsOptions": {
                                               "properties": {
@@ -4355,10 +4575,12 @@
                                                   "type": "string"
                                                 }
                                               },
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             }
                                           },
-                                          "type": "object"
+                                          "type": "object",
+                                          "additionalProperties": false
                                         },
                                         "startupProbe": {
                                           "properties": {
@@ -4372,7 +4594,8 @@
                                                   "x-kubernetes-list-type": "atomic"
                                                 }
                                               },
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "failureThreshold": {
                                               "format": "int32",
@@ -4392,7 +4615,8 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "httpGet": {
                                               "properties": {
@@ -4413,7 +4637,8 @@
                                                       "name",
                                                       "value"
                                                     ],
-                                                    "type": "object"
+                                                    "type": "object",
+                                                    "additionalProperties": false
                                                   },
                                                   "type": "array",
                                                   "x-kubernetes-list-type": "atomic"
@@ -4439,7 +4664,8 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "initialDelaySeconds": {
                                               "format": "int32",
@@ -4473,7 +4699,8 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "terminationGracePeriodSeconds": {
                                               "format": "int64",
@@ -4484,7 +4711,8 @@
                                               "type": "integer"
                                             }
                                           },
-                                          "type": "object"
+                                          "type": "object",
+                                          "additionalProperties": false
                                         },
                                         "stdin": {
                                           "type": "boolean"
@@ -4515,7 +4743,8 @@
                                               "devicePath",
                                               "name"
                                             ],
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           },
                                           "type": "array",
                                           "x-kubernetes-list-map-keys": [
@@ -4552,7 +4781,8 @@
                                               "mountPath",
                                               "name"
                                             ],
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           },
                                           "type": "array",
                                           "x-kubernetes-list-map-keys": [
@@ -4567,7 +4797,8 @@
                                       "required": [
                                         "name"
                                       ],
-                                      "type": "object"
+                                      "type": "object",
+                                      "additionalProperties": false
                                     },
                                     "type": "array",
                                     "x-kubernetes-list-map-keys": [
@@ -4594,7 +4825,8 @@
                                     "required": [
                                       "name"
                                     ],
-                                    "type": "object"
+                                    "type": "object",
+                                    "additionalProperties": false
                                   },
                                   "overhead": {
                                     "additionalProperties": {
@@ -4631,7 +4863,8 @@
                                       "required": [
                                         "conditionType"
                                       ],
-                                      "type": "object"
+                                      "type": "object",
+                                      "additionalProperties": false
                                     },
                                     "type": "array",
                                     "x-kubernetes-list-type": "atomic"
@@ -4652,7 +4885,8 @@
                                       "required": [
                                         "name"
                                       ],
-                                      "type": "object"
+                                      "type": "object",
+                                      "additionalProperties": false
                                     },
                                     "type": "array",
                                     "x-kubernetes-list-map-keys": [
@@ -4675,7 +4909,8 @@
                                           "required": [
                                             "name"
                                           ],
-                                          "type": "object"
+                                          "type": "object",
+                                          "additionalProperties": false
                                         },
                                         "type": "array",
                                         "x-kubernetes-list-map-keys": [
@@ -4714,7 +4949,8 @@
                                         "type": "object"
                                       }
                                     },
-                                    "type": "object"
+                                    "type": "object",
+                                    "additionalProperties": false
                                   },
                                   "restartPolicy": {
                                     "type": "string"
@@ -4735,7 +4971,8 @@
                                       "required": [
                                         "name"
                                       ],
-                                      "type": "object"
+                                      "type": "object",
+                                      "additionalProperties": false
                                     },
                                     "type": "array",
                                     "x-kubernetes-list-map-keys": [
@@ -4757,7 +4994,8 @@
                                         "required": [
                                           "type"
                                         ],
-                                        "type": "object"
+                                        "type": "object",
+                                        "additionalProperties": false
                                       },
                                       "fsGroup": {
                                         "format": "int64",
@@ -4795,7 +5033,8 @@
                                             "type": "string"
                                           }
                                         },
-                                        "type": "object"
+                                        "type": "object",
+                                        "additionalProperties": false
                                       },
                                       "seccompProfile": {
                                         "properties": {
@@ -4809,7 +5048,8 @@
                                         "required": [
                                           "type"
                                         ],
-                                        "type": "object"
+                                        "type": "object",
+                                        "additionalProperties": false
                                       },
                                       "supplementalGroups": {
                                         "items": {
@@ -4836,7 +5076,8 @@
                                             "name",
                                             "value"
                                           ],
-                                          "type": "object"
+                                          "type": "object",
+                                          "additionalProperties": false
                                         },
                                         "type": "array",
                                         "x-kubernetes-list-type": "atomic"
@@ -4856,10 +5097,12 @@
                                             "type": "string"
                                           }
                                         },
-                                        "type": "object"
+                                        "type": "object",
+                                        "additionalProperties": false
                                       }
                                     },
-                                    "type": "object"
+                                    "type": "object",
+                                    "additionalProperties": false
                                   },
                                   "serviceAccount": {
                                     "type": "string"
@@ -4900,7 +5143,8 @@
                                           "type": "string"
                                         }
                                       },
-                                      "type": "object"
+                                      "type": "object",
+                                      "additionalProperties": false
                                     },
                                     "type": "array",
                                     "x-kubernetes-list-type": "atomic"
@@ -4931,7 +5175,8 @@
                                                   "key",
                                                   "operator"
                                                 ],
-                                                "type": "object"
+                                                "type": "object",
+                                                "additionalProperties": false
                                               },
                                               "type": "array",
                                               "x-kubernetes-list-type": "atomic"
@@ -4944,7 +5189,8 @@
                                             }
                                           },
                                           "type": "object",
-                                          "x-kubernetes-map-type": "atomic"
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
                                         },
                                         "matchLabelKeys": {
                                           "items": {
@@ -4979,7 +5225,8 @@
                                         "topologyKey",
                                         "whenUnsatisfiable"
                                       ],
-                                      "type": "object"
+                                      "type": "object",
+                                      "additionalProperties": false
                                     },
                                     "type": "array",
                                     "x-kubernetes-list-map-keys": [
@@ -4995,10 +5242,12 @@
                                 "required": [
                                   "containers"
                                 ],
-                                "type": "object"
+                                "type": "object",
+                                "additionalProperties": false
                               }
                             },
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "ttlSecondsAfterFinished": {
                             "format": "int32",
@@ -5008,13 +5257,15 @@
                         "required": [
                           "template"
                         ],
-                        "type": "object"
+                        "type": "object",
+                        "additionalProperties": false
                       }
                     },
                     "required": [
                       "spec"
                     ],
-                    "type": "object"
+                    "type": "object",
+                    "additionalProperties": false
                   },
                   "kayenta": {
                     "properties": {
@@ -5063,7 +5314,8 @@
                                 "scope",
                                 "step"
                               ],
-                              "type": "object"
+                              "type": "object",
+                              "additionalProperties": false
                             },
                             "experimentScope": {
                               "properties": {
@@ -5089,7 +5341,8 @@
                                 "scope",
                                 "step"
                               ],
-                              "type": "object"
+                              "type": "object",
+                              "additionalProperties": false
                             },
                             "name": {
                               "type": "string"
@@ -5100,7 +5353,8 @@
                             "experimentScope",
                             "name"
                           ],
-                          "type": "object"
+                          "type": "object",
+                          "additionalProperties": false
                         },
                         "type": "array"
                       },
@@ -5122,7 +5376,8 @@
                           "marginal",
                           "pass"
                         ],
-                        "type": "object"
+                        "type": "object",
+                        "additionalProperties": false
                       }
                     },
                     "required": [
@@ -5135,7 +5390,8 @@
                       "storageAccountName",
                       "threshold"
                     ],
-                    "type": "object"
+                    "type": "object",
+                    "additionalProperties": false
                   },
                   "newRelic": {
                     "properties": {
@@ -5153,7 +5409,8 @@
                     "required": [
                       "query"
                     ],
-                    "type": "object"
+                    "type": "object",
+                    "additionalProperties": false
                   },
                   "plugin": {
                     "type": "object",
@@ -5184,7 +5441,8 @@
                                 "type": "string"
                               }
                             },
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "sigv4": {
                             "properties": {
@@ -5198,10 +5456,12 @@
                                 "type": "string"
                               }
                             },
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           }
                         },
-                        "type": "object"
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "headers": {
                         "items": {
@@ -5217,7 +5477,8 @@
                             "key",
                             "value"
                           ],
-                          "type": "object"
+                          "type": "object",
+                          "additionalProperties": false
                         },
                         "type": "array"
                       },
@@ -5239,14 +5500,16 @@
                             "type": "string"
                           }
                         },
-                        "type": "object"
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "timeout": {
                         "format": "int64",
                         "type": "integer"
                       }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "additionalProperties": false
                   },
                   "skywalking": {
                     "properties": {
@@ -5260,7 +5523,8 @@
                         "type": "string"
                       }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "additionalProperties": false
                   },
                   "wavefront": {
                     "properties": {
@@ -5271,7 +5535,8 @@
                         "type": "string"
                       }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "additionalProperties": false
                   },
                   "web": {
                     "properties": {
@@ -5295,7 +5560,8 @@
                                 "type": "string"
                               }
                             },
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "sigv4": {
                             "properties": {
@@ -5309,10 +5575,12 @@
                                 "type": "string"
                               }
                             },
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           }
                         },
-                        "type": "object"
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "body": {
                         "type": "string"
@@ -5331,7 +5599,8 @@
                             "key",
                             "value"
                           ],
-                          "type": "object"
+                          "type": "object",
+                          "additionalProperties": false
                         },
                         "type": "array"
                       },
@@ -5359,10 +5628,12 @@
                     "required": [
                       "url"
                     ],
-                    "type": "object"
+                    "type": "object",
+                    "additionalProperties": false
                   }
                 },
-                "type": "object"
+                "type": "object",
+                "additionalProperties": false
               },
               "successCondition": {
                 "type": "string"
@@ -5372,7 +5643,8 @@
               "name",
               "provider"
             ],
-            "type": "object"
+            "type": "object",
+            "additionalProperties": false
           },
           "type": "array"
         },
@@ -5394,13 +5666,15 @@
               "type": "integer"
             }
           },
-          "type": "object"
+          "type": "object",
+          "additionalProperties": false
         }
       },
       "required": [
         "metrics"
       ],
-      "type": "object"
+      "type": "object",
+      "additionalProperties": false
     },
     "status": {
       "properties": {
@@ -5431,7 +5705,8 @@
               "type": "integer"
             }
           },
-          "type": "object"
+          "type": "object",
+          "additionalProperties": false
         },
         "message": {
           "type": "string"
@@ -5500,7 +5775,8 @@
                   "required": [
                     "phase"
                   ],
-                  "type": "object"
+                  "type": "object",
+                  "additionalProperties": false
                 },
                 "type": "array"
               },
@@ -5528,7 +5804,8 @@
               "name",
               "phase"
             ],
-            "type": "object"
+            "type": "object",
+            "additionalProperties": false
           },
           "type": "array"
         },
@@ -5558,7 +5835,8 @@
               "type": "integer"
             }
           },
-          "type": "object"
+          "type": "object",
+          "additionalProperties": false
         },
         "startedAt": {
           "format": "date-time",
@@ -5568,7 +5846,8 @@
       "required": [
         "phase"
       ],
-      "type": "object"
+      "type": "object",
+      "additionalProperties": false
     }
   },
   "required": [

--- a/argoproj.io/analysistemplate_v1alpha1.json
+++ b/argoproj.io/analysistemplate_v1alpha1.json
@@ -31,8 +31,7 @@
                     "required": [
                       "fieldPath"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "secretKeyRef": {
                     "properties": {
@@ -47,19 +46,16 @@
                       "key",
                       "name"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   }
                 },
-                "type": "object",
-                "additionalProperties": false
+                "type": "object"
               }
             },
             "required": [
               "name"
             ],
-            "type": "object",
-            "additionalProperties": false
+            "type": "object"
           },
           "type": "array"
         },
@@ -73,8 +69,7 @@
             "required": [
               "metricName"
             ],
-            "type": "object",
-            "additionalProperties": false
+            "type": "object"
           },
           "type": "array"
         },
@@ -93,8 +88,7 @@
               "limit",
               "metricName"
             ],
-            "type": "object",
-            "additionalProperties": false
+            "type": "object"
           },
           "type": "array"
         },
@@ -201,8 +195,7 @@
                                             "type": "string"
                                           }
                                         },
-                                        "type": "object",
-                                        "additionalProperties": false
+                                        "type": "object"
                                       },
                                       "type": "array"
                                     },
@@ -213,8 +206,7 @@
                                       "type": "string"
                                     }
                                   },
-                                  "type": "object",
-                                  "additionalProperties": false
+                                  "type": "object"
                                 },
                                 "period": {
                                   "anyOf": [
@@ -234,8 +226,7 @@
                                   "type": "string"
                                 }
                               },
-                              "type": "object",
-                              "additionalProperties": false
+                              "type": "object"
                             },
                             "period": {
                               "anyOf": [
@@ -252,8 +243,7 @@
                               "type": "boolean"
                             }
                           },
-                          "type": "object",
-                          "additionalProperties": false
+                          "type": "object"
                         },
                         "type": "array"
                       }
@@ -261,8 +251,7 @@
                     "required": [
                       "metricDataQueries"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "datadog": {
                     "properties": {
@@ -313,12 +302,10 @@
                             "type": "boolean"
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "graphite": {
                     "properties": {
@@ -329,8 +316,7 @@
                         "type": "string"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "influxdb": {
                     "properties": {
@@ -341,8 +327,7 @@
                         "type": "string"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "job": {
                     "properties": {
@@ -361,8 +346,7 @@
                             "type": "object"
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "spec": {
                         "properties": {
@@ -384,6 +368,9 @@
                           "completions": {
                             "format": "int32",
                             "type": "integer"
+                          },
+                          "managedBy": {
+                            "type": "string"
                           },
                           "manualSelector": {
                             "type": "boolean"
@@ -425,8 +412,7 @@
                                         "operator",
                                         "values"
                                       ],
-                                      "type": "object",
-                                      "additionalProperties": false
+                                      "type": "object"
                                     },
                                     "onPodConditions": {
                                       "items": {
@@ -442,8 +428,7 @@
                                           "status",
                                           "type"
                                         ],
-                                        "type": "object",
-                                        "additionalProperties": false
+                                        "type": "object"
                                       },
                                       "type": "array",
                                       "x-kubernetes-list-type": "atomic"
@@ -452,8 +437,7 @@
                                   "required": [
                                     "action"
                                   ],
-                                  "type": "object",
-                                  "additionalProperties": false
+                                  "type": "object"
                                 },
                                 "type": "array",
                                 "x-kubernetes-list-type": "atomic"
@@ -462,8 +446,7 @@
                             "required": [
                               "rules"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "podReplacementPolicy": {
                             "type": "string"
@@ -483,17 +466,18 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
                                     "key",
                                     "operator"
                                   ],
-                                  "type": "object",
-                                  "additionalProperties": false
+                                  "type": "object"
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchLabels": {
                                 "additionalProperties": {
@@ -503,8 +487,31 @@
                               }
                             },
                             "type": "object",
-                            "x-kubernetes-map-type": "atomic",
-                            "additionalProperties": false
+                            "x-kubernetes-map-type": "atomic"
+                          },
+                          "successPolicy": {
+                            "properties": {
+                              "rules": {
+                                "items": {
+                                  "properties": {
+                                    "succeededCount": {
+                                      "format": "int32",
+                                      "type": "integer"
+                                    },
+                                    "succeededIndexes": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              }
+                            },
+                            "required": [
+                              "rules"
+                            ],
+                            "type": "object"
                           },
                           "suspend": {
                             "type": "boolean"
@@ -526,8 +533,7 @@
                                     "type": "object"
                                   }
                                 },
-                                "type": "object",
-                                "additionalProperties": false
+                                "type": "object"
                               },
                               "spec": {
                                 "properties": {
@@ -557,17 +563,18 @@
                                                             "items": {
                                                               "type": "string"
                                                             },
-                                                            "type": "array"
+                                                            "type": "array",
+                                                            "x-kubernetes-list-type": "atomic"
                                                           }
                                                         },
                                                         "required": [
                                                           "key",
                                                           "operator"
                                                         ],
-                                                        "type": "object",
-                                                        "additionalProperties": false
+                                                        "type": "object"
                                                       },
-                                                      "type": "array"
+                                                      "type": "array",
+                                                      "x-kubernetes-list-type": "atomic"
                                                     },
                                                     "matchFields": {
                                                       "items": {
@@ -582,22 +589,22 @@
                                                             "items": {
                                                               "type": "string"
                                                             },
-                                                            "type": "array"
+                                                            "type": "array",
+                                                            "x-kubernetes-list-type": "atomic"
                                                           }
                                                         },
                                                         "required": [
                                                           "key",
                                                           "operator"
                                                         ],
-                                                        "type": "object",
-                                                        "additionalProperties": false
+                                                        "type": "object"
                                                       },
-                                                      "type": "array"
+                                                      "type": "array",
+                                                      "x-kubernetes-list-type": "atomic"
                                                     }
                                                   },
                                                   "type": "object",
-                                                  "x-kubernetes-map-type": "atomic",
-                                                  "additionalProperties": false
+                                                  "x-kubernetes-map-type": "atomic"
                                                 },
                                                 "weight": {
                                                   "format": "int32",
@@ -608,10 +615,10 @@
                                                 "preference",
                                                 "weight"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
-                                            "type": "array"
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
                                           },
                                           "requiredDuringSchedulingIgnoredDuringExecution": {
                                             "properties": {
@@ -631,17 +638,18 @@
                                                             "items": {
                                                               "type": "string"
                                                             },
-                                                            "type": "array"
+                                                            "type": "array",
+                                                            "x-kubernetes-list-type": "atomic"
                                                           }
                                                         },
                                                         "required": [
                                                           "key",
                                                           "operator"
                                                         ],
-                                                        "type": "object",
-                                                        "additionalProperties": false
+                                                        "type": "object"
                                                       },
-                                                      "type": "array"
+                                                      "type": "array",
+                                                      "x-kubernetes-list-type": "atomic"
                                                     },
                                                     "matchFields": {
                                                       "items": {
@@ -656,36 +664,35 @@
                                                             "items": {
                                                               "type": "string"
                                                             },
-                                                            "type": "array"
+                                                            "type": "array",
+                                                            "x-kubernetes-list-type": "atomic"
                                                           }
                                                         },
                                                         "required": [
                                                           "key",
                                                           "operator"
                                                         ],
-                                                        "type": "object",
-                                                        "additionalProperties": false
+                                                        "type": "object"
                                                       },
-                                                      "type": "array"
+                                                      "type": "array",
+                                                      "x-kubernetes-list-type": "atomic"
                                                     }
                                                   },
                                                   "type": "object",
-                                                  "x-kubernetes-map-type": "atomic",
-                                                  "additionalProperties": false
+                                                  "x-kubernetes-map-type": "atomic"
                                                 },
-                                                "type": "array"
+                                                "type": "array",
+                                                "x-kubernetes-list-type": "atomic"
                                               }
                                             },
                                             "required": [
                                               "nodeSelectorTerms"
                                             ],
                                             "type": "object",
-                                            "x-kubernetes-map-type": "atomic",
-                                            "additionalProperties": false
+                                            "x-kubernetes-map-type": "atomic"
                                           }
                                         },
-                                        "type": "object",
-                                        "additionalProperties": false
+                                        "type": "object"
                                       },
                                       "podAffinity": {
                                         "properties": {
@@ -709,17 +716,18 @@
                                                                 "items": {
                                                                   "type": "string"
                                                                 },
-                                                                "type": "array"
+                                                                "type": "array",
+                                                                "x-kubernetes-list-type": "atomic"
                                                               }
                                                             },
                                                             "required": [
                                                               "key",
                                                               "operator"
                                                             ],
-                                                            "type": "object",
-                                                            "additionalProperties": false
+                                                            "type": "object"
                                                           },
-                                                          "type": "array"
+                                                          "type": "array",
+                                                          "x-kubernetes-list-type": "atomic"
                                                         },
                                                         "matchLabels": {
                                                           "additionalProperties": {
@@ -729,8 +737,7 @@
                                                         }
                                                       },
                                                       "type": "object",
-                                                      "x-kubernetes-map-type": "atomic",
-                                                      "additionalProperties": false
+                                                      "x-kubernetes-map-type": "atomic"
                                                     },
                                                     "matchLabelKeys": {
                                                       "items": {
@@ -761,17 +768,18 @@
                                                                 "items": {
                                                                   "type": "string"
                                                                 },
-                                                                "type": "array"
+                                                                "type": "array",
+                                                                "x-kubernetes-list-type": "atomic"
                                                               }
                                                             },
                                                             "required": [
                                                               "key",
                                                               "operator"
                                                             ],
-                                                            "type": "object",
-                                                            "additionalProperties": false
+                                                            "type": "object"
                                                           },
-                                                          "type": "array"
+                                                          "type": "array",
+                                                          "x-kubernetes-list-type": "atomic"
                                                         },
                                                         "matchLabels": {
                                                           "additionalProperties": {
@@ -781,14 +789,14 @@
                                                         }
                                                       },
                                                       "type": "object",
-                                                      "x-kubernetes-map-type": "atomic",
-                                                      "additionalProperties": false
+                                                      "x-kubernetes-map-type": "atomic"
                                                     },
                                                     "namespaces": {
                                                       "items": {
                                                         "type": "string"
                                                       },
-                                                      "type": "array"
+                                                      "type": "array",
+                                                      "x-kubernetes-list-type": "atomic"
                                                     },
                                                     "topologyKey": {
                                                       "type": "string"
@@ -797,8 +805,7 @@
                                                   "required": [
                                                     "topologyKey"
                                                   ],
-                                                  "type": "object",
-                                                  "additionalProperties": false
+                                                  "type": "object"
                                                 },
                                                 "weight": {
                                                   "format": "int32",
@@ -809,10 +816,10 @@
                                                 "podAffinityTerm",
                                                 "weight"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
-                                            "type": "array"
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
                                           },
                                           "requiredDuringSchedulingIgnoredDuringExecution": {
                                             "items": {
@@ -832,17 +839,18 @@
                                                             "items": {
                                                               "type": "string"
                                                             },
-                                                            "type": "array"
+                                                            "type": "array",
+                                                            "x-kubernetes-list-type": "atomic"
                                                           }
                                                         },
                                                         "required": [
                                                           "key",
                                                           "operator"
                                                         ],
-                                                        "type": "object",
-                                                        "additionalProperties": false
+                                                        "type": "object"
                                                       },
-                                                      "type": "array"
+                                                      "type": "array",
+                                                      "x-kubernetes-list-type": "atomic"
                                                     },
                                                     "matchLabels": {
                                                       "additionalProperties": {
@@ -852,8 +860,7 @@
                                                     }
                                                   },
                                                   "type": "object",
-                                                  "x-kubernetes-map-type": "atomic",
-                                                  "additionalProperties": false
+                                                  "x-kubernetes-map-type": "atomic"
                                                 },
                                                 "matchLabelKeys": {
                                                   "items": {
@@ -884,17 +891,18 @@
                                                             "items": {
                                                               "type": "string"
                                                             },
-                                                            "type": "array"
+                                                            "type": "array",
+                                                            "x-kubernetes-list-type": "atomic"
                                                           }
                                                         },
                                                         "required": [
                                                           "key",
                                                           "operator"
                                                         ],
-                                                        "type": "object",
-                                                        "additionalProperties": false
+                                                        "type": "object"
                                                       },
-                                                      "type": "array"
+                                                      "type": "array",
+                                                      "x-kubernetes-list-type": "atomic"
                                                     },
                                                     "matchLabels": {
                                                       "additionalProperties": {
@@ -904,14 +912,14 @@
                                                     }
                                                   },
                                                   "type": "object",
-                                                  "x-kubernetes-map-type": "atomic",
-                                                  "additionalProperties": false
+                                                  "x-kubernetes-map-type": "atomic"
                                                 },
                                                 "namespaces": {
                                                   "items": {
                                                     "type": "string"
                                                   },
-                                                  "type": "array"
+                                                  "type": "array",
+                                                  "x-kubernetes-list-type": "atomic"
                                                 },
                                                 "topologyKey": {
                                                   "type": "string"
@@ -920,14 +928,13 @@
                                               "required": [
                                                 "topologyKey"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
-                                            "type": "array"
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
                                           }
                                         },
-                                        "type": "object",
-                                        "additionalProperties": false
+                                        "type": "object"
                                       },
                                       "podAntiAffinity": {
                                         "properties": {
@@ -951,17 +958,18 @@
                                                                 "items": {
                                                                   "type": "string"
                                                                 },
-                                                                "type": "array"
+                                                                "type": "array",
+                                                                "x-kubernetes-list-type": "atomic"
                                                               }
                                                             },
                                                             "required": [
                                                               "key",
                                                               "operator"
                                                             ],
-                                                            "type": "object",
-                                                            "additionalProperties": false
+                                                            "type": "object"
                                                           },
-                                                          "type": "array"
+                                                          "type": "array",
+                                                          "x-kubernetes-list-type": "atomic"
                                                         },
                                                         "matchLabels": {
                                                           "additionalProperties": {
@@ -971,8 +979,7 @@
                                                         }
                                                       },
                                                       "type": "object",
-                                                      "x-kubernetes-map-type": "atomic",
-                                                      "additionalProperties": false
+                                                      "x-kubernetes-map-type": "atomic"
                                                     },
                                                     "matchLabelKeys": {
                                                       "items": {
@@ -1003,17 +1010,18 @@
                                                                 "items": {
                                                                   "type": "string"
                                                                 },
-                                                                "type": "array"
+                                                                "type": "array",
+                                                                "x-kubernetes-list-type": "atomic"
                                                               }
                                                             },
                                                             "required": [
                                                               "key",
                                                               "operator"
                                                             ],
-                                                            "type": "object",
-                                                            "additionalProperties": false
+                                                            "type": "object"
                                                           },
-                                                          "type": "array"
+                                                          "type": "array",
+                                                          "x-kubernetes-list-type": "atomic"
                                                         },
                                                         "matchLabels": {
                                                           "additionalProperties": {
@@ -1023,14 +1031,14 @@
                                                         }
                                                       },
                                                       "type": "object",
-                                                      "x-kubernetes-map-type": "atomic",
-                                                      "additionalProperties": false
+                                                      "x-kubernetes-map-type": "atomic"
                                                     },
                                                     "namespaces": {
                                                       "items": {
                                                         "type": "string"
                                                       },
-                                                      "type": "array"
+                                                      "type": "array",
+                                                      "x-kubernetes-list-type": "atomic"
                                                     },
                                                     "topologyKey": {
                                                       "type": "string"
@@ -1039,8 +1047,7 @@
                                                   "required": [
                                                     "topologyKey"
                                                   ],
-                                                  "type": "object",
-                                                  "additionalProperties": false
+                                                  "type": "object"
                                                 },
                                                 "weight": {
                                                   "format": "int32",
@@ -1051,10 +1058,10 @@
                                                 "podAffinityTerm",
                                                 "weight"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
-                                            "type": "array"
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
                                           },
                                           "requiredDuringSchedulingIgnoredDuringExecution": {
                                             "items": {
@@ -1074,17 +1081,18 @@
                                                             "items": {
                                                               "type": "string"
                                                             },
-                                                            "type": "array"
+                                                            "type": "array",
+                                                            "x-kubernetes-list-type": "atomic"
                                                           }
                                                         },
                                                         "required": [
                                                           "key",
                                                           "operator"
                                                         ],
-                                                        "type": "object",
-                                                        "additionalProperties": false
+                                                        "type": "object"
                                                       },
-                                                      "type": "array"
+                                                      "type": "array",
+                                                      "x-kubernetes-list-type": "atomic"
                                                     },
                                                     "matchLabels": {
                                                       "additionalProperties": {
@@ -1094,8 +1102,7 @@
                                                     }
                                                   },
                                                   "type": "object",
-                                                  "x-kubernetes-map-type": "atomic",
-                                                  "additionalProperties": false
+                                                  "x-kubernetes-map-type": "atomic"
                                                 },
                                                 "matchLabelKeys": {
                                                   "items": {
@@ -1126,17 +1133,18 @@
                                                             "items": {
                                                               "type": "string"
                                                             },
-                                                            "type": "array"
+                                                            "type": "array",
+                                                            "x-kubernetes-list-type": "atomic"
                                                           }
                                                         },
                                                         "required": [
                                                           "key",
                                                           "operator"
                                                         ],
-                                                        "type": "object",
-                                                        "additionalProperties": false
+                                                        "type": "object"
                                                       },
-                                                      "type": "array"
+                                                      "type": "array",
+                                                      "x-kubernetes-list-type": "atomic"
                                                     },
                                                     "matchLabels": {
                                                       "additionalProperties": {
@@ -1146,14 +1154,14 @@
                                                     }
                                                   },
                                                   "type": "object",
-                                                  "x-kubernetes-map-type": "atomic",
-                                                  "additionalProperties": false
+                                                  "x-kubernetes-map-type": "atomic"
                                                 },
                                                 "namespaces": {
                                                   "items": {
                                                     "type": "string"
                                                   },
-                                                  "type": "array"
+                                                  "type": "array",
+                                                  "x-kubernetes-list-type": "atomic"
                                                 },
                                                 "topologyKey": {
                                                   "type": "string"
@@ -1162,18 +1170,16 @@
                                               "required": [
                                                 "topologyKey"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
-                                            "type": "array"
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
                                           }
                                         },
-                                        "type": "object",
-                                        "additionalProperties": false
+                                        "type": "object"
                                       }
                                     },
-                                    "type": "object",
-                                    "additionalProperties": false
+                                    "type": "object"
                                   },
                                   "automountServiceAccountToken": {
                                     "type": "boolean"
@@ -1185,13 +1191,15 @@
                                           "items": {
                                             "type": "string"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "command": {
                                           "items": {
                                             "type": "string"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "env": {
                                           "items": {
@@ -1210,6 +1218,7 @@
                                                         "type": "string"
                                                       },
                                                       "name": {
+                                                        "default": "",
                                                         "type": "string"
                                                       },
                                                       "optional": {
@@ -1220,8 +1229,7 @@
                                                       "key"
                                                     ],
                                                     "type": "object",
-                                                    "x-kubernetes-map-type": "atomic",
-                                                    "additionalProperties": false
+                                                    "x-kubernetes-map-type": "atomic"
                                                   },
                                                   "fieldRef": {
                                                     "properties": {
@@ -1236,8 +1244,31 @@
                                                       "fieldPath"
                                                     ],
                                                     "type": "object",
-                                                    "x-kubernetes-map-type": "atomic",
-                                                    "additionalProperties": false
+                                                    "x-kubernetes-map-type": "atomic"
+                                                  },
+                                                  "fileKeyRef": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "optional": {
+                                                        "default": false,
+                                                        "type": "boolean"
+                                                      },
+                                                      "path": {
+                                                        "type": "string"
+                                                      },
+                                                      "volumeName": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key",
+                                                      "path",
+                                                      "volumeName"
+                                                    ],
+                                                    "type": "object",
+                                                    "x-kubernetes-map-type": "atomic"
                                                   },
                                                   "resourceFieldRef": {
                                                     "properties": {
@@ -1264,8 +1295,7 @@
                                                       "resource"
                                                     ],
                                                     "type": "object",
-                                                    "x-kubernetes-map-type": "atomic",
-                                                    "additionalProperties": false
+                                                    "x-kubernetes-map-type": "atomic"
                                                   },
                                                   "secretKeyRef": {
                                                     "properties": {
@@ -1273,6 +1303,7 @@
                                                         "type": "string"
                                                       },
                                                       "name": {
+                                                        "default": "",
                                                         "type": "string"
                                                       },
                                                       "optional": {
@@ -1283,21 +1314,22 @@
                                                       "key"
                                                     ],
                                                     "type": "object",
-                                                    "x-kubernetes-map-type": "atomic",
-                                                    "additionalProperties": false
+                                                    "x-kubernetes-map-type": "atomic"
                                                   }
                                                 },
-                                                "type": "object",
-                                                "additionalProperties": false
+                                                "type": "object"
                                               }
                                             },
                                             "required": [
                                               "name"
                                             ],
-                                            "type": "object",
-                                            "additionalProperties": false
+                                            "type": "object"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-map-keys": [
+                                            "name"
+                                          ],
+                                          "x-kubernetes-list-type": "map"
                                         },
                                         "envFrom": {
                                           "items": {
@@ -1305,6 +1337,7 @@
                                               "configMapRef": {
                                                 "properties": {
                                                   "name": {
+                                                    "default": "",
                                                     "type": "string"
                                                   },
                                                   "optional": {
@@ -1312,8 +1345,7 @@
                                                   }
                                                 },
                                                 "type": "object",
-                                                "x-kubernetes-map-type": "atomic",
-                                                "additionalProperties": false
+                                                "x-kubernetes-map-type": "atomic"
                                               },
                                               "prefix": {
                                                 "type": "string"
@@ -1321,6 +1353,7 @@
                                               "secretRef": {
                                                 "properties": {
                                                   "name": {
+                                                    "default": "",
                                                     "type": "string"
                                                   },
                                                   "optional": {
@@ -1328,14 +1361,13 @@
                                                   }
                                                 },
                                                 "type": "object",
-                                                "x-kubernetes-map-type": "atomic",
-                                                "additionalProperties": false
+                                                "x-kubernetes-map-type": "atomic"
                                               }
                                             },
-                                            "type": "object",
-                                            "additionalProperties": false
+                                            "type": "object"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "image": {
                                           "type": "string"
@@ -1353,11 +1385,11 @@
                                                       "items": {
                                                         "type": "string"
                                                       },
-                                                      "type": "array"
+                                                      "type": "array",
+                                                      "x-kubernetes-list-type": "atomic"
                                                     }
                                                   },
-                                                  "type": "object",
-                                                  "additionalProperties": false
+                                                  "type": "object"
                                                 },
                                                 "httpGet": {
                                                   "properties": {
@@ -1378,10 +1410,10 @@
                                                           "name",
                                                           "value"
                                                         ],
-                                                        "type": "object",
-                                                        "additionalProperties": false
+                                                        "type": "object"
                                                       },
-                                                      "type": "array"
+                                                      "type": "array",
+                                                      "x-kubernetes-list-type": "atomic"
                                                     },
                                                     "path": {
                                                       "type": "string"
@@ -1404,8 +1436,7 @@
                                                   "required": [
                                                     "port"
                                                   ],
-                                                  "type": "object",
-                                                  "additionalProperties": false
+                                                  "type": "object"
                                                 },
                                                 "sleep": {
                                                   "properties": {
@@ -1417,8 +1448,7 @@
                                                   "required": [
                                                     "seconds"
                                                   ],
-                                                  "type": "object",
-                                                  "additionalProperties": false
+                                                  "type": "object"
                                                 },
                                                 "tcpSocket": {
                                                   "properties": {
@@ -1440,12 +1470,10 @@
                                                   "required": [
                                                     "port"
                                                   ],
-                                                  "type": "object",
-                                                  "additionalProperties": false
+                                                  "type": "object"
                                                 }
                                               },
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "preStop": {
                                               "properties": {
@@ -1455,11 +1483,11 @@
                                                       "items": {
                                                         "type": "string"
                                                       },
-                                                      "type": "array"
+                                                      "type": "array",
+                                                      "x-kubernetes-list-type": "atomic"
                                                     }
                                                   },
-                                                  "type": "object",
-                                                  "additionalProperties": false
+                                                  "type": "object"
                                                 },
                                                 "httpGet": {
                                                   "properties": {
@@ -1480,10 +1508,10 @@
                                                           "name",
                                                           "value"
                                                         ],
-                                                        "type": "object",
-                                                        "additionalProperties": false
+                                                        "type": "object"
                                                       },
-                                                      "type": "array"
+                                                      "type": "array",
+                                                      "x-kubernetes-list-type": "atomic"
                                                     },
                                                     "path": {
                                                       "type": "string"
@@ -1506,8 +1534,7 @@
                                                   "required": [
                                                     "port"
                                                   ],
-                                                  "type": "object",
-                                                  "additionalProperties": false
+                                                  "type": "object"
                                                 },
                                                 "sleep": {
                                                   "properties": {
@@ -1519,8 +1546,7 @@
                                                   "required": [
                                                     "seconds"
                                                   ],
-                                                  "type": "object",
-                                                  "additionalProperties": false
+                                                  "type": "object"
                                                 },
                                                 "tcpSocket": {
                                                   "properties": {
@@ -1542,16 +1568,16 @@
                                                   "required": [
                                                     "port"
                                                   ],
-                                                  "type": "object",
-                                                  "additionalProperties": false
+                                                  "type": "object"
                                                 }
                                               },
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
+                                            },
+                                            "stopSignal": {
+                                              "type": "string"
                                             }
                                           },
-                                          "type": "object",
-                                          "additionalProperties": false
+                                          "type": "object"
                                         },
                                         "livenessProbe": {
                                           "properties": {
@@ -1561,11 +1587,11 @@
                                                   "items": {
                                                     "type": "string"
                                                   },
-                                                  "type": "array"
+                                                  "type": "array",
+                                                  "x-kubernetes-list-type": "atomic"
                                                 }
                                               },
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "failureThreshold": {
                                               "format": "int32",
@@ -1578,14 +1604,14 @@
                                                   "type": "integer"
                                                 },
                                                 "service": {
+                                                  "default": "",
                                                   "type": "string"
                                                 }
                                               },
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "httpGet": {
                                               "properties": {
@@ -1606,10 +1632,10 @@
                                                       "name",
                                                       "value"
                                                     ],
-                                                    "type": "object",
-                                                    "additionalProperties": false
+                                                    "type": "object"
                                                   },
-                                                  "type": "array"
+                                                  "type": "array",
+                                                  "x-kubernetes-list-type": "atomic"
                                                 },
                                                 "path": {
                                                   "type": "string"
@@ -1632,8 +1658,7 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "initialDelaySeconds": {
                                               "format": "int32",
@@ -1667,8 +1692,7 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "terminationGracePeriodSeconds": {
                                               "format": "int64",
@@ -1679,8 +1703,7 @@
                                               "type": "integer"
                                             }
                                           },
-                                          "type": "object",
-                                          "additionalProperties": false
+                                          "type": "object"
                                         },
                                         "name": {
                                           "type": "string"
@@ -1710,8 +1733,7 @@
                                             "required": [
                                               "containerPort"
                                             ],
-                                            "type": "object",
-                                            "additionalProperties": false
+                                            "type": "object"
                                           },
                                           "type": "array",
                                           "x-kubernetes-list-map-keys": [
@@ -1728,11 +1750,11 @@
                                                   "items": {
                                                     "type": "string"
                                                   },
-                                                  "type": "array"
+                                                  "type": "array",
+                                                  "x-kubernetes-list-type": "atomic"
                                                 }
                                               },
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "failureThreshold": {
                                               "format": "int32",
@@ -1745,14 +1767,14 @@
                                                   "type": "integer"
                                                 },
                                                 "service": {
+                                                  "default": "",
                                                   "type": "string"
                                                 }
                                               },
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "httpGet": {
                                               "properties": {
@@ -1773,10 +1795,10 @@
                                                       "name",
                                                       "value"
                                                     ],
-                                                    "type": "object",
-                                                    "additionalProperties": false
+                                                    "type": "object"
                                                   },
-                                                  "type": "array"
+                                                  "type": "array",
+                                                  "x-kubernetes-list-type": "atomic"
                                                 },
                                                 "path": {
                                                   "type": "string"
@@ -1799,8 +1821,7 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "initialDelaySeconds": {
                                               "format": "int32",
@@ -1834,8 +1855,7 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "terminationGracePeriodSeconds": {
                                               "format": "int64",
@@ -1846,8 +1866,7 @@
                                               "type": "integer"
                                             }
                                           },
-                                          "type": "object",
-                                          "additionalProperties": false
+                                          "type": "object"
                                         },
                                         "resizePolicy": {
                                           "items": {
@@ -1863,8 +1882,7 @@
                                               "resourceName",
                                               "restartPolicy"
                                             ],
-                                            "type": "object",
-                                            "additionalProperties": false
+                                            "type": "object"
                                           },
                                           "type": "array",
                                           "x-kubernetes-list-type": "atomic"
@@ -1876,13 +1894,15 @@
                                                 "properties": {
                                                   "name": {
                                                     "type": "string"
+                                                  },
+                                                  "request": {
+                                                    "type": "string"
                                                   }
                                                 },
                                                 "required": [
                                                   "name"
                                                 ],
-                                                "type": "object",
-                                                "additionalProperties": false
+                                                "type": "object"
                                               },
                                               "type": "array",
                                               "x-kubernetes-list-map-keys": [
@@ -1897,16 +1917,63 @@
                                               "x-kubernetes-preserve-unknown-fields": true
                                             }
                                           },
-                                          "type": "object",
-                                          "additionalProperties": false
+                                          "type": "object"
                                         },
                                         "restartPolicy": {
                                           "type": "string"
+                                        },
+                                        "restartPolicyRules": {
+                                          "items": {
+                                            "properties": {
+                                              "action": {
+                                                "type": "string"
+                                              },
+                                              "exitCodes": {
+                                                "properties": {
+                                                  "operator": {
+                                                    "type": "string"
+                                                  },
+                                                  "values": {
+                                                    "items": {
+                                                      "format": "int32",
+                                                      "type": "integer"
+                                                    },
+                                                    "type": "array",
+                                                    "x-kubernetes-list-type": "set"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "operator"
+                                                ],
+                                                "type": "object"
+                                              }
+                                            },
+                                            "required": [
+                                              "action"
+                                            ],
+                                            "type": "object"
+                                          },
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "securityContext": {
                                           "properties": {
                                             "allowPrivilegeEscalation": {
                                               "type": "boolean"
+                                            },
+                                            "appArmorProfile": {
+                                              "properties": {
+                                                "localhostProfile": {
+                                                  "type": "string"
+                                                },
+                                                "type": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "type"
+                                              ],
+                                              "type": "object"
                                             },
                                             "capabilities": {
                                               "properties": {
@@ -1914,17 +1981,18 @@
                                                   "items": {
                                                     "type": "string"
                                                   },
-                                                  "type": "array"
+                                                  "type": "array",
+                                                  "x-kubernetes-list-type": "atomic"
                                                 },
                                                 "drop": {
                                                   "items": {
                                                     "type": "string"
                                                   },
-                                                  "type": "array"
+                                                  "type": "array",
+                                                  "x-kubernetes-list-type": "atomic"
                                                 }
                                               },
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "privileged": {
                                               "type": "boolean"
@@ -1961,8 +2029,7 @@
                                                   "type": "string"
                                                 }
                                               },
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "seccompProfile": {
                                               "properties": {
@@ -1976,8 +2043,7 @@
                                               "required": [
                                                 "type"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "windowsOptions": {
                                               "properties": {
@@ -1994,12 +2060,10 @@
                                                   "type": "string"
                                                 }
                                               },
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             }
                                           },
-                                          "type": "object",
-                                          "additionalProperties": false
+                                          "type": "object"
                                         },
                                         "startupProbe": {
                                           "properties": {
@@ -2009,11 +2073,11 @@
                                                   "items": {
                                                     "type": "string"
                                                   },
-                                                  "type": "array"
+                                                  "type": "array",
+                                                  "x-kubernetes-list-type": "atomic"
                                                 }
                                               },
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "failureThreshold": {
                                               "format": "int32",
@@ -2026,14 +2090,14 @@
                                                   "type": "integer"
                                                 },
                                                 "service": {
+                                                  "default": "",
                                                   "type": "string"
                                                 }
                                               },
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "httpGet": {
                                               "properties": {
@@ -2054,10 +2118,10 @@
                                                       "name",
                                                       "value"
                                                     ],
-                                                    "type": "object",
-                                                    "additionalProperties": false
+                                                    "type": "object"
                                                   },
-                                                  "type": "array"
+                                                  "type": "array",
+                                                  "x-kubernetes-list-type": "atomic"
                                                 },
                                                 "path": {
                                                   "type": "string"
@@ -2080,8 +2144,7 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "initialDelaySeconds": {
                                               "format": "int32",
@@ -2115,8 +2178,7 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "terminationGracePeriodSeconds": {
                                               "format": "int64",
@@ -2127,8 +2189,7 @@
                                               "type": "integer"
                                             }
                                           },
-                                          "type": "object",
-                                          "additionalProperties": false
+                                          "type": "object"
                                         },
                                         "stdin": {
                                           "type": "boolean"
@@ -2159,10 +2220,13 @@
                                               "devicePath",
                                               "name"
                                             ],
-                                            "type": "object",
-                                            "additionalProperties": false
+                                            "type": "object"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-map-keys": [
+                                            "devicePath"
+                                          ],
+                                          "x-kubernetes-list-type": "map"
                                         },
                                         "volumeMounts": {
                                           "items": {
@@ -2179,6 +2243,9 @@
                                               "readOnly": {
                                                 "type": "boolean"
                                               },
+                                              "recursiveReadOnly": {
+                                                "type": "string"
+                                              },
                                               "subPath": {
                                                 "type": "string"
                                               },
@@ -2190,10 +2257,13 @@
                                               "mountPath",
                                               "name"
                                             ],
-                                            "type": "object",
-                                            "additionalProperties": false
+                                            "type": "object"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-map-keys": [
+                                            "mountPath"
+                                          ],
+                                          "x-kubernetes-list-type": "map"
                                         },
                                         "workingDir": {
                                           "type": "string"
@@ -2202,10 +2272,13 @@
                                       "required": [
                                         "name"
                                       ],
-                                      "type": "object",
-                                      "additionalProperties": false
+                                      "type": "object"
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-map-keys": [
+                                      "name"
+                                    ],
+                                    "x-kubernetes-list-type": "map"
                                   },
                                   "dnsConfig": {
                                     "properties": {
@@ -2213,7 +2286,8 @@
                                         "items": {
                                           "type": "string"
                                         },
-                                        "type": "array"
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
                                       },
                                       "options": {
                                         "items": {
@@ -2225,20 +2299,20 @@
                                               "type": "string"
                                             }
                                           },
-                                          "type": "object",
-                                          "additionalProperties": false
+                                          "type": "object"
                                         },
-                                        "type": "array"
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
                                       },
                                       "searches": {
                                         "items": {
                                           "type": "string"
                                         },
-                                        "type": "array"
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
                                       }
                                     },
-                                    "type": "object",
-                                    "additionalProperties": false
+                                    "type": "object"
                                   },
                                   "dnsPolicy": {
                                     "type": "string"
@@ -2253,13 +2327,15 @@
                                           "items": {
                                             "type": "string"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "command": {
                                           "items": {
                                             "type": "string"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "env": {
                                           "items": {
@@ -2278,6 +2354,7 @@
                                                         "type": "string"
                                                       },
                                                       "name": {
+                                                        "default": "",
                                                         "type": "string"
                                                       },
                                                       "optional": {
@@ -2288,8 +2365,7 @@
                                                       "key"
                                                     ],
                                                     "type": "object",
-                                                    "x-kubernetes-map-type": "atomic",
-                                                    "additionalProperties": false
+                                                    "x-kubernetes-map-type": "atomic"
                                                   },
                                                   "fieldRef": {
                                                     "properties": {
@@ -2304,8 +2380,31 @@
                                                       "fieldPath"
                                                     ],
                                                     "type": "object",
-                                                    "x-kubernetes-map-type": "atomic",
-                                                    "additionalProperties": false
+                                                    "x-kubernetes-map-type": "atomic"
+                                                  },
+                                                  "fileKeyRef": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "optional": {
+                                                        "default": false,
+                                                        "type": "boolean"
+                                                      },
+                                                      "path": {
+                                                        "type": "string"
+                                                      },
+                                                      "volumeName": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key",
+                                                      "path",
+                                                      "volumeName"
+                                                    ],
+                                                    "type": "object",
+                                                    "x-kubernetes-map-type": "atomic"
                                                   },
                                                   "resourceFieldRef": {
                                                     "properties": {
@@ -2332,8 +2431,7 @@
                                                       "resource"
                                                     ],
                                                     "type": "object",
-                                                    "x-kubernetes-map-type": "atomic",
-                                                    "additionalProperties": false
+                                                    "x-kubernetes-map-type": "atomic"
                                                   },
                                                   "secretKeyRef": {
                                                     "properties": {
@@ -2341,6 +2439,7 @@
                                                         "type": "string"
                                                       },
                                                       "name": {
+                                                        "default": "",
                                                         "type": "string"
                                                       },
                                                       "optional": {
@@ -2351,21 +2450,22 @@
                                                       "key"
                                                     ],
                                                     "type": "object",
-                                                    "x-kubernetes-map-type": "atomic",
-                                                    "additionalProperties": false
+                                                    "x-kubernetes-map-type": "atomic"
                                                   }
                                                 },
-                                                "type": "object",
-                                                "additionalProperties": false
+                                                "type": "object"
                                               }
                                             },
                                             "required": [
                                               "name"
                                             ],
-                                            "type": "object",
-                                            "additionalProperties": false
+                                            "type": "object"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-map-keys": [
+                                            "name"
+                                          ],
+                                          "x-kubernetes-list-type": "map"
                                         },
                                         "envFrom": {
                                           "items": {
@@ -2373,6 +2473,7 @@
                                               "configMapRef": {
                                                 "properties": {
                                                   "name": {
+                                                    "default": "",
                                                     "type": "string"
                                                   },
                                                   "optional": {
@@ -2380,8 +2481,7 @@
                                                   }
                                                 },
                                                 "type": "object",
-                                                "x-kubernetes-map-type": "atomic",
-                                                "additionalProperties": false
+                                                "x-kubernetes-map-type": "atomic"
                                               },
                                               "prefix": {
                                                 "type": "string"
@@ -2389,6 +2489,7 @@
                                               "secretRef": {
                                                 "properties": {
                                                   "name": {
+                                                    "default": "",
                                                     "type": "string"
                                                   },
                                                   "optional": {
@@ -2396,14 +2497,13 @@
                                                   }
                                                 },
                                                 "type": "object",
-                                                "x-kubernetes-map-type": "atomic",
-                                                "additionalProperties": false
+                                                "x-kubernetes-map-type": "atomic"
                                               }
                                             },
-                                            "type": "object",
-                                            "additionalProperties": false
+                                            "type": "object"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "image": {
                                           "type": "string"
@@ -2421,11 +2521,11 @@
                                                       "items": {
                                                         "type": "string"
                                                       },
-                                                      "type": "array"
+                                                      "type": "array",
+                                                      "x-kubernetes-list-type": "atomic"
                                                     }
                                                   },
-                                                  "type": "object",
-                                                  "additionalProperties": false
+                                                  "type": "object"
                                                 },
                                                 "httpGet": {
                                                   "properties": {
@@ -2446,10 +2546,10 @@
                                                           "name",
                                                           "value"
                                                         ],
-                                                        "type": "object",
-                                                        "additionalProperties": false
+                                                        "type": "object"
                                                       },
-                                                      "type": "array"
+                                                      "type": "array",
+                                                      "x-kubernetes-list-type": "atomic"
                                                     },
                                                     "path": {
                                                       "type": "string"
@@ -2472,8 +2572,7 @@
                                                   "required": [
                                                     "port"
                                                   ],
-                                                  "type": "object",
-                                                  "additionalProperties": false
+                                                  "type": "object"
                                                 },
                                                 "sleep": {
                                                   "properties": {
@@ -2485,8 +2584,7 @@
                                                   "required": [
                                                     "seconds"
                                                   ],
-                                                  "type": "object",
-                                                  "additionalProperties": false
+                                                  "type": "object"
                                                 },
                                                 "tcpSocket": {
                                                   "properties": {
@@ -2508,12 +2606,10 @@
                                                   "required": [
                                                     "port"
                                                   ],
-                                                  "type": "object",
-                                                  "additionalProperties": false
+                                                  "type": "object"
                                                 }
                                               },
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "preStop": {
                                               "properties": {
@@ -2523,11 +2619,11 @@
                                                       "items": {
                                                         "type": "string"
                                                       },
-                                                      "type": "array"
+                                                      "type": "array",
+                                                      "x-kubernetes-list-type": "atomic"
                                                     }
                                                   },
-                                                  "type": "object",
-                                                  "additionalProperties": false
+                                                  "type": "object"
                                                 },
                                                 "httpGet": {
                                                   "properties": {
@@ -2548,10 +2644,10 @@
                                                           "name",
                                                           "value"
                                                         ],
-                                                        "type": "object",
-                                                        "additionalProperties": false
+                                                        "type": "object"
                                                       },
-                                                      "type": "array"
+                                                      "type": "array",
+                                                      "x-kubernetes-list-type": "atomic"
                                                     },
                                                     "path": {
                                                       "type": "string"
@@ -2574,8 +2670,7 @@
                                                   "required": [
                                                     "port"
                                                   ],
-                                                  "type": "object",
-                                                  "additionalProperties": false
+                                                  "type": "object"
                                                 },
                                                 "sleep": {
                                                   "properties": {
@@ -2587,8 +2682,7 @@
                                                   "required": [
                                                     "seconds"
                                                   ],
-                                                  "type": "object",
-                                                  "additionalProperties": false
+                                                  "type": "object"
                                                 },
                                                 "tcpSocket": {
                                                   "properties": {
@@ -2610,16 +2704,16 @@
                                                   "required": [
                                                     "port"
                                                   ],
-                                                  "type": "object",
-                                                  "additionalProperties": false
+                                                  "type": "object"
                                                 }
                                               },
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
+                                            },
+                                            "stopSignal": {
+                                              "type": "string"
                                             }
                                           },
-                                          "type": "object",
-                                          "additionalProperties": false
+                                          "type": "object"
                                         },
                                         "livenessProbe": {
                                           "properties": {
@@ -2629,11 +2723,11 @@
                                                   "items": {
                                                     "type": "string"
                                                   },
-                                                  "type": "array"
+                                                  "type": "array",
+                                                  "x-kubernetes-list-type": "atomic"
                                                 }
                                               },
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "failureThreshold": {
                                               "format": "int32",
@@ -2646,14 +2740,14 @@
                                                   "type": "integer"
                                                 },
                                                 "service": {
+                                                  "default": "",
                                                   "type": "string"
                                                 }
                                               },
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "httpGet": {
                                               "properties": {
@@ -2674,10 +2768,10 @@
                                                       "name",
                                                       "value"
                                                     ],
-                                                    "type": "object",
-                                                    "additionalProperties": false
+                                                    "type": "object"
                                                   },
-                                                  "type": "array"
+                                                  "type": "array",
+                                                  "x-kubernetes-list-type": "atomic"
                                                 },
                                                 "path": {
                                                   "type": "string"
@@ -2700,8 +2794,7 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "initialDelaySeconds": {
                                               "format": "int32",
@@ -2735,8 +2828,7 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "terminationGracePeriodSeconds": {
                                               "format": "int64",
@@ -2747,8 +2839,7 @@
                                               "type": "integer"
                                             }
                                           },
-                                          "type": "object",
-                                          "additionalProperties": false
+                                          "type": "object"
                                         },
                                         "name": {
                                           "type": "string"
@@ -2778,8 +2869,7 @@
                                             "required": [
                                               "containerPort"
                                             ],
-                                            "type": "object",
-                                            "additionalProperties": false
+                                            "type": "object"
                                           },
                                           "type": "array",
                                           "x-kubernetes-list-map-keys": [
@@ -2796,11 +2886,11 @@
                                                   "items": {
                                                     "type": "string"
                                                   },
-                                                  "type": "array"
+                                                  "type": "array",
+                                                  "x-kubernetes-list-type": "atomic"
                                                 }
                                               },
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "failureThreshold": {
                                               "format": "int32",
@@ -2813,14 +2903,14 @@
                                                   "type": "integer"
                                                 },
                                                 "service": {
+                                                  "default": "",
                                                   "type": "string"
                                                 }
                                               },
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "httpGet": {
                                               "properties": {
@@ -2841,10 +2931,10 @@
                                                       "name",
                                                       "value"
                                                     ],
-                                                    "type": "object",
-                                                    "additionalProperties": false
+                                                    "type": "object"
                                                   },
-                                                  "type": "array"
+                                                  "type": "array",
+                                                  "x-kubernetes-list-type": "atomic"
                                                 },
                                                 "path": {
                                                   "type": "string"
@@ -2867,8 +2957,7 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "initialDelaySeconds": {
                                               "format": "int32",
@@ -2902,8 +2991,7 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "terminationGracePeriodSeconds": {
                                               "format": "int64",
@@ -2914,8 +3002,7 @@
                                               "type": "integer"
                                             }
                                           },
-                                          "type": "object",
-                                          "additionalProperties": false
+                                          "type": "object"
                                         },
                                         "resizePolicy": {
                                           "items": {
@@ -2931,8 +3018,7 @@
                                               "resourceName",
                                               "restartPolicy"
                                             ],
-                                            "type": "object",
-                                            "additionalProperties": false
+                                            "type": "object"
                                           },
                                           "type": "array",
                                           "x-kubernetes-list-type": "atomic"
@@ -2944,13 +3030,15 @@
                                                 "properties": {
                                                   "name": {
                                                     "type": "string"
+                                                  },
+                                                  "request": {
+                                                    "type": "string"
                                                   }
                                                 },
                                                 "required": [
                                                   "name"
                                                 ],
-                                                "type": "object",
-                                                "additionalProperties": false
+                                                "type": "object"
                                               },
                                               "type": "array",
                                               "x-kubernetes-list-map-keys": [
@@ -2965,16 +3053,63 @@
                                               "x-kubernetes-preserve-unknown-fields": true
                                             }
                                           },
-                                          "type": "object",
-                                          "additionalProperties": false
+                                          "type": "object"
                                         },
                                         "restartPolicy": {
                                           "type": "string"
+                                        },
+                                        "restartPolicyRules": {
+                                          "items": {
+                                            "properties": {
+                                              "action": {
+                                                "type": "string"
+                                              },
+                                              "exitCodes": {
+                                                "properties": {
+                                                  "operator": {
+                                                    "type": "string"
+                                                  },
+                                                  "values": {
+                                                    "items": {
+                                                      "format": "int32",
+                                                      "type": "integer"
+                                                    },
+                                                    "type": "array",
+                                                    "x-kubernetes-list-type": "set"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "operator"
+                                                ],
+                                                "type": "object"
+                                              }
+                                            },
+                                            "required": [
+                                              "action"
+                                            ],
+                                            "type": "object"
+                                          },
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "securityContext": {
                                           "properties": {
                                             "allowPrivilegeEscalation": {
                                               "type": "boolean"
+                                            },
+                                            "appArmorProfile": {
+                                              "properties": {
+                                                "localhostProfile": {
+                                                  "type": "string"
+                                                },
+                                                "type": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "type"
+                                              ],
+                                              "type": "object"
                                             },
                                             "capabilities": {
                                               "properties": {
@@ -2982,17 +3117,18 @@
                                                   "items": {
                                                     "type": "string"
                                                   },
-                                                  "type": "array"
+                                                  "type": "array",
+                                                  "x-kubernetes-list-type": "atomic"
                                                 },
                                                 "drop": {
                                                   "items": {
                                                     "type": "string"
                                                   },
-                                                  "type": "array"
+                                                  "type": "array",
+                                                  "x-kubernetes-list-type": "atomic"
                                                 }
                                               },
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "privileged": {
                                               "type": "boolean"
@@ -3029,8 +3165,7 @@
                                                   "type": "string"
                                                 }
                                               },
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "seccompProfile": {
                                               "properties": {
@@ -3044,8 +3179,7 @@
                                               "required": [
                                                 "type"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "windowsOptions": {
                                               "properties": {
@@ -3062,12 +3196,10 @@
                                                   "type": "string"
                                                 }
                                               },
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             }
                                           },
-                                          "type": "object",
-                                          "additionalProperties": false
+                                          "type": "object"
                                         },
                                         "startupProbe": {
                                           "properties": {
@@ -3077,11 +3209,11 @@
                                                   "items": {
                                                     "type": "string"
                                                   },
-                                                  "type": "array"
+                                                  "type": "array",
+                                                  "x-kubernetes-list-type": "atomic"
                                                 }
                                               },
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "failureThreshold": {
                                               "format": "int32",
@@ -3094,14 +3226,14 @@
                                                   "type": "integer"
                                                 },
                                                 "service": {
+                                                  "default": "",
                                                   "type": "string"
                                                 }
                                               },
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "httpGet": {
                                               "properties": {
@@ -3122,10 +3254,10 @@
                                                       "name",
                                                       "value"
                                                     ],
-                                                    "type": "object",
-                                                    "additionalProperties": false
+                                                    "type": "object"
                                                   },
-                                                  "type": "array"
+                                                  "type": "array",
+                                                  "x-kubernetes-list-type": "atomic"
                                                 },
                                                 "path": {
                                                   "type": "string"
@@ -3148,8 +3280,7 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "initialDelaySeconds": {
                                               "format": "int32",
@@ -3183,8 +3314,7 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "terminationGracePeriodSeconds": {
                                               "format": "int64",
@@ -3195,8 +3325,7 @@
                                               "type": "integer"
                                             }
                                           },
-                                          "type": "object",
-                                          "additionalProperties": false
+                                          "type": "object"
                                         },
                                         "stdin": {
                                           "type": "boolean"
@@ -3230,10 +3359,13 @@
                                               "devicePath",
                                               "name"
                                             ],
-                                            "type": "object",
-                                            "additionalProperties": false
+                                            "type": "object"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-map-keys": [
+                                            "devicePath"
+                                          ],
+                                          "x-kubernetes-list-type": "map"
                                         },
                                         "volumeMounts": {
                                           "items": {
@@ -3250,6 +3382,9 @@
                                               "readOnly": {
                                                 "type": "boolean"
                                               },
+                                              "recursiveReadOnly": {
+                                                "type": "string"
+                                              },
                                               "subPath": {
                                                 "type": "string"
                                               },
@@ -3261,10 +3396,13 @@
                                               "mountPath",
                                               "name"
                                             ],
-                                            "type": "object",
-                                            "additionalProperties": false
+                                            "type": "object"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-map-keys": [
+                                            "mountPath"
+                                          ],
+                                          "x-kubernetes-list-type": "map"
                                         },
                                         "workingDir": {
                                           "type": "string"
@@ -3273,10 +3411,13 @@
                                       "required": [
                                         "name"
                                       ],
-                                      "type": "object",
-                                      "additionalProperties": false
+                                      "type": "object"
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-map-keys": [
+                                      "name"
+                                    ],
+                                    "x-kubernetes-list-type": "map"
                                   },
                                   "hostAliases": {
                                     "items": {
@@ -3285,16 +3426,23 @@
                                           "items": {
                                             "type": "string"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "ip": {
                                           "type": "string"
                                         }
                                       },
-                                      "type": "object",
-                                      "additionalProperties": false
+                                      "required": [
+                                        "ip"
+                                      ],
+                                      "type": "object"
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-map-keys": [
+                                      "ip"
+                                    ],
+                                    "x-kubernetes-list-type": "map"
                                   },
                                   "hostIPC": {
                                     "type": "boolean"
@@ -3311,18 +3459,25 @@
                                   "hostname": {
                                     "type": "string"
                                   },
+                                  "hostnameOverride": {
+                                    "type": "string"
+                                  },
                                   "imagePullSecrets": {
                                     "items": {
                                       "properties": {
                                         "name": {
+                                          "default": "",
                                           "type": "string"
                                         }
                                       },
                                       "type": "object",
-                                      "x-kubernetes-map-type": "atomic",
-                                      "additionalProperties": false
+                                      "x-kubernetes-map-type": "atomic"
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-map-keys": [
+                                      "name"
+                                    ],
+                                    "x-kubernetes-list-type": "map"
                                   },
                                   "initContainers": {
                                     "items": {
@@ -3331,13 +3486,15 @@
                                           "items": {
                                             "type": "string"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "command": {
                                           "items": {
                                             "type": "string"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "env": {
                                           "items": {
@@ -3356,6 +3513,7 @@
                                                         "type": "string"
                                                       },
                                                       "name": {
+                                                        "default": "",
                                                         "type": "string"
                                                       },
                                                       "optional": {
@@ -3366,8 +3524,7 @@
                                                       "key"
                                                     ],
                                                     "type": "object",
-                                                    "x-kubernetes-map-type": "atomic",
-                                                    "additionalProperties": false
+                                                    "x-kubernetes-map-type": "atomic"
                                                   },
                                                   "fieldRef": {
                                                     "properties": {
@@ -3382,8 +3539,31 @@
                                                       "fieldPath"
                                                     ],
                                                     "type": "object",
-                                                    "x-kubernetes-map-type": "atomic",
-                                                    "additionalProperties": false
+                                                    "x-kubernetes-map-type": "atomic"
+                                                  },
+                                                  "fileKeyRef": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "optional": {
+                                                        "default": false,
+                                                        "type": "boolean"
+                                                      },
+                                                      "path": {
+                                                        "type": "string"
+                                                      },
+                                                      "volumeName": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key",
+                                                      "path",
+                                                      "volumeName"
+                                                    ],
+                                                    "type": "object",
+                                                    "x-kubernetes-map-type": "atomic"
                                                   },
                                                   "resourceFieldRef": {
                                                     "properties": {
@@ -3410,8 +3590,7 @@
                                                       "resource"
                                                     ],
                                                     "type": "object",
-                                                    "x-kubernetes-map-type": "atomic",
-                                                    "additionalProperties": false
+                                                    "x-kubernetes-map-type": "atomic"
                                                   },
                                                   "secretKeyRef": {
                                                     "properties": {
@@ -3419,6 +3598,7 @@
                                                         "type": "string"
                                                       },
                                                       "name": {
+                                                        "default": "",
                                                         "type": "string"
                                                       },
                                                       "optional": {
@@ -3429,21 +3609,22 @@
                                                       "key"
                                                     ],
                                                     "type": "object",
-                                                    "x-kubernetes-map-type": "atomic",
-                                                    "additionalProperties": false
+                                                    "x-kubernetes-map-type": "atomic"
                                                   }
                                                 },
-                                                "type": "object",
-                                                "additionalProperties": false
+                                                "type": "object"
                                               }
                                             },
                                             "required": [
                                               "name"
                                             ],
-                                            "type": "object",
-                                            "additionalProperties": false
+                                            "type": "object"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-map-keys": [
+                                            "name"
+                                          ],
+                                          "x-kubernetes-list-type": "map"
                                         },
                                         "envFrom": {
                                           "items": {
@@ -3451,6 +3632,7 @@
                                               "configMapRef": {
                                                 "properties": {
                                                   "name": {
+                                                    "default": "",
                                                     "type": "string"
                                                   },
                                                   "optional": {
@@ -3458,8 +3640,7 @@
                                                   }
                                                 },
                                                 "type": "object",
-                                                "x-kubernetes-map-type": "atomic",
-                                                "additionalProperties": false
+                                                "x-kubernetes-map-type": "atomic"
                                               },
                                               "prefix": {
                                                 "type": "string"
@@ -3467,6 +3648,7 @@
                                               "secretRef": {
                                                 "properties": {
                                                   "name": {
+                                                    "default": "",
                                                     "type": "string"
                                                   },
                                                   "optional": {
@@ -3474,14 +3656,13 @@
                                                   }
                                                 },
                                                 "type": "object",
-                                                "x-kubernetes-map-type": "atomic",
-                                                "additionalProperties": false
+                                                "x-kubernetes-map-type": "atomic"
                                               }
                                             },
-                                            "type": "object",
-                                            "additionalProperties": false
+                                            "type": "object"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "image": {
                                           "type": "string"
@@ -3499,11 +3680,11 @@
                                                       "items": {
                                                         "type": "string"
                                                       },
-                                                      "type": "array"
+                                                      "type": "array",
+                                                      "x-kubernetes-list-type": "atomic"
                                                     }
                                                   },
-                                                  "type": "object",
-                                                  "additionalProperties": false
+                                                  "type": "object"
                                                 },
                                                 "httpGet": {
                                                   "properties": {
@@ -3524,10 +3705,10 @@
                                                           "name",
                                                           "value"
                                                         ],
-                                                        "type": "object",
-                                                        "additionalProperties": false
+                                                        "type": "object"
                                                       },
-                                                      "type": "array"
+                                                      "type": "array",
+                                                      "x-kubernetes-list-type": "atomic"
                                                     },
                                                     "path": {
                                                       "type": "string"
@@ -3550,8 +3731,7 @@
                                                   "required": [
                                                     "port"
                                                   ],
-                                                  "type": "object",
-                                                  "additionalProperties": false
+                                                  "type": "object"
                                                 },
                                                 "sleep": {
                                                   "properties": {
@@ -3563,8 +3743,7 @@
                                                   "required": [
                                                     "seconds"
                                                   ],
-                                                  "type": "object",
-                                                  "additionalProperties": false
+                                                  "type": "object"
                                                 },
                                                 "tcpSocket": {
                                                   "properties": {
@@ -3586,12 +3765,10 @@
                                                   "required": [
                                                     "port"
                                                   ],
-                                                  "type": "object",
-                                                  "additionalProperties": false
+                                                  "type": "object"
                                                 }
                                               },
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "preStop": {
                                               "properties": {
@@ -3601,11 +3778,11 @@
                                                       "items": {
                                                         "type": "string"
                                                       },
-                                                      "type": "array"
+                                                      "type": "array",
+                                                      "x-kubernetes-list-type": "atomic"
                                                     }
                                                   },
-                                                  "type": "object",
-                                                  "additionalProperties": false
+                                                  "type": "object"
                                                 },
                                                 "httpGet": {
                                                   "properties": {
@@ -3626,10 +3803,10 @@
                                                           "name",
                                                           "value"
                                                         ],
-                                                        "type": "object",
-                                                        "additionalProperties": false
+                                                        "type": "object"
                                                       },
-                                                      "type": "array"
+                                                      "type": "array",
+                                                      "x-kubernetes-list-type": "atomic"
                                                     },
                                                     "path": {
                                                       "type": "string"
@@ -3652,8 +3829,7 @@
                                                   "required": [
                                                     "port"
                                                   ],
-                                                  "type": "object",
-                                                  "additionalProperties": false
+                                                  "type": "object"
                                                 },
                                                 "sleep": {
                                                   "properties": {
@@ -3665,8 +3841,7 @@
                                                   "required": [
                                                     "seconds"
                                                   ],
-                                                  "type": "object",
-                                                  "additionalProperties": false
+                                                  "type": "object"
                                                 },
                                                 "tcpSocket": {
                                                   "properties": {
@@ -3688,16 +3863,16 @@
                                                   "required": [
                                                     "port"
                                                   ],
-                                                  "type": "object",
-                                                  "additionalProperties": false
+                                                  "type": "object"
                                                 }
                                               },
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
+                                            },
+                                            "stopSignal": {
+                                              "type": "string"
                                             }
                                           },
-                                          "type": "object",
-                                          "additionalProperties": false
+                                          "type": "object"
                                         },
                                         "livenessProbe": {
                                           "properties": {
@@ -3707,11 +3882,11 @@
                                                   "items": {
                                                     "type": "string"
                                                   },
-                                                  "type": "array"
+                                                  "type": "array",
+                                                  "x-kubernetes-list-type": "atomic"
                                                 }
                                               },
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "failureThreshold": {
                                               "format": "int32",
@@ -3724,14 +3899,14 @@
                                                   "type": "integer"
                                                 },
                                                 "service": {
+                                                  "default": "",
                                                   "type": "string"
                                                 }
                                               },
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "httpGet": {
                                               "properties": {
@@ -3752,10 +3927,10 @@
                                                       "name",
                                                       "value"
                                                     ],
-                                                    "type": "object",
-                                                    "additionalProperties": false
+                                                    "type": "object"
                                                   },
-                                                  "type": "array"
+                                                  "type": "array",
+                                                  "x-kubernetes-list-type": "atomic"
                                                 },
                                                 "path": {
                                                   "type": "string"
@@ -3778,8 +3953,7 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "initialDelaySeconds": {
                                               "format": "int32",
@@ -3813,8 +3987,7 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "terminationGracePeriodSeconds": {
                                               "format": "int64",
@@ -3825,8 +3998,7 @@
                                               "type": "integer"
                                             }
                                           },
-                                          "type": "object",
-                                          "additionalProperties": false
+                                          "type": "object"
                                         },
                                         "name": {
                                           "type": "string"
@@ -3856,8 +4028,7 @@
                                             "required": [
                                               "containerPort"
                                             ],
-                                            "type": "object",
-                                            "additionalProperties": false
+                                            "type": "object"
                                           },
                                           "type": "array",
                                           "x-kubernetes-list-map-keys": [
@@ -3874,11 +4045,11 @@
                                                   "items": {
                                                     "type": "string"
                                                   },
-                                                  "type": "array"
+                                                  "type": "array",
+                                                  "x-kubernetes-list-type": "atomic"
                                                 }
                                               },
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "failureThreshold": {
                                               "format": "int32",
@@ -3891,14 +4062,14 @@
                                                   "type": "integer"
                                                 },
                                                 "service": {
+                                                  "default": "",
                                                   "type": "string"
                                                 }
                                               },
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "httpGet": {
                                               "properties": {
@@ -3919,10 +4090,10 @@
                                                       "name",
                                                       "value"
                                                     ],
-                                                    "type": "object",
-                                                    "additionalProperties": false
+                                                    "type": "object"
                                                   },
-                                                  "type": "array"
+                                                  "type": "array",
+                                                  "x-kubernetes-list-type": "atomic"
                                                 },
                                                 "path": {
                                                   "type": "string"
@@ -3945,8 +4116,7 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "initialDelaySeconds": {
                                               "format": "int32",
@@ -3980,8 +4150,7 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "terminationGracePeriodSeconds": {
                                               "format": "int64",
@@ -3992,8 +4161,7 @@
                                               "type": "integer"
                                             }
                                           },
-                                          "type": "object",
-                                          "additionalProperties": false
+                                          "type": "object"
                                         },
                                         "resizePolicy": {
                                           "items": {
@@ -4009,8 +4177,7 @@
                                               "resourceName",
                                               "restartPolicy"
                                             ],
-                                            "type": "object",
-                                            "additionalProperties": false
+                                            "type": "object"
                                           },
                                           "type": "array",
                                           "x-kubernetes-list-type": "atomic"
@@ -4022,13 +4189,15 @@
                                                 "properties": {
                                                   "name": {
                                                     "type": "string"
+                                                  },
+                                                  "request": {
+                                                    "type": "string"
                                                   }
                                                 },
                                                 "required": [
                                                   "name"
                                                 ],
-                                                "type": "object",
-                                                "additionalProperties": false
+                                                "type": "object"
                                               },
                                               "type": "array",
                                               "x-kubernetes-list-map-keys": [
@@ -4043,16 +4212,63 @@
                                               "x-kubernetes-preserve-unknown-fields": true
                                             }
                                           },
-                                          "type": "object",
-                                          "additionalProperties": false
+                                          "type": "object"
                                         },
                                         "restartPolicy": {
                                           "type": "string"
+                                        },
+                                        "restartPolicyRules": {
+                                          "items": {
+                                            "properties": {
+                                              "action": {
+                                                "type": "string"
+                                              },
+                                              "exitCodes": {
+                                                "properties": {
+                                                  "operator": {
+                                                    "type": "string"
+                                                  },
+                                                  "values": {
+                                                    "items": {
+                                                      "format": "int32",
+                                                      "type": "integer"
+                                                    },
+                                                    "type": "array",
+                                                    "x-kubernetes-list-type": "set"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "operator"
+                                                ],
+                                                "type": "object"
+                                              }
+                                            },
+                                            "required": [
+                                              "action"
+                                            ],
+                                            "type": "object"
+                                          },
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "securityContext": {
                                           "properties": {
                                             "allowPrivilegeEscalation": {
                                               "type": "boolean"
+                                            },
+                                            "appArmorProfile": {
+                                              "properties": {
+                                                "localhostProfile": {
+                                                  "type": "string"
+                                                },
+                                                "type": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "type"
+                                              ],
+                                              "type": "object"
                                             },
                                             "capabilities": {
                                               "properties": {
@@ -4060,17 +4276,18 @@
                                                   "items": {
                                                     "type": "string"
                                                   },
-                                                  "type": "array"
+                                                  "type": "array",
+                                                  "x-kubernetes-list-type": "atomic"
                                                 },
                                                 "drop": {
                                                   "items": {
                                                     "type": "string"
                                                   },
-                                                  "type": "array"
+                                                  "type": "array",
+                                                  "x-kubernetes-list-type": "atomic"
                                                 }
                                               },
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "privileged": {
                                               "type": "boolean"
@@ -4107,8 +4324,7 @@
                                                   "type": "string"
                                                 }
                                               },
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "seccompProfile": {
                                               "properties": {
@@ -4122,8 +4338,7 @@
                                               "required": [
                                                 "type"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "windowsOptions": {
                                               "properties": {
@@ -4140,12 +4355,10 @@
                                                   "type": "string"
                                                 }
                                               },
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             }
                                           },
-                                          "type": "object",
-                                          "additionalProperties": false
+                                          "type": "object"
                                         },
                                         "startupProbe": {
                                           "properties": {
@@ -4155,11 +4368,11 @@
                                                   "items": {
                                                     "type": "string"
                                                   },
-                                                  "type": "array"
+                                                  "type": "array",
+                                                  "x-kubernetes-list-type": "atomic"
                                                 }
                                               },
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "failureThreshold": {
                                               "format": "int32",
@@ -4172,14 +4385,14 @@
                                                   "type": "integer"
                                                 },
                                                 "service": {
+                                                  "default": "",
                                                   "type": "string"
                                                 }
                                               },
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "httpGet": {
                                               "properties": {
@@ -4200,10 +4413,10 @@
                                                       "name",
                                                       "value"
                                                     ],
-                                                    "type": "object",
-                                                    "additionalProperties": false
+                                                    "type": "object"
                                                   },
-                                                  "type": "array"
+                                                  "type": "array",
+                                                  "x-kubernetes-list-type": "atomic"
                                                 },
                                                 "path": {
                                                   "type": "string"
@@ -4226,8 +4439,7 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "initialDelaySeconds": {
                                               "format": "int32",
@@ -4261,8 +4473,7 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "terminationGracePeriodSeconds": {
                                               "format": "int64",
@@ -4273,8 +4484,7 @@
                                               "type": "integer"
                                             }
                                           },
-                                          "type": "object",
-                                          "additionalProperties": false
+                                          "type": "object"
                                         },
                                         "stdin": {
                                           "type": "boolean"
@@ -4305,10 +4515,13 @@
                                               "devicePath",
                                               "name"
                                             ],
-                                            "type": "object",
-                                            "additionalProperties": false
+                                            "type": "object"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-map-keys": [
+                                            "devicePath"
+                                          ],
+                                          "x-kubernetes-list-type": "map"
                                         },
                                         "volumeMounts": {
                                           "items": {
@@ -4325,6 +4538,9 @@
                                               "readOnly": {
                                                 "type": "boolean"
                                               },
+                                              "recursiveReadOnly": {
+                                                "type": "string"
+                                              },
                                               "subPath": {
                                                 "type": "string"
                                               },
@@ -4336,10 +4552,13 @@
                                               "mountPath",
                                               "name"
                                             ],
-                                            "type": "object",
-                                            "additionalProperties": false
+                                            "type": "object"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-map-keys": [
+                                            "mountPath"
+                                          ],
+                                          "x-kubernetes-list-type": "map"
                                         },
                                         "workingDir": {
                                           "type": "string"
@@ -4348,10 +4567,13 @@
                                       "required": [
                                         "name"
                                       ],
-                                      "type": "object",
-                                      "additionalProperties": false
+                                      "type": "object"
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-map-keys": [
+                                      "name"
+                                    ],
+                                    "x-kubernetes-list-type": "map"
                                   },
                                   "nodeName": {
                                     "type": "string"
@@ -4372,8 +4594,7 @@
                                     "required": [
                                       "name"
                                     ],
-                                    "type": "object",
-                                    "additionalProperties": false
+                                    "type": "object"
                                   },
                                   "overhead": {
                                     "additionalProperties": {
@@ -4410,10 +4631,10 @@
                                       "required": [
                                         "conditionType"
                                       ],
-                                      "type": "object",
-                                      "additionalProperties": false
+                                      "type": "object"
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "resourceClaims": {
                                     "items": {
@@ -4421,30 +4642,79 @@
                                         "name": {
                                           "type": "string"
                                         },
-                                        "source": {
-                                          "properties": {
-                                            "resourceClaimName": {
-                                              "type": "string"
-                                            },
-                                            "resourceClaimTemplateName": {
-                                              "type": "string"
-                                            }
-                                          },
-                                          "type": "object",
-                                          "additionalProperties": false
+                                        "resourceClaimName": {
+                                          "type": "string"
+                                        },
+                                        "resourceClaimTemplateName": {
+                                          "type": "string"
                                         }
                                       },
                                       "required": [
                                         "name"
                                       ],
-                                      "type": "object",
-                                      "additionalProperties": false
+                                      "type": "object"
                                     },
                                     "type": "array",
                                     "x-kubernetes-list-map-keys": [
                                       "name"
                                     ],
                                     "x-kubernetes-list-type": "map"
+                                  },
+                                  "resources": {
+                                    "properties": {
+                                      "claims": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "request": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name"
+                                          ],
+                                          "type": "object"
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-map-keys": [
+                                          "name"
+                                        ],
+                                        "x-kubernetes-list-type": "map"
+                                      },
+                                      "limits": {
+                                        "additionalProperties": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "type": "object"
+                                      },
+                                      "requests": {
+                                        "additionalProperties": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object"
                                   },
                                   "restartPolicy": {
                                     "type": "string"
@@ -4465,8 +4735,7 @@
                                       "required": [
                                         "name"
                                       ],
-                                      "type": "object",
-                                      "additionalProperties": false
+                                      "type": "object"
                                     },
                                     "type": "array",
                                     "x-kubernetes-list-map-keys": [
@@ -4476,6 +4745,20 @@
                                   },
                                   "securityContext": {
                                     "properties": {
+                                      "appArmorProfile": {
+                                        "properties": {
+                                          "localhostProfile": {
+                                            "type": "string"
+                                          },
+                                          "type": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "type"
+                                        ],
+                                        "type": "object"
+                                      },
                                       "fsGroup": {
                                         "format": "int64",
                                         "type": "integer"
@@ -4494,6 +4777,9 @@
                                         "format": "int64",
                                         "type": "integer"
                                       },
+                                      "seLinuxChangePolicy": {
+                                        "type": "string"
+                                      },
                                       "seLinuxOptions": {
                                         "properties": {
                                           "level": {
@@ -4509,8 +4795,7 @@
                                             "type": "string"
                                           }
                                         },
-                                        "type": "object",
-                                        "additionalProperties": false
+                                        "type": "object"
                                       },
                                       "seccompProfile": {
                                         "properties": {
@@ -4524,15 +4809,18 @@
                                         "required": [
                                           "type"
                                         ],
-                                        "type": "object",
-                                        "additionalProperties": false
+                                        "type": "object"
                                       },
                                       "supplementalGroups": {
                                         "items": {
                                           "format": "int64",
                                           "type": "integer"
                                         },
-                                        "type": "array"
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "supplementalGroupsPolicy": {
+                                        "type": "string"
                                       },
                                       "sysctls": {
                                         "items": {
@@ -4548,10 +4836,10 @@
                                             "name",
                                             "value"
                                           ],
-                                          "type": "object",
-                                          "additionalProperties": false
+                                          "type": "object"
                                         },
-                                        "type": "array"
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
                                       },
                                       "windowsOptions": {
                                         "properties": {
@@ -4568,12 +4856,10 @@
                                             "type": "string"
                                           }
                                         },
-                                        "type": "object",
-                                        "additionalProperties": false
+                                        "type": "object"
                                       }
                                     },
-                                    "type": "object",
-                                    "additionalProperties": false
+                                    "type": "object"
                                   },
                                   "serviceAccount": {
                                     "type": "string"
@@ -4614,10 +4900,10 @@
                                           "type": "string"
                                         }
                                       },
-                                      "type": "object",
-                                      "additionalProperties": false
+                                      "type": "object"
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "topologySpreadConstraints": {
                                     "items": {
@@ -4637,17 +4923,18 @@
                                                     "items": {
                                                       "type": "string"
                                                     },
-                                                    "type": "array"
+                                                    "type": "array",
+                                                    "x-kubernetes-list-type": "atomic"
                                                   }
                                                 },
                                                 "required": [
                                                   "key",
                                                   "operator"
                                                 ],
-                                                "type": "object",
-                                                "additionalProperties": false
+                                                "type": "object"
                                               },
-                                              "type": "array"
+                                              "type": "array",
+                                              "x-kubernetes-list-type": "atomic"
                                             },
                                             "matchLabels": {
                                               "additionalProperties": {
@@ -4657,8 +4944,7 @@
                                             }
                                           },
                                           "type": "object",
-                                          "x-kubernetes-map-type": "atomic",
-                                          "additionalProperties": false
+                                          "x-kubernetes-map-type": "atomic"
                                         },
                                         "matchLabelKeys": {
                                           "items": {
@@ -4693,8 +4979,7 @@
                                         "topologyKey",
                                         "whenUnsatisfiable"
                                       ],
-                                      "type": "object",
-                                      "additionalProperties": false
+                                      "type": "object"
                                     },
                                     "type": "array",
                                     "x-kubernetes-list-map-keys": [
@@ -4710,12 +4995,10 @@
                                 "required": [
                                   "containers"
                                 ],
-                                "type": "object",
-                                "additionalProperties": false
+                                "type": "object"
                               }
                             },
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "ttlSecondsAfterFinished": {
                             "format": "int32",
@@ -4725,15 +5008,13 @@
                         "required": [
                           "template"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       }
                     },
                     "required": [
                       "spec"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "kayenta": {
                     "properties": {
@@ -4748,6 +5029,9 @@
                       },
                       "configurationAccountName": {
                         "type": "string"
+                      },
+                      "lookback": {
+                        "type": "boolean"
                       },
                       "metricsAccountName": {
                         "type": "string"
@@ -4775,14 +5059,11 @@
                                 }
                               },
                               "required": [
-                                "end",
                                 "region",
                                 "scope",
-                                "start",
                                 "step"
                               ],
-                              "type": "object",
-                              "additionalProperties": false
+                              "type": "object"
                             },
                             "experimentScope": {
                               "properties": {
@@ -4804,14 +5085,11 @@
                                 }
                               },
                               "required": [
-                                "end",
                                 "region",
                                 "scope",
-                                "start",
                                 "step"
                               ],
-                              "type": "object",
-                              "additionalProperties": false
+                              "type": "object"
                             },
                             "name": {
                               "type": "string"
@@ -4822,8 +5100,7 @@
                             "experimentScope",
                             "name"
                           ],
-                          "type": "object",
-                          "additionalProperties": false
+                          "type": "object"
                         },
                         "type": "array"
                       },
@@ -4845,8 +5122,7 @@
                           "marginal",
                           "pass"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       }
                     },
                     "required": [
@@ -4859,8 +5135,7 @@
                       "storageAccountName",
                       "threshold"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "newRelic": {
                     "properties": {
@@ -4878,8 +5153,7 @@
                     "required": [
                       "query"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "plugin": {
                     "type": "object",
@@ -4910,8 +5184,7 @@
                                 "type": "string"
                               }
                             },
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "sigv4": {
                             "properties": {
@@ -4925,12 +5198,10 @@
                                 "type": "string"
                               }
                             },
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "headers": {
                         "items": {
@@ -4946,8 +5217,7 @@
                             "key",
                             "value"
                           ],
-                          "type": "object",
-                          "additionalProperties": false
+                          "type": "object"
                         },
                         "type": "array"
                       },
@@ -4969,16 +5239,14 @@
                             "type": "string"
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "timeout": {
                         "format": "int64",
                         "type": "integer"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "skywalking": {
                     "properties": {
@@ -4992,8 +5260,7 @@
                         "type": "string"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "wavefront": {
                     "properties": {
@@ -5004,8 +5271,7 @@
                         "type": "string"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "web": {
                     "properties": {
@@ -5029,8 +5295,7 @@
                                 "type": "string"
                               }
                             },
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "sigv4": {
                             "properties": {
@@ -5044,12 +5309,10 @@
                                 "type": "string"
                               }
                             },
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "body": {
                         "type": "string"
@@ -5068,8 +5331,7 @@
                             "key",
                             "value"
                           ],
-                          "type": "object",
-                          "additionalProperties": false
+                          "type": "object"
                         },
                         "type": "array"
                       },
@@ -5097,12 +5359,10 @@
                     "required": [
                       "url"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   }
                 },
-                "type": "object",
-                "additionalProperties": false
+                "type": "object"
               },
               "successCondition": {
                 "type": "string"
@@ -5112,8 +5372,7 @@
               "name",
               "provider"
             ],
-            "type": "object",
-            "additionalProperties": false
+            "type": "object"
           },
           "type": "array"
         },
@@ -5127,14 +5386,12 @@
                 "type": "string"
               }
             },
-            "type": "object",
-            "additionalProperties": false
+            "type": "object"
           },
           "type": "array"
         }
       },
-      "type": "object",
-      "additionalProperties": false
+      "type": "object"
     }
   },
   "required": [

--- a/argoproj.io/analysistemplate_v1alpha1.json
+++ b/argoproj.io/analysistemplate_v1alpha1.json
@@ -31,7 +31,8 @@
                     "required": [
                       "fieldPath"
                     ],
-                    "type": "object"
+                    "type": "object",
+                    "additionalProperties": false
                   },
                   "secretKeyRef": {
                     "properties": {
@@ -46,16 +47,19 @@
                       "key",
                       "name"
                     ],
-                    "type": "object"
+                    "type": "object",
+                    "additionalProperties": false
                   }
                 },
-                "type": "object"
+                "type": "object",
+                "additionalProperties": false
               }
             },
             "required": [
               "name"
             ],
-            "type": "object"
+            "type": "object",
+            "additionalProperties": false
           },
           "type": "array"
         },
@@ -69,7 +73,8 @@
             "required": [
               "metricName"
             ],
-            "type": "object"
+            "type": "object",
+            "additionalProperties": false
           },
           "type": "array"
         },
@@ -88,7 +93,8 @@
               "limit",
               "metricName"
             ],
-            "type": "object"
+            "type": "object",
+            "additionalProperties": false
           },
           "type": "array"
         },
@@ -195,7 +201,8 @@
                                             "type": "string"
                                           }
                                         },
-                                        "type": "object"
+                                        "type": "object",
+                                        "additionalProperties": false
                                       },
                                       "type": "array"
                                     },
@@ -206,7 +213,8 @@
                                       "type": "string"
                                     }
                                   },
-                                  "type": "object"
+                                  "type": "object",
+                                  "additionalProperties": false
                                 },
                                 "period": {
                                   "anyOf": [
@@ -226,7 +234,8 @@
                                   "type": "string"
                                 }
                               },
-                              "type": "object"
+                              "type": "object",
+                              "additionalProperties": false
                             },
                             "period": {
                               "anyOf": [
@@ -243,7 +252,8 @@
                               "type": "boolean"
                             }
                           },
-                          "type": "object"
+                          "type": "object",
+                          "additionalProperties": false
                         },
                         "type": "array"
                       }
@@ -251,7 +261,8 @@
                     "required": [
                       "metricDataQueries"
                     ],
-                    "type": "object"
+                    "type": "object",
+                    "additionalProperties": false
                   },
                   "datadog": {
                     "properties": {
@@ -302,10 +313,12 @@
                             "type": "boolean"
                           }
                         },
-                        "type": "object"
+                        "type": "object",
+                        "additionalProperties": false
                       }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "additionalProperties": false
                   },
                   "graphite": {
                     "properties": {
@@ -316,7 +329,8 @@
                         "type": "string"
                       }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "additionalProperties": false
                   },
                   "influxdb": {
                     "properties": {
@@ -327,7 +341,8 @@
                         "type": "string"
                       }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "additionalProperties": false
                   },
                   "job": {
                     "properties": {
@@ -346,7 +361,8 @@
                             "type": "object"
                           }
                         },
-                        "type": "object"
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "spec": {
                         "properties": {
@@ -412,7 +428,8 @@
                                         "operator",
                                         "values"
                                       ],
-                                      "type": "object"
+                                      "type": "object",
+                                      "additionalProperties": false
                                     },
                                     "onPodConditions": {
                                       "items": {
@@ -428,7 +445,8 @@
                                           "status",
                                           "type"
                                         ],
-                                        "type": "object"
+                                        "type": "object",
+                                        "additionalProperties": false
                                       },
                                       "type": "array",
                                       "x-kubernetes-list-type": "atomic"
@@ -437,7 +455,8 @@
                                   "required": [
                                     "action"
                                   ],
-                                  "type": "object"
+                                  "type": "object",
+                                  "additionalProperties": false
                                 },
                                 "type": "array",
                                 "x-kubernetes-list-type": "atomic"
@@ -446,7 +465,8 @@
                             "required": [
                               "rules"
                             ],
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "podReplacementPolicy": {
                             "type": "string"
@@ -474,7 +494,8 @@
                                     "key",
                                     "operator"
                                   ],
-                                  "type": "object"
+                                  "type": "object",
+                                  "additionalProperties": false
                                 },
                                 "type": "array",
                                 "x-kubernetes-list-type": "atomic"
@@ -487,7 +508,8 @@
                               }
                             },
                             "type": "object",
-                            "x-kubernetes-map-type": "atomic"
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
                           },
                           "successPolicy": {
                             "properties": {
@@ -502,7 +524,8 @@
                                       "type": "string"
                                     }
                                   },
-                                  "type": "object"
+                                  "type": "object",
+                                  "additionalProperties": false
                                 },
                                 "type": "array",
                                 "x-kubernetes-list-type": "atomic"
@@ -511,7 +534,8 @@
                             "required": [
                               "rules"
                             ],
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "suspend": {
                             "type": "boolean"
@@ -533,7 +557,8 @@
                                     "type": "object"
                                   }
                                 },
-                                "type": "object"
+                                "type": "object",
+                                "additionalProperties": false
                               },
                               "spec": {
                                 "properties": {
@@ -571,7 +596,8 @@
                                                           "key",
                                                           "operator"
                                                         ],
-                                                        "type": "object"
+                                                        "type": "object",
+                                                        "additionalProperties": false
                                                       },
                                                       "type": "array",
                                                       "x-kubernetes-list-type": "atomic"
@@ -597,14 +623,16 @@
                                                           "key",
                                                           "operator"
                                                         ],
-                                                        "type": "object"
+                                                        "type": "object",
+                                                        "additionalProperties": false
                                                       },
                                                       "type": "array",
                                                       "x-kubernetes-list-type": "atomic"
                                                     }
                                                   },
                                                   "type": "object",
-                                                  "x-kubernetes-map-type": "atomic"
+                                                  "x-kubernetes-map-type": "atomic",
+                                                  "additionalProperties": false
                                                 },
                                                 "weight": {
                                                   "format": "int32",
@@ -615,7 +643,8 @@
                                                 "preference",
                                                 "weight"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "type": "array",
                                             "x-kubernetes-list-type": "atomic"
@@ -646,7 +675,8 @@
                                                           "key",
                                                           "operator"
                                                         ],
-                                                        "type": "object"
+                                                        "type": "object",
+                                                        "additionalProperties": false
                                                       },
                                                       "type": "array",
                                                       "x-kubernetes-list-type": "atomic"
@@ -672,14 +702,16 @@
                                                           "key",
                                                           "operator"
                                                         ],
-                                                        "type": "object"
+                                                        "type": "object",
+                                                        "additionalProperties": false
                                                       },
                                                       "type": "array",
                                                       "x-kubernetes-list-type": "atomic"
                                                     }
                                                   },
                                                   "type": "object",
-                                                  "x-kubernetes-map-type": "atomic"
+                                                  "x-kubernetes-map-type": "atomic",
+                                                  "additionalProperties": false
                                                 },
                                                 "type": "array",
                                                 "x-kubernetes-list-type": "atomic"
@@ -689,10 +721,12 @@
                                               "nodeSelectorTerms"
                                             ],
                                             "type": "object",
-                                            "x-kubernetes-map-type": "atomic"
+                                            "x-kubernetes-map-type": "atomic",
+                                            "additionalProperties": false
                                           }
                                         },
-                                        "type": "object"
+                                        "type": "object",
+                                        "additionalProperties": false
                                       },
                                       "podAffinity": {
                                         "properties": {
@@ -724,7 +758,8 @@
                                                               "key",
                                                               "operator"
                                                             ],
-                                                            "type": "object"
+                                                            "type": "object",
+                                                            "additionalProperties": false
                                                           },
                                                           "type": "array",
                                                           "x-kubernetes-list-type": "atomic"
@@ -737,7 +772,8 @@
                                                         }
                                                       },
                                                       "type": "object",
-                                                      "x-kubernetes-map-type": "atomic"
+                                                      "x-kubernetes-map-type": "atomic",
+                                                      "additionalProperties": false
                                                     },
                                                     "matchLabelKeys": {
                                                       "items": {
@@ -776,7 +812,8 @@
                                                               "key",
                                                               "operator"
                                                             ],
-                                                            "type": "object"
+                                                            "type": "object",
+                                                            "additionalProperties": false
                                                           },
                                                           "type": "array",
                                                           "x-kubernetes-list-type": "atomic"
@@ -789,7 +826,8 @@
                                                         }
                                                       },
                                                       "type": "object",
-                                                      "x-kubernetes-map-type": "atomic"
+                                                      "x-kubernetes-map-type": "atomic",
+                                                      "additionalProperties": false
                                                     },
                                                     "namespaces": {
                                                       "items": {
@@ -805,7 +843,8 @@
                                                   "required": [
                                                     "topologyKey"
                                                   ],
-                                                  "type": "object"
+                                                  "type": "object",
+                                                  "additionalProperties": false
                                                 },
                                                 "weight": {
                                                   "format": "int32",
@@ -816,7 +855,8 @@
                                                 "podAffinityTerm",
                                                 "weight"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "type": "array",
                                             "x-kubernetes-list-type": "atomic"
@@ -847,7 +887,8 @@
                                                           "key",
                                                           "operator"
                                                         ],
-                                                        "type": "object"
+                                                        "type": "object",
+                                                        "additionalProperties": false
                                                       },
                                                       "type": "array",
                                                       "x-kubernetes-list-type": "atomic"
@@ -860,7 +901,8 @@
                                                     }
                                                   },
                                                   "type": "object",
-                                                  "x-kubernetes-map-type": "atomic"
+                                                  "x-kubernetes-map-type": "atomic",
+                                                  "additionalProperties": false
                                                 },
                                                 "matchLabelKeys": {
                                                   "items": {
@@ -899,7 +941,8 @@
                                                           "key",
                                                           "operator"
                                                         ],
-                                                        "type": "object"
+                                                        "type": "object",
+                                                        "additionalProperties": false
                                                       },
                                                       "type": "array",
                                                       "x-kubernetes-list-type": "atomic"
@@ -912,7 +955,8 @@
                                                     }
                                                   },
                                                   "type": "object",
-                                                  "x-kubernetes-map-type": "atomic"
+                                                  "x-kubernetes-map-type": "atomic",
+                                                  "additionalProperties": false
                                                 },
                                                 "namespaces": {
                                                   "items": {
@@ -928,13 +972,15 @@
                                               "required": [
                                                 "topologyKey"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "type": "array",
                                             "x-kubernetes-list-type": "atomic"
                                           }
                                         },
-                                        "type": "object"
+                                        "type": "object",
+                                        "additionalProperties": false
                                       },
                                       "podAntiAffinity": {
                                         "properties": {
@@ -966,7 +1012,8 @@
                                                               "key",
                                                               "operator"
                                                             ],
-                                                            "type": "object"
+                                                            "type": "object",
+                                                            "additionalProperties": false
                                                           },
                                                           "type": "array",
                                                           "x-kubernetes-list-type": "atomic"
@@ -979,7 +1026,8 @@
                                                         }
                                                       },
                                                       "type": "object",
-                                                      "x-kubernetes-map-type": "atomic"
+                                                      "x-kubernetes-map-type": "atomic",
+                                                      "additionalProperties": false
                                                     },
                                                     "matchLabelKeys": {
                                                       "items": {
@@ -1018,7 +1066,8 @@
                                                               "key",
                                                               "operator"
                                                             ],
-                                                            "type": "object"
+                                                            "type": "object",
+                                                            "additionalProperties": false
                                                           },
                                                           "type": "array",
                                                           "x-kubernetes-list-type": "atomic"
@@ -1031,7 +1080,8 @@
                                                         }
                                                       },
                                                       "type": "object",
-                                                      "x-kubernetes-map-type": "atomic"
+                                                      "x-kubernetes-map-type": "atomic",
+                                                      "additionalProperties": false
                                                     },
                                                     "namespaces": {
                                                       "items": {
@@ -1047,7 +1097,8 @@
                                                   "required": [
                                                     "topologyKey"
                                                   ],
-                                                  "type": "object"
+                                                  "type": "object",
+                                                  "additionalProperties": false
                                                 },
                                                 "weight": {
                                                   "format": "int32",
@@ -1058,7 +1109,8 @@
                                                 "podAffinityTerm",
                                                 "weight"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "type": "array",
                                             "x-kubernetes-list-type": "atomic"
@@ -1089,7 +1141,8 @@
                                                           "key",
                                                           "operator"
                                                         ],
-                                                        "type": "object"
+                                                        "type": "object",
+                                                        "additionalProperties": false
                                                       },
                                                       "type": "array",
                                                       "x-kubernetes-list-type": "atomic"
@@ -1102,7 +1155,8 @@
                                                     }
                                                   },
                                                   "type": "object",
-                                                  "x-kubernetes-map-type": "atomic"
+                                                  "x-kubernetes-map-type": "atomic",
+                                                  "additionalProperties": false
                                                 },
                                                 "matchLabelKeys": {
                                                   "items": {
@@ -1141,7 +1195,8 @@
                                                           "key",
                                                           "operator"
                                                         ],
-                                                        "type": "object"
+                                                        "type": "object",
+                                                        "additionalProperties": false
                                                       },
                                                       "type": "array",
                                                       "x-kubernetes-list-type": "atomic"
@@ -1154,7 +1209,8 @@
                                                     }
                                                   },
                                                   "type": "object",
-                                                  "x-kubernetes-map-type": "atomic"
+                                                  "x-kubernetes-map-type": "atomic",
+                                                  "additionalProperties": false
                                                 },
                                                 "namespaces": {
                                                   "items": {
@@ -1170,16 +1226,19 @@
                                               "required": [
                                                 "topologyKey"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "type": "array",
                                             "x-kubernetes-list-type": "atomic"
                                           }
                                         },
-                                        "type": "object"
+                                        "type": "object",
+                                        "additionalProperties": false
                                       }
                                     },
-                                    "type": "object"
+                                    "type": "object",
+                                    "additionalProperties": false
                                   },
                                   "automountServiceAccountToken": {
                                     "type": "boolean"
@@ -1229,7 +1288,8 @@
                                                       "key"
                                                     ],
                                                     "type": "object",
-                                                    "x-kubernetes-map-type": "atomic"
+                                                    "x-kubernetes-map-type": "atomic",
+                                                    "additionalProperties": false
                                                   },
                                                   "fieldRef": {
                                                     "properties": {
@@ -1244,7 +1304,8 @@
                                                       "fieldPath"
                                                     ],
                                                     "type": "object",
-                                                    "x-kubernetes-map-type": "atomic"
+                                                    "x-kubernetes-map-type": "atomic",
+                                                    "additionalProperties": false
                                                   },
                                                   "fileKeyRef": {
                                                     "properties": {
@@ -1268,7 +1329,8 @@
                                                       "volumeName"
                                                     ],
                                                     "type": "object",
-                                                    "x-kubernetes-map-type": "atomic"
+                                                    "x-kubernetes-map-type": "atomic",
+                                                    "additionalProperties": false
                                                   },
                                                   "resourceFieldRef": {
                                                     "properties": {
@@ -1295,7 +1357,8 @@
                                                       "resource"
                                                     ],
                                                     "type": "object",
-                                                    "x-kubernetes-map-type": "atomic"
+                                                    "x-kubernetes-map-type": "atomic",
+                                                    "additionalProperties": false
                                                   },
                                                   "secretKeyRef": {
                                                     "properties": {
@@ -1314,16 +1377,19 @@
                                                       "key"
                                                     ],
                                                     "type": "object",
-                                                    "x-kubernetes-map-type": "atomic"
+                                                    "x-kubernetes-map-type": "atomic",
+                                                    "additionalProperties": false
                                                   }
                                                 },
-                                                "type": "object"
+                                                "type": "object",
+                                                "additionalProperties": false
                                               }
                                             },
                                             "required": [
                                               "name"
                                             ],
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           },
                                           "type": "array",
                                           "x-kubernetes-list-map-keys": [
@@ -1345,7 +1411,8 @@
                                                   }
                                                 },
                                                 "type": "object",
-                                                "x-kubernetes-map-type": "atomic"
+                                                "x-kubernetes-map-type": "atomic",
+                                                "additionalProperties": false
                                               },
                                               "prefix": {
                                                 "type": "string"
@@ -1361,10 +1428,12 @@
                                                   }
                                                 },
                                                 "type": "object",
-                                                "x-kubernetes-map-type": "atomic"
+                                                "x-kubernetes-map-type": "atomic",
+                                                "additionalProperties": false
                                               }
                                             },
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           },
                                           "type": "array",
                                           "x-kubernetes-list-type": "atomic"
@@ -1389,7 +1458,8 @@
                                                       "x-kubernetes-list-type": "atomic"
                                                     }
                                                   },
-                                                  "type": "object"
+                                                  "type": "object",
+                                                  "additionalProperties": false
                                                 },
                                                 "httpGet": {
                                                   "properties": {
@@ -1410,7 +1480,8 @@
                                                           "name",
                                                           "value"
                                                         ],
-                                                        "type": "object"
+                                                        "type": "object",
+                                                        "additionalProperties": false
                                                       },
                                                       "type": "array",
                                                       "x-kubernetes-list-type": "atomic"
@@ -1436,7 +1507,8 @@
                                                   "required": [
                                                     "port"
                                                   ],
-                                                  "type": "object"
+                                                  "type": "object",
+                                                  "additionalProperties": false
                                                 },
                                                 "sleep": {
                                                   "properties": {
@@ -1448,7 +1520,8 @@
                                                   "required": [
                                                     "seconds"
                                                   ],
-                                                  "type": "object"
+                                                  "type": "object",
+                                                  "additionalProperties": false
                                                 },
                                                 "tcpSocket": {
                                                   "properties": {
@@ -1470,10 +1543,12 @@
                                                   "required": [
                                                     "port"
                                                   ],
-                                                  "type": "object"
+                                                  "type": "object",
+                                                  "additionalProperties": false
                                                 }
                                               },
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "preStop": {
                                               "properties": {
@@ -1487,7 +1562,8 @@
                                                       "x-kubernetes-list-type": "atomic"
                                                     }
                                                   },
-                                                  "type": "object"
+                                                  "type": "object",
+                                                  "additionalProperties": false
                                                 },
                                                 "httpGet": {
                                                   "properties": {
@@ -1508,7 +1584,8 @@
                                                           "name",
                                                           "value"
                                                         ],
-                                                        "type": "object"
+                                                        "type": "object",
+                                                        "additionalProperties": false
                                                       },
                                                       "type": "array",
                                                       "x-kubernetes-list-type": "atomic"
@@ -1534,7 +1611,8 @@
                                                   "required": [
                                                     "port"
                                                   ],
-                                                  "type": "object"
+                                                  "type": "object",
+                                                  "additionalProperties": false
                                                 },
                                                 "sleep": {
                                                   "properties": {
@@ -1546,7 +1624,8 @@
                                                   "required": [
                                                     "seconds"
                                                   ],
-                                                  "type": "object"
+                                                  "type": "object",
+                                                  "additionalProperties": false
                                                 },
                                                 "tcpSocket": {
                                                   "properties": {
@@ -1568,16 +1647,19 @@
                                                   "required": [
                                                     "port"
                                                   ],
-                                                  "type": "object"
+                                                  "type": "object",
+                                                  "additionalProperties": false
                                                 }
                                               },
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "stopSignal": {
                                               "type": "string"
                                             }
                                           },
-                                          "type": "object"
+                                          "type": "object",
+                                          "additionalProperties": false
                                         },
                                         "livenessProbe": {
                                           "properties": {
@@ -1591,7 +1673,8 @@
                                                   "x-kubernetes-list-type": "atomic"
                                                 }
                                               },
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "failureThreshold": {
                                               "format": "int32",
@@ -1611,7 +1694,8 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "httpGet": {
                                               "properties": {
@@ -1632,7 +1716,8 @@
                                                       "name",
                                                       "value"
                                                     ],
-                                                    "type": "object"
+                                                    "type": "object",
+                                                    "additionalProperties": false
                                                   },
                                                   "type": "array",
                                                   "x-kubernetes-list-type": "atomic"
@@ -1658,7 +1743,8 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "initialDelaySeconds": {
                                               "format": "int32",
@@ -1692,7 +1778,8 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "terminationGracePeriodSeconds": {
                                               "format": "int64",
@@ -1703,7 +1790,8 @@
                                               "type": "integer"
                                             }
                                           },
-                                          "type": "object"
+                                          "type": "object",
+                                          "additionalProperties": false
                                         },
                                         "name": {
                                           "type": "string"
@@ -1733,7 +1821,8 @@
                                             "required": [
                                               "containerPort"
                                             ],
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           },
                                           "type": "array",
                                           "x-kubernetes-list-map-keys": [
@@ -1754,7 +1843,8 @@
                                                   "x-kubernetes-list-type": "atomic"
                                                 }
                                               },
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "failureThreshold": {
                                               "format": "int32",
@@ -1774,7 +1864,8 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "httpGet": {
                                               "properties": {
@@ -1795,7 +1886,8 @@
                                                       "name",
                                                       "value"
                                                     ],
-                                                    "type": "object"
+                                                    "type": "object",
+                                                    "additionalProperties": false
                                                   },
                                                   "type": "array",
                                                   "x-kubernetes-list-type": "atomic"
@@ -1821,7 +1913,8 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "initialDelaySeconds": {
                                               "format": "int32",
@@ -1855,7 +1948,8 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "terminationGracePeriodSeconds": {
                                               "format": "int64",
@@ -1866,7 +1960,8 @@
                                               "type": "integer"
                                             }
                                           },
-                                          "type": "object"
+                                          "type": "object",
+                                          "additionalProperties": false
                                         },
                                         "resizePolicy": {
                                           "items": {
@@ -1882,7 +1977,8 @@
                                               "resourceName",
                                               "restartPolicy"
                                             ],
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           },
                                           "type": "array",
                                           "x-kubernetes-list-type": "atomic"
@@ -1902,7 +1998,8 @@
                                                 "required": [
                                                   "name"
                                                 ],
-                                                "type": "object"
+                                                "type": "object",
+                                                "additionalProperties": false
                                               },
                                               "type": "array",
                                               "x-kubernetes-list-map-keys": [
@@ -1917,7 +2014,8 @@
                                               "x-kubernetes-preserve-unknown-fields": true
                                             }
                                           },
-                                          "type": "object"
+                                          "type": "object",
+                                          "additionalProperties": false
                                         },
                                         "restartPolicy": {
                                           "type": "string"
@@ -1945,13 +2043,15 @@
                                                 "required": [
                                                   "operator"
                                                 ],
-                                                "type": "object"
+                                                "type": "object",
+                                                "additionalProperties": false
                                               }
                                             },
                                             "required": [
                                               "action"
                                             ],
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           },
                                           "type": "array",
                                           "x-kubernetes-list-type": "atomic"
@@ -1973,7 +2073,8 @@
                                               "required": [
                                                 "type"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "capabilities": {
                                               "properties": {
@@ -1992,7 +2093,8 @@
                                                   "x-kubernetes-list-type": "atomic"
                                                 }
                                               },
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "privileged": {
                                               "type": "boolean"
@@ -2029,7 +2131,8 @@
                                                   "type": "string"
                                                 }
                                               },
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "seccompProfile": {
                                               "properties": {
@@ -2043,7 +2146,8 @@
                                               "required": [
                                                 "type"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "windowsOptions": {
                                               "properties": {
@@ -2060,10 +2164,12 @@
                                                   "type": "string"
                                                 }
                                               },
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             }
                                           },
-                                          "type": "object"
+                                          "type": "object",
+                                          "additionalProperties": false
                                         },
                                         "startupProbe": {
                                           "properties": {
@@ -2077,7 +2183,8 @@
                                                   "x-kubernetes-list-type": "atomic"
                                                 }
                                               },
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "failureThreshold": {
                                               "format": "int32",
@@ -2097,7 +2204,8 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "httpGet": {
                                               "properties": {
@@ -2118,7 +2226,8 @@
                                                       "name",
                                                       "value"
                                                     ],
-                                                    "type": "object"
+                                                    "type": "object",
+                                                    "additionalProperties": false
                                                   },
                                                   "type": "array",
                                                   "x-kubernetes-list-type": "atomic"
@@ -2144,7 +2253,8 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "initialDelaySeconds": {
                                               "format": "int32",
@@ -2178,7 +2288,8 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "terminationGracePeriodSeconds": {
                                               "format": "int64",
@@ -2189,7 +2300,8 @@
                                               "type": "integer"
                                             }
                                           },
-                                          "type": "object"
+                                          "type": "object",
+                                          "additionalProperties": false
                                         },
                                         "stdin": {
                                           "type": "boolean"
@@ -2220,7 +2332,8 @@
                                               "devicePath",
                                               "name"
                                             ],
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           },
                                           "type": "array",
                                           "x-kubernetes-list-map-keys": [
@@ -2257,7 +2370,8 @@
                                               "mountPath",
                                               "name"
                                             ],
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           },
                                           "type": "array",
                                           "x-kubernetes-list-map-keys": [
@@ -2272,7 +2386,8 @@
                                       "required": [
                                         "name"
                                       ],
-                                      "type": "object"
+                                      "type": "object",
+                                      "additionalProperties": false
                                     },
                                     "type": "array",
                                     "x-kubernetes-list-map-keys": [
@@ -2299,7 +2414,8 @@
                                               "type": "string"
                                             }
                                           },
-                                          "type": "object"
+                                          "type": "object",
+                                          "additionalProperties": false
                                         },
                                         "type": "array",
                                         "x-kubernetes-list-type": "atomic"
@@ -2312,7 +2428,8 @@
                                         "x-kubernetes-list-type": "atomic"
                                       }
                                     },
-                                    "type": "object"
+                                    "type": "object",
+                                    "additionalProperties": false
                                   },
                                   "dnsPolicy": {
                                     "type": "string"
@@ -2365,7 +2482,8 @@
                                                       "key"
                                                     ],
                                                     "type": "object",
-                                                    "x-kubernetes-map-type": "atomic"
+                                                    "x-kubernetes-map-type": "atomic",
+                                                    "additionalProperties": false
                                                   },
                                                   "fieldRef": {
                                                     "properties": {
@@ -2380,7 +2498,8 @@
                                                       "fieldPath"
                                                     ],
                                                     "type": "object",
-                                                    "x-kubernetes-map-type": "atomic"
+                                                    "x-kubernetes-map-type": "atomic",
+                                                    "additionalProperties": false
                                                   },
                                                   "fileKeyRef": {
                                                     "properties": {
@@ -2404,7 +2523,8 @@
                                                       "volumeName"
                                                     ],
                                                     "type": "object",
-                                                    "x-kubernetes-map-type": "atomic"
+                                                    "x-kubernetes-map-type": "atomic",
+                                                    "additionalProperties": false
                                                   },
                                                   "resourceFieldRef": {
                                                     "properties": {
@@ -2431,7 +2551,8 @@
                                                       "resource"
                                                     ],
                                                     "type": "object",
-                                                    "x-kubernetes-map-type": "atomic"
+                                                    "x-kubernetes-map-type": "atomic",
+                                                    "additionalProperties": false
                                                   },
                                                   "secretKeyRef": {
                                                     "properties": {
@@ -2450,16 +2571,19 @@
                                                       "key"
                                                     ],
                                                     "type": "object",
-                                                    "x-kubernetes-map-type": "atomic"
+                                                    "x-kubernetes-map-type": "atomic",
+                                                    "additionalProperties": false
                                                   }
                                                 },
-                                                "type": "object"
+                                                "type": "object",
+                                                "additionalProperties": false
                                               }
                                             },
                                             "required": [
                                               "name"
                                             ],
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           },
                                           "type": "array",
                                           "x-kubernetes-list-map-keys": [
@@ -2481,7 +2605,8 @@
                                                   }
                                                 },
                                                 "type": "object",
-                                                "x-kubernetes-map-type": "atomic"
+                                                "x-kubernetes-map-type": "atomic",
+                                                "additionalProperties": false
                                               },
                                               "prefix": {
                                                 "type": "string"
@@ -2497,10 +2622,12 @@
                                                   }
                                                 },
                                                 "type": "object",
-                                                "x-kubernetes-map-type": "atomic"
+                                                "x-kubernetes-map-type": "atomic",
+                                                "additionalProperties": false
                                               }
                                             },
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           },
                                           "type": "array",
                                           "x-kubernetes-list-type": "atomic"
@@ -2525,7 +2652,8 @@
                                                       "x-kubernetes-list-type": "atomic"
                                                     }
                                                   },
-                                                  "type": "object"
+                                                  "type": "object",
+                                                  "additionalProperties": false
                                                 },
                                                 "httpGet": {
                                                   "properties": {
@@ -2546,7 +2674,8 @@
                                                           "name",
                                                           "value"
                                                         ],
-                                                        "type": "object"
+                                                        "type": "object",
+                                                        "additionalProperties": false
                                                       },
                                                       "type": "array",
                                                       "x-kubernetes-list-type": "atomic"
@@ -2572,7 +2701,8 @@
                                                   "required": [
                                                     "port"
                                                   ],
-                                                  "type": "object"
+                                                  "type": "object",
+                                                  "additionalProperties": false
                                                 },
                                                 "sleep": {
                                                   "properties": {
@@ -2584,7 +2714,8 @@
                                                   "required": [
                                                     "seconds"
                                                   ],
-                                                  "type": "object"
+                                                  "type": "object",
+                                                  "additionalProperties": false
                                                 },
                                                 "tcpSocket": {
                                                   "properties": {
@@ -2606,10 +2737,12 @@
                                                   "required": [
                                                     "port"
                                                   ],
-                                                  "type": "object"
+                                                  "type": "object",
+                                                  "additionalProperties": false
                                                 }
                                               },
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "preStop": {
                                               "properties": {
@@ -2623,7 +2756,8 @@
                                                       "x-kubernetes-list-type": "atomic"
                                                     }
                                                   },
-                                                  "type": "object"
+                                                  "type": "object",
+                                                  "additionalProperties": false
                                                 },
                                                 "httpGet": {
                                                   "properties": {
@@ -2644,7 +2778,8 @@
                                                           "name",
                                                           "value"
                                                         ],
-                                                        "type": "object"
+                                                        "type": "object",
+                                                        "additionalProperties": false
                                                       },
                                                       "type": "array",
                                                       "x-kubernetes-list-type": "atomic"
@@ -2670,7 +2805,8 @@
                                                   "required": [
                                                     "port"
                                                   ],
-                                                  "type": "object"
+                                                  "type": "object",
+                                                  "additionalProperties": false
                                                 },
                                                 "sleep": {
                                                   "properties": {
@@ -2682,7 +2818,8 @@
                                                   "required": [
                                                     "seconds"
                                                   ],
-                                                  "type": "object"
+                                                  "type": "object",
+                                                  "additionalProperties": false
                                                 },
                                                 "tcpSocket": {
                                                   "properties": {
@@ -2704,16 +2841,19 @@
                                                   "required": [
                                                     "port"
                                                   ],
-                                                  "type": "object"
+                                                  "type": "object",
+                                                  "additionalProperties": false
                                                 }
                                               },
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "stopSignal": {
                                               "type": "string"
                                             }
                                           },
-                                          "type": "object"
+                                          "type": "object",
+                                          "additionalProperties": false
                                         },
                                         "livenessProbe": {
                                           "properties": {
@@ -2727,7 +2867,8 @@
                                                   "x-kubernetes-list-type": "atomic"
                                                 }
                                               },
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "failureThreshold": {
                                               "format": "int32",
@@ -2747,7 +2888,8 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "httpGet": {
                                               "properties": {
@@ -2768,7 +2910,8 @@
                                                       "name",
                                                       "value"
                                                     ],
-                                                    "type": "object"
+                                                    "type": "object",
+                                                    "additionalProperties": false
                                                   },
                                                   "type": "array",
                                                   "x-kubernetes-list-type": "atomic"
@@ -2794,7 +2937,8 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "initialDelaySeconds": {
                                               "format": "int32",
@@ -2828,7 +2972,8 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "terminationGracePeriodSeconds": {
                                               "format": "int64",
@@ -2839,7 +2984,8 @@
                                               "type": "integer"
                                             }
                                           },
-                                          "type": "object"
+                                          "type": "object",
+                                          "additionalProperties": false
                                         },
                                         "name": {
                                           "type": "string"
@@ -2869,7 +3015,8 @@
                                             "required": [
                                               "containerPort"
                                             ],
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           },
                                           "type": "array",
                                           "x-kubernetes-list-map-keys": [
@@ -2890,7 +3037,8 @@
                                                   "x-kubernetes-list-type": "atomic"
                                                 }
                                               },
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "failureThreshold": {
                                               "format": "int32",
@@ -2910,7 +3058,8 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "httpGet": {
                                               "properties": {
@@ -2931,7 +3080,8 @@
                                                       "name",
                                                       "value"
                                                     ],
-                                                    "type": "object"
+                                                    "type": "object",
+                                                    "additionalProperties": false
                                                   },
                                                   "type": "array",
                                                   "x-kubernetes-list-type": "atomic"
@@ -2957,7 +3107,8 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "initialDelaySeconds": {
                                               "format": "int32",
@@ -2991,7 +3142,8 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "terminationGracePeriodSeconds": {
                                               "format": "int64",
@@ -3002,7 +3154,8 @@
                                               "type": "integer"
                                             }
                                           },
-                                          "type": "object"
+                                          "type": "object",
+                                          "additionalProperties": false
                                         },
                                         "resizePolicy": {
                                           "items": {
@@ -3018,7 +3171,8 @@
                                               "resourceName",
                                               "restartPolicy"
                                             ],
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           },
                                           "type": "array",
                                           "x-kubernetes-list-type": "atomic"
@@ -3038,7 +3192,8 @@
                                                 "required": [
                                                   "name"
                                                 ],
-                                                "type": "object"
+                                                "type": "object",
+                                                "additionalProperties": false
                                               },
                                               "type": "array",
                                               "x-kubernetes-list-map-keys": [
@@ -3053,7 +3208,8 @@
                                               "x-kubernetes-preserve-unknown-fields": true
                                             }
                                           },
-                                          "type": "object"
+                                          "type": "object",
+                                          "additionalProperties": false
                                         },
                                         "restartPolicy": {
                                           "type": "string"
@@ -3081,13 +3237,15 @@
                                                 "required": [
                                                   "operator"
                                                 ],
-                                                "type": "object"
+                                                "type": "object",
+                                                "additionalProperties": false
                                               }
                                             },
                                             "required": [
                                               "action"
                                             ],
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           },
                                           "type": "array",
                                           "x-kubernetes-list-type": "atomic"
@@ -3109,7 +3267,8 @@
                                               "required": [
                                                 "type"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "capabilities": {
                                               "properties": {
@@ -3128,7 +3287,8 @@
                                                   "x-kubernetes-list-type": "atomic"
                                                 }
                                               },
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "privileged": {
                                               "type": "boolean"
@@ -3165,7 +3325,8 @@
                                                   "type": "string"
                                                 }
                                               },
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "seccompProfile": {
                                               "properties": {
@@ -3179,7 +3340,8 @@
                                               "required": [
                                                 "type"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "windowsOptions": {
                                               "properties": {
@@ -3196,10 +3358,12 @@
                                                   "type": "string"
                                                 }
                                               },
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             }
                                           },
-                                          "type": "object"
+                                          "type": "object",
+                                          "additionalProperties": false
                                         },
                                         "startupProbe": {
                                           "properties": {
@@ -3213,7 +3377,8 @@
                                                   "x-kubernetes-list-type": "atomic"
                                                 }
                                               },
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "failureThreshold": {
                                               "format": "int32",
@@ -3233,7 +3398,8 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "httpGet": {
                                               "properties": {
@@ -3254,7 +3420,8 @@
                                                       "name",
                                                       "value"
                                                     ],
-                                                    "type": "object"
+                                                    "type": "object",
+                                                    "additionalProperties": false
                                                   },
                                                   "type": "array",
                                                   "x-kubernetes-list-type": "atomic"
@@ -3280,7 +3447,8 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "initialDelaySeconds": {
                                               "format": "int32",
@@ -3314,7 +3482,8 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "terminationGracePeriodSeconds": {
                                               "format": "int64",
@@ -3325,7 +3494,8 @@
                                               "type": "integer"
                                             }
                                           },
-                                          "type": "object"
+                                          "type": "object",
+                                          "additionalProperties": false
                                         },
                                         "stdin": {
                                           "type": "boolean"
@@ -3359,7 +3529,8 @@
                                               "devicePath",
                                               "name"
                                             ],
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           },
                                           "type": "array",
                                           "x-kubernetes-list-map-keys": [
@@ -3396,7 +3567,8 @@
                                               "mountPath",
                                               "name"
                                             ],
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           },
                                           "type": "array",
                                           "x-kubernetes-list-map-keys": [
@@ -3411,7 +3583,8 @@
                                       "required": [
                                         "name"
                                       ],
-                                      "type": "object"
+                                      "type": "object",
+                                      "additionalProperties": false
                                     },
                                     "type": "array",
                                     "x-kubernetes-list-map-keys": [
@@ -3436,7 +3609,8 @@
                                       "required": [
                                         "ip"
                                       ],
-                                      "type": "object"
+                                      "type": "object",
+                                      "additionalProperties": false
                                     },
                                     "type": "array",
                                     "x-kubernetes-list-map-keys": [
@@ -3471,7 +3645,8 @@
                                         }
                                       },
                                       "type": "object",
-                                      "x-kubernetes-map-type": "atomic"
+                                      "x-kubernetes-map-type": "atomic",
+                                      "additionalProperties": false
                                     },
                                     "type": "array",
                                     "x-kubernetes-list-map-keys": [
@@ -3524,7 +3699,8 @@
                                                       "key"
                                                     ],
                                                     "type": "object",
-                                                    "x-kubernetes-map-type": "atomic"
+                                                    "x-kubernetes-map-type": "atomic",
+                                                    "additionalProperties": false
                                                   },
                                                   "fieldRef": {
                                                     "properties": {
@@ -3539,7 +3715,8 @@
                                                       "fieldPath"
                                                     ],
                                                     "type": "object",
-                                                    "x-kubernetes-map-type": "atomic"
+                                                    "x-kubernetes-map-type": "atomic",
+                                                    "additionalProperties": false
                                                   },
                                                   "fileKeyRef": {
                                                     "properties": {
@@ -3563,7 +3740,8 @@
                                                       "volumeName"
                                                     ],
                                                     "type": "object",
-                                                    "x-kubernetes-map-type": "atomic"
+                                                    "x-kubernetes-map-type": "atomic",
+                                                    "additionalProperties": false
                                                   },
                                                   "resourceFieldRef": {
                                                     "properties": {
@@ -3590,7 +3768,8 @@
                                                       "resource"
                                                     ],
                                                     "type": "object",
-                                                    "x-kubernetes-map-type": "atomic"
+                                                    "x-kubernetes-map-type": "atomic",
+                                                    "additionalProperties": false
                                                   },
                                                   "secretKeyRef": {
                                                     "properties": {
@@ -3609,16 +3788,19 @@
                                                       "key"
                                                     ],
                                                     "type": "object",
-                                                    "x-kubernetes-map-type": "atomic"
+                                                    "x-kubernetes-map-type": "atomic",
+                                                    "additionalProperties": false
                                                   }
                                                 },
-                                                "type": "object"
+                                                "type": "object",
+                                                "additionalProperties": false
                                               }
                                             },
                                             "required": [
                                               "name"
                                             ],
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           },
                                           "type": "array",
                                           "x-kubernetes-list-map-keys": [
@@ -3640,7 +3822,8 @@
                                                   }
                                                 },
                                                 "type": "object",
-                                                "x-kubernetes-map-type": "atomic"
+                                                "x-kubernetes-map-type": "atomic",
+                                                "additionalProperties": false
                                               },
                                               "prefix": {
                                                 "type": "string"
@@ -3656,10 +3839,12 @@
                                                   }
                                                 },
                                                 "type": "object",
-                                                "x-kubernetes-map-type": "atomic"
+                                                "x-kubernetes-map-type": "atomic",
+                                                "additionalProperties": false
                                               }
                                             },
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           },
                                           "type": "array",
                                           "x-kubernetes-list-type": "atomic"
@@ -3684,7 +3869,8 @@
                                                       "x-kubernetes-list-type": "atomic"
                                                     }
                                                   },
-                                                  "type": "object"
+                                                  "type": "object",
+                                                  "additionalProperties": false
                                                 },
                                                 "httpGet": {
                                                   "properties": {
@@ -3705,7 +3891,8 @@
                                                           "name",
                                                           "value"
                                                         ],
-                                                        "type": "object"
+                                                        "type": "object",
+                                                        "additionalProperties": false
                                                       },
                                                       "type": "array",
                                                       "x-kubernetes-list-type": "atomic"
@@ -3731,7 +3918,8 @@
                                                   "required": [
                                                     "port"
                                                   ],
-                                                  "type": "object"
+                                                  "type": "object",
+                                                  "additionalProperties": false
                                                 },
                                                 "sleep": {
                                                   "properties": {
@@ -3743,7 +3931,8 @@
                                                   "required": [
                                                     "seconds"
                                                   ],
-                                                  "type": "object"
+                                                  "type": "object",
+                                                  "additionalProperties": false
                                                 },
                                                 "tcpSocket": {
                                                   "properties": {
@@ -3765,10 +3954,12 @@
                                                   "required": [
                                                     "port"
                                                   ],
-                                                  "type": "object"
+                                                  "type": "object",
+                                                  "additionalProperties": false
                                                 }
                                               },
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "preStop": {
                                               "properties": {
@@ -3782,7 +3973,8 @@
                                                       "x-kubernetes-list-type": "atomic"
                                                     }
                                                   },
-                                                  "type": "object"
+                                                  "type": "object",
+                                                  "additionalProperties": false
                                                 },
                                                 "httpGet": {
                                                   "properties": {
@@ -3803,7 +3995,8 @@
                                                           "name",
                                                           "value"
                                                         ],
-                                                        "type": "object"
+                                                        "type": "object",
+                                                        "additionalProperties": false
                                                       },
                                                       "type": "array",
                                                       "x-kubernetes-list-type": "atomic"
@@ -3829,7 +4022,8 @@
                                                   "required": [
                                                     "port"
                                                   ],
-                                                  "type": "object"
+                                                  "type": "object",
+                                                  "additionalProperties": false
                                                 },
                                                 "sleep": {
                                                   "properties": {
@@ -3841,7 +4035,8 @@
                                                   "required": [
                                                     "seconds"
                                                   ],
-                                                  "type": "object"
+                                                  "type": "object",
+                                                  "additionalProperties": false
                                                 },
                                                 "tcpSocket": {
                                                   "properties": {
@@ -3863,16 +4058,19 @@
                                                   "required": [
                                                     "port"
                                                   ],
-                                                  "type": "object"
+                                                  "type": "object",
+                                                  "additionalProperties": false
                                                 }
                                               },
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "stopSignal": {
                                               "type": "string"
                                             }
                                           },
-                                          "type": "object"
+                                          "type": "object",
+                                          "additionalProperties": false
                                         },
                                         "livenessProbe": {
                                           "properties": {
@@ -3886,7 +4084,8 @@
                                                   "x-kubernetes-list-type": "atomic"
                                                 }
                                               },
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "failureThreshold": {
                                               "format": "int32",
@@ -3906,7 +4105,8 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "httpGet": {
                                               "properties": {
@@ -3927,7 +4127,8 @@
                                                       "name",
                                                       "value"
                                                     ],
-                                                    "type": "object"
+                                                    "type": "object",
+                                                    "additionalProperties": false
                                                   },
                                                   "type": "array",
                                                   "x-kubernetes-list-type": "atomic"
@@ -3953,7 +4154,8 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "initialDelaySeconds": {
                                               "format": "int32",
@@ -3987,7 +4189,8 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "terminationGracePeriodSeconds": {
                                               "format": "int64",
@@ -3998,7 +4201,8 @@
                                               "type": "integer"
                                             }
                                           },
-                                          "type": "object"
+                                          "type": "object",
+                                          "additionalProperties": false
                                         },
                                         "name": {
                                           "type": "string"
@@ -4028,7 +4232,8 @@
                                             "required": [
                                               "containerPort"
                                             ],
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           },
                                           "type": "array",
                                           "x-kubernetes-list-map-keys": [
@@ -4049,7 +4254,8 @@
                                                   "x-kubernetes-list-type": "atomic"
                                                 }
                                               },
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "failureThreshold": {
                                               "format": "int32",
@@ -4069,7 +4275,8 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "httpGet": {
                                               "properties": {
@@ -4090,7 +4297,8 @@
                                                       "name",
                                                       "value"
                                                     ],
-                                                    "type": "object"
+                                                    "type": "object",
+                                                    "additionalProperties": false
                                                   },
                                                   "type": "array",
                                                   "x-kubernetes-list-type": "atomic"
@@ -4116,7 +4324,8 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "initialDelaySeconds": {
                                               "format": "int32",
@@ -4150,7 +4359,8 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "terminationGracePeriodSeconds": {
                                               "format": "int64",
@@ -4161,7 +4371,8 @@
                                               "type": "integer"
                                             }
                                           },
-                                          "type": "object"
+                                          "type": "object",
+                                          "additionalProperties": false
                                         },
                                         "resizePolicy": {
                                           "items": {
@@ -4177,7 +4388,8 @@
                                               "resourceName",
                                               "restartPolicy"
                                             ],
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           },
                                           "type": "array",
                                           "x-kubernetes-list-type": "atomic"
@@ -4197,7 +4409,8 @@
                                                 "required": [
                                                   "name"
                                                 ],
-                                                "type": "object"
+                                                "type": "object",
+                                                "additionalProperties": false
                                               },
                                               "type": "array",
                                               "x-kubernetes-list-map-keys": [
@@ -4212,7 +4425,8 @@
                                               "x-kubernetes-preserve-unknown-fields": true
                                             }
                                           },
-                                          "type": "object"
+                                          "type": "object",
+                                          "additionalProperties": false
                                         },
                                         "restartPolicy": {
                                           "type": "string"
@@ -4240,13 +4454,15 @@
                                                 "required": [
                                                   "operator"
                                                 ],
-                                                "type": "object"
+                                                "type": "object",
+                                                "additionalProperties": false
                                               }
                                             },
                                             "required": [
                                               "action"
                                             ],
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           },
                                           "type": "array",
                                           "x-kubernetes-list-type": "atomic"
@@ -4268,7 +4484,8 @@
                                               "required": [
                                                 "type"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "capabilities": {
                                               "properties": {
@@ -4287,7 +4504,8 @@
                                                   "x-kubernetes-list-type": "atomic"
                                                 }
                                               },
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "privileged": {
                                               "type": "boolean"
@@ -4324,7 +4542,8 @@
                                                   "type": "string"
                                                 }
                                               },
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "seccompProfile": {
                                               "properties": {
@@ -4338,7 +4557,8 @@
                                               "required": [
                                                 "type"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "windowsOptions": {
                                               "properties": {
@@ -4355,10 +4575,12 @@
                                                   "type": "string"
                                                 }
                                               },
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             }
                                           },
-                                          "type": "object"
+                                          "type": "object",
+                                          "additionalProperties": false
                                         },
                                         "startupProbe": {
                                           "properties": {
@@ -4372,7 +4594,8 @@
                                                   "x-kubernetes-list-type": "atomic"
                                                 }
                                               },
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "failureThreshold": {
                                               "format": "int32",
@@ -4392,7 +4615,8 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "httpGet": {
                                               "properties": {
@@ -4413,7 +4637,8 @@
                                                       "name",
                                                       "value"
                                                     ],
-                                                    "type": "object"
+                                                    "type": "object",
+                                                    "additionalProperties": false
                                                   },
                                                   "type": "array",
                                                   "x-kubernetes-list-type": "atomic"
@@ -4439,7 +4664,8 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "initialDelaySeconds": {
                                               "format": "int32",
@@ -4473,7 +4699,8 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "terminationGracePeriodSeconds": {
                                               "format": "int64",
@@ -4484,7 +4711,8 @@
                                               "type": "integer"
                                             }
                                           },
-                                          "type": "object"
+                                          "type": "object",
+                                          "additionalProperties": false
                                         },
                                         "stdin": {
                                           "type": "boolean"
@@ -4515,7 +4743,8 @@
                                               "devicePath",
                                               "name"
                                             ],
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           },
                                           "type": "array",
                                           "x-kubernetes-list-map-keys": [
@@ -4552,7 +4781,8 @@
                                               "mountPath",
                                               "name"
                                             ],
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           },
                                           "type": "array",
                                           "x-kubernetes-list-map-keys": [
@@ -4567,7 +4797,8 @@
                                       "required": [
                                         "name"
                                       ],
-                                      "type": "object"
+                                      "type": "object",
+                                      "additionalProperties": false
                                     },
                                     "type": "array",
                                     "x-kubernetes-list-map-keys": [
@@ -4594,7 +4825,8 @@
                                     "required": [
                                       "name"
                                     ],
-                                    "type": "object"
+                                    "type": "object",
+                                    "additionalProperties": false
                                   },
                                   "overhead": {
                                     "additionalProperties": {
@@ -4631,7 +4863,8 @@
                                       "required": [
                                         "conditionType"
                                       ],
-                                      "type": "object"
+                                      "type": "object",
+                                      "additionalProperties": false
                                     },
                                     "type": "array",
                                     "x-kubernetes-list-type": "atomic"
@@ -4652,7 +4885,8 @@
                                       "required": [
                                         "name"
                                       ],
-                                      "type": "object"
+                                      "type": "object",
+                                      "additionalProperties": false
                                     },
                                     "type": "array",
                                     "x-kubernetes-list-map-keys": [
@@ -4675,7 +4909,8 @@
                                           "required": [
                                             "name"
                                           ],
-                                          "type": "object"
+                                          "type": "object",
+                                          "additionalProperties": false
                                         },
                                         "type": "array",
                                         "x-kubernetes-list-map-keys": [
@@ -4714,7 +4949,8 @@
                                         "type": "object"
                                       }
                                     },
-                                    "type": "object"
+                                    "type": "object",
+                                    "additionalProperties": false
                                   },
                                   "restartPolicy": {
                                     "type": "string"
@@ -4735,7 +4971,8 @@
                                       "required": [
                                         "name"
                                       ],
-                                      "type": "object"
+                                      "type": "object",
+                                      "additionalProperties": false
                                     },
                                     "type": "array",
                                     "x-kubernetes-list-map-keys": [
@@ -4757,7 +4994,8 @@
                                         "required": [
                                           "type"
                                         ],
-                                        "type": "object"
+                                        "type": "object",
+                                        "additionalProperties": false
                                       },
                                       "fsGroup": {
                                         "format": "int64",
@@ -4795,7 +5033,8 @@
                                             "type": "string"
                                           }
                                         },
-                                        "type": "object"
+                                        "type": "object",
+                                        "additionalProperties": false
                                       },
                                       "seccompProfile": {
                                         "properties": {
@@ -4809,7 +5048,8 @@
                                         "required": [
                                           "type"
                                         ],
-                                        "type": "object"
+                                        "type": "object",
+                                        "additionalProperties": false
                                       },
                                       "supplementalGroups": {
                                         "items": {
@@ -4836,7 +5076,8 @@
                                             "name",
                                             "value"
                                           ],
-                                          "type": "object"
+                                          "type": "object",
+                                          "additionalProperties": false
                                         },
                                         "type": "array",
                                         "x-kubernetes-list-type": "atomic"
@@ -4856,10 +5097,12 @@
                                             "type": "string"
                                           }
                                         },
-                                        "type": "object"
+                                        "type": "object",
+                                        "additionalProperties": false
                                       }
                                     },
-                                    "type": "object"
+                                    "type": "object",
+                                    "additionalProperties": false
                                   },
                                   "serviceAccount": {
                                     "type": "string"
@@ -4900,7 +5143,8 @@
                                           "type": "string"
                                         }
                                       },
-                                      "type": "object"
+                                      "type": "object",
+                                      "additionalProperties": false
                                     },
                                     "type": "array",
                                     "x-kubernetes-list-type": "atomic"
@@ -4931,7 +5175,8 @@
                                                   "key",
                                                   "operator"
                                                 ],
-                                                "type": "object"
+                                                "type": "object",
+                                                "additionalProperties": false
                                               },
                                               "type": "array",
                                               "x-kubernetes-list-type": "atomic"
@@ -4944,7 +5189,8 @@
                                             }
                                           },
                                           "type": "object",
-                                          "x-kubernetes-map-type": "atomic"
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
                                         },
                                         "matchLabelKeys": {
                                           "items": {
@@ -4979,7 +5225,8 @@
                                         "topologyKey",
                                         "whenUnsatisfiable"
                                       ],
-                                      "type": "object"
+                                      "type": "object",
+                                      "additionalProperties": false
                                     },
                                     "type": "array",
                                     "x-kubernetes-list-map-keys": [
@@ -4995,10 +5242,12 @@
                                 "required": [
                                   "containers"
                                 ],
-                                "type": "object"
+                                "type": "object",
+                                "additionalProperties": false
                               }
                             },
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "ttlSecondsAfterFinished": {
                             "format": "int32",
@@ -5008,13 +5257,15 @@
                         "required": [
                           "template"
                         ],
-                        "type": "object"
+                        "type": "object",
+                        "additionalProperties": false
                       }
                     },
                     "required": [
                       "spec"
                     ],
-                    "type": "object"
+                    "type": "object",
+                    "additionalProperties": false
                   },
                   "kayenta": {
                     "properties": {
@@ -5063,7 +5314,8 @@
                                 "scope",
                                 "step"
                               ],
-                              "type": "object"
+                              "type": "object",
+                              "additionalProperties": false
                             },
                             "experimentScope": {
                               "properties": {
@@ -5089,7 +5341,8 @@
                                 "scope",
                                 "step"
                               ],
-                              "type": "object"
+                              "type": "object",
+                              "additionalProperties": false
                             },
                             "name": {
                               "type": "string"
@@ -5100,7 +5353,8 @@
                             "experimentScope",
                             "name"
                           ],
-                          "type": "object"
+                          "type": "object",
+                          "additionalProperties": false
                         },
                         "type": "array"
                       },
@@ -5122,7 +5376,8 @@
                           "marginal",
                           "pass"
                         ],
-                        "type": "object"
+                        "type": "object",
+                        "additionalProperties": false
                       }
                     },
                     "required": [
@@ -5135,7 +5390,8 @@
                       "storageAccountName",
                       "threshold"
                     ],
-                    "type": "object"
+                    "type": "object",
+                    "additionalProperties": false
                   },
                   "newRelic": {
                     "properties": {
@@ -5153,7 +5409,8 @@
                     "required": [
                       "query"
                     ],
-                    "type": "object"
+                    "type": "object",
+                    "additionalProperties": false
                   },
                   "plugin": {
                     "type": "object",
@@ -5184,7 +5441,8 @@
                                 "type": "string"
                               }
                             },
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "sigv4": {
                             "properties": {
@@ -5198,10 +5456,12 @@
                                 "type": "string"
                               }
                             },
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           }
                         },
-                        "type": "object"
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "headers": {
                         "items": {
@@ -5217,7 +5477,8 @@
                             "key",
                             "value"
                           ],
-                          "type": "object"
+                          "type": "object",
+                          "additionalProperties": false
                         },
                         "type": "array"
                       },
@@ -5239,14 +5500,16 @@
                             "type": "string"
                           }
                         },
-                        "type": "object"
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "timeout": {
                         "format": "int64",
                         "type": "integer"
                       }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "additionalProperties": false
                   },
                   "skywalking": {
                     "properties": {
@@ -5260,7 +5523,8 @@
                         "type": "string"
                       }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "additionalProperties": false
                   },
                   "wavefront": {
                     "properties": {
@@ -5271,7 +5535,8 @@
                         "type": "string"
                       }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "additionalProperties": false
                   },
                   "web": {
                     "properties": {
@@ -5295,7 +5560,8 @@
                                 "type": "string"
                               }
                             },
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "sigv4": {
                             "properties": {
@@ -5309,10 +5575,12 @@
                                 "type": "string"
                               }
                             },
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           }
                         },
-                        "type": "object"
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "body": {
                         "type": "string"
@@ -5331,7 +5599,8 @@
                             "key",
                             "value"
                           ],
-                          "type": "object"
+                          "type": "object",
+                          "additionalProperties": false
                         },
                         "type": "array"
                       },
@@ -5359,10 +5628,12 @@
                     "required": [
                       "url"
                     ],
-                    "type": "object"
+                    "type": "object",
+                    "additionalProperties": false
                   }
                 },
-                "type": "object"
+                "type": "object",
+                "additionalProperties": false
               },
               "successCondition": {
                 "type": "string"
@@ -5372,7 +5643,8 @@
               "name",
               "provider"
             ],
-            "type": "object"
+            "type": "object",
+            "additionalProperties": false
           },
           "type": "array"
         },
@@ -5386,12 +5658,14 @@
                 "type": "string"
               }
             },
-            "type": "object"
+            "type": "object",
+            "additionalProperties": false
           },
           "type": "array"
         }
       },
-      "type": "object"
+      "type": "object",
+      "additionalProperties": false
     }
   },
   "required": [

--- a/argoproj.io/clusteranalysistemplate_v1alpha1.json
+++ b/argoproj.io/clusteranalysistemplate_v1alpha1.json
@@ -31,8 +31,7 @@
                     "required": [
                       "fieldPath"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "secretKeyRef": {
                     "properties": {
@@ -47,19 +46,16 @@
                       "key",
                       "name"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   }
                 },
-                "type": "object",
-                "additionalProperties": false
+                "type": "object"
               }
             },
             "required": [
               "name"
             ],
-            "type": "object",
-            "additionalProperties": false
+            "type": "object"
           },
           "type": "array"
         },
@@ -73,8 +69,7 @@
             "required": [
               "metricName"
             ],
-            "type": "object",
-            "additionalProperties": false
+            "type": "object"
           },
           "type": "array"
         },
@@ -93,8 +88,7 @@
               "limit",
               "metricName"
             ],
-            "type": "object",
-            "additionalProperties": false
+            "type": "object"
           },
           "type": "array"
         },
@@ -102,6 +96,17 @@
           "items": {
             "properties": {
               "consecutiveErrorLimit": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ],
+                "x-kubernetes-int-or-string": true
+              },
+              "consecutiveSuccessLimit": {
                 "anyOf": [
                   {
                     "type": "integer"
@@ -190,8 +195,7 @@
                                             "type": "string"
                                           }
                                         },
-                                        "type": "object",
-                                        "additionalProperties": false
+                                        "type": "object"
                                       },
                                       "type": "array"
                                     },
@@ -202,8 +206,7 @@
                                       "type": "string"
                                     }
                                   },
-                                  "type": "object",
-                                  "additionalProperties": false
+                                  "type": "object"
                                 },
                                 "period": {
                                   "anyOf": [
@@ -223,8 +226,7 @@
                                   "type": "string"
                                 }
                               },
-                              "type": "object",
-                              "additionalProperties": false
+                              "type": "object"
                             },
                             "period": {
                               "anyOf": [
@@ -241,8 +243,7 @@
                               "type": "boolean"
                             }
                           },
-                          "type": "object",
-                          "additionalProperties": false
+                          "type": "object"
                         },
                         "type": "array"
                       }
@@ -250,8 +251,7 @@
                     "required": [
                       "metricDataQueries"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "datadog": {
                     "properties": {
@@ -302,12 +302,10 @@
                             "type": "boolean"
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "graphite": {
                     "properties": {
@@ -318,8 +316,7 @@
                         "type": "string"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "influxdb": {
                     "properties": {
@@ -330,8 +327,7 @@
                         "type": "string"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "job": {
                     "properties": {
@@ -350,8 +346,7 @@
                             "type": "object"
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "spec": {
                         "properties": {
@@ -373,6 +368,9 @@
                           "completions": {
                             "format": "int32",
                             "type": "integer"
+                          },
+                          "managedBy": {
+                            "type": "string"
                           },
                           "manualSelector": {
                             "type": "boolean"
@@ -414,8 +412,7 @@
                                         "operator",
                                         "values"
                                       ],
-                                      "type": "object",
-                                      "additionalProperties": false
+                                      "type": "object"
                                     },
                                     "onPodConditions": {
                                       "items": {
@@ -431,8 +428,7 @@
                                           "status",
                                           "type"
                                         ],
-                                        "type": "object",
-                                        "additionalProperties": false
+                                        "type": "object"
                                       },
                                       "type": "array",
                                       "x-kubernetes-list-type": "atomic"
@@ -441,8 +437,7 @@
                                   "required": [
                                     "action"
                                   ],
-                                  "type": "object",
-                                  "additionalProperties": false
+                                  "type": "object"
                                 },
                                 "type": "array",
                                 "x-kubernetes-list-type": "atomic"
@@ -451,8 +446,7 @@
                             "required": [
                               "rules"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "podReplacementPolicy": {
                             "type": "string"
@@ -472,17 +466,18 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "required": [
                                     "key",
                                     "operator"
                                   ],
-                                  "type": "object",
-                                  "additionalProperties": false
+                                  "type": "object"
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchLabels": {
                                 "additionalProperties": {
@@ -492,8 +487,31 @@
                               }
                             },
                             "type": "object",
-                            "x-kubernetes-map-type": "atomic",
-                            "additionalProperties": false
+                            "x-kubernetes-map-type": "atomic"
+                          },
+                          "successPolicy": {
+                            "properties": {
+                              "rules": {
+                                "items": {
+                                  "properties": {
+                                    "succeededCount": {
+                                      "format": "int32",
+                                      "type": "integer"
+                                    },
+                                    "succeededIndexes": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              }
+                            },
+                            "required": [
+                              "rules"
+                            ],
+                            "type": "object"
                           },
                           "suspend": {
                             "type": "boolean"
@@ -515,8 +533,7 @@
                                     "type": "object"
                                   }
                                 },
-                                "type": "object",
-                                "additionalProperties": false
+                                "type": "object"
                               },
                               "spec": {
                                 "properties": {
@@ -546,17 +563,18 @@
                                                             "items": {
                                                               "type": "string"
                                                             },
-                                                            "type": "array"
+                                                            "type": "array",
+                                                            "x-kubernetes-list-type": "atomic"
                                                           }
                                                         },
                                                         "required": [
                                                           "key",
                                                           "operator"
                                                         ],
-                                                        "type": "object",
-                                                        "additionalProperties": false
+                                                        "type": "object"
                                                       },
-                                                      "type": "array"
+                                                      "type": "array",
+                                                      "x-kubernetes-list-type": "atomic"
                                                     },
                                                     "matchFields": {
                                                       "items": {
@@ -571,22 +589,22 @@
                                                             "items": {
                                                               "type": "string"
                                                             },
-                                                            "type": "array"
+                                                            "type": "array",
+                                                            "x-kubernetes-list-type": "atomic"
                                                           }
                                                         },
                                                         "required": [
                                                           "key",
                                                           "operator"
                                                         ],
-                                                        "type": "object",
-                                                        "additionalProperties": false
+                                                        "type": "object"
                                                       },
-                                                      "type": "array"
+                                                      "type": "array",
+                                                      "x-kubernetes-list-type": "atomic"
                                                     }
                                                   },
                                                   "type": "object",
-                                                  "x-kubernetes-map-type": "atomic",
-                                                  "additionalProperties": false
+                                                  "x-kubernetes-map-type": "atomic"
                                                 },
                                                 "weight": {
                                                   "format": "int32",
@@ -597,10 +615,10 @@
                                                 "preference",
                                                 "weight"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
-                                            "type": "array"
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
                                           },
                                           "requiredDuringSchedulingIgnoredDuringExecution": {
                                             "properties": {
@@ -620,17 +638,18 @@
                                                             "items": {
                                                               "type": "string"
                                                             },
-                                                            "type": "array"
+                                                            "type": "array",
+                                                            "x-kubernetes-list-type": "atomic"
                                                           }
                                                         },
                                                         "required": [
                                                           "key",
                                                           "operator"
                                                         ],
-                                                        "type": "object",
-                                                        "additionalProperties": false
+                                                        "type": "object"
                                                       },
-                                                      "type": "array"
+                                                      "type": "array",
+                                                      "x-kubernetes-list-type": "atomic"
                                                     },
                                                     "matchFields": {
                                                       "items": {
@@ -645,36 +664,35 @@
                                                             "items": {
                                                               "type": "string"
                                                             },
-                                                            "type": "array"
+                                                            "type": "array",
+                                                            "x-kubernetes-list-type": "atomic"
                                                           }
                                                         },
                                                         "required": [
                                                           "key",
                                                           "operator"
                                                         ],
-                                                        "type": "object",
-                                                        "additionalProperties": false
+                                                        "type": "object"
                                                       },
-                                                      "type": "array"
+                                                      "type": "array",
+                                                      "x-kubernetes-list-type": "atomic"
                                                     }
                                                   },
                                                   "type": "object",
-                                                  "x-kubernetes-map-type": "atomic",
-                                                  "additionalProperties": false
+                                                  "x-kubernetes-map-type": "atomic"
                                                 },
-                                                "type": "array"
+                                                "type": "array",
+                                                "x-kubernetes-list-type": "atomic"
                                               }
                                             },
                                             "required": [
                                               "nodeSelectorTerms"
                                             ],
                                             "type": "object",
-                                            "x-kubernetes-map-type": "atomic",
-                                            "additionalProperties": false
+                                            "x-kubernetes-map-type": "atomic"
                                           }
                                         },
-                                        "type": "object",
-                                        "additionalProperties": false
+                                        "type": "object"
                                       },
                                       "podAffinity": {
                                         "properties": {
@@ -698,17 +716,18 @@
                                                                 "items": {
                                                                   "type": "string"
                                                                 },
-                                                                "type": "array"
+                                                                "type": "array",
+                                                                "x-kubernetes-list-type": "atomic"
                                                               }
                                                             },
                                                             "required": [
                                                               "key",
                                                               "operator"
                                                             ],
-                                                            "type": "object",
-                                                            "additionalProperties": false
+                                                            "type": "object"
                                                           },
-                                                          "type": "array"
+                                                          "type": "array",
+                                                          "x-kubernetes-list-type": "atomic"
                                                         },
                                                         "matchLabels": {
                                                           "additionalProperties": {
@@ -718,8 +737,7 @@
                                                         }
                                                       },
                                                       "type": "object",
-                                                      "x-kubernetes-map-type": "atomic",
-                                                      "additionalProperties": false
+                                                      "x-kubernetes-map-type": "atomic"
                                                     },
                                                     "matchLabelKeys": {
                                                       "items": {
@@ -750,17 +768,18 @@
                                                                 "items": {
                                                                   "type": "string"
                                                                 },
-                                                                "type": "array"
+                                                                "type": "array",
+                                                                "x-kubernetes-list-type": "atomic"
                                                               }
                                                             },
                                                             "required": [
                                                               "key",
                                                               "operator"
                                                             ],
-                                                            "type": "object",
-                                                            "additionalProperties": false
+                                                            "type": "object"
                                                           },
-                                                          "type": "array"
+                                                          "type": "array",
+                                                          "x-kubernetes-list-type": "atomic"
                                                         },
                                                         "matchLabels": {
                                                           "additionalProperties": {
@@ -770,14 +789,14 @@
                                                         }
                                                       },
                                                       "type": "object",
-                                                      "x-kubernetes-map-type": "atomic",
-                                                      "additionalProperties": false
+                                                      "x-kubernetes-map-type": "atomic"
                                                     },
                                                     "namespaces": {
                                                       "items": {
                                                         "type": "string"
                                                       },
-                                                      "type": "array"
+                                                      "type": "array",
+                                                      "x-kubernetes-list-type": "atomic"
                                                     },
                                                     "topologyKey": {
                                                       "type": "string"
@@ -786,8 +805,7 @@
                                                   "required": [
                                                     "topologyKey"
                                                   ],
-                                                  "type": "object",
-                                                  "additionalProperties": false
+                                                  "type": "object"
                                                 },
                                                 "weight": {
                                                   "format": "int32",
@@ -798,10 +816,10 @@
                                                 "podAffinityTerm",
                                                 "weight"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
-                                            "type": "array"
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
                                           },
                                           "requiredDuringSchedulingIgnoredDuringExecution": {
                                             "items": {
@@ -821,17 +839,18 @@
                                                             "items": {
                                                               "type": "string"
                                                             },
-                                                            "type": "array"
+                                                            "type": "array",
+                                                            "x-kubernetes-list-type": "atomic"
                                                           }
                                                         },
                                                         "required": [
                                                           "key",
                                                           "operator"
                                                         ],
-                                                        "type": "object",
-                                                        "additionalProperties": false
+                                                        "type": "object"
                                                       },
-                                                      "type": "array"
+                                                      "type": "array",
+                                                      "x-kubernetes-list-type": "atomic"
                                                     },
                                                     "matchLabels": {
                                                       "additionalProperties": {
@@ -841,8 +860,7 @@
                                                     }
                                                   },
                                                   "type": "object",
-                                                  "x-kubernetes-map-type": "atomic",
-                                                  "additionalProperties": false
+                                                  "x-kubernetes-map-type": "atomic"
                                                 },
                                                 "matchLabelKeys": {
                                                   "items": {
@@ -873,17 +891,18 @@
                                                             "items": {
                                                               "type": "string"
                                                             },
-                                                            "type": "array"
+                                                            "type": "array",
+                                                            "x-kubernetes-list-type": "atomic"
                                                           }
                                                         },
                                                         "required": [
                                                           "key",
                                                           "operator"
                                                         ],
-                                                        "type": "object",
-                                                        "additionalProperties": false
+                                                        "type": "object"
                                                       },
-                                                      "type": "array"
+                                                      "type": "array",
+                                                      "x-kubernetes-list-type": "atomic"
                                                     },
                                                     "matchLabels": {
                                                       "additionalProperties": {
@@ -893,14 +912,14 @@
                                                     }
                                                   },
                                                   "type": "object",
-                                                  "x-kubernetes-map-type": "atomic",
-                                                  "additionalProperties": false
+                                                  "x-kubernetes-map-type": "atomic"
                                                 },
                                                 "namespaces": {
                                                   "items": {
                                                     "type": "string"
                                                   },
-                                                  "type": "array"
+                                                  "type": "array",
+                                                  "x-kubernetes-list-type": "atomic"
                                                 },
                                                 "topologyKey": {
                                                   "type": "string"
@@ -909,14 +928,13 @@
                                               "required": [
                                                 "topologyKey"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
-                                            "type": "array"
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
                                           }
                                         },
-                                        "type": "object",
-                                        "additionalProperties": false
+                                        "type": "object"
                                       },
                                       "podAntiAffinity": {
                                         "properties": {
@@ -940,17 +958,18 @@
                                                                 "items": {
                                                                   "type": "string"
                                                                 },
-                                                                "type": "array"
+                                                                "type": "array",
+                                                                "x-kubernetes-list-type": "atomic"
                                                               }
                                                             },
                                                             "required": [
                                                               "key",
                                                               "operator"
                                                             ],
-                                                            "type": "object",
-                                                            "additionalProperties": false
+                                                            "type": "object"
                                                           },
-                                                          "type": "array"
+                                                          "type": "array",
+                                                          "x-kubernetes-list-type": "atomic"
                                                         },
                                                         "matchLabels": {
                                                           "additionalProperties": {
@@ -960,8 +979,7 @@
                                                         }
                                                       },
                                                       "type": "object",
-                                                      "x-kubernetes-map-type": "atomic",
-                                                      "additionalProperties": false
+                                                      "x-kubernetes-map-type": "atomic"
                                                     },
                                                     "matchLabelKeys": {
                                                       "items": {
@@ -992,17 +1010,18 @@
                                                                 "items": {
                                                                   "type": "string"
                                                                 },
-                                                                "type": "array"
+                                                                "type": "array",
+                                                                "x-kubernetes-list-type": "atomic"
                                                               }
                                                             },
                                                             "required": [
                                                               "key",
                                                               "operator"
                                                             ],
-                                                            "type": "object",
-                                                            "additionalProperties": false
+                                                            "type": "object"
                                                           },
-                                                          "type": "array"
+                                                          "type": "array",
+                                                          "x-kubernetes-list-type": "atomic"
                                                         },
                                                         "matchLabels": {
                                                           "additionalProperties": {
@@ -1012,14 +1031,14 @@
                                                         }
                                                       },
                                                       "type": "object",
-                                                      "x-kubernetes-map-type": "atomic",
-                                                      "additionalProperties": false
+                                                      "x-kubernetes-map-type": "atomic"
                                                     },
                                                     "namespaces": {
                                                       "items": {
                                                         "type": "string"
                                                       },
-                                                      "type": "array"
+                                                      "type": "array",
+                                                      "x-kubernetes-list-type": "atomic"
                                                     },
                                                     "topologyKey": {
                                                       "type": "string"
@@ -1028,8 +1047,7 @@
                                                   "required": [
                                                     "topologyKey"
                                                   ],
-                                                  "type": "object",
-                                                  "additionalProperties": false
+                                                  "type": "object"
                                                 },
                                                 "weight": {
                                                   "format": "int32",
@@ -1040,10 +1058,10 @@
                                                 "podAffinityTerm",
                                                 "weight"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
-                                            "type": "array"
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
                                           },
                                           "requiredDuringSchedulingIgnoredDuringExecution": {
                                             "items": {
@@ -1063,17 +1081,18 @@
                                                             "items": {
                                                               "type": "string"
                                                             },
-                                                            "type": "array"
+                                                            "type": "array",
+                                                            "x-kubernetes-list-type": "atomic"
                                                           }
                                                         },
                                                         "required": [
                                                           "key",
                                                           "operator"
                                                         ],
-                                                        "type": "object",
-                                                        "additionalProperties": false
+                                                        "type": "object"
                                                       },
-                                                      "type": "array"
+                                                      "type": "array",
+                                                      "x-kubernetes-list-type": "atomic"
                                                     },
                                                     "matchLabels": {
                                                       "additionalProperties": {
@@ -1083,8 +1102,7 @@
                                                     }
                                                   },
                                                   "type": "object",
-                                                  "x-kubernetes-map-type": "atomic",
-                                                  "additionalProperties": false
+                                                  "x-kubernetes-map-type": "atomic"
                                                 },
                                                 "matchLabelKeys": {
                                                   "items": {
@@ -1115,17 +1133,18 @@
                                                             "items": {
                                                               "type": "string"
                                                             },
-                                                            "type": "array"
+                                                            "type": "array",
+                                                            "x-kubernetes-list-type": "atomic"
                                                           }
                                                         },
                                                         "required": [
                                                           "key",
                                                           "operator"
                                                         ],
-                                                        "type": "object",
-                                                        "additionalProperties": false
+                                                        "type": "object"
                                                       },
-                                                      "type": "array"
+                                                      "type": "array",
+                                                      "x-kubernetes-list-type": "atomic"
                                                     },
                                                     "matchLabels": {
                                                       "additionalProperties": {
@@ -1135,14 +1154,14 @@
                                                     }
                                                   },
                                                   "type": "object",
-                                                  "x-kubernetes-map-type": "atomic",
-                                                  "additionalProperties": false
+                                                  "x-kubernetes-map-type": "atomic"
                                                 },
                                                 "namespaces": {
                                                   "items": {
                                                     "type": "string"
                                                   },
-                                                  "type": "array"
+                                                  "type": "array",
+                                                  "x-kubernetes-list-type": "atomic"
                                                 },
                                                 "topologyKey": {
                                                   "type": "string"
@@ -1151,18 +1170,16 @@
                                               "required": [
                                                 "topologyKey"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
-                                            "type": "array"
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
                                           }
                                         },
-                                        "type": "object",
-                                        "additionalProperties": false
+                                        "type": "object"
                                       }
                                     },
-                                    "type": "object",
-                                    "additionalProperties": false
+                                    "type": "object"
                                   },
                                   "automountServiceAccountToken": {
                                     "type": "boolean"
@@ -1174,13 +1191,15 @@
                                           "items": {
                                             "type": "string"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "command": {
                                           "items": {
                                             "type": "string"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "env": {
                                           "items": {
@@ -1199,6 +1218,7 @@
                                                         "type": "string"
                                                       },
                                                       "name": {
+                                                        "default": "",
                                                         "type": "string"
                                                       },
                                                       "optional": {
@@ -1209,8 +1229,7 @@
                                                       "key"
                                                     ],
                                                     "type": "object",
-                                                    "x-kubernetes-map-type": "atomic",
-                                                    "additionalProperties": false
+                                                    "x-kubernetes-map-type": "atomic"
                                                   },
                                                   "fieldRef": {
                                                     "properties": {
@@ -1225,8 +1244,31 @@
                                                       "fieldPath"
                                                     ],
                                                     "type": "object",
-                                                    "x-kubernetes-map-type": "atomic",
-                                                    "additionalProperties": false
+                                                    "x-kubernetes-map-type": "atomic"
+                                                  },
+                                                  "fileKeyRef": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "optional": {
+                                                        "default": false,
+                                                        "type": "boolean"
+                                                      },
+                                                      "path": {
+                                                        "type": "string"
+                                                      },
+                                                      "volumeName": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key",
+                                                      "path",
+                                                      "volumeName"
+                                                    ],
+                                                    "type": "object",
+                                                    "x-kubernetes-map-type": "atomic"
                                                   },
                                                   "resourceFieldRef": {
                                                     "properties": {
@@ -1253,8 +1295,7 @@
                                                       "resource"
                                                     ],
                                                     "type": "object",
-                                                    "x-kubernetes-map-type": "atomic",
-                                                    "additionalProperties": false
+                                                    "x-kubernetes-map-type": "atomic"
                                                   },
                                                   "secretKeyRef": {
                                                     "properties": {
@@ -1262,6 +1303,7 @@
                                                         "type": "string"
                                                       },
                                                       "name": {
+                                                        "default": "",
                                                         "type": "string"
                                                       },
                                                       "optional": {
@@ -1272,21 +1314,22 @@
                                                       "key"
                                                     ],
                                                     "type": "object",
-                                                    "x-kubernetes-map-type": "atomic",
-                                                    "additionalProperties": false
+                                                    "x-kubernetes-map-type": "atomic"
                                                   }
                                                 },
-                                                "type": "object",
-                                                "additionalProperties": false
+                                                "type": "object"
                                               }
                                             },
                                             "required": [
                                               "name"
                                             ],
-                                            "type": "object",
-                                            "additionalProperties": false
+                                            "type": "object"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-map-keys": [
+                                            "name"
+                                          ],
+                                          "x-kubernetes-list-type": "map"
                                         },
                                         "envFrom": {
                                           "items": {
@@ -1294,6 +1337,7 @@
                                               "configMapRef": {
                                                 "properties": {
                                                   "name": {
+                                                    "default": "",
                                                     "type": "string"
                                                   },
                                                   "optional": {
@@ -1301,8 +1345,7 @@
                                                   }
                                                 },
                                                 "type": "object",
-                                                "x-kubernetes-map-type": "atomic",
-                                                "additionalProperties": false
+                                                "x-kubernetes-map-type": "atomic"
                                               },
                                               "prefix": {
                                                 "type": "string"
@@ -1310,6 +1353,7 @@
                                               "secretRef": {
                                                 "properties": {
                                                   "name": {
+                                                    "default": "",
                                                     "type": "string"
                                                   },
                                                   "optional": {
@@ -1317,14 +1361,13 @@
                                                   }
                                                 },
                                                 "type": "object",
-                                                "x-kubernetes-map-type": "atomic",
-                                                "additionalProperties": false
+                                                "x-kubernetes-map-type": "atomic"
                                               }
                                             },
-                                            "type": "object",
-                                            "additionalProperties": false
+                                            "type": "object"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "image": {
                                           "type": "string"
@@ -1342,11 +1385,11 @@
                                                       "items": {
                                                         "type": "string"
                                                       },
-                                                      "type": "array"
+                                                      "type": "array",
+                                                      "x-kubernetes-list-type": "atomic"
                                                     }
                                                   },
-                                                  "type": "object",
-                                                  "additionalProperties": false
+                                                  "type": "object"
                                                 },
                                                 "httpGet": {
                                                   "properties": {
@@ -1367,10 +1410,10 @@
                                                           "name",
                                                           "value"
                                                         ],
-                                                        "type": "object",
-                                                        "additionalProperties": false
+                                                        "type": "object"
                                                       },
-                                                      "type": "array"
+                                                      "type": "array",
+                                                      "x-kubernetes-list-type": "atomic"
                                                     },
                                                     "path": {
                                                       "type": "string"
@@ -1393,8 +1436,7 @@
                                                   "required": [
                                                     "port"
                                                   ],
-                                                  "type": "object",
-                                                  "additionalProperties": false
+                                                  "type": "object"
                                                 },
                                                 "sleep": {
                                                   "properties": {
@@ -1406,8 +1448,7 @@
                                                   "required": [
                                                     "seconds"
                                                   ],
-                                                  "type": "object",
-                                                  "additionalProperties": false
+                                                  "type": "object"
                                                 },
                                                 "tcpSocket": {
                                                   "properties": {
@@ -1429,12 +1470,10 @@
                                                   "required": [
                                                     "port"
                                                   ],
-                                                  "type": "object",
-                                                  "additionalProperties": false
+                                                  "type": "object"
                                                 }
                                               },
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "preStop": {
                                               "properties": {
@@ -1444,11 +1483,11 @@
                                                       "items": {
                                                         "type": "string"
                                                       },
-                                                      "type": "array"
+                                                      "type": "array",
+                                                      "x-kubernetes-list-type": "atomic"
                                                     }
                                                   },
-                                                  "type": "object",
-                                                  "additionalProperties": false
+                                                  "type": "object"
                                                 },
                                                 "httpGet": {
                                                   "properties": {
@@ -1469,10 +1508,10 @@
                                                           "name",
                                                           "value"
                                                         ],
-                                                        "type": "object",
-                                                        "additionalProperties": false
+                                                        "type": "object"
                                                       },
-                                                      "type": "array"
+                                                      "type": "array",
+                                                      "x-kubernetes-list-type": "atomic"
                                                     },
                                                     "path": {
                                                       "type": "string"
@@ -1495,8 +1534,7 @@
                                                   "required": [
                                                     "port"
                                                   ],
-                                                  "type": "object",
-                                                  "additionalProperties": false
+                                                  "type": "object"
                                                 },
                                                 "sleep": {
                                                   "properties": {
@@ -1508,8 +1546,7 @@
                                                   "required": [
                                                     "seconds"
                                                   ],
-                                                  "type": "object",
-                                                  "additionalProperties": false
+                                                  "type": "object"
                                                 },
                                                 "tcpSocket": {
                                                   "properties": {
@@ -1531,16 +1568,16 @@
                                                   "required": [
                                                     "port"
                                                   ],
-                                                  "type": "object",
-                                                  "additionalProperties": false
+                                                  "type": "object"
                                                 }
                                               },
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
+                                            },
+                                            "stopSignal": {
+                                              "type": "string"
                                             }
                                           },
-                                          "type": "object",
-                                          "additionalProperties": false
+                                          "type": "object"
                                         },
                                         "livenessProbe": {
                                           "properties": {
@@ -1550,11 +1587,11 @@
                                                   "items": {
                                                     "type": "string"
                                                   },
-                                                  "type": "array"
+                                                  "type": "array",
+                                                  "x-kubernetes-list-type": "atomic"
                                                 }
                                               },
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "failureThreshold": {
                                               "format": "int32",
@@ -1567,14 +1604,14 @@
                                                   "type": "integer"
                                                 },
                                                 "service": {
+                                                  "default": "",
                                                   "type": "string"
                                                 }
                                               },
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "httpGet": {
                                               "properties": {
@@ -1595,10 +1632,10 @@
                                                       "name",
                                                       "value"
                                                     ],
-                                                    "type": "object",
-                                                    "additionalProperties": false
+                                                    "type": "object"
                                                   },
-                                                  "type": "array"
+                                                  "type": "array",
+                                                  "x-kubernetes-list-type": "atomic"
                                                 },
                                                 "path": {
                                                   "type": "string"
@@ -1621,8 +1658,7 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "initialDelaySeconds": {
                                               "format": "int32",
@@ -1656,8 +1692,7 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "terminationGracePeriodSeconds": {
                                               "format": "int64",
@@ -1668,8 +1703,7 @@
                                               "type": "integer"
                                             }
                                           },
-                                          "type": "object",
-                                          "additionalProperties": false
+                                          "type": "object"
                                         },
                                         "name": {
                                           "type": "string"
@@ -1699,8 +1733,7 @@
                                             "required": [
                                               "containerPort"
                                             ],
-                                            "type": "object",
-                                            "additionalProperties": false
+                                            "type": "object"
                                           },
                                           "type": "array",
                                           "x-kubernetes-list-map-keys": [
@@ -1717,11 +1750,11 @@
                                                   "items": {
                                                     "type": "string"
                                                   },
-                                                  "type": "array"
+                                                  "type": "array",
+                                                  "x-kubernetes-list-type": "atomic"
                                                 }
                                               },
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "failureThreshold": {
                                               "format": "int32",
@@ -1734,14 +1767,14 @@
                                                   "type": "integer"
                                                 },
                                                 "service": {
+                                                  "default": "",
                                                   "type": "string"
                                                 }
                                               },
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "httpGet": {
                                               "properties": {
@@ -1762,10 +1795,10 @@
                                                       "name",
                                                       "value"
                                                     ],
-                                                    "type": "object",
-                                                    "additionalProperties": false
+                                                    "type": "object"
                                                   },
-                                                  "type": "array"
+                                                  "type": "array",
+                                                  "x-kubernetes-list-type": "atomic"
                                                 },
                                                 "path": {
                                                   "type": "string"
@@ -1788,8 +1821,7 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "initialDelaySeconds": {
                                               "format": "int32",
@@ -1823,8 +1855,7 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "terminationGracePeriodSeconds": {
                                               "format": "int64",
@@ -1835,8 +1866,7 @@
                                               "type": "integer"
                                             }
                                           },
-                                          "type": "object",
-                                          "additionalProperties": false
+                                          "type": "object"
                                         },
                                         "resizePolicy": {
                                           "items": {
@@ -1852,8 +1882,7 @@
                                               "resourceName",
                                               "restartPolicy"
                                             ],
-                                            "type": "object",
-                                            "additionalProperties": false
+                                            "type": "object"
                                           },
                                           "type": "array",
                                           "x-kubernetes-list-type": "atomic"
@@ -1865,13 +1894,15 @@
                                                 "properties": {
                                                   "name": {
                                                     "type": "string"
+                                                  },
+                                                  "request": {
+                                                    "type": "string"
                                                   }
                                                 },
                                                 "required": [
                                                   "name"
                                                 ],
-                                                "type": "object",
-                                                "additionalProperties": false
+                                                "type": "object"
                                               },
                                               "type": "array",
                                               "x-kubernetes-list-map-keys": [
@@ -1886,16 +1917,63 @@
                                               "x-kubernetes-preserve-unknown-fields": true
                                             }
                                           },
-                                          "type": "object",
-                                          "additionalProperties": false
+                                          "type": "object"
                                         },
                                         "restartPolicy": {
                                           "type": "string"
+                                        },
+                                        "restartPolicyRules": {
+                                          "items": {
+                                            "properties": {
+                                              "action": {
+                                                "type": "string"
+                                              },
+                                              "exitCodes": {
+                                                "properties": {
+                                                  "operator": {
+                                                    "type": "string"
+                                                  },
+                                                  "values": {
+                                                    "items": {
+                                                      "format": "int32",
+                                                      "type": "integer"
+                                                    },
+                                                    "type": "array",
+                                                    "x-kubernetes-list-type": "set"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "operator"
+                                                ],
+                                                "type": "object"
+                                              }
+                                            },
+                                            "required": [
+                                              "action"
+                                            ],
+                                            "type": "object"
+                                          },
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "securityContext": {
                                           "properties": {
                                             "allowPrivilegeEscalation": {
                                               "type": "boolean"
+                                            },
+                                            "appArmorProfile": {
+                                              "properties": {
+                                                "localhostProfile": {
+                                                  "type": "string"
+                                                },
+                                                "type": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "type"
+                                              ],
+                                              "type": "object"
                                             },
                                             "capabilities": {
                                               "properties": {
@@ -1903,17 +1981,18 @@
                                                   "items": {
                                                     "type": "string"
                                                   },
-                                                  "type": "array"
+                                                  "type": "array",
+                                                  "x-kubernetes-list-type": "atomic"
                                                 },
                                                 "drop": {
                                                   "items": {
                                                     "type": "string"
                                                   },
-                                                  "type": "array"
+                                                  "type": "array",
+                                                  "x-kubernetes-list-type": "atomic"
                                                 }
                                               },
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "privileged": {
                                               "type": "boolean"
@@ -1950,8 +2029,7 @@
                                                   "type": "string"
                                                 }
                                               },
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "seccompProfile": {
                                               "properties": {
@@ -1965,8 +2043,7 @@
                                               "required": [
                                                 "type"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "windowsOptions": {
                                               "properties": {
@@ -1983,12 +2060,10 @@
                                                   "type": "string"
                                                 }
                                               },
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             }
                                           },
-                                          "type": "object",
-                                          "additionalProperties": false
+                                          "type": "object"
                                         },
                                         "startupProbe": {
                                           "properties": {
@@ -1998,11 +2073,11 @@
                                                   "items": {
                                                     "type": "string"
                                                   },
-                                                  "type": "array"
+                                                  "type": "array",
+                                                  "x-kubernetes-list-type": "atomic"
                                                 }
                                               },
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "failureThreshold": {
                                               "format": "int32",
@@ -2015,14 +2090,14 @@
                                                   "type": "integer"
                                                 },
                                                 "service": {
+                                                  "default": "",
                                                   "type": "string"
                                                 }
                                               },
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "httpGet": {
                                               "properties": {
@@ -2043,10 +2118,10 @@
                                                       "name",
                                                       "value"
                                                     ],
-                                                    "type": "object",
-                                                    "additionalProperties": false
+                                                    "type": "object"
                                                   },
-                                                  "type": "array"
+                                                  "type": "array",
+                                                  "x-kubernetes-list-type": "atomic"
                                                 },
                                                 "path": {
                                                   "type": "string"
@@ -2069,8 +2144,7 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "initialDelaySeconds": {
                                               "format": "int32",
@@ -2104,8 +2178,7 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "terminationGracePeriodSeconds": {
                                               "format": "int64",
@@ -2116,8 +2189,7 @@
                                               "type": "integer"
                                             }
                                           },
-                                          "type": "object",
-                                          "additionalProperties": false
+                                          "type": "object"
                                         },
                                         "stdin": {
                                           "type": "boolean"
@@ -2148,10 +2220,13 @@
                                               "devicePath",
                                               "name"
                                             ],
-                                            "type": "object",
-                                            "additionalProperties": false
+                                            "type": "object"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-map-keys": [
+                                            "devicePath"
+                                          ],
+                                          "x-kubernetes-list-type": "map"
                                         },
                                         "volumeMounts": {
                                           "items": {
@@ -2168,6 +2243,9 @@
                                               "readOnly": {
                                                 "type": "boolean"
                                               },
+                                              "recursiveReadOnly": {
+                                                "type": "string"
+                                              },
                                               "subPath": {
                                                 "type": "string"
                                               },
@@ -2179,10 +2257,13 @@
                                               "mountPath",
                                               "name"
                                             ],
-                                            "type": "object",
-                                            "additionalProperties": false
+                                            "type": "object"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-map-keys": [
+                                            "mountPath"
+                                          ],
+                                          "x-kubernetes-list-type": "map"
                                         },
                                         "workingDir": {
                                           "type": "string"
@@ -2191,10 +2272,13 @@
                                       "required": [
                                         "name"
                                       ],
-                                      "type": "object",
-                                      "additionalProperties": false
+                                      "type": "object"
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-map-keys": [
+                                      "name"
+                                    ],
+                                    "x-kubernetes-list-type": "map"
                                   },
                                   "dnsConfig": {
                                     "properties": {
@@ -2202,7 +2286,8 @@
                                         "items": {
                                           "type": "string"
                                         },
-                                        "type": "array"
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
                                       },
                                       "options": {
                                         "items": {
@@ -2214,20 +2299,20 @@
                                               "type": "string"
                                             }
                                           },
-                                          "type": "object",
-                                          "additionalProperties": false
+                                          "type": "object"
                                         },
-                                        "type": "array"
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
                                       },
                                       "searches": {
                                         "items": {
                                           "type": "string"
                                         },
-                                        "type": "array"
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
                                       }
                                     },
-                                    "type": "object",
-                                    "additionalProperties": false
+                                    "type": "object"
                                   },
                                   "dnsPolicy": {
                                     "type": "string"
@@ -2242,13 +2327,15 @@
                                           "items": {
                                             "type": "string"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "command": {
                                           "items": {
                                             "type": "string"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "env": {
                                           "items": {
@@ -2267,6 +2354,7 @@
                                                         "type": "string"
                                                       },
                                                       "name": {
+                                                        "default": "",
                                                         "type": "string"
                                                       },
                                                       "optional": {
@@ -2277,8 +2365,7 @@
                                                       "key"
                                                     ],
                                                     "type": "object",
-                                                    "x-kubernetes-map-type": "atomic",
-                                                    "additionalProperties": false
+                                                    "x-kubernetes-map-type": "atomic"
                                                   },
                                                   "fieldRef": {
                                                     "properties": {
@@ -2293,8 +2380,31 @@
                                                       "fieldPath"
                                                     ],
                                                     "type": "object",
-                                                    "x-kubernetes-map-type": "atomic",
-                                                    "additionalProperties": false
+                                                    "x-kubernetes-map-type": "atomic"
+                                                  },
+                                                  "fileKeyRef": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "optional": {
+                                                        "default": false,
+                                                        "type": "boolean"
+                                                      },
+                                                      "path": {
+                                                        "type": "string"
+                                                      },
+                                                      "volumeName": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key",
+                                                      "path",
+                                                      "volumeName"
+                                                    ],
+                                                    "type": "object",
+                                                    "x-kubernetes-map-type": "atomic"
                                                   },
                                                   "resourceFieldRef": {
                                                     "properties": {
@@ -2321,8 +2431,7 @@
                                                       "resource"
                                                     ],
                                                     "type": "object",
-                                                    "x-kubernetes-map-type": "atomic",
-                                                    "additionalProperties": false
+                                                    "x-kubernetes-map-type": "atomic"
                                                   },
                                                   "secretKeyRef": {
                                                     "properties": {
@@ -2330,6 +2439,7 @@
                                                         "type": "string"
                                                       },
                                                       "name": {
+                                                        "default": "",
                                                         "type": "string"
                                                       },
                                                       "optional": {
@@ -2340,21 +2450,22 @@
                                                       "key"
                                                     ],
                                                     "type": "object",
-                                                    "x-kubernetes-map-type": "atomic",
-                                                    "additionalProperties": false
+                                                    "x-kubernetes-map-type": "atomic"
                                                   }
                                                 },
-                                                "type": "object",
-                                                "additionalProperties": false
+                                                "type": "object"
                                               }
                                             },
                                             "required": [
                                               "name"
                                             ],
-                                            "type": "object",
-                                            "additionalProperties": false
+                                            "type": "object"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-map-keys": [
+                                            "name"
+                                          ],
+                                          "x-kubernetes-list-type": "map"
                                         },
                                         "envFrom": {
                                           "items": {
@@ -2362,6 +2473,7 @@
                                               "configMapRef": {
                                                 "properties": {
                                                   "name": {
+                                                    "default": "",
                                                     "type": "string"
                                                   },
                                                   "optional": {
@@ -2369,8 +2481,7 @@
                                                   }
                                                 },
                                                 "type": "object",
-                                                "x-kubernetes-map-type": "atomic",
-                                                "additionalProperties": false
+                                                "x-kubernetes-map-type": "atomic"
                                               },
                                               "prefix": {
                                                 "type": "string"
@@ -2378,6 +2489,7 @@
                                               "secretRef": {
                                                 "properties": {
                                                   "name": {
+                                                    "default": "",
                                                     "type": "string"
                                                   },
                                                   "optional": {
@@ -2385,14 +2497,13 @@
                                                   }
                                                 },
                                                 "type": "object",
-                                                "x-kubernetes-map-type": "atomic",
-                                                "additionalProperties": false
+                                                "x-kubernetes-map-type": "atomic"
                                               }
                                             },
-                                            "type": "object",
-                                            "additionalProperties": false
+                                            "type": "object"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "image": {
                                           "type": "string"
@@ -2410,11 +2521,11 @@
                                                       "items": {
                                                         "type": "string"
                                                       },
-                                                      "type": "array"
+                                                      "type": "array",
+                                                      "x-kubernetes-list-type": "atomic"
                                                     }
                                                   },
-                                                  "type": "object",
-                                                  "additionalProperties": false
+                                                  "type": "object"
                                                 },
                                                 "httpGet": {
                                                   "properties": {
@@ -2435,10 +2546,10 @@
                                                           "name",
                                                           "value"
                                                         ],
-                                                        "type": "object",
-                                                        "additionalProperties": false
+                                                        "type": "object"
                                                       },
-                                                      "type": "array"
+                                                      "type": "array",
+                                                      "x-kubernetes-list-type": "atomic"
                                                     },
                                                     "path": {
                                                       "type": "string"
@@ -2461,8 +2572,7 @@
                                                   "required": [
                                                     "port"
                                                   ],
-                                                  "type": "object",
-                                                  "additionalProperties": false
+                                                  "type": "object"
                                                 },
                                                 "sleep": {
                                                   "properties": {
@@ -2474,8 +2584,7 @@
                                                   "required": [
                                                     "seconds"
                                                   ],
-                                                  "type": "object",
-                                                  "additionalProperties": false
+                                                  "type": "object"
                                                 },
                                                 "tcpSocket": {
                                                   "properties": {
@@ -2497,12 +2606,10 @@
                                                   "required": [
                                                     "port"
                                                   ],
-                                                  "type": "object",
-                                                  "additionalProperties": false
+                                                  "type": "object"
                                                 }
                                               },
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "preStop": {
                                               "properties": {
@@ -2512,11 +2619,11 @@
                                                       "items": {
                                                         "type": "string"
                                                       },
-                                                      "type": "array"
+                                                      "type": "array",
+                                                      "x-kubernetes-list-type": "atomic"
                                                     }
                                                   },
-                                                  "type": "object",
-                                                  "additionalProperties": false
+                                                  "type": "object"
                                                 },
                                                 "httpGet": {
                                                   "properties": {
@@ -2537,10 +2644,10 @@
                                                           "name",
                                                           "value"
                                                         ],
-                                                        "type": "object",
-                                                        "additionalProperties": false
+                                                        "type": "object"
                                                       },
-                                                      "type": "array"
+                                                      "type": "array",
+                                                      "x-kubernetes-list-type": "atomic"
                                                     },
                                                     "path": {
                                                       "type": "string"
@@ -2563,8 +2670,7 @@
                                                   "required": [
                                                     "port"
                                                   ],
-                                                  "type": "object",
-                                                  "additionalProperties": false
+                                                  "type": "object"
                                                 },
                                                 "sleep": {
                                                   "properties": {
@@ -2576,8 +2682,7 @@
                                                   "required": [
                                                     "seconds"
                                                   ],
-                                                  "type": "object",
-                                                  "additionalProperties": false
+                                                  "type": "object"
                                                 },
                                                 "tcpSocket": {
                                                   "properties": {
@@ -2599,16 +2704,16 @@
                                                   "required": [
                                                     "port"
                                                   ],
-                                                  "type": "object",
-                                                  "additionalProperties": false
+                                                  "type": "object"
                                                 }
                                               },
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
+                                            },
+                                            "stopSignal": {
+                                              "type": "string"
                                             }
                                           },
-                                          "type": "object",
-                                          "additionalProperties": false
+                                          "type": "object"
                                         },
                                         "livenessProbe": {
                                           "properties": {
@@ -2618,11 +2723,11 @@
                                                   "items": {
                                                     "type": "string"
                                                   },
-                                                  "type": "array"
+                                                  "type": "array",
+                                                  "x-kubernetes-list-type": "atomic"
                                                 }
                                               },
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "failureThreshold": {
                                               "format": "int32",
@@ -2635,14 +2740,14 @@
                                                   "type": "integer"
                                                 },
                                                 "service": {
+                                                  "default": "",
                                                   "type": "string"
                                                 }
                                               },
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "httpGet": {
                                               "properties": {
@@ -2663,10 +2768,10 @@
                                                       "name",
                                                       "value"
                                                     ],
-                                                    "type": "object",
-                                                    "additionalProperties": false
+                                                    "type": "object"
                                                   },
-                                                  "type": "array"
+                                                  "type": "array",
+                                                  "x-kubernetes-list-type": "atomic"
                                                 },
                                                 "path": {
                                                   "type": "string"
@@ -2689,8 +2794,7 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "initialDelaySeconds": {
                                               "format": "int32",
@@ -2724,8 +2828,7 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "terminationGracePeriodSeconds": {
                                               "format": "int64",
@@ -2736,8 +2839,7 @@
                                               "type": "integer"
                                             }
                                           },
-                                          "type": "object",
-                                          "additionalProperties": false
+                                          "type": "object"
                                         },
                                         "name": {
                                           "type": "string"
@@ -2767,8 +2869,7 @@
                                             "required": [
                                               "containerPort"
                                             ],
-                                            "type": "object",
-                                            "additionalProperties": false
+                                            "type": "object"
                                           },
                                           "type": "array",
                                           "x-kubernetes-list-map-keys": [
@@ -2785,11 +2886,11 @@
                                                   "items": {
                                                     "type": "string"
                                                   },
-                                                  "type": "array"
+                                                  "type": "array",
+                                                  "x-kubernetes-list-type": "atomic"
                                                 }
                                               },
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "failureThreshold": {
                                               "format": "int32",
@@ -2802,14 +2903,14 @@
                                                   "type": "integer"
                                                 },
                                                 "service": {
+                                                  "default": "",
                                                   "type": "string"
                                                 }
                                               },
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "httpGet": {
                                               "properties": {
@@ -2830,10 +2931,10 @@
                                                       "name",
                                                       "value"
                                                     ],
-                                                    "type": "object",
-                                                    "additionalProperties": false
+                                                    "type": "object"
                                                   },
-                                                  "type": "array"
+                                                  "type": "array",
+                                                  "x-kubernetes-list-type": "atomic"
                                                 },
                                                 "path": {
                                                   "type": "string"
@@ -2856,8 +2957,7 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "initialDelaySeconds": {
                                               "format": "int32",
@@ -2891,8 +2991,7 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "terminationGracePeriodSeconds": {
                                               "format": "int64",
@@ -2903,8 +3002,7 @@
                                               "type": "integer"
                                             }
                                           },
-                                          "type": "object",
-                                          "additionalProperties": false
+                                          "type": "object"
                                         },
                                         "resizePolicy": {
                                           "items": {
@@ -2920,8 +3018,7 @@
                                               "resourceName",
                                               "restartPolicy"
                                             ],
-                                            "type": "object",
-                                            "additionalProperties": false
+                                            "type": "object"
                                           },
                                           "type": "array",
                                           "x-kubernetes-list-type": "atomic"
@@ -2933,13 +3030,15 @@
                                                 "properties": {
                                                   "name": {
                                                     "type": "string"
+                                                  },
+                                                  "request": {
+                                                    "type": "string"
                                                   }
                                                 },
                                                 "required": [
                                                   "name"
                                                 ],
-                                                "type": "object",
-                                                "additionalProperties": false
+                                                "type": "object"
                                               },
                                               "type": "array",
                                               "x-kubernetes-list-map-keys": [
@@ -2954,16 +3053,63 @@
                                               "x-kubernetes-preserve-unknown-fields": true
                                             }
                                           },
-                                          "type": "object",
-                                          "additionalProperties": false
+                                          "type": "object"
                                         },
                                         "restartPolicy": {
                                           "type": "string"
+                                        },
+                                        "restartPolicyRules": {
+                                          "items": {
+                                            "properties": {
+                                              "action": {
+                                                "type": "string"
+                                              },
+                                              "exitCodes": {
+                                                "properties": {
+                                                  "operator": {
+                                                    "type": "string"
+                                                  },
+                                                  "values": {
+                                                    "items": {
+                                                      "format": "int32",
+                                                      "type": "integer"
+                                                    },
+                                                    "type": "array",
+                                                    "x-kubernetes-list-type": "set"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "operator"
+                                                ],
+                                                "type": "object"
+                                              }
+                                            },
+                                            "required": [
+                                              "action"
+                                            ],
+                                            "type": "object"
+                                          },
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "securityContext": {
                                           "properties": {
                                             "allowPrivilegeEscalation": {
                                               "type": "boolean"
+                                            },
+                                            "appArmorProfile": {
+                                              "properties": {
+                                                "localhostProfile": {
+                                                  "type": "string"
+                                                },
+                                                "type": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "type"
+                                              ],
+                                              "type": "object"
                                             },
                                             "capabilities": {
                                               "properties": {
@@ -2971,17 +3117,18 @@
                                                   "items": {
                                                     "type": "string"
                                                   },
-                                                  "type": "array"
+                                                  "type": "array",
+                                                  "x-kubernetes-list-type": "atomic"
                                                 },
                                                 "drop": {
                                                   "items": {
                                                     "type": "string"
                                                   },
-                                                  "type": "array"
+                                                  "type": "array",
+                                                  "x-kubernetes-list-type": "atomic"
                                                 }
                                               },
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "privileged": {
                                               "type": "boolean"
@@ -3018,8 +3165,7 @@
                                                   "type": "string"
                                                 }
                                               },
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "seccompProfile": {
                                               "properties": {
@@ -3033,8 +3179,7 @@
                                               "required": [
                                                 "type"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "windowsOptions": {
                                               "properties": {
@@ -3051,12 +3196,10 @@
                                                   "type": "string"
                                                 }
                                               },
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             }
                                           },
-                                          "type": "object",
-                                          "additionalProperties": false
+                                          "type": "object"
                                         },
                                         "startupProbe": {
                                           "properties": {
@@ -3066,11 +3209,11 @@
                                                   "items": {
                                                     "type": "string"
                                                   },
-                                                  "type": "array"
+                                                  "type": "array",
+                                                  "x-kubernetes-list-type": "atomic"
                                                 }
                                               },
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "failureThreshold": {
                                               "format": "int32",
@@ -3083,14 +3226,14 @@
                                                   "type": "integer"
                                                 },
                                                 "service": {
+                                                  "default": "",
                                                   "type": "string"
                                                 }
                                               },
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "httpGet": {
                                               "properties": {
@@ -3111,10 +3254,10 @@
                                                       "name",
                                                       "value"
                                                     ],
-                                                    "type": "object",
-                                                    "additionalProperties": false
+                                                    "type": "object"
                                                   },
-                                                  "type": "array"
+                                                  "type": "array",
+                                                  "x-kubernetes-list-type": "atomic"
                                                 },
                                                 "path": {
                                                   "type": "string"
@@ -3137,8 +3280,7 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "initialDelaySeconds": {
                                               "format": "int32",
@@ -3172,8 +3314,7 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "terminationGracePeriodSeconds": {
                                               "format": "int64",
@@ -3184,8 +3325,7 @@
                                               "type": "integer"
                                             }
                                           },
-                                          "type": "object",
-                                          "additionalProperties": false
+                                          "type": "object"
                                         },
                                         "stdin": {
                                           "type": "boolean"
@@ -3219,10 +3359,13 @@
                                               "devicePath",
                                               "name"
                                             ],
-                                            "type": "object",
-                                            "additionalProperties": false
+                                            "type": "object"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-map-keys": [
+                                            "devicePath"
+                                          ],
+                                          "x-kubernetes-list-type": "map"
                                         },
                                         "volumeMounts": {
                                           "items": {
@@ -3239,6 +3382,9 @@
                                               "readOnly": {
                                                 "type": "boolean"
                                               },
+                                              "recursiveReadOnly": {
+                                                "type": "string"
+                                              },
                                               "subPath": {
                                                 "type": "string"
                                               },
@@ -3250,10 +3396,13 @@
                                               "mountPath",
                                               "name"
                                             ],
-                                            "type": "object",
-                                            "additionalProperties": false
+                                            "type": "object"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-map-keys": [
+                                            "mountPath"
+                                          ],
+                                          "x-kubernetes-list-type": "map"
                                         },
                                         "workingDir": {
                                           "type": "string"
@@ -3262,10 +3411,13 @@
                                       "required": [
                                         "name"
                                       ],
-                                      "type": "object",
-                                      "additionalProperties": false
+                                      "type": "object"
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-map-keys": [
+                                      "name"
+                                    ],
+                                    "x-kubernetes-list-type": "map"
                                   },
                                   "hostAliases": {
                                     "items": {
@@ -3274,16 +3426,23 @@
                                           "items": {
                                             "type": "string"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "ip": {
                                           "type": "string"
                                         }
                                       },
-                                      "type": "object",
-                                      "additionalProperties": false
+                                      "required": [
+                                        "ip"
+                                      ],
+                                      "type": "object"
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-map-keys": [
+                                      "ip"
+                                    ],
+                                    "x-kubernetes-list-type": "map"
                                   },
                                   "hostIPC": {
                                     "type": "boolean"
@@ -3300,18 +3459,25 @@
                                   "hostname": {
                                     "type": "string"
                                   },
+                                  "hostnameOverride": {
+                                    "type": "string"
+                                  },
                                   "imagePullSecrets": {
                                     "items": {
                                       "properties": {
                                         "name": {
+                                          "default": "",
                                           "type": "string"
                                         }
                                       },
                                       "type": "object",
-                                      "x-kubernetes-map-type": "atomic",
-                                      "additionalProperties": false
+                                      "x-kubernetes-map-type": "atomic"
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-map-keys": [
+                                      "name"
+                                    ],
+                                    "x-kubernetes-list-type": "map"
                                   },
                                   "initContainers": {
                                     "items": {
@@ -3320,13 +3486,15 @@
                                           "items": {
                                             "type": "string"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "command": {
                                           "items": {
                                             "type": "string"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "env": {
                                           "items": {
@@ -3345,6 +3513,7 @@
                                                         "type": "string"
                                                       },
                                                       "name": {
+                                                        "default": "",
                                                         "type": "string"
                                                       },
                                                       "optional": {
@@ -3355,8 +3524,7 @@
                                                       "key"
                                                     ],
                                                     "type": "object",
-                                                    "x-kubernetes-map-type": "atomic",
-                                                    "additionalProperties": false
+                                                    "x-kubernetes-map-type": "atomic"
                                                   },
                                                   "fieldRef": {
                                                     "properties": {
@@ -3371,8 +3539,31 @@
                                                       "fieldPath"
                                                     ],
                                                     "type": "object",
-                                                    "x-kubernetes-map-type": "atomic",
-                                                    "additionalProperties": false
+                                                    "x-kubernetes-map-type": "atomic"
+                                                  },
+                                                  "fileKeyRef": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "optional": {
+                                                        "default": false,
+                                                        "type": "boolean"
+                                                      },
+                                                      "path": {
+                                                        "type": "string"
+                                                      },
+                                                      "volumeName": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key",
+                                                      "path",
+                                                      "volumeName"
+                                                    ],
+                                                    "type": "object",
+                                                    "x-kubernetes-map-type": "atomic"
                                                   },
                                                   "resourceFieldRef": {
                                                     "properties": {
@@ -3399,8 +3590,7 @@
                                                       "resource"
                                                     ],
                                                     "type": "object",
-                                                    "x-kubernetes-map-type": "atomic",
-                                                    "additionalProperties": false
+                                                    "x-kubernetes-map-type": "atomic"
                                                   },
                                                   "secretKeyRef": {
                                                     "properties": {
@@ -3408,6 +3598,7 @@
                                                         "type": "string"
                                                       },
                                                       "name": {
+                                                        "default": "",
                                                         "type": "string"
                                                       },
                                                       "optional": {
@@ -3418,21 +3609,22 @@
                                                       "key"
                                                     ],
                                                     "type": "object",
-                                                    "x-kubernetes-map-type": "atomic",
-                                                    "additionalProperties": false
+                                                    "x-kubernetes-map-type": "atomic"
                                                   }
                                                 },
-                                                "type": "object",
-                                                "additionalProperties": false
+                                                "type": "object"
                                               }
                                             },
                                             "required": [
                                               "name"
                                             ],
-                                            "type": "object",
-                                            "additionalProperties": false
+                                            "type": "object"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-map-keys": [
+                                            "name"
+                                          ],
+                                          "x-kubernetes-list-type": "map"
                                         },
                                         "envFrom": {
                                           "items": {
@@ -3440,6 +3632,7 @@
                                               "configMapRef": {
                                                 "properties": {
                                                   "name": {
+                                                    "default": "",
                                                     "type": "string"
                                                   },
                                                   "optional": {
@@ -3447,8 +3640,7 @@
                                                   }
                                                 },
                                                 "type": "object",
-                                                "x-kubernetes-map-type": "atomic",
-                                                "additionalProperties": false
+                                                "x-kubernetes-map-type": "atomic"
                                               },
                                               "prefix": {
                                                 "type": "string"
@@ -3456,6 +3648,7 @@
                                               "secretRef": {
                                                 "properties": {
                                                   "name": {
+                                                    "default": "",
                                                     "type": "string"
                                                   },
                                                   "optional": {
@@ -3463,14 +3656,13 @@
                                                   }
                                                 },
                                                 "type": "object",
-                                                "x-kubernetes-map-type": "atomic",
-                                                "additionalProperties": false
+                                                "x-kubernetes-map-type": "atomic"
                                               }
                                             },
-                                            "type": "object",
-                                            "additionalProperties": false
+                                            "type": "object"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "image": {
                                           "type": "string"
@@ -3488,11 +3680,11 @@
                                                       "items": {
                                                         "type": "string"
                                                       },
-                                                      "type": "array"
+                                                      "type": "array",
+                                                      "x-kubernetes-list-type": "atomic"
                                                     }
                                                   },
-                                                  "type": "object",
-                                                  "additionalProperties": false
+                                                  "type": "object"
                                                 },
                                                 "httpGet": {
                                                   "properties": {
@@ -3513,10 +3705,10 @@
                                                           "name",
                                                           "value"
                                                         ],
-                                                        "type": "object",
-                                                        "additionalProperties": false
+                                                        "type": "object"
                                                       },
-                                                      "type": "array"
+                                                      "type": "array",
+                                                      "x-kubernetes-list-type": "atomic"
                                                     },
                                                     "path": {
                                                       "type": "string"
@@ -3539,8 +3731,7 @@
                                                   "required": [
                                                     "port"
                                                   ],
-                                                  "type": "object",
-                                                  "additionalProperties": false
+                                                  "type": "object"
                                                 },
                                                 "sleep": {
                                                   "properties": {
@@ -3552,8 +3743,7 @@
                                                   "required": [
                                                     "seconds"
                                                   ],
-                                                  "type": "object",
-                                                  "additionalProperties": false
+                                                  "type": "object"
                                                 },
                                                 "tcpSocket": {
                                                   "properties": {
@@ -3575,12 +3765,10 @@
                                                   "required": [
                                                     "port"
                                                   ],
-                                                  "type": "object",
-                                                  "additionalProperties": false
+                                                  "type": "object"
                                                 }
                                               },
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "preStop": {
                                               "properties": {
@@ -3590,11 +3778,11 @@
                                                       "items": {
                                                         "type": "string"
                                                       },
-                                                      "type": "array"
+                                                      "type": "array",
+                                                      "x-kubernetes-list-type": "atomic"
                                                     }
                                                   },
-                                                  "type": "object",
-                                                  "additionalProperties": false
+                                                  "type": "object"
                                                 },
                                                 "httpGet": {
                                                   "properties": {
@@ -3615,10 +3803,10 @@
                                                           "name",
                                                           "value"
                                                         ],
-                                                        "type": "object",
-                                                        "additionalProperties": false
+                                                        "type": "object"
                                                       },
-                                                      "type": "array"
+                                                      "type": "array",
+                                                      "x-kubernetes-list-type": "atomic"
                                                     },
                                                     "path": {
                                                       "type": "string"
@@ -3641,8 +3829,7 @@
                                                   "required": [
                                                     "port"
                                                   ],
-                                                  "type": "object",
-                                                  "additionalProperties": false
+                                                  "type": "object"
                                                 },
                                                 "sleep": {
                                                   "properties": {
@@ -3654,8 +3841,7 @@
                                                   "required": [
                                                     "seconds"
                                                   ],
-                                                  "type": "object",
-                                                  "additionalProperties": false
+                                                  "type": "object"
                                                 },
                                                 "tcpSocket": {
                                                   "properties": {
@@ -3677,16 +3863,16 @@
                                                   "required": [
                                                     "port"
                                                   ],
-                                                  "type": "object",
-                                                  "additionalProperties": false
+                                                  "type": "object"
                                                 }
                                               },
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
+                                            },
+                                            "stopSignal": {
+                                              "type": "string"
                                             }
                                           },
-                                          "type": "object",
-                                          "additionalProperties": false
+                                          "type": "object"
                                         },
                                         "livenessProbe": {
                                           "properties": {
@@ -3696,11 +3882,11 @@
                                                   "items": {
                                                     "type": "string"
                                                   },
-                                                  "type": "array"
+                                                  "type": "array",
+                                                  "x-kubernetes-list-type": "atomic"
                                                 }
                                               },
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "failureThreshold": {
                                               "format": "int32",
@@ -3713,14 +3899,14 @@
                                                   "type": "integer"
                                                 },
                                                 "service": {
+                                                  "default": "",
                                                   "type": "string"
                                                 }
                                               },
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "httpGet": {
                                               "properties": {
@@ -3741,10 +3927,10 @@
                                                       "name",
                                                       "value"
                                                     ],
-                                                    "type": "object",
-                                                    "additionalProperties": false
+                                                    "type": "object"
                                                   },
-                                                  "type": "array"
+                                                  "type": "array",
+                                                  "x-kubernetes-list-type": "atomic"
                                                 },
                                                 "path": {
                                                   "type": "string"
@@ -3767,8 +3953,7 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "initialDelaySeconds": {
                                               "format": "int32",
@@ -3802,8 +3987,7 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "terminationGracePeriodSeconds": {
                                               "format": "int64",
@@ -3814,8 +3998,7 @@
                                               "type": "integer"
                                             }
                                           },
-                                          "type": "object",
-                                          "additionalProperties": false
+                                          "type": "object"
                                         },
                                         "name": {
                                           "type": "string"
@@ -3845,8 +4028,7 @@
                                             "required": [
                                               "containerPort"
                                             ],
-                                            "type": "object",
-                                            "additionalProperties": false
+                                            "type": "object"
                                           },
                                           "type": "array",
                                           "x-kubernetes-list-map-keys": [
@@ -3863,11 +4045,11 @@
                                                   "items": {
                                                     "type": "string"
                                                   },
-                                                  "type": "array"
+                                                  "type": "array",
+                                                  "x-kubernetes-list-type": "atomic"
                                                 }
                                               },
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "failureThreshold": {
                                               "format": "int32",
@@ -3880,14 +4062,14 @@
                                                   "type": "integer"
                                                 },
                                                 "service": {
+                                                  "default": "",
                                                   "type": "string"
                                                 }
                                               },
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "httpGet": {
                                               "properties": {
@@ -3908,10 +4090,10 @@
                                                       "name",
                                                       "value"
                                                     ],
-                                                    "type": "object",
-                                                    "additionalProperties": false
+                                                    "type": "object"
                                                   },
-                                                  "type": "array"
+                                                  "type": "array",
+                                                  "x-kubernetes-list-type": "atomic"
                                                 },
                                                 "path": {
                                                   "type": "string"
@@ -3934,8 +4116,7 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "initialDelaySeconds": {
                                               "format": "int32",
@@ -3969,8 +4150,7 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "terminationGracePeriodSeconds": {
                                               "format": "int64",
@@ -3981,8 +4161,7 @@
                                               "type": "integer"
                                             }
                                           },
-                                          "type": "object",
-                                          "additionalProperties": false
+                                          "type": "object"
                                         },
                                         "resizePolicy": {
                                           "items": {
@@ -3998,8 +4177,7 @@
                                               "resourceName",
                                               "restartPolicy"
                                             ],
-                                            "type": "object",
-                                            "additionalProperties": false
+                                            "type": "object"
                                           },
                                           "type": "array",
                                           "x-kubernetes-list-type": "atomic"
@@ -4011,13 +4189,15 @@
                                                 "properties": {
                                                   "name": {
                                                     "type": "string"
+                                                  },
+                                                  "request": {
+                                                    "type": "string"
                                                   }
                                                 },
                                                 "required": [
                                                   "name"
                                                 ],
-                                                "type": "object",
-                                                "additionalProperties": false
+                                                "type": "object"
                                               },
                                               "type": "array",
                                               "x-kubernetes-list-map-keys": [
@@ -4032,16 +4212,63 @@
                                               "x-kubernetes-preserve-unknown-fields": true
                                             }
                                           },
-                                          "type": "object",
-                                          "additionalProperties": false
+                                          "type": "object"
                                         },
                                         "restartPolicy": {
                                           "type": "string"
+                                        },
+                                        "restartPolicyRules": {
+                                          "items": {
+                                            "properties": {
+                                              "action": {
+                                                "type": "string"
+                                              },
+                                              "exitCodes": {
+                                                "properties": {
+                                                  "operator": {
+                                                    "type": "string"
+                                                  },
+                                                  "values": {
+                                                    "items": {
+                                                      "format": "int32",
+                                                      "type": "integer"
+                                                    },
+                                                    "type": "array",
+                                                    "x-kubernetes-list-type": "set"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "operator"
+                                                ],
+                                                "type": "object"
+                                              }
+                                            },
+                                            "required": [
+                                              "action"
+                                            ],
+                                            "type": "object"
+                                          },
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "securityContext": {
                                           "properties": {
                                             "allowPrivilegeEscalation": {
                                               "type": "boolean"
+                                            },
+                                            "appArmorProfile": {
+                                              "properties": {
+                                                "localhostProfile": {
+                                                  "type": "string"
+                                                },
+                                                "type": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "type"
+                                              ],
+                                              "type": "object"
                                             },
                                             "capabilities": {
                                               "properties": {
@@ -4049,17 +4276,18 @@
                                                   "items": {
                                                     "type": "string"
                                                   },
-                                                  "type": "array"
+                                                  "type": "array",
+                                                  "x-kubernetes-list-type": "atomic"
                                                 },
                                                 "drop": {
                                                   "items": {
                                                     "type": "string"
                                                   },
-                                                  "type": "array"
+                                                  "type": "array",
+                                                  "x-kubernetes-list-type": "atomic"
                                                 }
                                               },
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "privileged": {
                                               "type": "boolean"
@@ -4096,8 +4324,7 @@
                                                   "type": "string"
                                                 }
                                               },
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "seccompProfile": {
                                               "properties": {
@@ -4111,8 +4338,7 @@
                                               "required": [
                                                 "type"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "windowsOptions": {
                                               "properties": {
@@ -4129,12 +4355,10 @@
                                                   "type": "string"
                                                 }
                                               },
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             }
                                           },
-                                          "type": "object",
-                                          "additionalProperties": false
+                                          "type": "object"
                                         },
                                         "startupProbe": {
                                           "properties": {
@@ -4144,11 +4368,11 @@
                                                   "items": {
                                                     "type": "string"
                                                   },
-                                                  "type": "array"
+                                                  "type": "array",
+                                                  "x-kubernetes-list-type": "atomic"
                                                 }
                                               },
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "failureThreshold": {
                                               "format": "int32",
@@ -4161,14 +4385,14 @@
                                                   "type": "integer"
                                                 },
                                                 "service": {
+                                                  "default": "",
                                                   "type": "string"
                                                 }
                                               },
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "httpGet": {
                                               "properties": {
@@ -4189,10 +4413,10 @@
                                                       "name",
                                                       "value"
                                                     ],
-                                                    "type": "object",
-                                                    "additionalProperties": false
+                                                    "type": "object"
                                                   },
-                                                  "type": "array"
+                                                  "type": "array",
+                                                  "x-kubernetes-list-type": "atomic"
                                                 },
                                                 "path": {
                                                   "type": "string"
@@ -4215,8 +4439,7 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "initialDelaySeconds": {
                                               "format": "int32",
@@ -4250,8 +4473,7 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "terminationGracePeriodSeconds": {
                                               "format": "int64",
@@ -4262,8 +4484,7 @@
                                               "type": "integer"
                                             }
                                           },
-                                          "type": "object",
-                                          "additionalProperties": false
+                                          "type": "object"
                                         },
                                         "stdin": {
                                           "type": "boolean"
@@ -4294,10 +4515,13 @@
                                               "devicePath",
                                               "name"
                                             ],
-                                            "type": "object",
-                                            "additionalProperties": false
+                                            "type": "object"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-map-keys": [
+                                            "devicePath"
+                                          ],
+                                          "x-kubernetes-list-type": "map"
                                         },
                                         "volumeMounts": {
                                           "items": {
@@ -4314,6 +4538,9 @@
                                               "readOnly": {
                                                 "type": "boolean"
                                               },
+                                              "recursiveReadOnly": {
+                                                "type": "string"
+                                              },
                                               "subPath": {
                                                 "type": "string"
                                               },
@@ -4325,10 +4552,13 @@
                                               "mountPath",
                                               "name"
                                             ],
-                                            "type": "object",
-                                            "additionalProperties": false
+                                            "type": "object"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-map-keys": [
+                                            "mountPath"
+                                          ],
+                                          "x-kubernetes-list-type": "map"
                                         },
                                         "workingDir": {
                                           "type": "string"
@@ -4337,10 +4567,13 @@
                                       "required": [
                                         "name"
                                       ],
-                                      "type": "object",
-                                      "additionalProperties": false
+                                      "type": "object"
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-map-keys": [
+                                      "name"
+                                    ],
+                                    "x-kubernetes-list-type": "map"
                                   },
                                   "nodeName": {
                                     "type": "string"
@@ -4361,8 +4594,7 @@
                                     "required": [
                                       "name"
                                     ],
-                                    "type": "object",
-                                    "additionalProperties": false
+                                    "type": "object"
                                   },
                                   "overhead": {
                                     "additionalProperties": {
@@ -4399,10 +4631,10 @@
                                       "required": [
                                         "conditionType"
                                       ],
-                                      "type": "object",
-                                      "additionalProperties": false
+                                      "type": "object"
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "resourceClaims": {
                                     "items": {
@@ -4410,30 +4642,79 @@
                                         "name": {
                                           "type": "string"
                                         },
-                                        "source": {
-                                          "properties": {
-                                            "resourceClaimName": {
-                                              "type": "string"
-                                            },
-                                            "resourceClaimTemplateName": {
-                                              "type": "string"
-                                            }
-                                          },
-                                          "type": "object",
-                                          "additionalProperties": false
+                                        "resourceClaimName": {
+                                          "type": "string"
+                                        },
+                                        "resourceClaimTemplateName": {
+                                          "type": "string"
                                         }
                                       },
                                       "required": [
                                         "name"
                                       ],
-                                      "type": "object",
-                                      "additionalProperties": false
+                                      "type": "object"
                                     },
                                     "type": "array",
                                     "x-kubernetes-list-map-keys": [
                                       "name"
                                     ],
                                     "x-kubernetes-list-type": "map"
+                                  },
+                                  "resources": {
+                                    "properties": {
+                                      "claims": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "request": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name"
+                                          ],
+                                          "type": "object"
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-map-keys": [
+                                          "name"
+                                        ],
+                                        "x-kubernetes-list-type": "map"
+                                      },
+                                      "limits": {
+                                        "additionalProperties": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "type": "object"
+                                      },
+                                      "requests": {
+                                        "additionalProperties": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object"
                                   },
                                   "restartPolicy": {
                                     "type": "string"
@@ -4454,8 +4735,7 @@
                                       "required": [
                                         "name"
                                       ],
-                                      "type": "object",
-                                      "additionalProperties": false
+                                      "type": "object"
                                     },
                                     "type": "array",
                                     "x-kubernetes-list-map-keys": [
@@ -4465,6 +4745,20 @@
                                   },
                                   "securityContext": {
                                     "properties": {
+                                      "appArmorProfile": {
+                                        "properties": {
+                                          "localhostProfile": {
+                                            "type": "string"
+                                          },
+                                          "type": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "type"
+                                        ],
+                                        "type": "object"
+                                      },
                                       "fsGroup": {
                                         "format": "int64",
                                         "type": "integer"
@@ -4483,6 +4777,9 @@
                                         "format": "int64",
                                         "type": "integer"
                                       },
+                                      "seLinuxChangePolicy": {
+                                        "type": "string"
+                                      },
                                       "seLinuxOptions": {
                                         "properties": {
                                           "level": {
@@ -4498,8 +4795,7 @@
                                             "type": "string"
                                           }
                                         },
-                                        "type": "object",
-                                        "additionalProperties": false
+                                        "type": "object"
                                       },
                                       "seccompProfile": {
                                         "properties": {
@@ -4513,15 +4809,18 @@
                                         "required": [
                                           "type"
                                         ],
-                                        "type": "object",
-                                        "additionalProperties": false
+                                        "type": "object"
                                       },
                                       "supplementalGroups": {
                                         "items": {
                                           "format": "int64",
                                           "type": "integer"
                                         },
-                                        "type": "array"
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "supplementalGroupsPolicy": {
+                                        "type": "string"
                                       },
                                       "sysctls": {
                                         "items": {
@@ -4537,10 +4836,10 @@
                                             "name",
                                             "value"
                                           ],
-                                          "type": "object",
-                                          "additionalProperties": false
+                                          "type": "object"
                                         },
-                                        "type": "array"
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
                                       },
                                       "windowsOptions": {
                                         "properties": {
@@ -4557,12 +4856,10 @@
                                             "type": "string"
                                           }
                                         },
-                                        "type": "object",
-                                        "additionalProperties": false
+                                        "type": "object"
                                       }
                                     },
-                                    "type": "object",
-                                    "additionalProperties": false
+                                    "type": "object"
                                   },
                                   "serviceAccount": {
                                     "type": "string"
@@ -4603,10 +4900,10 @@
                                           "type": "string"
                                         }
                                       },
-                                      "type": "object",
-                                      "additionalProperties": false
+                                      "type": "object"
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "topologySpreadConstraints": {
                                     "items": {
@@ -4626,17 +4923,18 @@
                                                     "items": {
                                                       "type": "string"
                                                     },
-                                                    "type": "array"
+                                                    "type": "array",
+                                                    "x-kubernetes-list-type": "atomic"
                                                   }
                                                 },
                                                 "required": [
                                                   "key",
                                                   "operator"
                                                 ],
-                                                "type": "object",
-                                                "additionalProperties": false
+                                                "type": "object"
                                               },
-                                              "type": "array"
+                                              "type": "array",
+                                              "x-kubernetes-list-type": "atomic"
                                             },
                                             "matchLabels": {
                                               "additionalProperties": {
@@ -4646,8 +4944,7 @@
                                             }
                                           },
                                           "type": "object",
-                                          "x-kubernetes-map-type": "atomic",
-                                          "additionalProperties": false
+                                          "x-kubernetes-map-type": "atomic"
                                         },
                                         "matchLabelKeys": {
                                           "items": {
@@ -4682,8 +4979,7 @@
                                         "topologyKey",
                                         "whenUnsatisfiable"
                                       ],
-                                      "type": "object",
-                                      "additionalProperties": false
+                                      "type": "object"
                                     },
                                     "type": "array",
                                     "x-kubernetes-list-map-keys": [
@@ -4699,12 +4995,10 @@
                                 "required": [
                                   "containers"
                                 ],
-                                "type": "object",
-                                "additionalProperties": false
+                                "type": "object"
                               }
                             },
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "ttlSecondsAfterFinished": {
                             "format": "int32",
@@ -4714,15 +5008,13 @@
                         "required": [
                           "template"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       }
                     },
                     "required": [
                       "spec"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "kayenta": {
                     "properties": {
@@ -4737,6 +5029,9 @@
                       },
                       "configurationAccountName": {
                         "type": "string"
+                      },
+                      "lookback": {
+                        "type": "boolean"
                       },
                       "metricsAccountName": {
                         "type": "string"
@@ -4764,14 +5059,11 @@
                                 }
                               },
                               "required": [
-                                "end",
                                 "region",
                                 "scope",
-                                "start",
                                 "step"
                               ],
-                              "type": "object",
-                              "additionalProperties": false
+                              "type": "object"
                             },
                             "experimentScope": {
                               "properties": {
@@ -4793,14 +5085,11 @@
                                 }
                               },
                               "required": [
-                                "end",
                                 "region",
                                 "scope",
-                                "start",
                                 "step"
                               ],
-                              "type": "object",
-                              "additionalProperties": false
+                              "type": "object"
                             },
                             "name": {
                               "type": "string"
@@ -4811,8 +5100,7 @@
                             "experimentScope",
                             "name"
                           ],
-                          "type": "object",
-                          "additionalProperties": false
+                          "type": "object"
                         },
                         "type": "array"
                       },
@@ -4834,8 +5122,7 @@
                           "marginal",
                           "pass"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       }
                     },
                     "required": [
@@ -4848,8 +5135,7 @@
                       "storageAccountName",
                       "threshold"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "newRelic": {
                     "properties": {
@@ -4858,13 +5144,16 @@
                       },
                       "query": {
                         "type": "string"
+                      },
+                      "timeout": {
+                        "format": "int64",
+                        "type": "integer"
                       }
                     },
                     "required": [
                       "query"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "plugin": {
                     "type": "object",
@@ -4895,8 +5184,7 @@
                                 "type": "string"
                               }
                             },
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "sigv4": {
                             "properties": {
@@ -4910,12 +5198,10 @@
                                 "type": "string"
                               }
                             },
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "headers": {
                         "items": {
@@ -4931,8 +5217,7 @@
                             "key",
                             "value"
                           ],
-                          "type": "object",
-                          "additionalProperties": false
+                          "type": "object"
                         },
                         "type": "array"
                       },
@@ -4954,16 +5239,14 @@
                             "type": "string"
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "timeout": {
                         "format": "int64",
                         "type": "integer"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "skywalking": {
                     "properties": {
@@ -4977,8 +5260,7 @@
                         "type": "string"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "wavefront": {
                     "properties": {
@@ -4989,8 +5271,7 @@
                         "type": "string"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "web": {
                     "properties": {
@@ -5014,8 +5295,7 @@
                                 "type": "string"
                               }
                             },
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "sigv4": {
                             "properties": {
@@ -5029,12 +5309,10 @@
                                 "type": "string"
                               }
                             },
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "body": {
                         "type": "string"
@@ -5053,8 +5331,7 @@
                             "key",
                             "value"
                           ],
-                          "type": "object",
-                          "additionalProperties": false
+                          "type": "object"
                         },
                         "type": "array"
                       },
@@ -5082,12 +5359,10 @@
                     "required": [
                       "url"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   }
                 },
-                "type": "object",
-                "additionalProperties": false
+                "type": "object"
               },
               "successCondition": {
                 "type": "string"
@@ -5097,8 +5372,7 @@
               "name",
               "provider"
             ],
-            "type": "object",
-            "additionalProperties": false
+            "type": "object"
           },
           "type": "array"
         },
@@ -5112,14 +5386,12 @@
                 "type": "string"
               }
             },
-            "type": "object",
-            "additionalProperties": false
+            "type": "object"
           },
           "type": "array"
         }
       },
-      "type": "object",
-      "additionalProperties": false
+      "type": "object"
     }
   },
   "required": [

--- a/argoproj.io/clusteranalysistemplate_v1alpha1.json
+++ b/argoproj.io/clusteranalysistemplate_v1alpha1.json
@@ -31,7 +31,8 @@
                     "required": [
                       "fieldPath"
                     ],
-                    "type": "object"
+                    "type": "object",
+                    "additionalProperties": false
                   },
                   "secretKeyRef": {
                     "properties": {
@@ -46,16 +47,19 @@
                       "key",
                       "name"
                     ],
-                    "type": "object"
+                    "type": "object",
+                    "additionalProperties": false
                   }
                 },
-                "type": "object"
+                "type": "object",
+                "additionalProperties": false
               }
             },
             "required": [
               "name"
             ],
-            "type": "object"
+            "type": "object",
+            "additionalProperties": false
           },
           "type": "array"
         },
@@ -69,7 +73,8 @@
             "required": [
               "metricName"
             ],
-            "type": "object"
+            "type": "object",
+            "additionalProperties": false
           },
           "type": "array"
         },
@@ -88,7 +93,8 @@
               "limit",
               "metricName"
             ],
-            "type": "object"
+            "type": "object",
+            "additionalProperties": false
           },
           "type": "array"
         },
@@ -195,7 +201,8 @@
                                             "type": "string"
                                           }
                                         },
-                                        "type": "object"
+                                        "type": "object",
+                                        "additionalProperties": false
                                       },
                                       "type": "array"
                                     },
@@ -206,7 +213,8 @@
                                       "type": "string"
                                     }
                                   },
-                                  "type": "object"
+                                  "type": "object",
+                                  "additionalProperties": false
                                 },
                                 "period": {
                                   "anyOf": [
@@ -226,7 +234,8 @@
                                   "type": "string"
                                 }
                               },
-                              "type": "object"
+                              "type": "object",
+                              "additionalProperties": false
                             },
                             "period": {
                               "anyOf": [
@@ -243,7 +252,8 @@
                               "type": "boolean"
                             }
                           },
-                          "type": "object"
+                          "type": "object",
+                          "additionalProperties": false
                         },
                         "type": "array"
                       }
@@ -251,7 +261,8 @@
                     "required": [
                       "metricDataQueries"
                     ],
-                    "type": "object"
+                    "type": "object",
+                    "additionalProperties": false
                   },
                   "datadog": {
                     "properties": {
@@ -302,10 +313,12 @@
                             "type": "boolean"
                           }
                         },
-                        "type": "object"
+                        "type": "object",
+                        "additionalProperties": false
                       }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "additionalProperties": false
                   },
                   "graphite": {
                     "properties": {
@@ -316,7 +329,8 @@
                         "type": "string"
                       }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "additionalProperties": false
                   },
                   "influxdb": {
                     "properties": {
@@ -327,7 +341,8 @@
                         "type": "string"
                       }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "additionalProperties": false
                   },
                   "job": {
                     "properties": {
@@ -346,7 +361,8 @@
                             "type": "object"
                           }
                         },
-                        "type": "object"
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "spec": {
                         "properties": {
@@ -412,7 +428,8 @@
                                         "operator",
                                         "values"
                                       ],
-                                      "type": "object"
+                                      "type": "object",
+                                      "additionalProperties": false
                                     },
                                     "onPodConditions": {
                                       "items": {
@@ -428,7 +445,8 @@
                                           "status",
                                           "type"
                                         ],
-                                        "type": "object"
+                                        "type": "object",
+                                        "additionalProperties": false
                                       },
                                       "type": "array",
                                       "x-kubernetes-list-type": "atomic"
@@ -437,7 +455,8 @@
                                   "required": [
                                     "action"
                                   ],
-                                  "type": "object"
+                                  "type": "object",
+                                  "additionalProperties": false
                                 },
                                 "type": "array",
                                 "x-kubernetes-list-type": "atomic"
@@ -446,7 +465,8 @@
                             "required": [
                               "rules"
                             ],
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "podReplacementPolicy": {
                             "type": "string"
@@ -474,7 +494,8 @@
                                     "key",
                                     "operator"
                                   ],
-                                  "type": "object"
+                                  "type": "object",
+                                  "additionalProperties": false
                                 },
                                 "type": "array",
                                 "x-kubernetes-list-type": "atomic"
@@ -487,7 +508,8 @@
                               }
                             },
                             "type": "object",
-                            "x-kubernetes-map-type": "atomic"
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
                           },
                           "successPolicy": {
                             "properties": {
@@ -502,7 +524,8 @@
                                       "type": "string"
                                     }
                                   },
-                                  "type": "object"
+                                  "type": "object",
+                                  "additionalProperties": false
                                 },
                                 "type": "array",
                                 "x-kubernetes-list-type": "atomic"
@@ -511,7 +534,8 @@
                             "required": [
                               "rules"
                             ],
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "suspend": {
                             "type": "boolean"
@@ -533,7 +557,8 @@
                                     "type": "object"
                                   }
                                 },
-                                "type": "object"
+                                "type": "object",
+                                "additionalProperties": false
                               },
                               "spec": {
                                 "properties": {
@@ -571,7 +596,8 @@
                                                           "key",
                                                           "operator"
                                                         ],
-                                                        "type": "object"
+                                                        "type": "object",
+                                                        "additionalProperties": false
                                                       },
                                                       "type": "array",
                                                       "x-kubernetes-list-type": "atomic"
@@ -597,14 +623,16 @@
                                                           "key",
                                                           "operator"
                                                         ],
-                                                        "type": "object"
+                                                        "type": "object",
+                                                        "additionalProperties": false
                                                       },
                                                       "type": "array",
                                                       "x-kubernetes-list-type": "atomic"
                                                     }
                                                   },
                                                   "type": "object",
-                                                  "x-kubernetes-map-type": "atomic"
+                                                  "x-kubernetes-map-type": "atomic",
+                                                  "additionalProperties": false
                                                 },
                                                 "weight": {
                                                   "format": "int32",
@@ -615,7 +643,8 @@
                                                 "preference",
                                                 "weight"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "type": "array",
                                             "x-kubernetes-list-type": "atomic"
@@ -646,7 +675,8 @@
                                                           "key",
                                                           "operator"
                                                         ],
-                                                        "type": "object"
+                                                        "type": "object",
+                                                        "additionalProperties": false
                                                       },
                                                       "type": "array",
                                                       "x-kubernetes-list-type": "atomic"
@@ -672,14 +702,16 @@
                                                           "key",
                                                           "operator"
                                                         ],
-                                                        "type": "object"
+                                                        "type": "object",
+                                                        "additionalProperties": false
                                                       },
                                                       "type": "array",
                                                       "x-kubernetes-list-type": "atomic"
                                                     }
                                                   },
                                                   "type": "object",
-                                                  "x-kubernetes-map-type": "atomic"
+                                                  "x-kubernetes-map-type": "atomic",
+                                                  "additionalProperties": false
                                                 },
                                                 "type": "array",
                                                 "x-kubernetes-list-type": "atomic"
@@ -689,10 +721,12 @@
                                               "nodeSelectorTerms"
                                             ],
                                             "type": "object",
-                                            "x-kubernetes-map-type": "atomic"
+                                            "x-kubernetes-map-type": "atomic",
+                                            "additionalProperties": false
                                           }
                                         },
-                                        "type": "object"
+                                        "type": "object",
+                                        "additionalProperties": false
                                       },
                                       "podAffinity": {
                                         "properties": {
@@ -724,7 +758,8 @@
                                                               "key",
                                                               "operator"
                                                             ],
-                                                            "type": "object"
+                                                            "type": "object",
+                                                            "additionalProperties": false
                                                           },
                                                           "type": "array",
                                                           "x-kubernetes-list-type": "atomic"
@@ -737,7 +772,8 @@
                                                         }
                                                       },
                                                       "type": "object",
-                                                      "x-kubernetes-map-type": "atomic"
+                                                      "x-kubernetes-map-type": "atomic",
+                                                      "additionalProperties": false
                                                     },
                                                     "matchLabelKeys": {
                                                       "items": {
@@ -776,7 +812,8 @@
                                                               "key",
                                                               "operator"
                                                             ],
-                                                            "type": "object"
+                                                            "type": "object",
+                                                            "additionalProperties": false
                                                           },
                                                           "type": "array",
                                                           "x-kubernetes-list-type": "atomic"
@@ -789,7 +826,8 @@
                                                         }
                                                       },
                                                       "type": "object",
-                                                      "x-kubernetes-map-type": "atomic"
+                                                      "x-kubernetes-map-type": "atomic",
+                                                      "additionalProperties": false
                                                     },
                                                     "namespaces": {
                                                       "items": {
@@ -805,7 +843,8 @@
                                                   "required": [
                                                     "topologyKey"
                                                   ],
-                                                  "type": "object"
+                                                  "type": "object",
+                                                  "additionalProperties": false
                                                 },
                                                 "weight": {
                                                   "format": "int32",
@@ -816,7 +855,8 @@
                                                 "podAffinityTerm",
                                                 "weight"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "type": "array",
                                             "x-kubernetes-list-type": "atomic"
@@ -847,7 +887,8 @@
                                                           "key",
                                                           "operator"
                                                         ],
-                                                        "type": "object"
+                                                        "type": "object",
+                                                        "additionalProperties": false
                                                       },
                                                       "type": "array",
                                                       "x-kubernetes-list-type": "atomic"
@@ -860,7 +901,8 @@
                                                     }
                                                   },
                                                   "type": "object",
-                                                  "x-kubernetes-map-type": "atomic"
+                                                  "x-kubernetes-map-type": "atomic",
+                                                  "additionalProperties": false
                                                 },
                                                 "matchLabelKeys": {
                                                   "items": {
@@ -899,7 +941,8 @@
                                                           "key",
                                                           "operator"
                                                         ],
-                                                        "type": "object"
+                                                        "type": "object",
+                                                        "additionalProperties": false
                                                       },
                                                       "type": "array",
                                                       "x-kubernetes-list-type": "atomic"
@@ -912,7 +955,8 @@
                                                     }
                                                   },
                                                   "type": "object",
-                                                  "x-kubernetes-map-type": "atomic"
+                                                  "x-kubernetes-map-type": "atomic",
+                                                  "additionalProperties": false
                                                 },
                                                 "namespaces": {
                                                   "items": {
@@ -928,13 +972,15 @@
                                               "required": [
                                                 "topologyKey"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "type": "array",
                                             "x-kubernetes-list-type": "atomic"
                                           }
                                         },
-                                        "type": "object"
+                                        "type": "object",
+                                        "additionalProperties": false
                                       },
                                       "podAntiAffinity": {
                                         "properties": {
@@ -966,7 +1012,8 @@
                                                               "key",
                                                               "operator"
                                                             ],
-                                                            "type": "object"
+                                                            "type": "object",
+                                                            "additionalProperties": false
                                                           },
                                                           "type": "array",
                                                           "x-kubernetes-list-type": "atomic"
@@ -979,7 +1026,8 @@
                                                         }
                                                       },
                                                       "type": "object",
-                                                      "x-kubernetes-map-type": "atomic"
+                                                      "x-kubernetes-map-type": "atomic",
+                                                      "additionalProperties": false
                                                     },
                                                     "matchLabelKeys": {
                                                       "items": {
@@ -1018,7 +1066,8 @@
                                                               "key",
                                                               "operator"
                                                             ],
-                                                            "type": "object"
+                                                            "type": "object",
+                                                            "additionalProperties": false
                                                           },
                                                           "type": "array",
                                                           "x-kubernetes-list-type": "atomic"
@@ -1031,7 +1080,8 @@
                                                         }
                                                       },
                                                       "type": "object",
-                                                      "x-kubernetes-map-type": "atomic"
+                                                      "x-kubernetes-map-type": "atomic",
+                                                      "additionalProperties": false
                                                     },
                                                     "namespaces": {
                                                       "items": {
@@ -1047,7 +1097,8 @@
                                                   "required": [
                                                     "topologyKey"
                                                   ],
-                                                  "type": "object"
+                                                  "type": "object",
+                                                  "additionalProperties": false
                                                 },
                                                 "weight": {
                                                   "format": "int32",
@@ -1058,7 +1109,8 @@
                                                 "podAffinityTerm",
                                                 "weight"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "type": "array",
                                             "x-kubernetes-list-type": "atomic"
@@ -1089,7 +1141,8 @@
                                                           "key",
                                                           "operator"
                                                         ],
-                                                        "type": "object"
+                                                        "type": "object",
+                                                        "additionalProperties": false
                                                       },
                                                       "type": "array",
                                                       "x-kubernetes-list-type": "atomic"
@@ -1102,7 +1155,8 @@
                                                     }
                                                   },
                                                   "type": "object",
-                                                  "x-kubernetes-map-type": "atomic"
+                                                  "x-kubernetes-map-type": "atomic",
+                                                  "additionalProperties": false
                                                 },
                                                 "matchLabelKeys": {
                                                   "items": {
@@ -1141,7 +1195,8 @@
                                                           "key",
                                                           "operator"
                                                         ],
-                                                        "type": "object"
+                                                        "type": "object",
+                                                        "additionalProperties": false
                                                       },
                                                       "type": "array",
                                                       "x-kubernetes-list-type": "atomic"
@@ -1154,7 +1209,8 @@
                                                     }
                                                   },
                                                   "type": "object",
-                                                  "x-kubernetes-map-type": "atomic"
+                                                  "x-kubernetes-map-type": "atomic",
+                                                  "additionalProperties": false
                                                 },
                                                 "namespaces": {
                                                   "items": {
@@ -1170,16 +1226,19 @@
                                               "required": [
                                                 "topologyKey"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "type": "array",
                                             "x-kubernetes-list-type": "atomic"
                                           }
                                         },
-                                        "type": "object"
+                                        "type": "object",
+                                        "additionalProperties": false
                                       }
                                     },
-                                    "type": "object"
+                                    "type": "object",
+                                    "additionalProperties": false
                                   },
                                   "automountServiceAccountToken": {
                                     "type": "boolean"
@@ -1229,7 +1288,8 @@
                                                       "key"
                                                     ],
                                                     "type": "object",
-                                                    "x-kubernetes-map-type": "atomic"
+                                                    "x-kubernetes-map-type": "atomic",
+                                                    "additionalProperties": false
                                                   },
                                                   "fieldRef": {
                                                     "properties": {
@@ -1244,7 +1304,8 @@
                                                       "fieldPath"
                                                     ],
                                                     "type": "object",
-                                                    "x-kubernetes-map-type": "atomic"
+                                                    "x-kubernetes-map-type": "atomic",
+                                                    "additionalProperties": false
                                                   },
                                                   "fileKeyRef": {
                                                     "properties": {
@@ -1268,7 +1329,8 @@
                                                       "volumeName"
                                                     ],
                                                     "type": "object",
-                                                    "x-kubernetes-map-type": "atomic"
+                                                    "x-kubernetes-map-type": "atomic",
+                                                    "additionalProperties": false
                                                   },
                                                   "resourceFieldRef": {
                                                     "properties": {
@@ -1295,7 +1357,8 @@
                                                       "resource"
                                                     ],
                                                     "type": "object",
-                                                    "x-kubernetes-map-type": "atomic"
+                                                    "x-kubernetes-map-type": "atomic",
+                                                    "additionalProperties": false
                                                   },
                                                   "secretKeyRef": {
                                                     "properties": {
@@ -1314,16 +1377,19 @@
                                                       "key"
                                                     ],
                                                     "type": "object",
-                                                    "x-kubernetes-map-type": "atomic"
+                                                    "x-kubernetes-map-type": "atomic",
+                                                    "additionalProperties": false
                                                   }
                                                 },
-                                                "type": "object"
+                                                "type": "object",
+                                                "additionalProperties": false
                                               }
                                             },
                                             "required": [
                                               "name"
                                             ],
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           },
                                           "type": "array",
                                           "x-kubernetes-list-map-keys": [
@@ -1345,7 +1411,8 @@
                                                   }
                                                 },
                                                 "type": "object",
-                                                "x-kubernetes-map-type": "atomic"
+                                                "x-kubernetes-map-type": "atomic",
+                                                "additionalProperties": false
                                               },
                                               "prefix": {
                                                 "type": "string"
@@ -1361,10 +1428,12 @@
                                                   }
                                                 },
                                                 "type": "object",
-                                                "x-kubernetes-map-type": "atomic"
+                                                "x-kubernetes-map-type": "atomic",
+                                                "additionalProperties": false
                                               }
                                             },
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           },
                                           "type": "array",
                                           "x-kubernetes-list-type": "atomic"
@@ -1389,7 +1458,8 @@
                                                       "x-kubernetes-list-type": "atomic"
                                                     }
                                                   },
-                                                  "type": "object"
+                                                  "type": "object",
+                                                  "additionalProperties": false
                                                 },
                                                 "httpGet": {
                                                   "properties": {
@@ -1410,7 +1480,8 @@
                                                           "name",
                                                           "value"
                                                         ],
-                                                        "type": "object"
+                                                        "type": "object",
+                                                        "additionalProperties": false
                                                       },
                                                       "type": "array",
                                                       "x-kubernetes-list-type": "atomic"
@@ -1436,7 +1507,8 @@
                                                   "required": [
                                                     "port"
                                                   ],
-                                                  "type": "object"
+                                                  "type": "object",
+                                                  "additionalProperties": false
                                                 },
                                                 "sleep": {
                                                   "properties": {
@@ -1448,7 +1520,8 @@
                                                   "required": [
                                                     "seconds"
                                                   ],
-                                                  "type": "object"
+                                                  "type": "object",
+                                                  "additionalProperties": false
                                                 },
                                                 "tcpSocket": {
                                                   "properties": {
@@ -1470,10 +1543,12 @@
                                                   "required": [
                                                     "port"
                                                   ],
-                                                  "type": "object"
+                                                  "type": "object",
+                                                  "additionalProperties": false
                                                 }
                                               },
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "preStop": {
                                               "properties": {
@@ -1487,7 +1562,8 @@
                                                       "x-kubernetes-list-type": "atomic"
                                                     }
                                                   },
-                                                  "type": "object"
+                                                  "type": "object",
+                                                  "additionalProperties": false
                                                 },
                                                 "httpGet": {
                                                   "properties": {
@@ -1508,7 +1584,8 @@
                                                           "name",
                                                           "value"
                                                         ],
-                                                        "type": "object"
+                                                        "type": "object",
+                                                        "additionalProperties": false
                                                       },
                                                       "type": "array",
                                                       "x-kubernetes-list-type": "atomic"
@@ -1534,7 +1611,8 @@
                                                   "required": [
                                                     "port"
                                                   ],
-                                                  "type": "object"
+                                                  "type": "object",
+                                                  "additionalProperties": false
                                                 },
                                                 "sleep": {
                                                   "properties": {
@@ -1546,7 +1624,8 @@
                                                   "required": [
                                                     "seconds"
                                                   ],
-                                                  "type": "object"
+                                                  "type": "object",
+                                                  "additionalProperties": false
                                                 },
                                                 "tcpSocket": {
                                                   "properties": {
@@ -1568,16 +1647,19 @@
                                                   "required": [
                                                     "port"
                                                   ],
-                                                  "type": "object"
+                                                  "type": "object",
+                                                  "additionalProperties": false
                                                 }
                                               },
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "stopSignal": {
                                               "type": "string"
                                             }
                                           },
-                                          "type": "object"
+                                          "type": "object",
+                                          "additionalProperties": false
                                         },
                                         "livenessProbe": {
                                           "properties": {
@@ -1591,7 +1673,8 @@
                                                   "x-kubernetes-list-type": "atomic"
                                                 }
                                               },
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "failureThreshold": {
                                               "format": "int32",
@@ -1611,7 +1694,8 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "httpGet": {
                                               "properties": {
@@ -1632,7 +1716,8 @@
                                                       "name",
                                                       "value"
                                                     ],
-                                                    "type": "object"
+                                                    "type": "object",
+                                                    "additionalProperties": false
                                                   },
                                                   "type": "array",
                                                   "x-kubernetes-list-type": "atomic"
@@ -1658,7 +1743,8 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "initialDelaySeconds": {
                                               "format": "int32",
@@ -1692,7 +1778,8 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "terminationGracePeriodSeconds": {
                                               "format": "int64",
@@ -1703,7 +1790,8 @@
                                               "type": "integer"
                                             }
                                           },
-                                          "type": "object"
+                                          "type": "object",
+                                          "additionalProperties": false
                                         },
                                         "name": {
                                           "type": "string"
@@ -1733,7 +1821,8 @@
                                             "required": [
                                               "containerPort"
                                             ],
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           },
                                           "type": "array",
                                           "x-kubernetes-list-map-keys": [
@@ -1754,7 +1843,8 @@
                                                   "x-kubernetes-list-type": "atomic"
                                                 }
                                               },
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "failureThreshold": {
                                               "format": "int32",
@@ -1774,7 +1864,8 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "httpGet": {
                                               "properties": {
@@ -1795,7 +1886,8 @@
                                                       "name",
                                                       "value"
                                                     ],
-                                                    "type": "object"
+                                                    "type": "object",
+                                                    "additionalProperties": false
                                                   },
                                                   "type": "array",
                                                   "x-kubernetes-list-type": "atomic"
@@ -1821,7 +1913,8 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "initialDelaySeconds": {
                                               "format": "int32",
@@ -1855,7 +1948,8 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "terminationGracePeriodSeconds": {
                                               "format": "int64",
@@ -1866,7 +1960,8 @@
                                               "type": "integer"
                                             }
                                           },
-                                          "type": "object"
+                                          "type": "object",
+                                          "additionalProperties": false
                                         },
                                         "resizePolicy": {
                                           "items": {
@@ -1882,7 +1977,8 @@
                                               "resourceName",
                                               "restartPolicy"
                                             ],
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           },
                                           "type": "array",
                                           "x-kubernetes-list-type": "atomic"
@@ -1902,7 +1998,8 @@
                                                 "required": [
                                                   "name"
                                                 ],
-                                                "type": "object"
+                                                "type": "object",
+                                                "additionalProperties": false
                                               },
                                               "type": "array",
                                               "x-kubernetes-list-map-keys": [
@@ -1917,7 +2014,8 @@
                                               "x-kubernetes-preserve-unknown-fields": true
                                             }
                                           },
-                                          "type": "object"
+                                          "type": "object",
+                                          "additionalProperties": false
                                         },
                                         "restartPolicy": {
                                           "type": "string"
@@ -1945,13 +2043,15 @@
                                                 "required": [
                                                   "operator"
                                                 ],
-                                                "type": "object"
+                                                "type": "object",
+                                                "additionalProperties": false
                                               }
                                             },
                                             "required": [
                                               "action"
                                             ],
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           },
                                           "type": "array",
                                           "x-kubernetes-list-type": "atomic"
@@ -1973,7 +2073,8 @@
                                               "required": [
                                                 "type"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "capabilities": {
                                               "properties": {
@@ -1992,7 +2093,8 @@
                                                   "x-kubernetes-list-type": "atomic"
                                                 }
                                               },
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "privileged": {
                                               "type": "boolean"
@@ -2029,7 +2131,8 @@
                                                   "type": "string"
                                                 }
                                               },
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "seccompProfile": {
                                               "properties": {
@@ -2043,7 +2146,8 @@
                                               "required": [
                                                 "type"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "windowsOptions": {
                                               "properties": {
@@ -2060,10 +2164,12 @@
                                                   "type": "string"
                                                 }
                                               },
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             }
                                           },
-                                          "type": "object"
+                                          "type": "object",
+                                          "additionalProperties": false
                                         },
                                         "startupProbe": {
                                           "properties": {
@@ -2077,7 +2183,8 @@
                                                   "x-kubernetes-list-type": "atomic"
                                                 }
                                               },
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "failureThreshold": {
                                               "format": "int32",
@@ -2097,7 +2204,8 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "httpGet": {
                                               "properties": {
@@ -2118,7 +2226,8 @@
                                                       "name",
                                                       "value"
                                                     ],
-                                                    "type": "object"
+                                                    "type": "object",
+                                                    "additionalProperties": false
                                                   },
                                                   "type": "array",
                                                   "x-kubernetes-list-type": "atomic"
@@ -2144,7 +2253,8 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "initialDelaySeconds": {
                                               "format": "int32",
@@ -2178,7 +2288,8 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "terminationGracePeriodSeconds": {
                                               "format": "int64",
@@ -2189,7 +2300,8 @@
                                               "type": "integer"
                                             }
                                           },
-                                          "type": "object"
+                                          "type": "object",
+                                          "additionalProperties": false
                                         },
                                         "stdin": {
                                           "type": "boolean"
@@ -2220,7 +2332,8 @@
                                               "devicePath",
                                               "name"
                                             ],
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           },
                                           "type": "array",
                                           "x-kubernetes-list-map-keys": [
@@ -2257,7 +2370,8 @@
                                               "mountPath",
                                               "name"
                                             ],
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           },
                                           "type": "array",
                                           "x-kubernetes-list-map-keys": [
@@ -2272,7 +2386,8 @@
                                       "required": [
                                         "name"
                                       ],
-                                      "type": "object"
+                                      "type": "object",
+                                      "additionalProperties": false
                                     },
                                     "type": "array",
                                     "x-kubernetes-list-map-keys": [
@@ -2299,7 +2414,8 @@
                                               "type": "string"
                                             }
                                           },
-                                          "type": "object"
+                                          "type": "object",
+                                          "additionalProperties": false
                                         },
                                         "type": "array",
                                         "x-kubernetes-list-type": "atomic"
@@ -2312,7 +2428,8 @@
                                         "x-kubernetes-list-type": "atomic"
                                       }
                                     },
-                                    "type": "object"
+                                    "type": "object",
+                                    "additionalProperties": false
                                   },
                                   "dnsPolicy": {
                                     "type": "string"
@@ -2365,7 +2482,8 @@
                                                       "key"
                                                     ],
                                                     "type": "object",
-                                                    "x-kubernetes-map-type": "atomic"
+                                                    "x-kubernetes-map-type": "atomic",
+                                                    "additionalProperties": false
                                                   },
                                                   "fieldRef": {
                                                     "properties": {
@@ -2380,7 +2498,8 @@
                                                       "fieldPath"
                                                     ],
                                                     "type": "object",
-                                                    "x-kubernetes-map-type": "atomic"
+                                                    "x-kubernetes-map-type": "atomic",
+                                                    "additionalProperties": false
                                                   },
                                                   "fileKeyRef": {
                                                     "properties": {
@@ -2404,7 +2523,8 @@
                                                       "volumeName"
                                                     ],
                                                     "type": "object",
-                                                    "x-kubernetes-map-type": "atomic"
+                                                    "x-kubernetes-map-type": "atomic",
+                                                    "additionalProperties": false
                                                   },
                                                   "resourceFieldRef": {
                                                     "properties": {
@@ -2431,7 +2551,8 @@
                                                       "resource"
                                                     ],
                                                     "type": "object",
-                                                    "x-kubernetes-map-type": "atomic"
+                                                    "x-kubernetes-map-type": "atomic",
+                                                    "additionalProperties": false
                                                   },
                                                   "secretKeyRef": {
                                                     "properties": {
@@ -2450,16 +2571,19 @@
                                                       "key"
                                                     ],
                                                     "type": "object",
-                                                    "x-kubernetes-map-type": "atomic"
+                                                    "x-kubernetes-map-type": "atomic",
+                                                    "additionalProperties": false
                                                   }
                                                 },
-                                                "type": "object"
+                                                "type": "object",
+                                                "additionalProperties": false
                                               }
                                             },
                                             "required": [
                                               "name"
                                             ],
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           },
                                           "type": "array",
                                           "x-kubernetes-list-map-keys": [
@@ -2481,7 +2605,8 @@
                                                   }
                                                 },
                                                 "type": "object",
-                                                "x-kubernetes-map-type": "atomic"
+                                                "x-kubernetes-map-type": "atomic",
+                                                "additionalProperties": false
                                               },
                                               "prefix": {
                                                 "type": "string"
@@ -2497,10 +2622,12 @@
                                                   }
                                                 },
                                                 "type": "object",
-                                                "x-kubernetes-map-type": "atomic"
+                                                "x-kubernetes-map-type": "atomic",
+                                                "additionalProperties": false
                                               }
                                             },
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           },
                                           "type": "array",
                                           "x-kubernetes-list-type": "atomic"
@@ -2525,7 +2652,8 @@
                                                       "x-kubernetes-list-type": "atomic"
                                                     }
                                                   },
-                                                  "type": "object"
+                                                  "type": "object",
+                                                  "additionalProperties": false
                                                 },
                                                 "httpGet": {
                                                   "properties": {
@@ -2546,7 +2674,8 @@
                                                           "name",
                                                           "value"
                                                         ],
-                                                        "type": "object"
+                                                        "type": "object",
+                                                        "additionalProperties": false
                                                       },
                                                       "type": "array",
                                                       "x-kubernetes-list-type": "atomic"
@@ -2572,7 +2701,8 @@
                                                   "required": [
                                                     "port"
                                                   ],
-                                                  "type": "object"
+                                                  "type": "object",
+                                                  "additionalProperties": false
                                                 },
                                                 "sleep": {
                                                   "properties": {
@@ -2584,7 +2714,8 @@
                                                   "required": [
                                                     "seconds"
                                                   ],
-                                                  "type": "object"
+                                                  "type": "object",
+                                                  "additionalProperties": false
                                                 },
                                                 "tcpSocket": {
                                                   "properties": {
@@ -2606,10 +2737,12 @@
                                                   "required": [
                                                     "port"
                                                   ],
-                                                  "type": "object"
+                                                  "type": "object",
+                                                  "additionalProperties": false
                                                 }
                                               },
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "preStop": {
                                               "properties": {
@@ -2623,7 +2756,8 @@
                                                       "x-kubernetes-list-type": "atomic"
                                                     }
                                                   },
-                                                  "type": "object"
+                                                  "type": "object",
+                                                  "additionalProperties": false
                                                 },
                                                 "httpGet": {
                                                   "properties": {
@@ -2644,7 +2778,8 @@
                                                           "name",
                                                           "value"
                                                         ],
-                                                        "type": "object"
+                                                        "type": "object",
+                                                        "additionalProperties": false
                                                       },
                                                       "type": "array",
                                                       "x-kubernetes-list-type": "atomic"
@@ -2670,7 +2805,8 @@
                                                   "required": [
                                                     "port"
                                                   ],
-                                                  "type": "object"
+                                                  "type": "object",
+                                                  "additionalProperties": false
                                                 },
                                                 "sleep": {
                                                   "properties": {
@@ -2682,7 +2818,8 @@
                                                   "required": [
                                                     "seconds"
                                                   ],
-                                                  "type": "object"
+                                                  "type": "object",
+                                                  "additionalProperties": false
                                                 },
                                                 "tcpSocket": {
                                                   "properties": {
@@ -2704,16 +2841,19 @@
                                                   "required": [
                                                     "port"
                                                   ],
-                                                  "type": "object"
+                                                  "type": "object",
+                                                  "additionalProperties": false
                                                 }
                                               },
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "stopSignal": {
                                               "type": "string"
                                             }
                                           },
-                                          "type": "object"
+                                          "type": "object",
+                                          "additionalProperties": false
                                         },
                                         "livenessProbe": {
                                           "properties": {
@@ -2727,7 +2867,8 @@
                                                   "x-kubernetes-list-type": "atomic"
                                                 }
                                               },
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "failureThreshold": {
                                               "format": "int32",
@@ -2747,7 +2888,8 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "httpGet": {
                                               "properties": {
@@ -2768,7 +2910,8 @@
                                                       "name",
                                                       "value"
                                                     ],
-                                                    "type": "object"
+                                                    "type": "object",
+                                                    "additionalProperties": false
                                                   },
                                                   "type": "array",
                                                   "x-kubernetes-list-type": "atomic"
@@ -2794,7 +2937,8 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "initialDelaySeconds": {
                                               "format": "int32",
@@ -2828,7 +2972,8 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "terminationGracePeriodSeconds": {
                                               "format": "int64",
@@ -2839,7 +2984,8 @@
                                               "type": "integer"
                                             }
                                           },
-                                          "type": "object"
+                                          "type": "object",
+                                          "additionalProperties": false
                                         },
                                         "name": {
                                           "type": "string"
@@ -2869,7 +3015,8 @@
                                             "required": [
                                               "containerPort"
                                             ],
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           },
                                           "type": "array",
                                           "x-kubernetes-list-map-keys": [
@@ -2890,7 +3037,8 @@
                                                   "x-kubernetes-list-type": "atomic"
                                                 }
                                               },
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "failureThreshold": {
                                               "format": "int32",
@@ -2910,7 +3058,8 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "httpGet": {
                                               "properties": {
@@ -2931,7 +3080,8 @@
                                                       "name",
                                                       "value"
                                                     ],
-                                                    "type": "object"
+                                                    "type": "object",
+                                                    "additionalProperties": false
                                                   },
                                                   "type": "array",
                                                   "x-kubernetes-list-type": "atomic"
@@ -2957,7 +3107,8 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "initialDelaySeconds": {
                                               "format": "int32",
@@ -2991,7 +3142,8 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "terminationGracePeriodSeconds": {
                                               "format": "int64",
@@ -3002,7 +3154,8 @@
                                               "type": "integer"
                                             }
                                           },
-                                          "type": "object"
+                                          "type": "object",
+                                          "additionalProperties": false
                                         },
                                         "resizePolicy": {
                                           "items": {
@@ -3018,7 +3171,8 @@
                                               "resourceName",
                                               "restartPolicy"
                                             ],
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           },
                                           "type": "array",
                                           "x-kubernetes-list-type": "atomic"
@@ -3038,7 +3192,8 @@
                                                 "required": [
                                                   "name"
                                                 ],
-                                                "type": "object"
+                                                "type": "object",
+                                                "additionalProperties": false
                                               },
                                               "type": "array",
                                               "x-kubernetes-list-map-keys": [
@@ -3053,7 +3208,8 @@
                                               "x-kubernetes-preserve-unknown-fields": true
                                             }
                                           },
-                                          "type": "object"
+                                          "type": "object",
+                                          "additionalProperties": false
                                         },
                                         "restartPolicy": {
                                           "type": "string"
@@ -3081,13 +3237,15 @@
                                                 "required": [
                                                   "operator"
                                                 ],
-                                                "type": "object"
+                                                "type": "object",
+                                                "additionalProperties": false
                                               }
                                             },
                                             "required": [
                                               "action"
                                             ],
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           },
                                           "type": "array",
                                           "x-kubernetes-list-type": "atomic"
@@ -3109,7 +3267,8 @@
                                               "required": [
                                                 "type"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "capabilities": {
                                               "properties": {
@@ -3128,7 +3287,8 @@
                                                   "x-kubernetes-list-type": "atomic"
                                                 }
                                               },
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "privileged": {
                                               "type": "boolean"
@@ -3165,7 +3325,8 @@
                                                   "type": "string"
                                                 }
                                               },
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "seccompProfile": {
                                               "properties": {
@@ -3179,7 +3340,8 @@
                                               "required": [
                                                 "type"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "windowsOptions": {
                                               "properties": {
@@ -3196,10 +3358,12 @@
                                                   "type": "string"
                                                 }
                                               },
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             }
                                           },
-                                          "type": "object"
+                                          "type": "object",
+                                          "additionalProperties": false
                                         },
                                         "startupProbe": {
                                           "properties": {
@@ -3213,7 +3377,8 @@
                                                   "x-kubernetes-list-type": "atomic"
                                                 }
                                               },
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "failureThreshold": {
                                               "format": "int32",
@@ -3233,7 +3398,8 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "httpGet": {
                                               "properties": {
@@ -3254,7 +3420,8 @@
                                                       "name",
                                                       "value"
                                                     ],
-                                                    "type": "object"
+                                                    "type": "object",
+                                                    "additionalProperties": false
                                                   },
                                                   "type": "array",
                                                   "x-kubernetes-list-type": "atomic"
@@ -3280,7 +3447,8 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "initialDelaySeconds": {
                                               "format": "int32",
@@ -3314,7 +3482,8 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "terminationGracePeriodSeconds": {
                                               "format": "int64",
@@ -3325,7 +3494,8 @@
                                               "type": "integer"
                                             }
                                           },
-                                          "type": "object"
+                                          "type": "object",
+                                          "additionalProperties": false
                                         },
                                         "stdin": {
                                           "type": "boolean"
@@ -3359,7 +3529,8 @@
                                               "devicePath",
                                               "name"
                                             ],
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           },
                                           "type": "array",
                                           "x-kubernetes-list-map-keys": [
@@ -3396,7 +3567,8 @@
                                               "mountPath",
                                               "name"
                                             ],
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           },
                                           "type": "array",
                                           "x-kubernetes-list-map-keys": [
@@ -3411,7 +3583,8 @@
                                       "required": [
                                         "name"
                                       ],
-                                      "type": "object"
+                                      "type": "object",
+                                      "additionalProperties": false
                                     },
                                     "type": "array",
                                     "x-kubernetes-list-map-keys": [
@@ -3436,7 +3609,8 @@
                                       "required": [
                                         "ip"
                                       ],
-                                      "type": "object"
+                                      "type": "object",
+                                      "additionalProperties": false
                                     },
                                     "type": "array",
                                     "x-kubernetes-list-map-keys": [
@@ -3471,7 +3645,8 @@
                                         }
                                       },
                                       "type": "object",
-                                      "x-kubernetes-map-type": "atomic"
+                                      "x-kubernetes-map-type": "atomic",
+                                      "additionalProperties": false
                                     },
                                     "type": "array",
                                     "x-kubernetes-list-map-keys": [
@@ -3524,7 +3699,8 @@
                                                       "key"
                                                     ],
                                                     "type": "object",
-                                                    "x-kubernetes-map-type": "atomic"
+                                                    "x-kubernetes-map-type": "atomic",
+                                                    "additionalProperties": false
                                                   },
                                                   "fieldRef": {
                                                     "properties": {
@@ -3539,7 +3715,8 @@
                                                       "fieldPath"
                                                     ],
                                                     "type": "object",
-                                                    "x-kubernetes-map-type": "atomic"
+                                                    "x-kubernetes-map-type": "atomic",
+                                                    "additionalProperties": false
                                                   },
                                                   "fileKeyRef": {
                                                     "properties": {
@@ -3563,7 +3740,8 @@
                                                       "volumeName"
                                                     ],
                                                     "type": "object",
-                                                    "x-kubernetes-map-type": "atomic"
+                                                    "x-kubernetes-map-type": "atomic",
+                                                    "additionalProperties": false
                                                   },
                                                   "resourceFieldRef": {
                                                     "properties": {
@@ -3590,7 +3768,8 @@
                                                       "resource"
                                                     ],
                                                     "type": "object",
-                                                    "x-kubernetes-map-type": "atomic"
+                                                    "x-kubernetes-map-type": "atomic",
+                                                    "additionalProperties": false
                                                   },
                                                   "secretKeyRef": {
                                                     "properties": {
@@ -3609,16 +3788,19 @@
                                                       "key"
                                                     ],
                                                     "type": "object",
-                                                    "x-kubernetes-map-type": "atomic"
+                                                    "x-kubernetes-map-type": "atomic",
+                                                    "additionalProperties": false
                                                   }
                                                 },
-                                                "type": "object"
+                                                "type": "object",
+                                                "additionalProperties": false
                                               }
                                             },
                                             "required": [
                                               "name"
                                             ],
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           },
                                           "type": "array",
                                           "x-kubernetes-list-map-keys": [
@@ -3640,7 +3822,8 @@
                                                   }
                                                 },
                                                 "type": "object",
-                                                "x-kubernetes-map-type": "atomic"
+                                                "x-kubernetes-map-type": "atomic",
+                                                "additionalProperties": false
                                               },
                                               "prefix": {
                                                 "type": "string"
@@ -3656,10 +3839,12 @@
                                                   }
                                                 },
                                                 "type": "object",
-                                                "x-kubernetes-map-type": "atomic"
+                                                "x-kubernetes-map-type": "atomic",
+                                                "additionalProperties": false
                                               }
                                             },
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           },
                                           "type": "array",
                                           "x-kubernetes-list-type": "atomic"
@@ -3684,7 +3869,8 @@
                                                       "x-kubernetes-list-type": "atomic"
                                                     }
                                                   },
-                                                  "type": "object"
+                                                  "type": "object",
+                                                  "additionalProperties": false
                                                 },
                                                 "httpGet": {
                                                   "properties": {
@@ -3705,7 +3891,8 @@
                                                           "name",
                                                           "value"
                                                         ],
-                                                        "type": "object"
+                                                        "type": "object",
+                                                        "additionalProperties": false
                                                       },
                                                       "type": "array",
                                                       "x-kubernetes-list-type": "atomic"
@@ -3731,7 +3918,8 @@
                                                   "required": [
                                                     "port"
                                                   ],
-                                                  "type": "object"
+                                                  "type": "object",
+                                                  "additionalProperties": false
                                                 },
                                                 "sleep": {
                                                   "properties": {
@@ -3743,7 +3931,8 @@
                                                   "required": [
                                                     "seconds"
                                                   ],
-                                                  "type": "object"
+                                                  "type": "object",
+                                                  "additionalProperties": false
                                                 },
                                                 "tcpSocket": {
                                                   "properties": {
@@ -3765,10 +3954,12 @@
                                                   "required": [
                                                     "port"
                                                   ],
-                                                  "type": "object"
+                                                  "type": "object",
+                                                  "additionalProperties": false
                                                 }
                                               },
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "preStop": {
                                               "properties": {
@@ -3782,7 +3973,8 @@
                                                       "x-kubernetes-list-type": "atomic"
                                                     }
                                                   },
-                                                  "type": "object"
+                                                  "type": "object",
+                                                  "additionalProperties": false
                                                 },
                                                 "httpGet": {
                                                   "properties": {
@@ -3803,7 +3995,8 @@
                                                           "name",
                                                           "value"
                                                         ],
-                                                        "type": "object"
+                                                        "type": "object",
+                                                        "additionalProperties": false
                                                       },
                                                       "type": "array",
                                                       "x-kubernetes-list-type": "atomic"
@@ -3829,7 +4022,8 @@
                                                   "required": [
                                                     "port"
                                                   ],
-                                                  "type": "object"
+                                                  "type": "object",
+                                                  "additionalProperties": false
                                                 },
                                                 "sleep": {
                                                   "properties": {
@@ -3841,7 +4035,8 @@
                                                   "required": [
                                                     "seconds"
                                                   ],
-                                                  "type": "object"
+                                                  "type": "object",
+                                                  "additionalProperties": false
                                                 },
                                                 "tcpSocket": {
                                                   "properties": {
@@ -3863,16 +4058,19 @@
                                                   "required": [
                                                     "port"
                                                   ],
-                                                  "type": "object"
+                                                  "type": "object",
+                                                  "additionalProperties": false
                                                 }
                                               },
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "stopSignal": {
                                               "type": "string"
                                             }
                                           },
-                                          "type": "object"
+                                          "type": "object",
+                                          "additionalProperties": false
                                         },
                                         "livenessProbe": {
                                           "properties": {
@@ -3886,7 +4084,8 @@
                                                   "x-kubernetes-list-type": "atomic"
                                                 }
                                               },
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "failureThreshold": {
                                               "format": "int32",
@@ -3906,7 +4105,8 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "httpGet": {
                                               "properties": {
@@ -3927,7 +4127,8 @@
                                                       "name",
                                                       "value"
                                                     ],
-                                                    "type": "object"
+                                                    "type": "object",
+                                                    "additionalProperties": false
                                                   },
                                                   "type": "array",
                                                   "x-kubernetes-list-type": "atomic"
@@ -3953,7 +4154,8 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "initialDelaySeconds": {
                                               "format": "int32",
@@ -3987,7 +4189,8 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "terminationGracePeriodSeconds": {
                                               "format": "int64",
@@ -3998,7 +4201,8 @@
                                               "type": "integer"
                                             }
                                           },
-                                          "type": "object"
+                                          "type": "object",
+                                          "additionalProperties": false
                                         },
                                         "name": {
                                           "type": "string"
@@ -4028,7 +4232,8 @@
                                             "required": [
                                               "containerPort"
                                             ],
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           },
                                           "type": "array",
                                           "x-kubernetes-list-map-keys": [
@@ -4049,7 +4254,8 @@
                                                   "x-kubernetes-list-type": "atomic"
                                                 }
                                               },
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "failureThreshold": {
                                               "format": "int32",
@@ -4069,7 +4275,8 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "httpGet": {
                                               "properties": {
@@ -4090,7 +4297,8 @@
                                                       "name",
                                                       "value"
                                                     ],
-                                                    "type": "object"
+                                                    "type": "object",
+                                                    "additionalProperties": false
                                                   },
                                                   "type": "array",
                                                   "x-kubernetes-list-type": "atomic"
@@ -4116,7 +4324,8 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "initialDelaySeconds": {
                                               "format": "int32",
@@ -4150,7 +4359,8 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "terminationGracePeriodSeconds": {
                                               "format": "int64",
@@ -4161,7 +4371,8 @@
                                               "type": "integer"
                                             }
                                           },
-                                          "type": "object"
+                                          "type": "object",
+                                          "additionalProperties": false
                                         },
                                         "resizePolicy": {
                                           "items": {
@@ -4177,7 +4388,8 @@
                                               "resourceName",
                                               "restartPolicy"
                                             ],
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           },
                                           "type": "array",
                                           "x-kubernetes-list-type": "atomic"
@@ -4197,7 +4409,8 @@
                                                 "required": [
                                                   "name"
                                                 ],
-                                                "type": "object"
+                                                "type": "object",
+                                                "additionalProperties": false
                                               },
                                               "type": "array",
                                               "x-kubernetes-list-map-keys": [
@@ -4212,7 +4425,8 @@
                                               "x-kubernetes-preserve-unknown-fields": true
                                             }
                                           },
-                                          "type": "object"
+                                          "type": "object",
+                                          "additionalProperties": false
                                         },
                                         "restartPolicy": {
                                           "type": "string"
@@ -4240,13 +4454,15 @@
                                                 "required": [
                                                   "operator"
                                                 ],
-                                                "type": "object"
+                                                "type": "object",
+                                                "additionalProperties": false
                                               }
                                             },
                                             "required": [
                                               "action"
                                             ],
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           },
                                           "type": "array",
                                           "x-kubernetes-list-type": "atomic"
@@ -4268,7 +4484,8 @@
                                               "required": [
                                                 "type"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "capabilities": {
                                               "properties": {
@@ -4287,7 +4504,8 @@
                                                   "x-kubernetes-list-type": "atomic"
                                                 }
                                               },
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "privileged": {
                                               "type": "boolean"
@@ -4324,7 +4542,8 @@
                                                   "type": "string"
                                                 }
                                               },
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "seccompProfile": {
                                               "properties": {
@@ -4338,7 +4557,8 @@
                                               "required": [
                                                 "type"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "windowsOptions": {
                                               "properties": {
@@ -4355,10 +4575,12 @@
                                                   "type": "string"
                                                 }
                                               },
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             }
                                           },
-                                          "type": "object"
+                                          "type": "object",
+                                          "additionalProperties": false
                                         },
                                         "startupProbe": {
                                           "properties": {
@@ -4372,7 +4594,8 @@
                                                   "x-kubernetes-list-type": "atomic"
                                                 }
                                               },
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "failureThreshold": {
                                               "format": "int32",
@@ -4392,7 +4615,8 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "httpGet": {
                                               "properties": {
@@ -4413,7 +4637,8 @@
                                                       "name",
                                                       "value"
                                                     ],
-                                                    "type": "object"
+                                                    "type": "object",
+                                                    "additionalProperties": false
                                                   },
                                                   "type": "array",
                                                   "x-kubernetes-list-type": "atomic"
@@ -4439,7 +4664,8 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "initialDelaySeconds": {
                                               "format": "int32",
@@ -4473,7 +4699,8 @@
                                               "required": [
                                                 "port"
                                               ],
-                                              "type": "object"
+                                              "type": "object",
+                                              "additionalProperties": false
                                             },
                                             "terminationGracePeriodSeconds": {
                                               "format": "int64",
@@ -4484,7 +4711,8 @@
                                               "type": "integer"
                                             }
                                           },
-                                          "type": "object"
+                                          "type": "object",
+                                          "additionalProperties": false
                                         },
                                         "stdin": {
                                           "type": "boolean"
@@ -4515,7 +4743,8 @@
                                               "devicePath",
                                               "name"
                                             ],
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           },
                                           "type": "array",
                                           "x-kubernetes-list-map-keys": [
@@ -4552,7 +4781,8 @@
                                               "mountPath",
                                               "name"
                                             ],
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           },
                                           "type": "array",
                                           "x-kubernetes-list-map-keys": [
@@ -4567,7 +4797,8 @@
                                       "required": [
                                         "name"
                                       ],
-                                      "type": "object"
+                                      "type": "object",
+                                      "additionalProperties": false
                                     },
                                     "type": "array",
                                     "x-kubernetes-list-map-keys": [
@@ -4594,7 +4825,8 @@
                                     "required": [
                                       "name"
                                     ],
-                                    "type": "object"
+                                    "type": "object",
+                                    "additionalProperties": false
                                   },
                                   "overhead": {
                                     "additionalProperties": {
@@ -4631,7 +4863,8 @@
                                       "required": [
                                         "conditionType"
                                       ],
-                                      "type": "object"
+                                      "type": "object",
+                                      "additionalProperties": false
                                     },
                                     "type": "array",
                                     "x-kubernetes-list-type": "atomic"
@@ -4652,7 +4885,8 @@
                                       "required": [
                                         "name"
                                       ],
-                                      "type": "object"
+                                      "type": "object",
+                                      "additionalProperties": false
                                     },
                                     "type": "array",
                                     "x-kubernetes-list-map-keys": [
@@ -4675,7 +4909,8 @@
                                           "required": [
                                             "name"
                                           ],
-                                          "type": "object"
+                                          "type": "object",
+                                          "additionalProperties": false
                                         },
                                         "type": "array",
                                         "x-kubernetes-list-map-keys": [
@@ -4714,7 +4949,8 @@
                                         "type": "object"
                                       }
                                     },
-                                    "type": "object"
+                                    "type": "object",
+                                    "additionalProperties": false
                                   },
                                   "restartPolicy": {
                                     "type": "string"
@@ -4735,7 +4971,8 @@
                                       "required": [
                                         "name"
                                       ],
-                                      "type": "object"
+                                      "type": "object",
+                                      "additionalProperties": false
                                     },
                                     "type": "array",
                                     "x-kubernetes-list-map-keys": [
@@ -4757,7 +4994,8 @@
                                         "required": [
                                           "type"
                                         ],
-                                        "type": "object"
+                                        "type": "object",
+                                        "additionalProperties": false
                                       },
                                       "fsGroup": {
                                         "format": "int64",
@@ -4795,7 +5033,8 @@
                                             "type": "string"
                                           }
                                         },
-                                        "type": "object"
+                                        "type": "object",
+                                        "additionalProperties": false
                                       },
                                       "seccompProfile": {
                                         "properties": {
@@ -4809,7 +5048,8 @@
                                         "required": [
                                           "type"
                                         ],
-                                        "type": "object"
+                                        "type": "object",
+                                        "additionalProperties": false
                                       },
                                       "supplementalGroups": {
                                         "items": {
@@ -4836,7 +5076,8 @@
                                             "name",
                                             "value"
                                           ],
-                                          "type": "object"
+                                          "type": "object",
+                                          "additionalProperties": false
                                         },
                                         "type": "array",
                                         "x-kubernetes-list-type": "atomic"
@@ -4856,10 +5097,12 @@
                                             "type": "string"
                                           }
                                         },
-                                        "type": "object"
+                                        "type": "object",
+                                        "additionalProperties": false
                                       }
                                     },
-                                    "type": "object"
+                                    "type": "object",
+                                    "additionalProperties": false
                                   },
                                   "serviceAccount": {
                                     "type": "string"
@@ -4900,7 +5143,8 @@
                                           "type": "string"
                                         }
                                       },
-                                      "type": "object"
+                                      "type": "object",
+                                      "additionalProperties": false
                                     },
                                     "type": "array",
                                     "x-kubernetes-list-type": "atomic"
@@ -4931,7 +5175,8 @@
                                                   "key",
                                                   "operator"
                                                 ],
-                                                "type": "object"
+                                                "type": "object",
+                                                "additionalProperties": false
                                               },
                                               "type": "array",
                                               "x-kubernetes-list-type": "atomic"
@@ -4944,7 +5189,8 @@
                                             }
                                           },
                                           "type": "object",
-                                          "x-kubernetes-map-type": "atomic"
+                                          "x-kubernetes-map-type": "atomic",
+                                          "additionalProperties": false
                                         },
                                         "matchLabelKeys": {
                                           "items": {
@@ -4979,7 +5225,8 @@
                                         "topologyKey",
                                         "whenUnsatisfiable"
                                       ],
-                                      "type": "object"
+                                      "type": "object",
+                                      "additionalProperties": false
                                     },
                                     "type": "array",
                                     "x-kubernetes-list-map-keys": [
@@ -4995,10 +5242,12 @@
                                 "required": [
                                   "containers"
                                 ],
-                                "type": "object"
+                                "type": "object",
+                                "additionalProperties": false
                               }
                             },
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "ttlSecondsAfterFinished": {
                             "format": "int32",
@@ -5008,13 +5257,15 @@
                         "required": [
                           "template"
                         ],
-                        "type": "object"
+                        "type": "object",
+                        "additionalProperties": false
                       }
                     },
                     "required": [
                       "spec"
                     ],
-                    "type": "object"
+                    "type": "object",
+                    "additionalProperties": false
                   },
                   "kayenta": {
                     "properties": {
@@ -5063,7 +5314,8 @@
                                 "scope",
                                 "step"
                               ],
-                              "type": "object"
+                              "type": "object",
+                              "additionalProperties": false
                             },
                             "experimentScope": {
                               "properties": {
@@ -5089,7 +5341,8 @@
                                 "scope",
                                 "step"
                               ],
-                              "type": "object"
+                              "type": "object",
+                              "additionalProperties": false
                             },
                             "name": {
                               "type": "string"
@@ -5100,7 +5353,8 @@
                             "experimentScope",
                             "name"
                           ],
-                          "type": "object"
+                          "type": "object",
+                          "additionalProperties": false
                         },
                         "type": "array"
                       },
@@ -5122,7 +5376,8 @@
                           "marginal",
                           "pass"
                         ],
-                        "type": "object"
+                        "type": "object",
+                        "additionalProperties": false
                       }
                     },
                     "required": [
@@ -5135,7 +5390,8 @@
                       "storageAccountName",
                       "threshold"
                     ],
-                    "type": "object"
+                    "type": "object",
+                    "additionalProperties": false
                   },
                   "newRelic": {
                     "properties": {
@@ -5153,7 +5409,8 @@
                     "required": [
                       "query"
                     ],
-                    "type": "object"
+                    "type": "object",
+                    "additionalProperties": false
                   },
                   "plugin": {
                     "type": "object",
@@ -5184,7 +5441,8 @@
                                 "type": "string"
                               }
                             },
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "sigv4": {
                             "properties": {
@@ -5198,10 +5456,12 @@
                                 "type": "string"
                               }
                             },
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           }
                         },
-                        "type": "object"
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "headers": {
                         "items": {
@@ -5217,7 +5477,8 @@
                             "key",
                             "value"
                           ],
-                          "type": "object"
+                          "type": "object",
+                          "additionalProperties": false
                         },
                         "type": "array"
                       },
@@ -5239,14 +5500,16 @@
                             "type": "string"
                           }
                         },
-                        "type": "object"
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "timeout": {
                         "format": "int64",
                         "type": "integer"
                       }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "additionalProperties": false
                   },
                   "skywalking": {
                     "properties": {
@@ -5260,7 +5523,8 @@
                         "type": "string"
                       }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "additionalProperties": false
                   },
                   "wavefront": {
                     "properties": {
@@ -5271,7 +5535,8 @@
                         "type": "string"
                       }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "additionalProperties": false
                   },
                   "web": {
                     "properties": {
@@ -5295,7 +5560,8 @@
                                 "type": "string"
                               }
                             },
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "sigv4": {
                             "properties": {
@@ -5309,10 +5575,12 @@
                                 "type": "string"
                               }
                             },
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           }
                         },
-                        "type": "object"
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "body": {
                         "type": "string"
@@ -5331,7 +5599,8 @@
                             "key",
                             "value"
                           ],
-                          "type": "object"
+                          "type": "object",
+                          "additionalProperties": false
                         },
                         "type": "array"
                       },
@@ -5359,10 +5628,12 @@
                     "required": [
                       "url"
                     ],
-                    "type": "object"
+                    "type": "object",
+                    "additionalProperties": false
                   }
                 },
-                "type": "object"
+                "type": "object",
+                "additionalProperties": false
               },
               "successCondition": {
                 "type": "string"
@@ -5372,7 +5643,8 @@
               "name",
               "provider"
             ],
-            "type": "object"
+            "type": "object",
+            "additionalProperties": false
           },
           "type": "array"
         },
@@ -5386,12 +5658,14 @@
                 "type": "string"
               }
             },
-            "type": "object"
+            "type": "object",
+            "additionalProperties": false
           },
           "type": "array"
         }
       },
-      "type": "object"
+      "type": "object",
+      "additionalProperties": false
     }
   },
   "required": [

--- a/argoproj.io/experiment_v1alpha1.json
+++ b/argoproj.io/experiment_v1alpha1.json
@@ -181,7 +181,8 @@
                           "items": {
                             "type": "string"
                           },
-                          "type": "array"
+                          "type": "array",
+                          "x-kubernetes-list-type": "atomic"
                         }
                       },
                       "required": [
@@ -191,7 +192,8 @@
                       "type": "object",
                       "additionalProperties": false
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   },
                   "matchLabels": {
                     "additionalProperties": {
@@ -261,7 +263,8 @@
                                                 "items": {
                                                   "type": "string"
                                                 },
-                                                "type": "array"
+                                                "type": "array",
+                                                "x-kubernetes-list-type": "atomic"
                                               }
                                             },
                                             "required": [
@@ -271,7 +274,8 @@
                                             "type": "object",
                                             "additionalProperties": false
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "matchFields": {
                                           "items": {
@@ -286,7 +290,8 @@
                                                 "items": {
                                                   "type": "string"
                                                 },
-                                                "type": "array"
+                                                "type": "array",
+                                                "x-kubernetes-list-type": "atomic"
                                               }
                                             },
                                             "required": [
@@ -296,7 +301,8 @@
                                             "type": "object",
                                             "additionalProperties": false
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       },
                                       "type": "object",
@@ -315,7 +321,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "requiredDuringSchedulingIgnoredDuringExecution": {
                                 "properties": {
@@ -335,7 +342,8 @@
                                                 "items": {
                                                   "type": "string"
                                                 },
-                                                "type": "array"
+                                                "type": "array",
+                                                "x-kubernetes-list-type": "atomic"
                                               }
                                             },
                                             "required": [
@@ -345,7 +353,8 @@
                                             "type": "object",
                                             "additionalProperties": false
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "matchFields": {
                                           "items": {
@@ -360,7 +369,8 @@
                                                 "items": {
                                                   "type": "string"
                                                 },
-                                                "type": "array"
+                                                "type": "array",
+                                                "x-kubernetes-list-type": "atomic"
                                               }
                                             },
                                             "required": [
@@ -370,14 +380,16 @@
                                             "type": "object",
                                             "additionalProperties": false
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       },
                                       "type": "object",
                                       "x-kubernetes-map-type": "atomic",
                                       "additionalProperties": false
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   }
                                 },
                                 "required": [
@@ -413,7 +425,8 @@
                                                     "items": {
                                                       "type": "string"
                                                     },
-                                                    "type": "array"
+                                                    "type": "array",
+                                                    "x-kubernetes-list-type": "atomic"
                                                   }
                                                 },
                                                 "required": [
@@ -423,7 +436,8 @@
                                                 "type": "object",
                                                 "additionalProperties": false
                                               },
-                                              "type": "array"
+                                              "type": "array",
+                                              "x-kubernetes-list-type": "atomic"
                                             },
                                             "matchLabels": {
                                               "additionalProperties": {
@@ -465,7 +479,8 @@
                                                     "items": {
                                                       "type": "string"
                                                     },
-                                                    "type": "array"
+                                                    "type": "array",
+                                                    "x-kubernetes-list-type": "atomic"
                                                   }
                                                 },
                                                 "required": [
@@ -475,7 +490,8 @@
                                                 "type": "object",
                                                 "additionalProperties": false
                                               },
-                                              "type": "array"
+                                              "type": "array",
+                                              "x-kubernetes-list-type": "atomic"
                                             },
                                             "matchLabels": {
                                               "additionalProperties": {
@@ -492,7 +508,8 @@
                                           "items": {
                                             "type": "string"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "topologyKey": {
                                           "type": "string"
@@ -516,7 +533,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "requiredDuringSchedulingIgnoredDuringExecution": {
                                 "items": {
@@ -536,7 +554,8 @@
                                                 "items": {
                                                   "type": "string"
                                                 },
-                                                "type": "array"
+                                                "type": "array",
+                                                "x-kubernetes-list-type": "atomic"
                                               }
                                             },
                                             "required": [
@@ -546,7 +565,8 @@
                                             "type": "object",
                                             "additionalProperties": false
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "matchLabels": {
                                           "additionalProperties": {
@@ -588,7 +608,8 @@
                                                 "items": {
                                                   "type": "string"
                                                 },
-                                                "type": "array"
+                                                "type": "array",
+                                                "x-kubernetes-list-type": "atomic"
                                               }
                                             },
                                             "required": [
@@ -598,7 +619,8 @@
                                             "type": "object",
                                             "additionalProperties": false
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "matchLabels": {
                                           "additionalProperties": {
@@ -615,7 +637,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "topologyKey": {
                                       "type": "string"
@@ -627,7 +650,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               }
                             },
                             "type": "object",
@@ -655,7 +679,8 @@
                                                     "items": {
                                                       "type": "string"
                                                     },
-                                                    "type": "array"
+                                                    "type": "array",
+                                                    "x-kubernetes-list-type": "atomic"
                                                   }
                                                 },
                                                 "required": [
@@ -665,7 +690,8 @@
                                                 "type": "object",
                                                 "additionalProperties": false
                                               },
-                                              "type": "array"
+                                              "type": "array",
+                                              "x-kubernetes-list-type": "atomic"
                                             },
                                             "matchLabels": {
                                               "additionalProperties": {
@@ -707,7 +733,8 @@
                                                     "items": {
                                                       "type": "string"
                                                     },
-                                                    "type": "array"
+                                                    "type": "array",
+                                                    "x-kubernetes-list-type": "atomic"
                                                   }
                                                 },
                                                 "required": [
@@ -717,7 +744,8 @@
                                                 "type": "object",
                                                 "additionalProperties": false
                                               },
-                                              "type": "array"
+                                              "type": "array",
+                                              "x-kubernetes-list-type": "atomic"
                                             },
                                             "matchLabels": {
                                               "additionalProperties": {
@@ -734,7 +762,8 @@
                                           "items": {
                                             "type": "string"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "topologyKey": {
                                           "type": "string"
@@ -758,7 +787,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "requiredDuringSchedulingIgnoredDuringExecution": {
                                 "items": {
@@ -778,7 +808,8 @@
                                                 "items": {
                                                   "type": "string"
                                                 },
-                                                "type": "array"
+                                                "type": "array",
+                                                "x-kubernetes-list-type": "atomic"
                                               }
                                             },
                                             "required": [
@@ -788,7 +819,8 @@
                                             "type": "object",
                                             "additionalProperties": false
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "matchLabels": {
                                           "additionalProperties": {
@@ -830,7 +862,8 @@
                                                 "items": {
                                                   "type": "string"
                                                 },
-                                                "type": "array"
+                                                "type": "array",
+                                                "x-kubernetes-list-type": "atomic"
                                               }
                                             },
                                             "required": [
@@ -840,7 +873,8 @@
                                             "type": "object",
                                             "additionalProperties": false
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "matchLabels": {
                                           "additionalProperties": {
@@ -857,7 +891,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "topologyKey": {
                                       "type": "string"
@@ -869,7 +904,8 @@
                                   "type": "object",
                                   "additionalProperties": false
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               }
                             },
                             "type": "object",
@@ -889,13 +925,15 @@
                               "items": {
                                 "type": "string"
                               },
-                              "type": "array"
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "command": {
                               "items": {
                                 "type": "string"
                               },
-                              "type": "array"
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "env": {
                               "items": {
@@ -914,6 +952,7 @@
                                             "type": "string"
                                           },
                                           "name": {
+                                            "default": "",
                                             "type": "string"
                                           },
                                           "optional": {
@@ -938,6 +977,31 @@
                                         },
                                         "required": [
                                           "fieldPath"
+                                        ],
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic",
+                                        "additionalProperties": false
+                                      },
+                                      "fileKeyRef": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "default": false,
+                                            "type": "boolean"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "volumeName": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "key",
+                                          "path",
+                                          "volumeName"
                                         ],
                                         "type": "object",
                                         "x-kubernetes-map-type": "atomic",
@@ -977,6 +1041,7 @@
                                             "type": "string"
                                           },
                                           "name": {
+                                            "default": "",
                                             "type": "string"
                                           },
                                           "optional": {
@@ -1001,7 +1066,11 @@
                                 "type": "object",
                                 "additionalProperties": false
                               },
-                              "type": "array"
+                              "type": "array",
+                              "x-kubernetes-list-map-keys": [
+                                "name"
+                              ],
+                              "x-kubernetes-list-type": "map"
                             },
                             "envFrom": {
                               "items": {
@@ -1009,6 +1078,7 @@
                                   "configMapRef": {
                                     "properties": {
                                       "name": {
+                                        "default": "",
                                         "type": "string"
                                       },
                                       "optional": {
@@ -1025,6 +1095,7 @@
                                   "secretRef": {
                                     "properties": {
                                       "name": {
+                                        "default": "",
                                         "type": "string"
                                       },
                                       "optional": {
@@ -1039,7 +1110,8 @@
                                 "type": "object",
                                 "additionalProperties": false
                               },
-                              "type": "array"
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "image": {
                               "type": "string"
@@ -1057,7 +1129,8 @@
                                           "items": {
                                             "type": "string"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       },
                                       "type": "object",
@@ -1085,7 +1158,8 @@
                                             "type": "object",
                                             "additionalProperties": false
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "path": {
                                           "type": "string"
@@ -1159,7 +1233,8 @@
                                           "items": {
                                             "type": "string"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       },
                                       "type": "object",
@@ -1187,7 +1262,8 @@
                                             "type": "object",
                                             "additionalProperties": false
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "path": {
                                           "type": "string"
@@ -1252,6 +1328,9 @@
                                   },
                                   "type": "object",
                                   "additionalProperties": false
+                                },
+                                "stopSignal": {
+                                  "type": "string"
                                 }
                               },
                               "type": "object",
@@ -1265,7 +1344,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "type": "object",
@@ -1282,6 +1362,7 @@
                                       "type": "integer"
                                     },
                                     "service": {
+                                      "default": "",
                                       "type": "string"
                                     }
                                   },
@@ -1313,7 +1394,8 @@
                                         "type": "object",
                                         "additionalProperties": false
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "path": {
                                       "type": "string"
@@ -1432,7 +1514,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "type": "object",
@@ -1449,6 +1532,7 @@
                                       "type": "integer"
                                     },
                                     "service": {
+                                      "default": "",
                                       "type": "string"
                                     }
                                   },
@@ -1480,7 +1564,8 @@
                                         "type": "object",
                                         "additionalProperties": false
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "path": {
                                       "type": "string"
@@ -1580,6 +1665,9 @@
                                     "properties": {
                                       "name": {
                                         "type": "string"
+                                      },
+                                      "request": {
+                                        "type": "string"
                                       }
                                     },
                                     "required": [
@@ -1607,10 +1695,61 @@
                             "restartPolicy": {
                               "type": "string"
                             },
+                            "restartPolicyRules": {
+                              "items": {
+                                "properties": {
+                                  "action": {
+                                    "type": "string"
+                                  },
+                                  "exitCodes": {
+                                    "properties": {
+                                      "operator": {
+                                        "type": "string"
+                                      },
+                                      "values": {
+                                        "items": {
+                                          "format": "int32",
+                                          "type": "integer"
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "set"
+                                      }
+                                    },
+                                    "required": [
+                                      "operator"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "required": [
+                                  "action"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
+                            },
                             "securityContext": {
                               "properties": {
                                 "allowPrivilegeEscalation": {
                                   "type": "boolean"
+                                },
+                                "appArmorProfile": {
+                                  "properties": {
+                                    "localhostProfile": {
+                                      "type": "string"
+                                    },
+                                    "type": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "type"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
                                 },
                                 "capabilities": {
                                   "properties": {
@@ -1618,13 +1757,15 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "drop": {
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "type": "object",
@@ -1713,7 +1854,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "type": "object",
@@ -1730,6 +1872,7 @@
                                       "type": "integer"
                                     },
                                     "service": {
+                                      "default": "",
                                       "type": "string"
                                     }
                                   },
@@ -1761,7 +1904,8 @@
                                         "type": "object",
                                         "additionalProperties": false
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "path": {
                                       "type": "string"
@@ -1866,7 +2010,11 @@
                                 "type": "object",
                                 "additionalProperties": false
                               },
-                              "type": "array"
+                              "type": "array",
+                              "x-kubernetes-list-map-keys": [
+                                "devicePath"
+                              ],
+                              "x-kubernetes-list-type": "map"
                             },
                             "volumeMounts": {
                               "items": {
@@ -1883,6 +2031,9 @@
                                   "readOnly": {
                                     "type": "boolean"
                                   },
+                                  "recursiveReadOnly": {
+                                    "type": "string"
+                                  },
                                   "subPath": {
                                     "type": "string"
                                   },
@@ -1897,7 +2048,11 @@
                                 "type": "object",
                                 "additionalProperties": false
                               },
-                              "type": "array"
+                              "type": "array",
+                              "x-kubernetes-list-map-keys": [
+                                "mountPath"
+                              ],
+                              "x-kubernetes-list-type": "map"
                             },
                             "workingDir": {
                               "type": "string"
@@ -1909,7 +2064,11 @@
                           "type": "object",
                           "additionalProperties": false
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-map-keys": [
+                          "name"
+                        ],
+                        "x-kubernetes-list-type": "map"
                       },
                       "dnsConfig": {
                         "properties": {
@@ -1917,7 +2076,8 @@
                             "items": {
                               "type": "string"
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "options": {
                             "items": {
@@ -1932,13 +2092,15 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "searches": {
                             "items": {
                               "type": "string"
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           }
                         },
                         "type": "object",
@@ -1957,13 +2119,15 @@
                               "items": {
                                 "type": "string"
                               },
-                              "type": "array"
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "command": {
                               "items": {
                                 "type": "string"
                               },
-                              "type": "array"
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "env": {
                               "items": {
@@ -1982,6 +2146,7 @@
                                             "type": "string"
                                           },
                                           "name": {
+                                            "default": "",
                                             "type": "string"
                                           },
                                           "optional": {
@@ -2006,6 +2171,31 @@
                                         },
                                         "required": [
                                           "fieldPath"
+                                        ],
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic",
+                                        "additionalProperties": false
+                                      },
+                                      "fileKeyRef": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "default": false,
+                                            "type": "boolean"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "volumeName": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "key",
+                                          "path",
+                                          "volumeName"
                                         ],
                                         "type": "object",
                                         "x-kubernetes-map-type": "atomic",
@@ -2045,6 +2235,7 @@
                                             "type": "string"
                                           },
                                           "name": {
+                                            "default": "",
                                             "type": "string"
                                           },
                                           "optional": {
@@ -2069,7 +2260,11 @@
                                 "type": "object",
                                 "additionalProperties": false
                               },
-                              "type": "array"
+                              "type": "array",
+                              "x-kubernetes-list-map-keys": [
+                                "name"
+                              ],
+                              "x-kubernetes-list-type": "map"
                             },
                             "envFrom": {
                               "items": {
@@ -2077,6 +2272,7 @@
                                   "configMapRef": {
                                     "properties": {
                                       "name": {
+                                        "default": "",
                                         "type": "string"
                                       },
                                       "optional": {
@@ -2093,6 +2289,7 @@
                                   "secretRef": {
                                     "properties": {
                                       "name": {
+                                        "default": "",
                                         "type": "string"
                                       },
                                       "optional": {
@@ -2107,7 +2304,8 @@
                                 "type": "object",
                                 "additionalProperties": false
                               },
-                              "type": "array"
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "image": {
                               "type": "string"
@@ -2125,7 +2323,8 @@
                                           "items": {
                                             "type": "string"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       },
                                       "type": "object",
@@ -2153,7 +2352,8 @@
                                             "type": "object",
                                             "additionalProperties": false
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "path": {
                                           "type": "string"
@@ -2227,7 +2427,8 @@
                                           "items": {
                                             "type": "string"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       },
                                       "type": "object",
@@ -2255,7 +2456,8 @@
                                             "type": "object",
                                             "additionalProperties": false
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "path": {
                                           "type": "string"
@@ -2320,6 +2522,9 @@
                                   },
                                   "type": "object",
                                   "additionalProperties": false
+                                },
+                                "stopSignal": {
+                                  "type": "string"
                                 }
                               },
                               "type": "object",
@@ -2333,7 +2538,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "type": "object",
@@ -2350,6 +2556,7 @@
                                       "type": "integer"
                                     },
                                     "service": {
+                                      "default": "",
                                       "type": "string"
                                     }
                                   },
@@ -2381,7 +2588,8 @@
                                         "type": "object",
                                         "additionalProperties": false
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "path": {
                                       "type": "string"
@@ -2500,7 +2708,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "type": "object",
@@ -2517,6 +2726,7 @@
                                       "type": "integer"
                                     },
                                     "service": {
+                                      "default": "",
                                       "type": "string"
                                     }
                                   },
@@ -2548,7 +2758,8 @@
                                         "type": "object",
                                         "additionalProperties": false
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "path": {
                                       "type": "string"
@@ -2648,6 +2859,9 @@
                                     "properties": {
                                       "name": {
                                         "type": "string"
+                                      },
+                                      "request": {
+                                        "type": "string"
                                       }
                                     },
                                     "required": [
@@ -2675,10 +2889,61 @@
                             "restartPolicy": {
                               "type": "string"
                             },
+                            "restartPolicyRules": {
+                              "items": {
+                                "properties": {
+                                  "action": {
+                                    "type": "string"
+                                  },
+                                  "exitCodes": {
+                                    "properties": {
+                                      "operator": {
+                                        "type": "string"
+                                      },
+                                      "values": {
+                                        "items": {
+                                          "format": "int32",
+                                          "type": "integer"
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "set"
+                                      }
+                                    },
+                                    "required": [
+                                      "operator"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "required": [
+                                  "action"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
+                            },
                             "securityContext": {
                               "properties": {
                                 "allowPrivilegeEscalation": {
                                   "type": "boolean"
+                                },
+                                "appArmorProfile": {
+                                  "properties": {
+                                    "localhostProfile": {
+                                      "type": "string"
+                                    },
+                                    "type": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "type"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
                                 },
                                 "capabilities": {
                                   "properties": {
@@ -2686,13 +2951,15 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "drop": {
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "type": "object",
@@ -2781,7 +3048,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "type": "object",
@@ -2798,6 +3066,7 @@
                                       "type": "integer"
                                     },
                                     "service": {
+                                      "default": "",
                                       "type": "string"
                                     }
                                   },
@@ -2829,7 +3098,8 @@
                                         "type": "object",
                                         "additionalProperties": false
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "path": {
                                       "type": "string"
@@ -2937,7 +3207,11 @@
                                 "type": "object",
                                 "additionalProperties": false
                               },
-                              "type": "array"
+                              "type": "array",
+                              "x-kubernetes-list-map-keys": [
+                                "devicePath"
+                              ],
+                              "x-kubernetes-list-type": "map"
                             },
                             "volumeMounts": {
                               "items": {
@@ -2954,6 +3228,9 @@
                                   "readOnly": {
                                     "type": "boolean"
                                   },
+                                  "recursiveReadOnly": {
+                                    "type": "string"
+                                  },
                                   "subPath": {
                                     "type": "string"
                                   },
@@ -2968,7 +3245,11 @@
                                 "type": "object",
                                 "additionalProperties": false
                               },
-                              "type": "array"
+                              "type": "array",
+                              "x-kubernetes-list-map-keys": [
+                                "mountPath"
+                              ],
+                              "x-kubernetes-list-type": "map"
                             },
                             "workingDir": {
                               "type": "string"
@@ -2980,7 +3261,11 @@
                           "type": "object",
                           "additionalProperties": false
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-map-keys": [
+                          "name"
+                        ],
+                        "x-kubernetes-list-type": "map"
                       },
                       "hostAliases": {
                         "items": {
@@ -2989,16 +3274,24 @@
                               "items": {
                                 "type": "string"
                               },
-                              "type": "array"
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "ip": {
                               "type": "string"
                             }
                           },
+                          "required": [
+                            "ip"
+                          ],
                           "type": "object",
                           "additionalProperties": false
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-map-keys": [
+                          "ip"
+                        ],
+                        "x-kubernetes-list-type": "map"
                       },
                       "hostIPC": {
                         "type": "boolean"
@@ -3015,10 +3308,14 @@
                       "hostname": {
                         "type": "string"
                       },
+                      "hostnameOverride": {
+                        "type": "string"
+                      },
                       "imagePullSecrets": {
                         "items": {
                           "properties": {
                             "name": {
+                              "default": "",
                               "type": "string"
                             }
                           },
@@ -3026,7 +3323,11 @@
                           "x-kubernetes-map-type": "atomic",
                           "additionalProperties": false
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-map-keys": [
+                          "name"
+                        ],
+                        "x-kubernetes-list-type": "map"
                       },
                       "initContainers": {
                         "items": {
@@ -3035,13 +3336,15 @@
                               "items": {
                                 "type": "string"
                               },
-                              "type": "array"
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "command": {
                               "items": {
                                 "type": "string"
                               },
-                              "type": "array"
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "env": {
                               "items": {
@@ -3060,6 +3363,7 @@
                                             "type": "string"
                                           },
                                           "name": {
+                                            "default": "",
                                             "type": "string"
                                           },
                                           "optional": {
@@ -3084,6 +3388,31 @@
                                         },
                                         "required": [
                                           "fieldPath"
+                                        ],
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic",
+                                        "additionalProperties": false
+                                      },
+                                      "fileKeyRef": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "default": false,
+                                            "type": "boolean"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "volumeName": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "key",
+                                          "path",
+                                          "volumeName"
                                         ],
                                         "type": "object",
                                         "x-kubernetes-map-type": "atomic",
@@ -3123,6 +3452,7 @@
                                             "type": "string"
                                           },
                                           "name": {
+                                            "default": "",
                                             "type": "string"
                                           },
                                           "optional": {
@@ -3147,7 +3477,11 @@
                                 "type": "object",
                                 "additionalProperties": false
                               },
-                              "type": "array"
+                              "type": "array",
+                              "x-kubernetes-list-map-keys": [
+                                "name"
+                              ],
+                              "x-kubernetes-list-type": "map"
                             },
                             "envFrom": {
                               "items": {
@@ -3155,6 +3489,7 @@
                                   "configMapRef": {
                                     "properties": {
                                       "name": {
+                                        "default": "",
                                         "type": "string"
                                       },
                                       "optional": {
@@ -3171,6 +3506,7 @@
                                   "secretRef": {
                                     "properties": {
                                       "name": {
+                                        "default": "",
                                         "type": "string"
                                       },
                                       "optional": {
@@ -3185,7 +3521,8 @@
                                 "type": "object",
                                 "additionalProperties": false
                               },
-                              "type": "array"
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "image": {
                               "type": "string"
@@ -3203,7 +3540,8 @@
                                           "items": {
                                             "type": "string"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       },
                                       "type": "object",
@@ -3231,7 +3569,8 @@
                                             "type": "object",
                                             "additionalProperties": false
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "path": {
                                           "type": "string"
@@ -3305,7 +3644,8 @@
                                           "items": {
                                             "type": "string"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       },
                                       "type": "object",
@@ -3333,7 +3673,8 @@
                                             "type": "object",
                                             "additionalProperties": false
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "path": {
                                           "type": "string"
@@ -3398,6 +3739,9 @@
                                   },
                                   "type": "object",
                                   "additionalProperties": false
+                                },
+                                "stopSignal": {
+                                  "type": "string"
                                 }
                               },
                               "type": "object",
@@ -3411,7 +3755,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "type": "object",
@@ -3428,6 +3773,7 @@
                                       "type": "integer"
                                     },
                                     "service": {
+                                      "default": "",
                                       "type": "string"
                                     }
                                   },
@@ -3459,7 +3805,8 @@
                                         "type": "object",
                                         "additionalProperties": false
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "path": {
                                       "type": "string"
@@ -3578,7 +3925,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "type": "object",
@@ -3595,6 +3943,7 @@
                                       "type": "integer"
                                     },
                                     "service": {
+                                      "default": "",
                                       "type": "string"
                                     }
                                   },
@@ -3626,7 +3975,8 @@
                                         "type": "object",
                                         "additionalProperties": false
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "path": {
                                       "type": "string"
@@ -3726,6 +4076,9 @@
                                     "properties": {
                                       "name": {
                                         "type": "string"
+                                      },
+                                      "request": {
+                                        "type": "string"
                                       }
                                     },
                                     "required": [
@@ -3753,10 +4106,61 @@
                             "restartPolicy": {
                               "type": "string"
                             },
+                            "restartPolicyRules": {
+                              "items": {
+                                "properties": {
+                                  "action": {
+                                    "type": "string"
+                                  },
+                                  "exitCodes": {
+                                    "properties": {
+                                      "operator": {
+                                        "type": "string"
+                                      },
+                                      "values": {
+                                        "items": {
+                                          "format": "int32",
+                                          "type": "integer"
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "set"
+                                      }
+                                    },
+                                    "required": [
+                                      "operator"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "required": [
+                                  "action"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
+                            },
                             "securityContext": {
                               "properties": {
                                 "allowPrivilegeEscalation": {
                                   "type": "boolean"
+                                },
+                                "appArmorProfile": {
+                                  "properties": {
+                                    "localhostProfile": {
+                                      "type": "string"
+                                    },
+                                    "type": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "type"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
                                 },
                                 "capabilities": {
                                   "properties": {
@@ -3764,13 +4168,15 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "drop": {
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "type": "object",
@@ -3859,7 +4265,8 @@
                                       "items": {
                                         "type": "string"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "type": "object",
@@ -3876,6 +4283,7 @@
                                       "type": "integer"
                                     },
                                     "service": {
+                                      "default": "",
                                       "type": "string"
                                     }
                                   },
@@ -3907,7 +4315,8 @@
                                         "type": "object",
                                         "additionalProperties": false
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "path": {
                                       "type": "string"
@@ -4012,7 +4421,11 @@
                                 "type": "object",
                                 "additionalProperties": false
                               },
-                              "type": "array"
+                              "type": "array",
+                              "x-kubernetes-list-map-keys": [
+                                "devicePath"
+                              ],
+                              "x-kubernetes-list-type": "map"
                             },
                             "volumeMounts": {
                               "items": {
@@ -4029,6 +4442,9 @@
                                   "readOnly": {
                                     "type": "boolean"
                                   },
+                                  "recursiveReadOnly": {
+                                    "type": "string"
+                                  },
                                   "subPath": {
                                     "type": "string"
                                   },
@@ -4043,7 +4459,11 @@
                                 "type": "object",
                                 "additionalProperties": false
                               },
-                              "type": "array"
+                              "type": "array",
+                              "x-kubernetes-list-map-keys": [
+                                "mountPath"
+                              ],
+                              "x-kubernetes-list-type": "map"
                             },
                             "workingDir": {
                               "type": "string"
@@ -4055,7 +4475,11 @@
                           "type": "object",
                           "additionalProperties": false
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-map-keys": [
+                          "name"
+                        ],
+                        "x-kubernetes-list-type": "map"
                       },
                       "nodeName": {
                         "type": "string"
@@ -4117,7 +4541,8 @@
                           "type": "object",
                           "additionalProperties": false
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "resourceClaims": {
                         "items": {
@@ -4125,17 +4550,11 @@
                             "name": {
                               "type": "string"
                             },
-                            "source": {
-                              "properties": {
-                                "resourceClaimName": {
-                                  "type": "string"
-                                },
-                                "resourceClaimTemplateName": {
-                                  "type": "string"
-                                }
-                              },
-                              "type": "object",
-                              "additionalProperties": false
+                            "resourceClaimName": {
+                              "type": "string"
+                            },
+                            "resourceClaimTemplateName": {
+                              "type": "string"
                             }
                           },
                           "required": [
@@ -4149,6 +4568,64 @@
                           "name"
                         ],
                         "x-kubernetes-list-type": "map"
+                      },
+                      "resources": {
+                        "properties": {
+                          "claims": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "request": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-map-keys": [
+                              "name"
+                            ],
+                            "x-kubernetes-list-type": "map"
+                          },
+                          "limits": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          },
+                          "requests": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "restartPolicy": {
                         "type": "string"
@@ -4180,6 +4657,21 @@
                       },
                       "securityContext": {
                         "properties": {
+                          "appArmorProfile": {
+                            "properties": {
+                              "localhostProfile": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "type"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
                           "fsGroup": {
                             "format": "int64",
                             "type": "integer"
@@ -4197,6 +4689,9 @@
                           "runAsUser": {
                             "format": "int64",
                             "type": "integer"
+                          },
+                          "seLinuxChangePolicy": {
+                            "type": "string"
                           },
                           "seLinuxOptions": {
                             "properties": {
@@ -4236,7 +4731,11 @@
                               "format": "int64",
                               "type": "integer"
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "supplementalGroupsPolicy": {
+                            "type": "string"
                           },
                           "sysctls": {
                             "items": {
@@ -4255,7 +4754,8 @@
                               "type": "object",
                               "additionalProperties": false
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "windowsOptions": {
                             "properties": {
@@ -4321,7 +4821,8 @@
                           "type": "object",
                           "additionalProperties": false
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "topologySpreadConstraints": {
                         "items": {
@@ -4341,7 +4842,8 @@
                                         "items": {
                                           "type": "string"
                                         },
-                                        "type": "array"
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
                                       }
                                     },
                                     "required": [
@@ -4351,7 +4853,8 @@
                                     "type": "object",
                                     "additionalProperties": false
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "matchLabels": {
                                   "additionalProperties": {

--- a/argoproj.io/rollout_v1alpha1.json
+++ b/argoproj.io/rollout_v1alpha1.json
@@ -22,8 +22,7 @@
               "type": "integer"
             }
           },
-          "type": "object",
-          "additionalProperties": false
+          "type": "object"
         },
         "minReadySeconds": {
           "format": "int32",
@@ -58,8 +57,7 @@
               "type": "integer"
             }
           },
-          "type": "object",
-          "additionalProperties": false
+          "type": "object"
         },
         "selector": {
           "properties": {
@@ -76,17 +74,18 @@
                     "items": {
                       "type": "string"
                     },
-                    "type": "array"
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
                   }
                 },
                 "required": [
                   "key",
                   "operator"
                 ],
-                "type": "object",
-                "additionalProperties": false
+                "type": "object"
               },
-              "type": "array"
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
             },
             "matchLabels": {
               "additionalProperties": {
@@ -97,7 +96,12 @@
           },
           "type": "object",
           "x-kubernetes-map-type": "atomic",
-          "additionalProperties": false
+          "x-kubernetes-validations": [
+            {
+              "message": ".spec.selector is immutable",
+              "rule": "self == oldSelf"
+            }
+          ]
         },
         "strategy": {
           "properties": {
@@ -122,8 +126,7 @@
                       "type": "object"
                     }
                   },
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 },
                 "activeService": {
                   "type": "string"
@@ -140,15 +143,13 @@
                       "required": [
                         "weight"
                       ],
-                      "type": "object",
-                      "additionalProperties": false
+                      "type": "object"
                     },
                     "requiredDuringSchedulingIgnoredDuringExecution": {
                       "type": "object"
                     }
                   },
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 },
                 "autoPromotionEnabled": {
                   "type": "boolean"
@@ -185,8 +186,7 @@
                           "type": "object"
                         }
                       },
-                      "type": "object",
-                      "additionalProperties": false
+                      "type": "object"
                     },
                     "args": {
                       "items": {
@@ -208,22 +208,19 @@
                                 "required": [
                                   "fieldPath"
                                 ],
-                                "type": "object",
-                                "additionalProperties": false
+                                "type": "object"
                               },
                               "podTemplateHashValue": {
                                 "type": "string"
                               }
                             },
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           }
                         },
                         "required": [
                           "name"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "type": "array"
                     },
@@ -237,8 +234,7 @@
                         "required": [
                           "metricName"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "type": "array"
                     },
@@ -257,8 +253,7 @@
                           "limit",
                           "metricName"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "type": "array"
                     },
@@ -272,14 +267,12 @@
                             "type": "string"
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "type": "array"
                     }
                   },
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 },
                 "prePromotionAnalysis": {
                   "properties": {
@@ -298,8 +291,7 @@
                           "type": "object"
                         }
                       },
-                      "type": "object",
-                      "additionalProperties": false
+                      "type": "object"
                     },
                     "args": {
                       "items": {
@@ -321,22 +313,19 @@
                                 "required": [
                                   "fieldPath"
                                 ],
-                                "type": "object",
-                                "additionalProperties": false
+                                "type": "object"
                               },
                               "podTemplateHashValue": {
                                 "type": "string"
                               }
                             },
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           }
                         },
                         "required": [
                           "name"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "type": "array"
                     },
@@ -350,8 +339,7 @@
                         "required": [
                           "metricName"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "type": "array"
                     },
@@ -370,8 +358,7 @@
                           "limit",
                           "metricName"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "type": "array"
                     },
@@ -385,14 +372,12 @@
                             "type": "string"
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "type": "array"
                     }
                   },
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 },
                 "previewMetadata": {
                   "properties": {
@@ -409,8 +394,7 @@
                       "type": "object"
                     }
                   },
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 },
                 "previewReplicaCount": {
                   "format": "int32",
@@ -431,8 +415,7 @@
               "required": [
                 "activeService"
               ],
-              "type": "object",
-              "additionalProperties": false
+              "type": "object"
             },
             "canary": {
               "properties": {
@@ -457,8 +440,7 @@
                           "type": "object"
                         }
                       },
-                      "type": "object",
-                      "additionalProperties": false
+                      "type": "object"
                     },
                     "args": {
                       "items": {
@@ -480,22 +462,19 @@
                                 "required": [
                                   "fieldPath"
                                 ],
-                                "type": "object",
-                                "additionalProperties": false
+                                "type": "object"
                               },
                               "podTemplateHashValue": {
                                 "type": "string"
                               }
                             },
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           }
                         },
                         "required": [
                           "name"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "type": "array"
                     },
@@ -509,8 +488,7 @@
                         "required": [
                           "metricName"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "type": "array"
                     },
@@ -529,8 +507,7 @@
                           "limit",
                           "metricName"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "type": "array"
                     },
@@ -548,14 +525,12 @@
                             "type": "string"
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "type": "array"
                     }
                   },
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 },
                 "antiAffinity": {
                   "properties": {
@@ -569,15 +544,13 @@
                       "required": [
                         "weight"
                       ],
-                      "type": "object",
-                      "additionalProperties": false
+                      "type": "object"
                     },
                     "requiredDuringSchedulingIgnoredDuringExecution": {
                       "type": "object"
                     }
                   },
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 },
                 "canaryMetadata": {
                   "properties": {
@@ -594,8 +567,7 @@
                       "type": "object"
                     }
                   },
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 },
                 "canaryService": {
                   "type": "string"
@@ -642,8 +614,23 @@
                     "pingService",
                     "pongService"
                   ],
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
+                },
+                "replicaProgressThreshold": {
+                  "properties": {
+                    "type": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "format": "int32",
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "type",
+                    "value"
+                  ],
+                  "type": "object"
                 },
                 "scaleDownDelayRevisionLimit": {
                   "format": "int32",
@@ -668,8 +655,7 @@
                       "type": "object"
                     }
                   },
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 },
                 "stableService": {
                   "type": "string"
@@ -694,8 +680,7 @@
                                 "type": "object"
                               }
                             },
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "args": {
                             "items": {
@@ -717,22 +702,19 @@
                                       "required": [
                                         "fieldPath"
                                       ],
-                                      "type": "object",
-                                      "additionalProperties": false
+                                      "type": "object"
                                     },
                                     "podTemplateHashValue": {
                                       "type": "string"
                                     }
                                   },
-                                  "type": "object",
-                                  "additionalProperties": false
+                                  "type": "object"
                                 }
                               },
                               "required": [
                                 "name"
                               ],
-                              "type": "object",
-                              "additionalProperties": false
+                              "type": "object"
                             },
                             "type": "array"
                           },
@@ -746,8 +728,7 @@
                               "required": [
                                 "metricName"
                               ],
-                              "type": "object",
-                              "additionalProperties": false
+                              "type": "object"
                             },
                             "type": "array"
                           },
@@ -766,8 +747,7 @@
                                 "limit",
                                 "metricName"
                               ],
-                              "type": "object",
-                              "additionalProperties": false
+                              "type": "object"
                             },
                             "type": "array"
                           },
@@ -781,14 +761,12 @@
                                   "type": "string"
                                 }
                               },
-                              "type": "object",
-                              "additionalProperties": false
+                              "type": "object"
                             },
                             "type": "array"
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "experiment": {
                         "properties": {
@@ -815,22 +793,19 @@
                                             "required": [
                                               "fieldPath"
                                             ],
-                                            "type": "object",
-                                            "additionalProperties": false
+                                            "type": "object"
                                           },
                                           "podTemplateHashValue": {
                                             "type": "string"
                                           }
                                         },
-                                        "type": "object",
-                                        "additionalProperties": false
+                                        "type": "object"
                                       }
                                     },
                                     "required": [
                                       "name"
                                     ],
-                                    "type": "object",
-                                    "additionalProperties": false
+                                    "type": "object"
                                   },
                                   "type": "array"
                                 },
@@ -851,8 +826,7 @@
                                 "name",
                                 "templateName"
                               ],
-                              "type": "object",
-                              "additionalProperties": false
+                              "type": "object"
                             },
                             "type": "array"
                           },
@@ -871,8 +845,7 @@
                                 "type": "object"
                               }
                             },
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "dryRun": {
                             "items": {
@@ -884,13 +857,16 @@
                               "required": [
                                 "metricName"
                               ],
-                              "type": "object",
-                              "additionalProperties": false
+                              "type": "object"
                             },
                             "type": "array"
                           },
                           "duration": {
                             "type": "string"
+                          },
+                          "scaleDownDelaySeconds": {
+                            "format": "int32",
+                            "type": "integer"
                           },
                           "templates": {
                             "items": {
@@ -910,8 +886,7 @@
                                       "type": "object"
                                     }
                                   },
-                                  "type": "object",
-                                  "additionalProperties": false
+                                  "type": "object"
                                 },
                                 "name": {
                                   "type": "string"
@@ -935,17 +910,18 @@
                                             "items": {
                                               "type": "string"
                                             },
-                                            "type": "array"
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
                                           }
                                         },
                                         "required": [
                                           "key",
                                           "operator"
                                         ],
-                                        "type": "object",
-                                        "additionalProperties": false
+                                        "type": "object"
                                       },
-                                      "type": "array"
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "matchLabels": {
                                       "additionalProperties": {
@@ -955,8 +931,7 @@
                                     }
                                   },
                                   "type": "object",
-                                  "x-kubernetes-map-type": "atomic",
-                                  "additionalProperties": false
+                                  "x-kubernetes-map-type": "atomic"
                                 },
                                 "service": {
                                   "properties": {
@@ -964,8 +939,7 @@
                                       "type": "string"
                                     }
                                   },
-                                  "type": "object",
-                                  "additionalProperties": false
+                                  "type": "object"
                                 },
                                 "specRef": {
                                   "type": "string"
@@ -979,8 +953,7 @@
                                 "name",
                                 "specRef"
                               ],
-                              "type": "object",
-                              "additionalProperties": false
+                              "type": "object"
                             },
                             "type": "array"
                           }
@@ -988,8 +961,7 @@
                         "required": [
                           "templates"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "pause": {
                         "properties": {
@@ -1005,8 +977,7 @@
                             "x-kubernetes-int-or-string": true
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "plugin": {
                         "properties": {
@@ -1021,8 +992,7 @@
                         "required": [
                           "name"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "setCanaryScale": {
                         "properties": {
@@ -1038,8 +1008,7 @@
                             "type": "integer"
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "setHeaderRoute": {
                         "properties": {
@@ -1061,16 +1030,14 @@
                                       "type": "string"
                                     }
                                   },
-                                  "type": "object",
-                                  "additionalProperties": false
+                                  "type": "object"
                                 }
                               },
                               "required": [
                                 "headerName",
                                 "headerValue"
                               ],
-                              "type": "object",
-                              "additionalProperties": false
+                              "type": "object"
                             },
                             "type": "array"
                           },
@@ -1078,8 +1045,7 @@
                             "type": "string"
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "setMirrorRoute": {
                         "properties": {
@@ -1099,8 +1065,7 @@
                                         "type": "string"
                                       }
                                     },
-                                    "type": "object",
-                                    "additionalProperties": false
+                                    "type": "object"
                                   },
                                   "type": "object"
                                 },
@@ -1116,8 +1081,7 @@
                                       "type": "string"
                                     }
                                   },
-                                  "type": "object",
-                                  "additionalProperties": false
+                                  "type": "object"
                                 },
                                 "path": {
                                   "properties": {
@@ -1131,12 +1095,10 @@
                                       "type": "string"
                                     }
                                   },
-                                  "type": "object",
-                                  "additionalProperties": false
+                                  "type": "object"
                                 }
                               },
-                              "type": "object",
-                              "additionalProperties": false
+                              "type": "object"
                             },
                             "type": "array"
                           },
@@ -1151,16 +1113,14 @@
                         "required": [
                           "name"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "setWeight": {
                         "format": "int32",
                         "type": "integer"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "type": "array"
                 },
@@ -1201,15 +1161,13 @@
                             "durationSeconds",
                             "enabled"
                           ],
-                          "type": "object",
-                          "additionalProperties": false
+                          "type": "object"
                         }
                       },
                       "required": [
                         "servicePort"
                       ],
-                      "type": "object",
-                      "additionalProperties": false
+                      "type": "object"
                     },
                     "ambassador": {
                       "properties": {
@@ -1223,8 +1181,7 @@
                       "required": [
                         "mappings"
                       ],
-                      "type": "object",
-                      "additionalProperties": false
+                      "type": "object"
                     },
                     "apisix": {
                       "properties": {
@@ -1243,12 +1200,10 @@
                           "required": [
                             "name"
                           ],
-                          "type": "object",
-                          "additionalProperties": false
+                          "type": "object"
                         }
                       },
-                      "type": "object",
-                      "additionalProperties": false
+                      "type": "object"
                     },
                     "appMesh": {
                       "properties": {
@@ -1263,8 +1218,7 @@
                               "required": [
                                 "name"
                               ],
-                              "type": "object",
-                              "additionalProperties": false
+                              "type": "object"
                             },
                             "stableVirtualNodeRef": {
                               "properties": {
@@ -1275,16 +1229,14 @@
                               "required": [
                                 "name"
                               ],
-                              "type": "object",
-                              "additionalProperties": false
+                              "type": "object"
                             }
                           },
                           "required": [
                             "canaryVirtualNodeRef",
                             "stableVirtualNodeRef"
                           ],
-                          "type": "object",
-                          "additionalProperties": false
+                          "type": "object"
                         },
                         "virtualService": {
                           "properties": {
@@ -1301,17 +1253,21 @@
                           "required": [
                             "name"
                           ],
-                          "type": "object",
-                          "additionalProperties": false
+                          "type": "object"
                         }
                       },
-                      "type": "object",
-                      "additionalProperties": false
+                      "type": "object"
                     },
                     "istio": {
                       "properties": {
                         "destinationRule": {
                           "properties": {
+                            "additionalSubsetNames": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
                             "canarySubsetName": {
                               "type": "string"
                             },
@@ -1327,8 +1283,7 @@
                             "name",
                             "stableSubsetName"
                           ],
-                          "type": "object",
-                          "additionalProperties": false
+                          "type": "object"
                         },
                         "virtualService": {
                           "properties": {
@@ -1349,8 +1304,7 @@
                                     "type": "integer"
                                   }
                                 },
-                                "type": "object",
-                                "additionalProperties": false
+                                "type": "object"
                               },
                               "type": "array"
                             },
@@ -1368,8 +1322,7 @@
                                     "type": "array"
                                   }
                                 },
-                                "type": "object",
-                                "additionalProperties": false
+                                "type": "object"
                               },
                               "type": "array"
                             }
@@ -1377,8 +1330,7 @@
                           "required": [
                             "name"
                           ],
-                          "type": "object",
-                          "additionalProperties": false
+                          "type": "object"
                         },
                         "virtualServices": {
                           "items": {
@@ -1400,8 +1352,7 @@
                                       "type": "integer"
                                     }
                                   },
-                                  "type": "object",
-                                  "additionalProperties": false
+                                  "type": "object"
                                 },
                                 "type": "array"
                               },
@@ -1419,8 +1370,7 @@
                                       "type": "array"
                                     }
                                   },
-                                  "type": "object",
-                                  "additionalProperties": false
+                                  "type": "object"
                                 },
                                 "type": "array"
                               }
@@ -1428,14 +1378,12 @@
                             "required": [
                               "name"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "type": "array"
                         }
                       },
-                      "type": "object",
-                      "additionalProperties": false
+                      "type": "object"
                     },
                     "managedRoutes": {
                       "items": {
@@ -1447,8 +1395,7 @@
                         "required": [
                           "name"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "type": "array"
                     },
@@ -1483,8 +1430,7 @@
                           "type": "array"
                         }
                       },
-                      "type": "object",
-                      "additionalProperties": false
+                      "type": "object"
                     },
                     "plugins": {
                       "type": "object",
@@ -1499,8 +1445,7 @@
                           "type": "string"
                         }
                       },
-                      "type": "object",
-                      "additionalProperties": false
+                      "type": "object"
                     },
                     "traefik": {
                       "properties": {
@@ -1511,20 +1456,16 @@
                       "required": [
                         "weightedTraefikServiceName"
                       ],
-                      "type": "object",
-                      "additionalProperties": false
+                      "type": "object"
                     }
                   },
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 }
               },
-              "type": "object",
-              "additionalProperties": false
+              "type": "object"
             }
           },
-          "type": "object",
-          "additionalProperties": false
+          "type": "object"
         },
         "template": {
           "properties": {
@@ -1543,8 +1484,7 @@
                   "type": "object"
                 }
               },
-              "type": "object",
-              "additionalProperties": false
+              "type": "object"
             },
             "spec": {
               "properties": {
@@ -1574,17 +1514,18 @@
                                           "items": {
                                             "type": "string"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       },
                                       "required": [
                                         "key",
                                         "operator"
                                       ],
-                                      "type": "object",
-                                      "additionalProperties": false
+                                      "type": "object"
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "matchFields": {
                                     "items": {
@@ -1599,22 +1540,22 @@
                                           "items": {
                                             "type": "string"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       },
                                       "required": [
                                         "key",
                                         "operator"
                                       ],
-                                      "type": "object",
-                                      "additionalProperties": false
+                                      "type": "object"
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   }
                                 },
                                 "type": "object",
-                                "x-kubernetes-map-type": "atomic",
-                                "additionalProperties": false
+                                "x-kubernetes-map-type": "atomic"
                               },
                               "weight": {
                                 "format": "int32",
@@ -1625,10 +1566,10 @@
                               "preference",
                               "weight"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
-                          "type": "array"
+                          "type": "array",
+                          "x-kubernetes-list-type": "atomic"
                         },
                         "requiredDuringSchedulingIgnoredDuringExecution": {
                           "properties": {
@@ -1648,17 +1589,18 @@
                                           "items": {
                                             "type": "string"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       },
                                       "required": [
                                         "key",
                                         "operator"
                                       ],
-                                      "type": "object",
-                                      "additionalProperties": false
+                                      "type": "object"
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "matchFields": {
                                     "items": {
@@ -1673,36 +1615,35 @@
                                           "items": {
                                             "type": "string"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       },
                                       "required": [
                                         "key",
                                         "operator"
                                       ],
-                                      "type": "object",
-                                      "additionalProperties": false
+                                      "type": "object"
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   }
                                 },
                                 "type": "object",
-                                "x-kubernetes-map-type": "atomic",
-                                "additionalProperties": false
+                                "x-kubernetes-map-type": "atomic"
                               },
-                              "type": "array"
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
                             }
                           },
                           "required": [
                             "nodeSelectorTerms"
                           ],
                           "type": "object",
-                          "x-kubernetes-map-type": "atomic",
-                          "additionalProperties": false
+                          "x-kubernetes-map-type": "atomic"
                         }
                       },
-                      "type": "object",
-                      "additionalProperties": false
+                      "type": "object"
                     },
                     "podAffinity": {
                       "properties": {
@@ -1726,17 +1667,18 @@
                                               "items": {
                                                 "type": "string"
                                               },
-                                              "type": "array"
+                                              "type": "array",
+                                              "x-kubernetes-list-type": "atomic"
                                             }
                                           },
                                           "required": [
                                             "key",
                                             "operator"
                                           ],
-                                          "type": "object",
-                                          "additionalProperties": false
+                                          "type": "object"
                                         },
-                                        "type": "array"
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
                                       },
                                       "matchLabels": {
                                         "additionalProperties": {
@@ -1746,8 +1688,7 @@
                                       }
                                     },
                                     "type": "object",
-                                    "x-kubernetes-map-type": "atomic",
-                                    "additionalProperties": false
+                                    "x-kubernetes-map-type": "atomic"
                                   },
                                   "matchLabelKeys": {
                                     "items": {
@@ -1778,17 +1719,18 @@
                                               "items": {
                                                 "type": "string"
                                               },
-                                              "type": "array"
+                                              "type": "array",
+                                              "x-kubernetes-list-type": "atomic"
                                             }
                                           },
                                           "required": [
                                             "key",
                                             "operator"
                                           ],
-                                          "type": "object",
-                                          "additionalProperties": false
+                                          "type": "object"
                                         },
-                                        "type": "array"
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
                                       },
                                       "matchLabels": {
                                         "additionalProperties": {
@@ -1798,14 +1740,14 @@
                                       }
                                     },
                                     "type": "object",
-                                    "x-kubernetes-map-type": "atomic",
-                                    "additionalProperties": false
+                                    "x-kubernetes-map-type": "atomic"
                                   },
                                   "namespaces": {
                                     "items": {
                                       "type": "string"
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "topologyKey": {
                                     "type": "string"
@@ -1814,8 +1756,7 @@
                                 "required": [
                                   "topologyKey"
                                 ],
-                                "type": "object",
-                                "additionalProperties": false
+                                "type": "object"
                               },
                               "weight": {
                                 "format": "int32",
@@ -1826,10 +1767,10 @@
                               "podAffinityTerm",
                               "weight"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
-                          "type": "array"
+                          "type": "array",
+                          "x-kubernetes-list-type": "atomic"
                         },
                         "requiredDuringSchedulingIgnoredDuringExecution": {
                           "items": {
@@ -1849,17 +1790,18 @@
                                           "items": {
                                             "type": "string"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       },
                                       "required": [
                                         "key",
                                         "operator"
                                       ],
-                                      "type": "object",
-                                      "additionalProperties": false
+                                      "type": "object"
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "matchLabels": {
                                     "additionalProperties": {
@@ -1869,8 +1811,7 @@
                                   }
                                 },
                                 "type": "object",
-                                "x-kubernetes-map-type": "atomic",
-                                "additionalProperties": false
+                                "x-kubernetes-map-type": "atomic"
                               },
                               "matchLabelKeys": {
                                 "items": {
@@ -1901,17 +1842,18 @@
                                           "items": {
                                             "type": "string"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       },
                                       "required": [
                                         "key",
                                         "operator"
                                       ],
-                                      "type": "object",
-                                      "additionalProperties": false
+                                      "type": "object"
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "matchLabels": {
                                     "additionalProperties": {
@@ -1921,14 +1863,14 @@
                                   }
                                 },
                                 "type": "object",
-                                "x-kubernetes-map-type": "atomic",
-                                "additionalProperties": false
+                                "x-kubernetes-map-type": "atomic"
                               },
                               "namespaces": {
                                 "items": {
                                   "type": "string"
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "topologyKey": {
                                 "type": "string"
@@ -1937,14 +1879,13 @@
                             "required": [
                               "topologyKey"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
-                          "type": "array"
+                          "type": "array",
+                          "x-kubernetes-list-type": "atomic"
                         }
                       },
-                      "type": "object",
-                      "additionalProperties": false
+                      "type": "object"
                     },
                     "podAntiAffinity": {
                       "properties": {
@@ -1968,17 +1909,18 @@
                                               "items": {
                                                 "type": "string"
                                               },
-                                              "type": "array"
+                                              "type": "array",
+                                              "x-kubernetes-list-type": "atomic"
                                             }
                                           },
                                           "required": [
                                             "key",
                                             "operator"
                                           ],
-                                          "type": "object",
-                                          "additionalProperties": false
+                                          "type": "object"
                                         },
-                                        "type": "array"
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
                                       },
                                       "matchLabels": {
                                         "additionalProperties": {
@@ -1988,8 +1930,7 @@
                                       }
                                     },
                                     "type": "object",
-                                    "x-kubernetes-map-type": "atomic",
-                                    "additionalProperties": false
+                                    "x-kubernetes-map-type": "atomic"
                                   },
                                   "matchLabelKeys": {
                                     "items": {
@@ -2020,17 +1961,18 @@
                                               "items": {
                                                 "type": "string"
                                               },
-                                              "type": "array"
+                                              "type": "array",
+                                              "x-kubernetes-list-type": "atomic"
                                             }
                                           },
                                           "required": [
                                             "key",
                                             "operator"
                                           ],
-                                          "type": "object",
-                                          "additionalProperties": false
+                                          "type": "object"
                                         },
-                                        "type": "array"
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
                                       },
                                       "matchLabels": {
                                         "additionalProperties": {
@@ -2040,14 +1982,14 @@
                                       }
                                     },
                                     "type": "object",
-                                    "x-kubernetes-map-type": "atomic",
-                                    "additionalProperties": false
+                                    "x-kubernetes-map-type": "atomic"
                                   },
                                   "namespaces": {
                                     "items": {
                                       "type": "string"
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "topologyKey": {
                                     "type": "string"
@@ -2056,8 +1998,7 @@
                                 "required": [
                                   "topologyKey"
                                 ],
-                                "type": "object",
-                                "additionalProperties": false
+                                "type": "object"
                               },
                               "weight": {
                                 "format": "int32",
@@ -2068,10 +2009,10 @@
                               "podAffinityTerm",
                               "weight"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
-                          "type": "array"
+                          "type": "array",
+                          "x-kubernetes-list-type": "atomic"
                         },
                         "requiredDuringSchedulingIgnoredDuringExecution": {
                           "items": {
@@ -2091,17 +2032,18 @@
                                           "items": {
                                             "type": "string"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       },
                                       "required": [
                                         "key",
                                         "operator"
                                       ],
-                                      "type": "object",
-                                      "additionalProperties": false
+                                      "type": "object"
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "matchLabels": {
                                     "additionalProperties": {
@@ -2111,8 +2053,7 @@
                                   }
                                 },
                                 "type": "object",
-                                "x-kubernetes-map-type": "atomic",
-                                "additionalProperties": false
+                                "x-kubernetes-map-type": "atomic"
                               },
                               "matchLabelKeys": {
                                 "items": {
@@ -2143,17 +2084,18 @@
                                           "items": {
                                             "type": "string"
                                           },
-                                          "type": "array"
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       },
                                       "required": [
                                         "key",
                                         "operator"
                                       ],
-                                      "type": "object",
-                                      "additionalProperties": false
+                                      "type": "object"
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "matchLabels": {
                                     "additionalProperties": {
@@ -2163,14 +2105,14 @@
                                   }
                                 },
                                 "type": "object",
-                                "x-kubernetes-map-type": "atomic",
-                                "additionalProperties": false
+                                "x-kubernetes-map-type": "atomic"
                               },
                               "namespaces": {
                                 "items": {
                                   "type": "string"
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "topologyKey": {
                                 "type": "string"
@@ -2179,18 +2121,16 @@
                             "required": [
                               "topologyKey"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
-                          "type": "array"
+                          "type": "array",
+                          "x-kubernetes-list-type": "atomic"
                         }
                       },
-                      "type": "object",
-                      "additionalProperties": false
+                      "type": "object"
                     }
                   },
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 },
                 "automountServiceAccountToken": {
                   "type": "boolean"
@@ -2202,13 +2142,15 @@
                         "items": {
                           "type": "string"
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "command": {
                         "items": {
                           "type": "string"
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "env": {
                         "items": {
@@ -2227,6 +2169,7 @@
                                       "type": "string"
                                     },
                                     "name": {
+                                      "default": "",
                                       "type": "string"
                                     },
                                     "optional": {
@@ -2237,8 +2180,7 @@
                                     "key"
                                   ],
                                   "type": "object",
-                                  "x-kubernetes-map-type": "atomic",
-                                  "additionalProperties": false
+                                  "x-kubernetes-map-type": "atomic"
                                 },
                                 "fieldRef": {
                                   "properties": {
@@ -2253,8 +2195,31 @@
                                     "fieldPath"
                                   ],
                                   "type": "object",
-                                  "x-kubernetes-map-type": "atomic",
-                                  "additionalProperties": false
+                                  "x-kubernetes-map-type": "atomic"
+                                },
+                                "fileKeyRef": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "default": false,
+                                      "type": "boolean"
+                                    },
+                                    "path": {
+                                      "type": "string"
+                                    },
+                                    "volumeName": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "path",
+                                    "volumeName"
+                                  ],
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic"
                                 },
                                 "resourceFieldRef": {
                                   "properties": {
@@ -2281,8 +2246,7 @@
                                     "resource"
                                   ],
                                   "type": "object",
-                                  "x-kubernetes-map-type": "atomic",
-                                  "additionalProperties": false
+                                  "x-kubernetes-map-type": "atomic"
                                 },
                                 "secretKeyRef": {
                                   "properties": {
@@ -2290,6 +2254,7 @@
                                       "type": "string"
                                     },
                                     "name": {
+                                      "default": "",
                                       "type": "string"
                                     },
                                     "optional": {
@@ -2300,21 +2265,22 @@
                                     "key"
                                   ],
                                   "type": "object",
-                                  "x-kubernetes-map-type": "atomic",
-                                  "additionalProperties": false
+                                  "x-kubernetes-map-type": "atomic"
                                 }
                               },
-                              "type": "object",
-                              "additionalProperties": false
+                              "type": "object"
                             }
                           },
                           "required": [
                             "name"
                           ],
-                          "type": "object",
-                          "additionalProperties": false
+                          "type": "object"
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-map-keys": [
+                          "name"
+                        ],
+                        "x-kubernetes-list-type": "map"
                       },
                       "envFrom": {
                         "items": {
@@ -2322,6 +2288,7 @@
                             "configMapRef": {
                               "properties": {
                                 "name": {
+                                  "default": "",
                                   "type": "string"
                                 },
                                 "optional": {
@@ -2329,8 +2296,7 @@
                                 }
                               },
                               "type": "object",
-                              "x-kubernetes-map-type": "atomic",
-                              "additionalProperties": false
+                              "x-kubernetes-map-type": "atomic"
                             },
                             "prefix": {
                               "type": "string"
@@ -2338,6 +2304,7 @@
                             "secretRef": {
                               "properties": {
                                 "name": {
+                                  "default": "",
                                   "type": "string"
                                 },
                                 "optional": {
@@ -2345,14 +2312,13 @@
                                 }
                               },
                               "type": "object",
-                              "x-kubernetes-map-type": "atomic",
-                              "additionalProperties": false
+                              "x-kubernetes-map-type": "atomic"
                             }
                           },
-                          "type": "object",
-                          "additionalProperties": false
+                          "type": "object"
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "image": {
                         "type": "string"
@@ -2370,11 +2336,11 @@
                                     "items": {
                                       "type": "string"
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   }
                                 },
-                                "type": "object",
-                                "additionalProperties": false
+                                "type": "object"
                               },
                               "httpGet": {
                                 "properties": {
@@ -2395,10 +2361,10 @@
                                         "name",
                                         "value"
                                       ],
-                                      "type": "object",
-                                      "additionalProperties": false
+                                      "type": "object"
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "path": {
                                     "type": "string"
@@ -2421,8 +2387,7 @@
                                 "required": [
                                   "port"
                                 ],
-                                "type": "object",
-                                "additionalProperties": false
+                                "type": "object"
                               },
                               "sleep": {
                                 "properties": {
@@ -2434,8 +2399,7 @@
                                 "required": [
                                   "seconds"
                                 ],
-                                "type": "object",
-                                "additionalProperties": false
+                                "type": "object"
                               },
                               "tcpSocket": {
                                 "properties": {
@@ -2457,12 +2421,10 @@
                                 "required": [
                                   "port"
                                 ],
-                                "type": "object",
-                                "additionalProperties": false
+                                "type": "object"
                               }
                             },
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "preStop": {
                             "properties": {
@@ -2472,11 +2434,11 @@
                                     "items": {
                                       "type": "string"
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   }
                                 },
-                                "type": "object",
-                                "additionalProperties": false
+                                "type": "object"
                               },
                               "httpGet": {
                                 "properties": {
@@ -2497,10 +2459,10 @@
                                         "name",
                                         "value"
                                       ],
-                                      "type": "object",
-                                      "additionalProperties": false
+                                      "type": "object"
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "path": {
                                     "type": "string"
@@ -2523,8 +2485,7 @@
                                 "required": [
                                   "port"
                                 ],
-                                "type": "object",
-                                "additionalProperties": false
+                                "type": "object"
                               },
                               "sleep": {
                                 "properties": {
@@ -2536,8 +2497,7 @@
                                 "required": [
                                   "seconds"
                                 ],
-                                "type": "object",
-                                "additionalProperties": false
+                                "type": "object"
                               },
                               "tcpSocket": {
                                 "properties": {
@@ -2559,16 +2519,16 @@
                                 "required": [
                                   "port"
                                 ],
-                                "type": "object",
-                                "additionalProperties": false
+                                "type": "object"
                               }
                             },
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
+                          },
+                          "stopSignal": {
+                            "type": "string"
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "livenessProbe": {
                         "properties": {
@@ -2578,11 +2538,11 @@
                                 "items": {
                                   "type": "string"
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               }
                             },
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "failureThreshold": {
                             "format": "int32",
@@ -2595,14 +2555,14 @@
                                 "type": "integer"
                               },
                               "service": {
+                                "default": "",
                                 "type": "string"
                               }
                             },
                             "required": [
                               "port"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "httpGet": {
                             "properties": {
@@ -2623,10 +2583,10 @@
                                     "name",
                                     "value"
                                   ],
-                                  "type": "object",
-                                  "additionalProperties": false
+                                  "type": "object"
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "path": {
                                 "type": "string"
@@ -2649,8 +2609,7 @@
                             "required": [
                               "port"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "initialDelaySeconds": {
                             "format": "int32",
@@ -2684,8 +2643,7 @@
                             "required": [
                               "port"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "terminationGracePeriodSeconds": {
                             "format": "int64",
@@ -2696,8 +2654,7 @@
                             "type": "integer"
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "name": {
                         "type": "string"
@@ -2727,8 +2684,7 @@
                           "required": [
                             "containerPort"
                           ],
-                          "type": "object",
-                          "additionalProperties": false
+                          "type": "object"
                         },
                         "type": "array",
                         "x-kubernetes-list-map-keys": [
@@ -2745,11 +2701,11 @@
                                 "items": {
                                   "type": "string"
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               }
                             },
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "failureThreshold": {
                             "format": "int32",
@@ -2762,14 +2718,14 @@
                                 "type": "integer"
                               },
                               "service": {
+                                "default": "",
                                 "type": "string"
                               }
                             },
                             "required": [
                               "port"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "httpGet": {
                             "properties": {
@@ -2790,10 +2746,10 @@
                                     "name",
                                     "value"
                                   ],
-                                  "type": "object",
-                                  "additionalProperties": false
+                                  "type": "object"
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "path": {
                                 "type": "string"
@@ -2816,8 +2772,7 @@
                             "required": [
                               "port"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "initialDelaySeconds": {
                             "format": "int32",
@@ -2851,8 +2806,7 @@
                             "required": [
                               "port"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "terminationGracePeriodSeconds": {
                             "format": "int64",
@@ -2863,8 +2817,7 @@
                             "type": "integer"
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "resizePolicy": {
                         "items": {
@@ -2880,8 +2833,7 @@
                             "resourceName",
                             "restartPolicy"
                           ],
-                          "type": "object",
-                          "additionalProperties": false
+                          "type": "object"
                         },
                         "type": "array",
                         "x-kubernetes-list-type": "atomic"
@@ -2893,13 +2845,15 @@
                               "properties": {
                                 "name": {
                                   "type": "string"
+                                },
+                                "request": {
+                                  "type": "string"
                                 }
                               },
                               "required": [
                                 "name"
                               ],
-                              "type": "object",
-                              "additionalProperties": false
+                              "type": "object"
                             },
                             "type": "array",
                             "x-kubernetes-list-map-keys": [
@@ -2914,16 +2868,63 @@
                             "x-kubernetes-preserve-unknown-fields": true
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "restartPolicy": {
                         "type": "string"
+                      },
+                      "restartPolicyRules": {
+                        "items": {
+                          "properties": {
+                            "action": {
+                              "type": "string"
+                            },
+                            "exitCodes": {
+                              "properties": {
+                                "operator": {
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "items": {
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "set"
+                                }
+                              },
+                              "required": [
+                                "operator"
+                              ],
+                              "type": "object"
+                            }
+                          },
+                          "required": [
+                            "action"
+                          ],
+                          "type": "object"
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "securityContext": {
                         "properties": {
                           "allowPrivilegeEscalation": {
                             "type": "boolean"
+                          },
+                          "appArmorProfile": {
+                            "properties": {
+                              "localhostProfile": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "type"
+                            ],
+                            "type": "object"
                           },
                           "capabilities": {
                             "properties": {
@@ -2931,17 +2932,18 @@
                                 "items": {
                                   "type": "string"
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "drop": {
                                 "items": {
                                   "type": "string"
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               }
                             },
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "privileged": {
                             "type": "boolean"
@@ -2978,8 +2980,7 @@
                                 "type": "string"
                               }
                             },
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "seccompProfile": {
                             "properties": {
@@ -2993,8 +2994,7 @@
                             "required": [
                               "type"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "windowsOptions": {
                             "properties": {
@@ -3011,12 +3011,10 @@
                                 "type": "string"
                               }
                             },
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "startupProbe": {
                         "properties": {
@@ -3026,11 +3024,11 @@
                                 "items": {
                                   "type": "string"
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               }
                             },
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "failureThreshold": {
                             "format": "int32",
@@ -3043,14 +3041,14 @@
                                 "type": "integer"
                               },
                               "service": {
+                                "default": "",
                                 "type": "string"
                               }
                             },
                             "required": [
                               "port"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "httpGet": {
                             "properties": {
@@ -3071,10 +3069,10 @@
                                     "name",
                                     "value"
                                   ],
-                                  "type": "object",
-                                  "additionalProperties": false
+                                  "type": "object"
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "path": {
                                 "type": "string"
@@ -3097,8 +3095,7 @@
                             "required": [
                               "port"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "initialDelaySeconds": {
                             "format": "int32",
@@ -3132,8 +3129,7 @@
                             "required": [
                               "port"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "terminationGracePeriodSeconds": {
                             "format": "int64",
@@ -3144,8 +3140,7 @@
                             "type": "integer"
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "stdin": {
                         "type": "boolean"
@@ -3176,10 +3171,13 @@
                             "devicePath",
                             "name"
                           ],
-                          "type": "object",
-                          "additionalProperties": false
+                          "type": "object"
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-map-keys": [
+                          "devicePath"
+                        ],
+                        "x-kubernetes-list-type": "map"
                       },
                       "volumeMounts": {
                         "items": {
@@ -3196,6 +3194,9 @@
                             "readOnly": {
                               "type": "boolean"
                             },
+                            "recursiveReadOnly": {
+                              "type": "string"
+                            },
                             "subPath": {
                               "type": "string"
                             },
@@ -3207,10 +3208,13 @@
                             "mountPath",
                             "name"
                           ],
-                          "type": "object",
-                          "additionalProperties": false
+                          "type": "object"
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-map-keys": [
+                          "mountPath"
+                        ],
+                        "x-kubernetes-list-type": "map"
                       },
                       "workingDir": {
                         "type": "string"
@@ -3219,10 +3223,13 @@
                     "required": [
                       "name"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
-                  "type": "array"
+                  "type": "array",
+                  "x-kubernetes-list-map-keys": [
+                    "name"
+                  ],
+                  "x-kubernetes-list-type": "map"
                 },
                 "dnsConfig": {
                   "properties": {
@@ -3230,7 +3237,8 @@
                       "items": {
                         "type": "string"
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     },
                     "options": {
                       "items": {
@@ -3242,20 +3250,20 @@
                             "type": "string"
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     },
                     "searches": {
                       "items": {
                         "type": "string"
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     }
                   },
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 },
                 "dnsPolicy": {
                   "type": "string"
@@ -3270,13 +3278,15 @@
                         "items": {
                           "type": "string"
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "command": {
                         "items": {
                           "type": "string"
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "env": {
                         "items": {
@@ -3295,6 +3305,7 @@
                                       "type": "string"
                                     },
                                     "name": {
+                                      "default": "",
                                       "type": "string"
                                     },
                                     "optional": {
@@ -3305,8 +3316,7 @@
                                     "key"
                                   ],
                                   "type": "object",
-                                  "x-kubernetes-map-type": "atomic",
-                                  "additionalProperties": false
+                                  "x-kubernetes-map-type": "atomic"
                                 },
                                 "fieldRef": {
                                   "properties": {
@@ -3321,8 +3331,31 @@
                                     "fieldPath"
                                   ],
                                   "type": "object",
-                                  "x-kubernetes-map-type": "atomic",
-                                  "additionalProperties": false
+                                  "x-kubernetes-map-type": "atomic"
+                                },
+                                "fileKeyRef": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "default": false,
+                                      "type": "boolean"
+                                    },
+                                    "path": {
+                                      "type": "string"
+                                    },
+                                    "volumeName": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "path",
+                                    "volumeName"
+                                  ],
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic"
                                 },
                                 "resourceFieldRef": {
                                   "properties": {
@@ -3349,8 +3382,7 @@
                                     "resource"
                                   ],
                                   "type": "object",
-                                  "x-kubernetes-map-type": "atomic",
-                                  "additionalProperties": false
+                                  "x-kubernetes-map-type": "atomic"
                                 },
                                 "secretKeyRef": {
                                   "properties": {
@@ -3358,6 +3390,7 @@
                                       "type": "string"
                                     },
                                     "name": {
+                                      "default": "",
                                       "type": "string"
                                     },
                                     "optional": {
@@ -3368,21 +3401,22 @@
                                     "key"
                                   ],
                                   "type": "object",
-                                  "x-kubernetes-map-type": "atomic",
-                                  "additionalProperties": false
+                                  "x-kubernetes-map-type": "atomic"
                                 }
                               },
-                              "type": "object",
-                              "additionalProperties": false
+                              "type": "object"
                             }
                           },
                           "required": [
                             "name"
                           ],
-                          "type": "object",
-                          "additionalProperties": false
+                          "type": "object"
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-map-keys": [
+                          "name"
+                        ],
+                        "x-kubernetes-list-type": "map"
                       },
                       "envFrom": {
                         "items": {
@@ -3390,6 +3424,7 @@
                             "configMapRef": {
                               "properties": {
                                 "name": {
+                                  "default": "",
                                   "type": "string"
                                 },
                                 "optional": {
@@ -3397,8 +3432,7 @@
                                 }
                               },
                               "type": "object",
-                              "x-kubernetes-map-type": "atomic",
-                              "additionalProperties": false
+                              "x-kubernetes-map-type": "atomic"
                             },
                             "prefix": {
                               "type": "string"
@@ -3406,6 +3440,7 @@
                             "secretRef": {
                               "properties": {
                                 "name": {
+                                  "default": "",
                                   "type": "string"
                                 },
                                 "optional": {
@@ -3413,14 +3448,13 @@
                                 }
                               },
                               "type": "object",
-                              "x-kubernetes-map-type": "atomic",
-                              "additionalProperties": false
+                              "x-kubernetes-map-type": "atomic"
                             }
                           },
-                          "type": "object",
-                          "additionalProperties": false
+                          "type": "object"
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "image": {
                         "type": "string"
@@ -3438,11 +3472,11 @@
                                     "items": {
                                       "type": "string"
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   }
                                 },
-                                "type": "object",
-                                "additionalProperties": false
+                                "type": "object"
                               },
                               "httpGet": {
                                 "properties": {
@@ -3463,10 +3497,10 @@
                                         "name",
                                         "value"
                                       ],
-                                      "type": "object",
-                                      "additionalProperties": false
+                                      "type": "object"
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "path": {
                                     "type": "string"
@@ -3489,8 +3523,7 @@
                                 "required": [
                                   "port"
                                 ],
-                                "type": "object",
-                                "additionalProperties": false
+                                "type": "object"
                               },
                               "sleep": {
                                 "properties": {
@@ -3502,8 +3535,7 @@
                                 "required": [
                                   "seconds"
                                 ],
-                                "type": "object",
-                                "additionalProperties": false
+                                "type": "object"
                               },
                               "tcpSocket": {
                                 "properties": {
@@ -3525,12 +3557,10 @@
                                 "required": [
                                   "port"
                                 ],
-                                "type": "object",
-                                "additionalProperties": false
+                                "type": "object"
                               }
                             },
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "preStop": {
                             "properties": {
@@ -3540,11 +3570,11 @@
                                     "items": {
                                       "type": "string"
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   }
                                 },
-                                "type": "object",
-                                "additionalProperties": false
+                                "type": "object"
                               },
                               "httpGet": {
                                 "properties": {
@@ -3565,10 +3595,10 @@
                                         "name",
                                         "value"
                                       ],
-                                      "type": "object",
-                                      "additionalProperties": false
+                                      "type": "object"
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "path": {
                                     "type": "string"
@@ -3591,8 +3621,7 @@
                                 "required": [
                                   "port"
                                 ],
-                                "type": "object",
-                                "additionalProperties": false
+                                "type": "object"
                               },
                               "sleep": {
                                 "properties": {
@@ -3604,8 +3633,7 @@
                                 "required": [
                                   "seconds"
                                 ],
-                                "type": "object",
-                                "additionalProperties": false
+                                "type": "object"
                               },
                               "tcpSocket": {
                                 "properties": {
@@ -3627,16 +3655,16 @@
                                 "required": [
                                   "port"
                                 ],
-                                "type": "object",
-                                "additionalProperties": false
+                                "type": "object"
                               }
                             },
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
+                          },
+                          "stopSignal": {
+                            "type": "string"
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "livenessProbe": {
                         "properties": {
@@ -3646,11 +3674,11 @@
                                 "items": {
                                   "type": "string"
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               }
                             },
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "failureThreshold": {
                             "format": "int32",
@@ -3663,14 +3691,14 @@
                                 "type": "integer"
                               },
                               "service": {
+                                "default": "",
                                 "type": "string"
                               }
                             },
                             "required": [
                               "port"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "httpGet": {
                             "properties": {
@@ -3691,10 +3719,10 @@
                                     "name",
                                     "value"
                                   ],
-                                  "type": "object",
-                                  "additionalProperties": false
+                                  "type": "object"
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "path": {
                                 "type": "string"
@@ -3717,8 +3745,7 @@
                             "required": [
                               "port"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "initialDelaySeconds": {
                             "format": "int32",
@@ -3752,8 +3779,7 @@
                             "required": [
                               "port"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "terminationGracePeriodSeconds": {
                             "format": "int64",
@@ -3764,8 +3790,7 @@
                             "type": "integer"
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "name": {
                         "type": "string"
@@ -3795,8 +3820,7 @@
                           "required": [
                             "containerPort"
                           ],
-                          "type": "object",
-                          "additionalProperties": false
+                          "type": "object"
                         },
                         "type": "array",
                         "x-kubernetes-list-map-keys": [
@@ -3813,11 +3837,11 @@
                                 "items": {
                                   "type": "string"
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               }
                             },
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "failureThreshold": {
                             "format": "int32",
@@ -3830,14 +3854,14 @@
                                 "type": "integer"
                               },
                               "service": {
+                                "default": "",
                                 "type": "string"
                               }
                             },
                             "required": [
                               "port"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "httpGet": {
                             "properties": {
@@ -3858,10 +3882,10 @@
                                     "name",
                                     "value"
                                   ],
-                                  "type": "object",
-                                  "additionalProperties": false
+                                  "type": "object"
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "path": {
                                 "type": "string"
@@ -3884,8 +3908,7 @@
                             "required": [
                               "port"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "initialDelaySeconds": {
                             "format": "int32",
@@ -3919,8 +3942,7 @@
                             "required": [
                               "port"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "terminationGracePeriodSeconds": {
                             "format": "int64",
@@ -3931,8 +3953,7 @@
                             "type": "integer"
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "resizePolicy": {
                         "items": {
@@ -3948,8 +3969,7 @@
                             "resourceName",
                             "restartPolicy"
                           ],
-                          "type": "object",
-                          "additionalProperties": false
+                          "type": "object"
                         },
                         "type": "array",
                         "x-kubernetes-list-type": "atomic"
@@ -3961,13 +3981,15 @@
                               "properties": {
                                 "name": {
                                   "type": "string"
+                                },
+                                "request": {
+                                  "type": "string"
                                 }
                               },
                               "required": [
                                 "name"
                               ],
-                              "type": "object",
-                              "additionalProperties": false
+                              "type": "object"
                             },
                             "type": "array",
                             "x-kubernetes-list-map-keys": [
@@ -3982,16 +4004,63 @@
                             "x-kubernetes-preserve-unknown-fields": true
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "restartPolicy": {
                         "type": "string"
+                      },
+                      "restartPolicyRules": {
+                        "items": {
+                          "properties": {
+                            "action": {
+                              "type": "string"
+                            },
+                            "exitCodes": {
+                              "properties": {
+                                "operator": {
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "items": {
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "set"
+                                }
+                              },
+                              "required": [
+                                "operator"
+                              ],
+                              "type": "object"
+                            }
+                          },
+                          "required": [
+                            "action"
+                          ],
+                          "type": "object"
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "securityContext": {
                         "properties": {
                           "allowPrivilegeEscalation": {
                             "type": "boolean"
+                          },
+                          "appArmorProfile": {
+                            "properties": {
+                              "localhostProfile": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "type"
+                            ],
+                            "type": "object"
                           },
                           "capabilities": {
                             "properties": {
@@ -3999,17 +4068,18 @@
                                 "items": {
                                   "type": "string"
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "drop": {
                                 "items": {
                                   "type": "string"
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               }
                             },
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "privileged": {
                             "type": "boolean"
@@ -4046,8 +4116,7 @@
                                 "type": "string"
                               }
                             },
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "seccompProfile": {
                             "properties": {
@@ -4061,8 +4130,7 @@
                             "required": [
                               "type"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "windowsOptions": {
                             "properties": {
@@ -4079,12 +4147,10 @@
                                 "type": "string"
                               }
                             },
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "startupProbe": {
                         "properties": {
@@ -4094,11 +4160,11 @@
                                 "items": {
                                   "type": "string"
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               }
                             },
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "failureThreshold": {
                             "format": "int32",
@@ -4111,14 +4177,14 @@
                                 "type": "integer"
                               },
                               "service": {
+                                "default": "",
                                 "type": "string"
                               }
                             },
                             "required": [
                               "port"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "httpGet": {
                             "properties": {
@@ -4139,10 +4205,10 @@
                                     "name",
                                     "value"
                                   ],
-                                  "type": "object",
-                                  "additionalProperties": false
+                                  "type": "object"
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "path": {
                                 "type": "string"
@@ -4165,8 +4231,7 @@
                             "required": [
                               "port"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "initialDelaySeconds": {
                             "format": "int32",
@@ -4200,8 +4265,7 @@
                             "required": [
                               "port"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "terminationGracePeriodSeconds": {
                             "format": "int64",
@@ -4212,8 +4276,7 @@
                             "type": "integer"
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "stdin": {
                         "type": "boolean"
@@ -4247,10 +4310,13 @@
                             "devicePath",
                             "name"
                           ],
-                          "type": "object",
-                          "additionalProperties": false
+                          "type": "object"
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-map-keys": [
+                          "devicePath"
+                        ],
+                        "x-kubernetes-list-type": "map"
                       },
                       "volumeMounts": {
                         "items": {
@@ -4267,6 +4333,9 @@
                             "readOnly": {
                               "type": "boolean"
                             },
+                            "recursiveReadOnly": {
+                              "type": "string"
+                            },
                             "subPath": {
                               "type": "string"
                             },
@@ -4278,10 +4347,13 @@
                             "mountPath",
                             "name"
                           ],
-                          "type": "object",
-                          "additionalProperties": false
+                          "type": "object"
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-map-keys": [
+                          "mountPath"
+                        ],
+                        "x-kubernetes-list-type": "map"
                       },
                       "workingDir": {
                         "type": "string"
@@ -4290,10 +4362,13 @@
                     "required": [
                       "name"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
-                  "type": "array"
+                  "type": "array",
+                  "x-kubernetes-list-map-keys": [
+                    "name"
+                  ],
+                  "x-kubernetes-list-type": "map"
                 },
                 "hostAliases": {
                   "items": {
@@ -4302,16 +4377,23 @@
                         "items": {
                           "type": "string"
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "ip": {
                         "type": "string"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "required": [
+                      "ip"
+                    ],
+                    "type": "object"
                   },
-                  "type": "array"
+                  "type": "array",
+                  "x-kubernetes-list-map-keys": [
+                    "ip"
+                  ],
+                  "x-kubernetes-list-type": "map"
                 },
                 "hostIPC": {
                   "type": "boolean"
@@ -4328,18 +4410,25 @@
                 "hostname": {
                   "type": "string"
                 },
+                "hostnameOverride": {
+                  "type": "string"
+                },
                 "imagePullSecrets": {
                   "items": {
                     "properties": {
                       "name": {
+                        "default": "",
                         "type": "string"
                       }
                     },
                     "type": "object",
-                    "x-kubernetes-map-type": "atomic",
-                    "additionalProperties": false
+                    "x-kubernetes-map-type": "atomic"
                   },
-                  "type": "array"
+                  "type": "array",
+                  "x-kubernetes-list-map-keys": [
+                    "name"
+                  ],
+                  "x-kubernetes-list-type": "map"
                 },
                 "initContainers": {
                   "items": {
@@ -4348,13 +4437,15 @@
                         "items": {
                           "type": "string"
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "command": {
                         "items": {
                           "type": "string"
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "env": {
                         "items": {
@@ -4373,6 +4464,7 @@
                                       "type": "string"
                                     },
                                     "name": {
+                                      "default": "",
                                       "type": "string"
                                     },
                                     "optional": {
@@ -4383,8 +4475,7 @@
                                     "key"
                                   ],
                                   "type": "object",
-                                  "x-kubernetes-map-type": "atomic",
-                                  "additionalProperties": false
+                                  "x-kubernetes-map-type": "atomic"
                                 },
                                 "fieldRef": {
                                   "properties": {
@@ -4399,8 +4490,31 @@
                                     "fieldPath"
                                   ],
                                   "type": "object",
-                                  "x-kubernetes-map-type": "atomic",
-                                  "additionalProperties": false
+                                  "x-kubernetes-map-type": "atomic"
+                                },
+                                "fileKeyRef": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "default": false,
+                                      "type": "boolean"
+                                    },
+                                    "path": {
+                                      "type": "string"
+                                    },
+                                    "volumeName": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "path",
+                                    "volumeName"
+                                  ],
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic"
                                 },
                                 "resourceFieldRef": {
                                   "properties": {
@@ -4427,8 +4541,7 @@
                                     "resource"
                                   ],
                                   "type": "object",
-                                  "x-kubernetes-map-type": "atomic",
-                                  "additionalProperties": false
+                                  "x-kubernetes-map-type": "atomic"
                                 },
                                 "secretKeyRef": {
                                   "properties": {
@@ -4436,6 +4549,7 @@
                                       "type": "string"
                                     },
                                     "name": {
+                                      "default": "",
                                       "type": "string"
                                     },
                                     "optional": {
@@ -4446,21 +4560,22 @@
                                     "key"
                                   ],
                                   "type": "object",
-                                  "x-kubernetes-map-type": "atomic",
-                                  "additionalProperties": false
+                                  "x-kubernetes-map-type": "atomic"
                                 }
                               },
-                              "type": "object",
-                              "additionalProperties": false
+                              "type": "object"
                             }
                           },
                           "required": [
                             "name"
                           ],
-                          "type": "object",
-                          "additionalProperties": false
+                          "type": "object"
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-map-keys": [
+                          "name"
+                        ],
+                        "x-kubernetes-list-type": "map"
                       },
                       "envFrom": {
                         "items": {
@@ -4468,6 +4583,7 @@
                             "configMapRef": {
                               "properties": {
                                 "name": {
+                                  "default": "",
                                   "type": "string"
                                 },
                                 "optional": {
@@ -4475,8 +4591,7 @@
                                 }
                               },
                               "type": "object",
-                              "x-kubernetes-map-type": "atomic",
-                              "additionalProperties": false
+                              "x-kubernetes-map-type": "atomic"
                             },
                             "prefix": {
                               "type": "string"
@@ -4484,6 +4599,7 @@
                             "secretRef": {
                               "properties": {
                                 "name": {
+                                  "default": "",
                                   "type": "string"
                                 },
                                 "optional": {
@@ -4491,14 +4607,13 @@
                                 }
                               },
                               "type": "object",
-                              "x-kubernetes-map-type": "atomic",
-                              "additionalProperties": false
+                              "x-kubernetes-map-type": "atomic"
                             }
                           },
-                          "type": "object",
-                          "additionalProperties": false
+                          "type": "object"
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "image": {
                         "type": "string"
@@ -4516,11 +4631,11 @@
                                     "items": {
                                       "type": "string"
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   }
                                 },
-                                "type": "object",
-                                "additionalProperties": false
+                                "type": "object"
                               },
                               "httpGet": {
                                 "properties": {
@@ -4541,10 +4656,10 @@
                                         "name",
                                         "value"
                                       ],
-                                      "type": "object",
-                                      "additionalProperties": false
+                                      "type": "object"
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "path": {
                                     "type": "string"
@@ -4567,8 +4682,7 @@
                                 "required": [
                                   "port"
                                 ],
-                                "type": "object",
-                                "additionalProperties": false
+                                "type": "object"
                               },
                               "sleep": {
                                 "properties": {
@@ -4580,8 +4694,7 @@
                                 "required": [
                                   "seconds"
                                 ],
-                                "type": "object",
-                                "additionalProperties": false
+                                "type": "object"
                               },
                               "tcpSocket": {
                                 "properties": {
@@ -4603,12 +4716,10 @@
                                 "required": [
                                   "port"
                                 ],
-                                "type": "object",
-                                "additionalProperties": false
+                                "type": "object"
                               }
                             },
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "preStop": {
                             "properties": {
@@ -4618,11 +4729,11 @@
                                     "items": {
                                       "type": "string"
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   }
                                 },
-                                "type": "object",
-                                "additionalProperties": false
+                                "type": "object"
                               },
                               "httpGet": {
                                 "properties": {
@@ -4643,10 +4754,10 @@
                                         "name",
                                         "value"
                                       ],
-                                      "type": "object",
-                                      "additionalProperties": false
+                                      "type": "object"
                                     },
-                                    "type": "array"
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "path": {
                                     "type": "string"
@@ -4669,8 +4780,7 @@
                                 "required": [
                                   "port"
                                 ],
-                                "type": "object",
-                                "additionalProperties": false
+                                "type": "object"
                               },
                               "sleep": {
                                 "properties": {
@@ -4682,8 +4792,7 @@
                                 "required": [
                                   "seconds"
                                 ],
-                                "type": "object",
-                                "additionalProperties": false
+                                "type": "object"
                               },
                               "tcpSocket": {
                                 "properties": {
@@ -4705,16 +4814,16 @@
                                 "required": [
                                   "port"
                                 ],
-                                "type": "object",
-                                "additionalProperties": false
+                                "type": "object"
                               }
                             },
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
+                          },
+                          "stopSignal": {
+                            "type": "string"
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "livenessProbe": {
                         "properties": {
@@ -4724,11 +4833,11 @@
                                 "items": {
                                   "type": "string"
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               }
                             },
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "failureThreshold": {
                             "format": "int32",
@@ -4741,14 +4850,14 @@
                                 "type": "integer"
                               },
                               "service": {
+                                "default": "",
                                 "type": "string"
                               }
                             },
                             "required": [
                               "port"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "httpGet": {
                             "properties": {
@@ -4769,10 +4878,10 @@
                                     "name",
                                     "value"
                                   ],
-                                  "type": "object",
-                                  "additionalProperties": false
+                                  "type": "object"
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "path": {
                                 "type": "string"
@@ -4795,8 +4904,7 @@
                             "required": [
                               "port"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "initialDelaySeconds": {
                             "format": "int32",
@@ -4830,8 +4938,7 @@
                             "required": [
                               "port"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "terminationGracePeriodSeconds": {
                             "format": "int64",
@@ -4842,8 +4949,7 @@
                             "type": "integer"
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "name": {
                         "type": "string"
@@ -4873,8 +4979,7 @@
                           "required": [
                             "containerPort"
                           ],
-                          "type": "object",
-                          "additionalProperties": false
+                          "type": "object"
                         },
                         "type": "array",
                         "x-kubernetes-list-map-keys": [
@@ -4891,11 +4996,11 @@
                                 "items": {
                                   "type": "string"
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               }
                             },
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "failureThreshold": {
                             "format": "int32",
@@ -4908,14 +5013,14 @@
                                 "type": "integer"
                               },
                               "service": {
+                                "default": "",
                                 "type": "string"
                               }
                             },
                             "required": [
                               "port"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "httpGet": {
                             "properties": {
@@ -4936,10 +5041,10 @@
                                     "name",
                                     "value"
                                   ],
-                                  "type": "object",
-                                  "additionalProperties": false
+                                  "type": "object"
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "path": {
                                 "type": "string"
@@ -4962,8 +5067,7 @@
                             "required": [
                               "port"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "initialDelaySeconds": {
                             "format": "int32",
@@ -4997,8 +5101,7 @@
                             "required": [
                               "port"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "terminationGracePeriodSeconds": {
                             "format": "int64",
@@ -5009,8 +5112,7 @@
                             "type": "integer"
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "resizePolicy": {
                         "items": {
@@ -5026,8 +5128,7 @@
                             "resourceName",
                             "restartPolicy"
                           ],
-                          "type": "object",
-                          "additionalProperties": false
+                          "type": "object"
                         },
                         "type": "array",
                         "x-kubernetes-list-type": "atomic"
@@ -5039,13 +5140,15 @@
                               "properties": {
                                 "name": {
                                   "type": "string"
+                                },
+                                "request": {
+                                  "type": "string"
                                 }
                               },
                               "required": [
                                 "name"
                               ],
-                              "type": "object",
-                              "additionalProperties": false
+                              "type": "object"
                             },
                             "type": "array",
                             "x-kubernetes-list-map-keys": [
@@ -5060,16 +5163,63 @@
                             "x-kubernetes-preserve-unknown-fields": true
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "restartPolicy": {
                         "type": "string"
+                      },
+                      "restartPolicyRules": {
+                        "items": {
+                          "properties": {
+                            "action": {
+                              "type": "string"
+                            },
+                            "exitCodes": {
+                              "properties": {
+                                "operator": {
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "items": {
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "set"
+                                }
+                              },
+                              "required": [
+                                "operator"
+                              ],
+                              "type": "object"
+                            }
+                          },
+                          "required": [
+                            "action"
+                          ],
+                          "type": "object"
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "securityContext": {
                         "properties": {
                           "allowPrivilegeEscalation": {
                             "type": "boolean"
+                          },
+                          "appArmorProfile": {
+                            "properties": {
+                              "localhostProfile": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "type"
+                            ],
+                            "type": "object"
                           },
                           "capabilities": {
                             "properties": {
@@ -5077,17 +5227,18 @@
                                 "items": {
                                   "type": "string"
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "drop": {
                                 "items": {
                                   "type": "string"
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               }
                             },
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "privileged": {
                             "type": "boolean"
@@ -5124,8 +5275,7 @@
                                 "type": "string"
                               }
                             },
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "seccompProfile": {
                             "properties": {
@@ -5139,8 +5289,7 @@
                             "required": [
                               "type"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "windowsOptions": {
                             "properties": {
@@ -5157,12 +5306,10 @@
                                 "type": "string"
                               }
                             },
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "startupProbe": {
                         "properties": {
@@ -5172,11 +5319,11 @@
                                 "items": {
                                   "type": "string"
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               }
                             },
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "failureThreshold": {
                             "format": "int32",
@@ -5189,14 +5336,14 @@
                                 "type": "integer"
                               },
                               "service": {
+                                "default": "",
                                 "type": "string"
                               }
                             },
                             "required": [
                               "port"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "httpGet": {
                             "properties": {
@@ -5217,10 +5364,10 @@
                                     "name",
                                     "value"
                                   ],
-                                  "type": "object",
-                                  "additionalProperties": false
+                                  "type": "object"
                                 },
-                                "type": "array"
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "path": {
                                 "type": "string"
@@ -5243,8 +5390,7 @@
                             "required": [
                               "port"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "initialDelaySeconds": {
                             "format": "int32",
@@ -5278,8 +5424,7 @@
                             "required": [
                               "port"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "terminationGracePeriodSeconds": {
                             "format": "int64",
@@ -5290,8 +5435,7 @@
                             "type": "integer"
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "stdin": {
                         "type": "boolean"
@@ -5322,10 +5466,13 @@
                             "devicePath",
                             "name"
                           ],
-                          "type": "object",
-                          "additionalProperties": false
+                          "type": "object"
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-map-keys": [
+                          "devicePath"
+                        ],
+                        "x-kubernetes-list-type": "map"
                       },
                       "volumeMounts": {
                         "items": {
@@ -5342,6 +5489,9 @@
                             "readOnly": {
                               "type": "boolean"
                             },
+                            "recursiveReadOnly": {
+                              "type": "string"
+                            },
                             "subPath": {
                               "type": "string"
                             },
@@ -5353,10 +5503,13 @@
                             "mountPath",
                             "name"
                           ],
-                          "type": "object",
-                          "additionalProperties": false
+                          "type": "object"
                         },
-                        "type": "array"
+                        "type": "array",
+                        "x-kubernetes-list-map-keys": [
+                          "mountPath"
+                        ],
+                        "x-kubernetes-list-type": "map"
                       },
                       "workingDir": {
                         "type": "string"
@@ -5365,10 +5518,13 @@
                     "required": [
                       "name"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
-                  "type": "array"
+                  "type": "array",
+                  "x-kubernetes-list-map-keys": [
+                    "name"
+                  ],
+                  "x-kubernetes-list-type": "map"
                 },
                 "nodeName": {
                   "type": "string"
@@ -5389,8 +5545,7 @@
                   "required": [
                     "name"
                   ],
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 },
                 "overhead": {
                   "additionalProperties": {
@@ -5427,10 +5582,10 @@
                     "required": [
                       "conditionType"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
-                  "type": "array"
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
                 },
                 "resourceClaims": {
                   "items": {
@@ -5438,30 +5593,79 @@
                       "name": {
                         "type": "string"
                       },
-                      "source": {
-                        "properties": {
-                          "resourceClaimName": {
-                            "type": "string"
-                          },
-                          "resourceClaimTemplateName": {
-                            "type": "string"
-                          }
-                        },
-                        "type": "object",
-                        "additionalProperties": false
+                      "resourceClaimName": {
+                        "type": "string"
+                      },
+                      "resourceClaimTemplateName": {
+                        "type": "string"
                       }
                     },
                     "required": [
                       "name"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "type": "array",
                   "x-kubernetes-list-map-keys": [
                     "name"
                   ],
                   "x-kubernetes-list-type": "map"
+                },
+                "resources": {
+                  "properties": {
+                    "claims": {
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "request": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array",
+                      "x-kubernetes-list-map-keys": [
+                        "name"
+                      ],
+                      "x-kubernetes-list-type": "map"
+                    },
+                    "limits": {
+                      "additionalProperties": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "type": "object"
+                    },
+                    "requests": {
+                      "additionalProperties": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
                 },
                 "restartPolicy": {
                   "type": "string"
@@ -5482,8 +5686,7 @@
                     "required": [
                       "name"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "type": "array",
                   "x-kubernetes-list-map-keys": [
@@ -5493,6 +5696,20 @@
                 },
                 "securityContext": {
                   "properties": {
+                    "appArmorProfile": {
+                      "properties": {
+                        "localhostProfile": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "type"
+                      ],
+                      "type": "object"
+                    },
                     "fsGroup": {
                       "format": "int64",
                       "type": "integer"
@@ -5511,6 +5728,9 @@
                       "format": "int64",
                       "type": "integer"
                     },
+                    "seLinuxChangePolicy": {
+                      "type": "string"
+                    },
                     "seLinuxOptions": {
                       "properties": {
                         "level": {
@@ -5526,8 +5746,7 @@
                           "type": "string"
                         }
                       },
-                      "type": "object",
-                      "additionalProperties": false
+                      "type": "object"
                     },
                     "seccompProfile": {
                       "properties": {
@@ -5541,15 +5760,18 @@
                       "required": [
                         "type"
                       ],
-                      "type": "object",
-                      "additionalProperties": false
+                      "type": "object"
                     },
                     "supplementalGroups": {
                       "items": {
                         "format": "int64",
                         "type": "integer"
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
+                    },
+                    "supplementalGroupsPolicy": {
+                      "type": "string"
                     },
                     "sysctls": {
                       "items": {
@@ -5565,10 +5787,10 @@
                           "name",
                           "value"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
-                      "type": "array"
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
                     },
                     "windowsOptions": {
                       "properties": {
@@ -5585,12 +5807,10 @@
                           "type": "string"
                         }
                       },
-                      "type": "object",
-                      "additionalProperties": false
+                      "type": "object"
                     }
                   },
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 },
                 "serviceAccount": {
                   "type": "string"
@@ -5631,10 +5851,10 @@
                         "type": "string"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
-                  "type": "array"
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
                 },
                 "topologySpreadConstraints": {
                   "items": {
@@ -5654,17 +5874,18 @@
                                   "items": {
                                     "type": "string"
                                   },
-                                  "type": "array"
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               },
                               "required": [
                                 "key",
                                 "operator"
                               ],
-                              "type": "object",
-                              "additionalProperties": false
+                              "type": "object"
                             },
-                            "type": "array"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "matchLabels": {
                             "additionalProperties": {
@@ -5674,8 +5895,7 @@
                           }
                         },
                         "type": "object",
-                        "x-kubernetes-map-type": "atomic",
-                        "additionalProperties": false
+                        "x-kubernetes-map-type": "atomic"
                       },
                       "matchLabelKeys": {
                         "items": {
@@ -5710,8 +5930,7 @@
                       "topologyKey",
                       "whenUnsatisfiable"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "type": "array",
                   "x-kubernetes-list-map-keys": [
@@ -5721,21 +5940,16 @@
                   "x-kubernetes-list-type": "map"
                 },
                 "volumes": {
-                  "items": {
-                    "x-kubernetes-preserve-unknown-fields": true
-                  },
-                  "type": "array"
+                  "x-kubernetes-preserve-unknown-fields": true
                 }
               },
               "required": [
                 "containers"
               ],
-              "type": "object",
-              "additionalProperties": false
+              "type": "object"
             }
           },
-          "type": "object",
-          "additionalProperties": false
+          "type": "object"
         },
         "workloadRef": {
           "properties": {
@@ -5752,12 +5966,10 @@
               "type": "string"
             }
           },
-          "type": "object",
-          "additionalProperties": false
+          "type": "object"
         }
       },
-      "type": "object",
-      "additionalProperties": false
+      "type": "object"
     },
     "status": {
       "properties": {
@@ -5790,8 +6002,7 @@
                 "arn",
                 "name"
               ],
-              "type": "object",
-              "additionalProperties": false
+              "type": "object"
             },
             "ingress": {
               "type": "string"
@@ -5812,8 +6023,7 @@
                 "arn",
                 "name"
               ],
-              "type": "object",
-              "additionalProperties": false
+              "type": "object"
             },
             "stableTargetGroup": {
               "properties": {
@@ -5831,12 +6041,10 @@
                 "arn",
                 "name"
               ],
-              "type": "object",
-              "additionalProperties": false
+              "type": "object"
             }
           },
-          "type": "object",
-          "additionalProperties": false
+          "type": "object"
         },
         "albs": {
           "items": {
@@ -5857,8 +6065,7 @@
                   "arn",
                   "name"
                 ],
-                "type": "object",
-                "additionalProperties": false
+                "type": "object"
               },
               "ingress": {
                 "type": "string"
@@ -5879,8 +6086,7 @@
                   "arn",
                   "name"
                 ],
-                "type": "object",
-                "additionalProperties": false
+                "type": "object"
               },
               "stableTargetGroup": {
                 "properties": {
@@ -5898,12 +6104,10 @@
                   "arn",
                   "name"
                 ],
-                "type": "object",
-                "additionalProperties": false
+                "type": "object"
               }
             },
-            "type": "object",
-            "additionalProperties": false
+            "type": "object"
           },
           "type": "array"
         },
@@ -5932,8 +6136,7 @@
                 "name",
                 "status"
               ],
-              "type": "object",
-              "additionalProperties": false
+              "type": "object"
             },
             "prePromotionAnalysisRunStatus": {
               "properties": {
@@ -5951,8 +6154,7 @@
                 "name",
                 "status"
               ],
-              "type": "object",
-              "additionalProperties": false
+              "type": "object"
             },
             "previewSelector": {
               "type": "string"
@@ -5961,8 +6163,7 @@
               "type": "boolean"
             }
           },
-          "type": "object",
-          "additionalProperties": false
+          "type": "object"
         },
         "canary": {
           "properties": {
@@ -5982,8 +6183,7 @@
                 "name",
                 "status"
               ],
-              "type": "object",
-              "additionalProperties": false
+              "type": "object"
             },
             "currentExperiment": {
               "type": "string"
@@ -6004,8 +6204,7 @@
                 "name",
                 "status"
               ],
-              "type": "object",
-              "additionalProperties": false
+              "type": "object"
             },
             "stablePingPong": {
               "type": "string"
@@ -6061,8 +6260,7 @@
                   "name",
                   "operation"
                 ],
-                "type": "object",
-                "additionalProperties": false
+                "type": "object"
               },
               "type": "array"
             },
@@ -6085,8 +6283,7 @@
                     "required": [
                       "weight"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "type": "array"
                 },
@@ -6106,8 +6303,7 @@
                   "required": [
                     "weight"
                   ],
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 },
                 "stable": {
                   "properties": {
@@ -6125,8 +6321,7 @@
                   "required": [
                     "weight"
                   ],
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 },
                 "verified": {
                   "type": "boolean"
@@ -6136,12 +6331,10 @@
                 "canary",
                 "stable"
               ],
-              "type": "object",
-              "additionalProperties": false
+              "type": "object"
             }
           },
-          "type": "object",
-          "additionalProperties": false
+          "type": "object"
         },
         "collisionCount": {
           "format": "int32",
@@ -6179,8 +6372,7 @@
               "status",
               "type"
             ],
-            "type": "object",
-            "additionalProperties": false
+            "type": "object"
           },
           "type": "array"
         },
@@ -6218,8 +6410,7 @@
               "reason",
               "startTime"
             ],
-            "type": "object",
-            "additionalProperties": false
+            "type": "object"
           },
           "type": "array"
         },
@@ -6255,8 +6446,7 @@
           "type": "string"
         }
       },
-      "type": "object",
-      "additionalProperties": false
+      "type": "object"
     }
   },
   "required": [

--- a/argoproj.io/rollout_v1alpha1.json
+++ b/argoproj.io/rollout_v1alpha1.json
@@ -22,7 +22,8 @@
               "type": "integer"
             }
           },
-          "type": "object"
+          "type": "object",
+          "additionalProperties": false
         },
         "minReadySeconds": {
           "format": "int32",
@@ -57,7 +58,8 @@
               "type": "integer"
             }
           },
-          "type": "object"
+          "type": "object",
+          "additionalProperties": false
         },
         "selector": {
           "properties": {
@@ -82,7 +84,8 @@
                   "key",
                   "operator"
                 ],
-                "type": "object"
+                "type": "object",
+                "additionalProperties": false
               },
               "type": "array",
               "x-kubernetes-list-type": "atomic"
@@ -101,7 +104,8 @@
               "message": ".spec.selector is immutable",
               "rule": "self == oldSelf"
             }
-          ]
+          ],
+          "additionalProperties": false
         },
         "strategy": {
           "properties": {
@@ -126,7 +130,8 @@
                       "type": "object"
                     }
                   },
-                  "type": "object"
+                  "type": "object",
+                  "additionalProperties": false
                 },
                 "activeService": {
                   "type": "string"
@@ -143,13 +148,15 @@
                       "required": [
                         "weight"
                       ],
-                      "type": "object"
+                      "type": "object",
+                      "additionalProperties": false
                     },
                     "requiredDuringSchedulingIgnoredDuringExecution": {
                       "type": "object"
                     }
                   },
-                  "type": "object"
+                  "type": "object",
+                  "additionalProperties": false
                 },
                 "autoPromotionEnabled": {
                   "type": "boolean"
@@ -186,7 +193,8 @@
                           "type": "object"
                         }
                       },
-                      "type": "object"
+                      "type": "object",
+                      "additionalProperties": false
                     },
                     "args": {
                       "items": {
@@ -208,19 +216,22 @@
                                 "required": [
                                   "fieldPath"
                                 ],
-                                "type": "object"
+                                "type": "object",
+                                "additionalProperties": false
                               },
                               "podTemplateHashValue": {
                                 "type": "string"
                               }
                             },
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           }
                         },
                         "required": [
                           "name"
                         ],
-                        "type": "object"
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "type": "array"
                     },
@@ -234,7 +245,8 @@
                         "required": [
                           "metricName"
                         ],
-                        "type": "object"
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "type": "array"
                     },
@@ -253,7 +265,8 @@
                           "limit",
                           "metricName"
                         ],
-                        "type": "object"
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "type": "array"
                     },
@@ -267,12 +280,14 @@
                             "type": "string"
                           }
                         },
-                        "type": "object"
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "type": "array"
                     }
                   },
-                  "type": "object"
+                  "type": "object",
+                  "additionalProperties": false
                 },
                 "prePromotionAnalysis": {
                   "properties": {
@@ -291,7 +306,8 @@
                           "type": "object"
                         }
                       },
-                      "type": "object"
+                      "type": "object",
+                      "additionalProperties": false
                     },
                     "args": {
                       "items": {
@@ -313,19 +329,22 @@
                                 "required": [
                                   "fieldPath"
                                 ],
-                                "type": "object"
+                                "type": "object",
+                                "additionalProperties": false
                               },
                               "podTemplateHashValue": {
                                 "type": "string"
                               }
                             },
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           }
                         },
                         "required": [
                           "name"
                         ],
-                        "type": "object"
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "type": "array"
                     },
@@ -339,7 +358,8 @@
                         "required": [
                           "metricName"
                         ],
-                        "type": "object"
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "type": "array"
                     },
@@ -358,7 +378,8 @@
                           "limit",
                           "metricName"
                         ],
-                        "type": "object"
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "type": "array"
                     },
@@ -372,12 +393,14 @@
                             "type": "string"
                           }
                         },
-                        "type": "object"
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "type": "array"
                     }
                   },
-                  "type": "object"
+                  "type": "object",
+                  "additionalProperties": false
                 },
                 "previewMetadata": {
                   "properties": {
@@ -394,7 +417,8 @@
                       "type": "object"
                     }
                   },
-                  "type": "object"
+                  "type": "object",
+                  "additionalProperties": false
                 },
                 "previewReplicaCount": {
                   "format": "int32",
@@ -415,7 +439,8 @@
               "required": [
                 "activeService"
               ],
-              "type": "object"
+              "type": "object",
+              "additionalProperties": false
             },
             "canary": {
               "properties": {
@@ -440,7 +465,8 @@
                           "type": "object"
                         }
                       },
-                      "type": "object"
+                      "type": "object",
+                      "additionalProperties": false
                     },
                     "args": {
                       "items": {
@@ -462,19 +488,22 @@
                                 "required": [
                                   "fieldPath"
                                 ],
-                                "type": "object"
+                                "type": "object",
+                                "additionalProperties": false
                               },
                               "podTemplateHashValue": {
                                 "type": "string"
                               }
                             },
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           }
                         },
                         "required": [
                           "name"
                         ],
-                        "type": "object"
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "type": "array"
                     },
@@ -488,7 +517,8 @@
                         "required": [
                           "metricName"
                         ],
-                        "type": "object"
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "type": "array"
                     },
@@ -507,7 +537,8 @@
                           "limit",
                           "metricName"
                         ],
-                        "type": "object"
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "type": "array"
                     },
@@ -525,12 +556,14 @@
                             "type": "string"
                           }
                         },
-                        "type": "object"
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "type": "array"
                     }
                   },
-                  "type": "object"
+                  "type": "object",
+                  "additionalProperties": false
                 },
                 "antiAffinity": {
                   "properties": {
@@ -544,13 +577,15 @@
                       "required": [
                         "weight"
                       ],
-                      "type": "object"
+                      "type": "object",
+                      "additionalProperties": false
                     },
                     "requiredDuringSchedulingIgnoredDuringExecution": {
                       "type": "object"
                     }
                   },
-                  "type": "object"
+                  "type": "object",
+                  "additionalProperties": false
                 },
                 "canaryMetadata": {
                   "properties": {
@@ -567,7 +602,8 @@
                       "type": "object"
                     }
                   },
-                  "type": "object"
+                  "type": "object",
+                  "additionalProperties": false
                 },
                 "canaryService": {
                   "type": "string"
@@ -614,7 +650,8 @@
                     "pingService",
                     "pongService"
                   ],
-                  "type": "object"
+                  "type": "object",
+                  "additionalProperties": false
                 },
                 "replicaProgressThreshold": {
                   "properties": {
@@ -630,7 +667,8 @@
                     "type",
                     "value"
                   ],
-                  "type": "object"
+                  "type": "object",
+                  "additionalProperties": false
                 },
                 "scaleDownDelayRevisionLimit": {
                   "format": "int32",
@@ -655,7 +693,8 @@
                       "type": "object"
                     }
                   },
-                  "type": "object"
+                  "type": "object",
+                  "additionalProperties": false
                 },
                 "stableService": {
                   "type": "string"
@@ -680,7 +719,8 @@
                                 "type": "object"
                               }
                             },
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "args": {
                             "items": {
@@ -702,19 +742,22 @@
                                       "required": [
                                         "fieldPath"
                                       ],
-                                      "type": "object"
+                                      "type": "object",
+                                      "additionalProperties": false
                                     },
                                     "podTemplateHashValue": {
                                       "type": "string"
                                     }
                                   },
-                                  "type": "object"
+                                  "type": "object",
+                                  "additionalProperties": false
                                 }
                               },
                               "required": [
                                 "name"
                               ],
-                              "type": "object"
+                              "type": "object",
+                              "additionalProperties": false
                             },
                             "type": "array"
                           },
@@ -728,7 +771,8 @@
                               "required": [
                                 "metricName"
                               ],
-                              "type": "object"
+                              "type": "object",
+                              "additionalProperties": false
                             },
                             "type": "array"
                           },
@@ -747,7 +791,8 @@
                                 "limit",
                                 "metricName"
                               ],
-                              "type": "object"
+                              "type": "object",
+                              "additionalProperties": false
                             },
                             "type": "array"
                           },
@@ -761,12 +806,14 @@
                                   "type": "string"
                                 }
                               },
-                              "type": "object"
+                              "type": "object",
+                              "additionalProperties": false
                             },
                             "type": "array"
                           }
                         },
-                        "type": "object"
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "experiment": {
                         "properties": {
@@ -793,19 +840,22 @@
                                             "required": [
                                               "fieldPath"
                                             ],
-                                            "type": "object"
+                                            "type": "object",
+                                            "additionalProperties": false
                                           },
                                           "podTemplateHashValue": {
                                             "type": "string"
                                           }
                                         },
-                                        "type": "object"
+                                        "type": "object",
+                                        "additionalProperties": false
                                       }
                                     },
                                     "required": [
                                       "name"
                                     ],
-                                    "type": "object"
+                                    "type": "object",
+                                    "additionalProperties": false
                                   },
                                   "type": "array"
                                 },
@@ -826,7 +876,8 @@
                                 "name",
                                 "templateName"
                               ],
-                              "type": "object"
+                              "type": "object",
+                              "additionalProperties": false
                             },
                             "type": "array"
                           },
@@ -845,7 +896,8 @@
                                 "type": "object"
                               }
                             },
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "dryRun": {
                             "items": {
@@ -857,7 +909,8 @@
                               "required": [
                                 "metricName"
                               ],
-                              "type": "object"
+                              "type": "object",
+                              "additionalProperties": false
                             },
                             "type": "array"
                           },
@@ -886,7 +939,8 @@
                                       "type": "object"
                                     }
                                   },
-                                  "type": "object"
+                                  "type": "object",
+                                  "additionalProperties": false
                                 },
                                 "name": {
                                   "type": "string"
@@ -918,7 +972,8 @@
                                           "key",
                                           "operator"
                                         ],
-                                        "type": "object"
+                                        "type": "object",
+                                        "additionalProperties": false
                                       },
                                       "type": "array",
                                       "x-kubernetes-list-type": "atomic"
@@ -931,7 +986,8 @@
                                     }
                                   },
                                   "type": "object",
-                                  "x-kubernetes-map-type": "atomic"
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
                                 },
                                 "service": {
                                   "properties": {
@@ -939,7 +995,8 @@
                                       "type": "string"
                                     }
                                   },
-                                  "type": "object"
+                                  "type": "object",
+                                  "additionalProperties": false
                                 },
                                 "specRef": {
                                   "type": "string"
@@ -953,7 +1010,8 @@
                                 "name",
                                 "specRef"
                               ],
-                              "type": "object"
+                              "type": "object",
+                              "additionalProperties": false
                             },
                             "type": "array"
                           }
@@ -961,7 +1019,8 @@
                         "required": [
                           "templates"
                         ],
-                        "type": "object"
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "pause": {
                         "properties": {
@@ -977,7 +1036,8 @@
                             "x-kubernetes-int-or-string": true
                           }
                         },
-                        "type": "object"
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "plugin": {
                         "properties": {
@@ -992,7 +1052,8 @@
                         "required": [
                           "name"
                         ],
-                        "type": "object"
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "setCanaryScale": {
                         "properties": {
@@ -1008,7 +1069,8 @@
                             "type": "integer"
                           }
                         },
-                        "type": "object"
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "setHeaderRoute": {
                         "properties": {
@@ -1030,14 +1092,16 @@
                                       "type": "string"
                                     }
                                   },
-                                  "type": "object"
+                                  "type": "object",
+                                  "additionalProperties": false
                                 }
                               },
                               "required": [
                                 "headerName",
                                 "headerValue"
                               ],
-                              "type": "object"
+                              "type": "object",
+                              "additionalProperties": false
                             },
                             "type": "array"
                           },
@@ -1045,7 +1109,8 @@
                             "type": "string"
                           }
                         },
-                        "type": "object"
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "setMirrorRoute": {
                         "properties": {
@@ -1065,7 +1130,8 @@
                                         "type": "string"
                                       }
                                     },
-                                    "type": "object"
+                                    "type": "object",
+                                    "additionalProperties": false
                                   },
                                   "type": "object"
                                 },
@@ -1081,7 +1147,8 @@
                                       "type": "string"
                                     }
                                   },
-                                  "type": "object"
+                                  "type": "object",
+                                  "additionalProperties": false
                                 },
                                 "path": {
                                   "properties": {
@@ -1095,10 +1162,12 @@
                                       "type": "string"
                                     }
                                   },
-                                  "type": "object"
+                                  "type": "object",
+                                  "additionalProperties": false
                                 }
                               },
-                              "type": "object"
+                              "type": "object",
+                              "additionalProperties": false
                             },
                             "type": "array"
                           },
@@ -1113,14 +1182,16 @@
                         "required": [
                           "name"
                         ],
-                        "type": "object"
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "setWeight": {
                         "format": "int32",
                         "type": "integer"
                       }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "additionalProperties": false
                   },
                   "type": "array"
                 },
@@ -1161,13 +1232,15 @@
                             "durationSeconds",
                             "enabled"
                           ],
-                          "type": "object"
+                          "type": "object",
+                          "additionalProperties": false
                         }
                       },
                       "required": [
                         "servicePort"
                       ],
-                      "type": "object"
+                      "type": "object",
+                      "additionalProperties": false
                     },
                     "ambassador": {
                       "properties": {
@@ -1181,7 +1254,8 @@
                       "required": [
                         "mappings"
                       ],
-                      "type": "object"
+                      "type": "object",
+                      "additionalProperties": false
                     },
                     "apisix": {
                       "properties": {
@@ -1200,10 +1274,12 @@
                           "required": [
                             "name"
                           ],
-                          "type": "object"
+                          "type": "object",
+                          "additionalProperties": false
                         }
                       },
-                      "type": "object"
+                      "type": "object",
+                      "additionalProperties": false
                     },
                     "appMesh": {
                       "properties": {
@@ -1218,7 +1294,8 @@
                               "required": [
                                 "name"
                               ],
-                              "type": "object"
+                              "type": "object",
+                              "additionalProperties": false
                             },
                             "stableVirtualNodeRef": {
                               "properties": {
@@ -1229,14 +1306,16 @@
                               "required": [
                                 "name"
                               ],
-                              "type": "object"
+                              "type": "object",
+                              "additionalProperties": false
                             }
                           },
                           "required": [
                             "canaryVirtualNodeRef",
                             "stableVirtualNodeRef"
                           ],
-                          "type": "object"
+                          "type": "object",
+                          "additionalProperties": false
                         },
                         "virtualService": {
                           "properties": {
@@ -1253,10 +1332,12 @@
                           "required": [
                             "name"
                           ],
-                          "type": "object"
+                          "type": "object",
+                          "additionalProperties": false
                         }
                       },
-                      "type": "object"
+                      "type": "object",
+                      "additionalProperties": false
                     },
                     "istio": {
                       "properties": {
@@ -1283,7 +1364,8 @@
                             "name",
                             "stableSubsetName"
                           ],
-                          "type": "object"
+                          "type": "object",
+                          "additionalProperties": false
                         },
                         "virtualService": {
                           "properties": {
@@ -1304,7 +1386,8 @@
                                     "type": "integer"
                                   }
                                 },
-                                "type": "object"
+                                "type": "object",
+                                "additionalProperties": false
                               },
                               "type": "array"
                             },
@@ -1322,7 +1405,8 @@
                                     "type": "array"
                                   }
                                 },
-                                "type": "object"
+                                "type": "object",
+                                "additionalProperties": false
                               },
                               "type": "array"
                             }
@@ -1330,7 +1414,8 @@
                           "required": [
                             "name"
                           ],
-                          "type": "object"
+                          "type": "object",
+                          "additionalProperties": false
                         },
                         "virtualServices": {
                           "items": {
@@ -1352,7 +1437,8 @@
                                       "type": "integer"
                                     }
                                   },
-                                  "type": "object"
+                                  "type": "object",
+                                  "additionalProperties": false
                                 },
                                 "type": "array"
                               },
@@ -1370,7 +1456,8 @@
                                       "type": "array"
                                     }
                                   },
-                                  "type": "object"
+                                  "type": "object",
+                                  "additionalProperties": false
                                 },
                                 "type": "array"
                               }
@@ -1378,12 +1465,14 @@
                             "required": [
                               "name"
                             ],
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "type": "array"
                         }
                       },
-                      "type": "object"
+                      "type": "object",
+                      "additionalProperties": false
                     },
                     "managedRoutes": {
                       "items": {
@@ -1395,7 +1484,8 @@
                         "required": [
                           "name"
                         ],
-                        "type": "object"
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "type": "array"
                     },
@@ -1430,7 +1520,8 @@
                           "type": "array"
                         }
                       },
-                      "type": "object"
+                      "type": "object",
+                      "additionalProperties": false
                     },
                     "plugins": {
                       "type": "object",
@@ -1445,7 +1536,8 @@
                           "type": "string"
                         }
                       },
-                      "type": "object"
+                      "type": "object",
+                      "additionalProperties": false
                     },
                     "traefik": {
                       "properties": {
@@ -1456,16 +1548,20 @@
                       "required": [
                         "weightedTraefikServiceName"
                       ],
-                      "type": "object"
+                      "type": "object",
+                      "additionalProperties": false
                     }
                   },
-                  "type": "object"
+                  "type": "object",
+                  "additionalProperties": false
                 }
               },
-              "type": "object"
+              "type": "object",
+              "additionalProperties": false
             }
           },
-          "type": "object"
+          "type": "object",
+          "additionalProperties": false
         },
         "template": {
           "properties": {
@@ -1484,7 +1580,8 @@
                   "type": "object"
                 }
               },
-              "type": "object"
+              "type": "object",
+              "additionalProperties": false
             },
             "spec": {
               "properties": {
@@ -1522,7 +1619,8 @@
                                         "key",
                                         "operator"
                                       ],
-                                      "type": "object"
+                                      "type": "object",
+                                      "additionalProperties": false
                                     },
                                     "type": "array",
                                     "x-kubernetes-list-type": "atomic"
@@ -1548,14 +1646,16 @@
                                         "key",
                                         "operator"
                                       ],
-                                      "type": "object"
+                                      "type": "object",
+                                      "additionalProperties": false
                                     },
                                     "type": "array",
                                     "x-kubernetes-list-type": "atomic"
                                   }
                                 },
                                 "type": "object",
-                                "x-kubernetes-map-type": "atomic"
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
                               },
                               "weight": {
                                 "format": "int32",
@@ -1566,7 +1666,8 @@
                               "preference",
                               "weight"
                             ],
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "type": "array",
                           "x-kubernetes-list-type": "atomic"
@@ -1597,7 +1698,8 @@
                                         "key",
                                         "operator"
                                       ],
-                                      "type": "object"
+                                      "type": "object",
+                                      "additionalProperties": false
                                     },
                                     "type": "array",
                                     "x-kubernetes-list-type": "atomic"
@@ -1623,14 +1725,16 @@
                                         "key",
                                         "operator"
                                       ],
-                                      "type": "object"
+                                      "type": "object",
+                                      "additionalProperties": false
                                     },
                                     "type": "array",
                                     "x-kubernetes-list-type": "atomic"
                                   }
                                 },
                                 "type": "object",
-                                "x-kubernetes-map-type": "atomic"
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
                               },
                               "type": "array",
                               "x-kubernetes-list-type": "atomic"
@@ -1640,10 +1744,12 @@
                             "nodeSelectorTerms"
                           ],
                           "type": "object",
-                          "x-kubernetes-map-type": "atomic"
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
                         }
                       },
-                      "type": "object"
+                      "type": "object",
+                      "additionalProperties": false
                     },
                     "podAffinity": {
                       "properties": {
@@ -1675,7 +1781,8 @@
                                             "key",
                                             "operator"
                                           ],
-                                          "type": "object"
+                                          "type": "object",
+                                          "additionalProperties": false
                                         },
                                         "type": "array",
                                         "x-kubernetes-list-type": "atomic"
@@ -1688,7 +1795,8 @@
                                       }
                                     },
                                     "type": "object",
-                                    "x-kubernetes-map-type": "atomic"
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
                                   },
                                   "matchLabelKeys": {
                                     "items": {
@@ -1727,7 +1835,8 @@
                                             "key",
                                             "operator"
                                           ],
-                                          "type": "object"
+                                          "type": "object",
+                                          "additionalProperties": false
                                         },
                                         "type": "array",
                                         "x-kubernetes-list-type": "atomic"
@@ -1740,7 +1849,8 @@
                                       }
                                     },
                                     "type": "object",
-                                    "x-kubernetes-map-type": "atomic"
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
                                   },
                                   "namespaces": {
                                     "items": {
@@ -1756,7 +1866,8 @@
                                 "required": [
                                   "topologyKey"
                                 ],
-                                "type": "object"
+                                "type": "object",
+                                "additionalProperties": false
                               },
                               "weight": {
                                 "format": "int32",
@@ -1767,7 +1878,8 @@
                               "podAffinityTerm",
                               "weight"
                             ],
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "type": "array",
                           "x-kubernetes-list-type": "atomic"
@@ -1798,7 +1910,8 @@
                                         "key",
                                         "operator"
                                       ],
-                                      "type": "object"
+                                      "type": "object",
+                                      "additionalProperties": false
                                     },
                                     "type": "array",
                                     "x-kubernetes-list-type": "atomic"
@@ -1811,7 +1924,8 @@
                                   }
                                 },
                                 "type": "object",
-                                "x-kubernetes-map-type": "atomic"
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
                               },
                               "matchLabelKeys": {
                                 "items": {
@@ -1850,7 +1964,8 @@
                                         "key",
                                         "operator"
                                       ],
-                                      "type": "object"
+                                      "type": "object",
+                                      "additionalProperties": false
                                     },
                                     "type": "array",
                                     "x-kubernetes-list-type": "atomic"
@@ -1863,7 +1978,8 @@
                                   }
                                 },
                                 "type": "object",
-                                "x-kubernetes-map-type": "atomic"
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
                               },
                               "namespaces": {
                                 "items": {
@@ -1879,13 +1995,15 @@
                             "required": [
                               "topologyKey"
                             ],
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "type": "array",
                           "x-kubernetes-list-type": "atomic"
                         }
                       },
-                      "type": "object"
+                      "type": "object",
+                      "additionalProperties": false
                     },
                     "podAntiAffinity": {
                       "properties": {
@@ -1917,7 +2035,8 @@
                                             "key",
                                             "operator"
                                           ],
-                                          "type": "object"
+                                          "type": "object",
+                                          "additionalProperties": false
                                         },
                                         "type": "array",
                                         "x-kubernetes-list-type": "atomic"
@@ -1930,7 +2049,8 @@
                                       }
                                     },
                                     "type": "object",
-                                    "x-kubernetes-map-type": "atomic"
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
                                   },
                                   "matchLabelKeys": {
                                     "items": {
@@ -1969,7 +2089,8 @@
                                             "key",
                                             "operator"
                                           ],
-                                          "type": "object"
+                                          "type": "object",
+                                          "additionalProperties": false
                                         },
                                         "type": "array",
                                         "x-kubernetes-list-type": "atomic"
@@ -1982,7 +2103,8 @@
                                       }
                                     },
                                     "type": "object",
-                                    "x-kubernetes-map-type": "atomic"
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
                                   },
                                   "namespaces": {
                                     "items": {
@@ -1998,7 +2120,8 @@
                                 "required": [
                                   "topologyKey"
                                 ],
-                                "type": "object"
+                                "type": "object",
+                                "additionalProperties": false
                               },
                               "weight": {
                                 "format": "int32",
@@ -2009,7 +2132,8 @@
                               "podAffinityTerm",
                               "weight"
                             ],
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "type": "array",
                           "x-kubernetes-list-type": "atomic"
@@ -2040,7 +2164,8 @@
                                         "key",
                                         "operator"
                                       ],
-                                      "type": "object"
+                                      "type": "object",
+                                      "additionalProperties": false
                                     },
                                     "type": "array",
                                     "x-kubernetes-list-type": "atomic"
@@ -2053,7 +2178,8 @@
                                   }
                                 },
                                 "type": "object",
-                                "x-kubernetes-map-type": "atomic"
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
                               },
                               "matchLabelKeys": {
                                 "items": {
@@ -2092,7 +2218,8 @@
                                         "key",
                                         "operator"
                                       ],
-                                      "type": "object"
+                                      "type": "object",
+                                      "additionalProperties": false
                                     },
                                     "type": "array",
                                     "x-kubernetes-list-type": "atomic"
@@ -2105,7 +2232,8 @@
                                   }
                                 },
                                 "type": "object",
-                                "x-kubernetes-map-type": "atomic"
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
                               },
                               "namespaces": {
                                 "items": {
@@ -2121,16 +2249,19 @@
                             "required": [
                               "topologyKey"
                             ],
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "type": "array",
                           "x-kubernetes-list-type": "atomic"
                         }
                       },
-                      "type": "object"
+                      "type": "object",
+                      "additionalProperties": false
                     }
                   },
-                  "type": "object"
+                  "type": "object",
+                  "additionalProperties": false
                 },
                 "automountServiceAccountToken": {
                   "type": "boolean"
@@ -2180,7 +2311,8 @@
                                     "key"
                                   ],
                                   "type": "object",
-                                  "x-kubernetes-map-type": "atomic"
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
                                 },
                                 "fieldRef": {
                                   "properties": {
@@ -2195,7 +2327,8 @@
                                     "fieldPath"
                                   ],
                                   "type": "object",
-                                  "x-kubernetes-map-type": "atomic"
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
                                 },
                                 "fileKeyRef": {
                                   "properties": {
@@ -2219,7 +2352,8 @@
                                     "volumeName"
                                   ],
                                   "type": "object",
-                                  "x-kubernetes-map-type": "atomic"
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
                                 },
                                 "resourceFieldRef": {
                                   "properties": {
@@ -2246,7 +2380,8 @@
                                     "resource"
                                   ],
                                   "type": "object",
-                                  "x-kubernetes-map-type": "atomic"
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
                                 },
                                 "secretKeyRef": {
                                   "properties": {
@@ -2265,16 +2400,19 @@
                                     "key"
                                   ],
                                   "type": "object",
-                                  "x-kubernetes-map-type": "atomic"
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
                                 }
                               },
-                              "type": "object"
+                              "type": "object",
+                              "additionalProperties": false
                             }
                           },
                           "required": [
                             "name"
                           ],
-                          "type": "object"
+                          "type": "object",
+                          "additionalProperties": false
                         },
                         "type": "array",
                         "x-kubernetes-list-map-keys": [
@@ -2296,7 +2434,8 @@
                                 }
                               },
                               "type": "object",
-                              "x-kubernetes-map-type": "atomic"
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
                             },
                             "prefix": {
                               "type": "string"
@@ -2312,10 +2451,12 @@
                                 }
                               },
                               "type": "object",
-                              "x-kubernetes-map-type": "atomic"
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
                             }
                           },
-                          "type": "object"
+                          "type": "object",
+                          "additionalProperties": false
                         },
                         "type": "array",
                         "x-kubernetes-list-type": "atomic"
@@ -2340,7 +2481,8 @@
                                     "x-kubernetes-list-type": "atomic"
                                   }
                                 },
-                                "type": "object"
+                                "type": "object",
+                                "additionalProperties": false
                               },
                               "httpGet": {
                                 "properties": {
@@ -2361,7 +2503,8 @@
                                         "name",
                                         "value"
                                       ],
-                                      "type": "object"
+                                      "type": "object",
+                                      "additionalProperties": false
                                     },
                                     "type": "array",
                                     "x-kubernetes-list-type": "atomic"
@@ -2387,7 +2530,8 @@
                                 "required": [
                                   "port"
                                 ],
-                                "type": "object"
+                                "type": "object",
+                                "additionalProperties": false
                               },
                               "sleep": {
                                 "properties": {
@@ -2399,7 +2543,8 @@
                                 "required": [
                                   "seconds"
                                 ],
-                                "type": "object"
+                                "type": "object",
+                                "additionalProperties": false
                               },
                               "tcpSocket": {
                                 "properties": {
@@ -2421,10 +2566,12 @@
                                 "required": [
                                   "port"
                                 ],
-                                "type": "object"
+                                "type": "object",
+                                "additionalProperties": false
                               }
                             },
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "preStop": {
                             "properties": {
@@ -2438,7 +2585,8 @@
                                     "x-kubernetes-list-type": "atomic"
                                   }
                                 },
-                                "type": "object"
+                                "type": "object",
+                                "additionalProperties": false
                               },
                               "httpGet": {
                                 "properties": {
@@ -2459,7 +2607,8 @@
                                         "name",
                                         "value"
                                       ],
-                                      "type": "object"
+                                      "type": "object",
+                                      "additionalProperties": false
                                     },
                                     "type": "array",
                                     "x-kubernetes-list-type": "atomic"
@@ -2485,7 +2634,8 @@
                                 "required": [
                                   "port"
                                 ],
-                                "type": "object"
+                                "type": "object",
+                                "additionalProperties": false
                               },
                               "sleep": {
                                 "properties": {
@@ -2497,7 +2647,8 @@
                                 "required": [
                                   "seconds"
                                 ],
-                                "type": "object"
+                                "type": "object",
+                                "additionalProperties": false
                               },
                               "tcpSocket": {
                                 "properties": {
@@ -2519,16 +2670,19 @@
                                 "required": [
                                   "port"
                                 ],
-                                "type": "object"
+                                "type": "object",
+                                "additionalProperties": false
                               }
                             },
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "stopSignal": {
                             "type": "string"
                           }
                         },
-                        "type": "object"
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "livenessProbe": {
                         "properties": {
@@ -2542,7 +2696,8 @@
                                 "x-kubernetes-list-type": "atomic"
                               }
                             },
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "failureThreshold": {
                             "format": "int32",
@@ -2562,7 +2717,8 @@
                             "required": [
                               "port"
                             ],
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "httpGet": {
                             "properties": {
@@ -2583,7 +2739,8 @@
                                     "name",
                                     "value"
                                   ],
-                                  "type": "object"
+                                  "type": "object",
+                                  "additionalProperties": false
                                 },
                                 "type": "array",
                                 "x-kubernetes-list-type": "atomic"
@@ -2609,7 +2766,8 @@
                             "required": [
                               "port"
                             ],
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "initialDelaySeconds": {
                             "format": "int32",
@@ -2643,7 +2801,8 @@
                             "required": [
                               "port"
                             ],
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "terminationGracePeriodSeconds": {
                             "format": "int64",
@@ -2654,7 +2813,8 @@
                             "type": "integer"
                           }
                         },
-                        "type": "object"
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "name": {
                         "type": "string"
@@ -2684,7 +2844,8 @@
                           "required": [
                             "containerPort"
                           ],
-                          "type": "object"
+                          "type": "object",
+                          "additionalProperties": false
                         },
                         "type": "array",
                         "x-kubernetes-list-map-keys": [
@@ -2705,7 +2866,8 @@
                                 "x-kubernetes-list-type": "atomic"
                               }
                             },
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "failureThreshold": {
                             "format": "int32",
@@ -2725,7 +2887,8 @@
                             "required": [
                               "port"
                             ],
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "httpGet": {
                             "properties": {
@@ -2746,7 +2909,8 @@
                                     "name",
                                     "value"
                                   ],
-                                  "type": "object"
+                                  "type": "object",
+                                  "additionalProperties": false
                                 },
                                 "type": "array",
                                 "x-kubernetes-list-type": "atomic"
@@ -2772,7 +2936,8 @@
                             "required": [
                               "port"
                             ],
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "initialDelaySeconds": {
                             "format": "int32",
@@ -2806,7 +2971,8 @@
                             "required": [
                               "port"
                             ],
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "terminationGracePeriodSeconds": {
                             "format": "int64",
@@ -2817,7 +2983,8 @@
                             "type": "integer"
                           }
                         },
-                        "type": "object"
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "resizePolicy": {
                         "items": {
@@ -2833,7 +3000,8 @@
                             "resourceName",
                             "restartPolicy"
                           ],
-                          "type": "object"
+                          "type": "object",
+                          "additionalProperties": false
                         },
                         "type": "array",
                         "x-kubernetes-list-type": "atomic"
@@ -2853,7 +3021,8 @@
                               "required": [
                                 "name"
                               ],
-                              "type": "object"
+                              "type": "object",
+                              "additionalProperties": false
                             },
                             "type": "array",
                             "x-kubernetes-list-map-keys": [
@@ -2868,7 +3037,8 @@
                             "x-kubernetes-preserve-unknown-fields": true
                           }
                         },
-                        "type": "object"
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "restartPolicy": {
                         "type": "string"
@@ -2896,13 +3066,15 @@
                               "required": [
                                 "operator"
                               ],
-                              "type": "object"
+                              "type": "object",
+                              "additionalProperties": false
                             }
                           },
                           "required": [
                             "action"
                           ],
-                          "type": "object"
+                          "type": "object",
+                          "additionalProperties": false
                         },
                         "type": "array",
                         "x-kubernetes-list-type": "atomic"
@@ -2924,7 +3096,8 @@
                             "required": [
                               "type"
                             ],
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "capabilities": {
                             "properties": {
@@ -2943,7 +3116,8 @@
                                 "x-kubernetes-list-type": "atomic"
                               }
                             },
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "privileged": {
                             "type": "boolean"
@@ -2980,7 +3154,8 @@
                                 "type": "string"
                               }
                             },
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "seccompProfile": {
                             "properties": {
@@ -2994,7 +3169,8 @@
                             "required": [
                               "type"
                             ],
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "windowsOptions": {
                             "properties": {
@@ -3011,10 +3187,12 @@
                                 "type": "string"
                               }
                             },
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           }
                         },
-                        "type": "object"
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "startupProbe": {
                         "properties": {
@@ -3028,7 +3206,8 @@
                                 "x-kubernetes-list-type": "atomic"
                               }
                             },
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "failureThreshold": {
                             "format": "int32",
@@ -3048,7 +3227,8 @@
                             "required": [
                               "port"
                             ],
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "httpGet": {
                             "properties": {
@@ -3069,7 +3249,8 @@
                                     "name",
                                     "value"
                                   ],
-                                  "type": "object"
+                                  "type": "object",
+                                  "additionalProperties": false
                                 },
                                 "type": "array",
                                 "x-kubernetes-list-type": "atomic"
@@ -3095,7 +3276,8 @@
                             "required": [
                               "port"
                             ],
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "initialDelaySeconds": {
                             "format": "int32",
@@ -3129,7 +3311,8 @@
                             "required": [
                               "port"
                             ],
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "terminationGracePeriodSeconds": {
                             "format": "int64",
@@ -3140,7 +3323,8 @@
                             "type": "integer"
                           }
                         },
-                        "type": "object"
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "stdin": {
                         "type": "boolean"
@@ -3171,7 +3355,8 @@
                             "devicePath",
                             "name"
                           ],
-                          "type": "object"
+                          "type": "object",
+                          "additionalProperties": false
                         },
                         "type": "array",
                         "x-kubernetes-list-map-keys": [
@@ -3208,7 +3393,8 @@
                             "mountPath",
                             "name"
                           ],
-                          "type": "object"
+                          "type": "object",
+                          "additionalProperties": false
                         },
                         "type": "array",
                         "x-kubernetes-list-map-keys": [
@@ -3223,7 +3409,8 @@
                     "required": [
                       "name"
                     ],
-                    "type": "object"
+                    "type": "object",
+                    "additionalProperties": false
                   },
                   "type": "array",
                   "x-kubernetes-list-map-keys": [
@@ -3250,7 +3437,8 @@
                             "type": "string"
                           }
                         },
-                        "type": "object"
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "type": "array",
                       "x-kubernetes-list-type": "atomic"
@@ -3263,7 +3451,8 @@
                       "x-kubernetes-list-type": "atomic"
                     }
                   },
-                  "type": "object"
+                  "type": "object",
+                  "additionalProperties": false
                 },
                 "dnsPolicy": {
                   "type": "string"
@@ -3316,7 +3505,8 @@
                                     "key"
                                   ],
                                   "type": "object",
-                                  "x-kubernetes-map-type": "atomic"
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
                                 },
                                 "fieldRef": {
                                   "properties": {
@@ -3331,7 +3521,8 @@
                                     "fieldPath"
                                   ],
                                   "type": "object",
-                                  "x-kubernetes-map-type": "atomic"
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
                                 },
                                 "fileKeyRef": {
                                   "properties": {
@@ -3355,7 +3546,8 @@
                                     "volumeName"
                                   ],
                                   "type": "object",
-                                  "x-kubernetes-map-type": "atomic"
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
                                 },
                                 "resourceFieldRef": {
                                   "properties": {
@@ -3382,7 +3574,8 @@
                                     "resource"
                                   ],
                                   "type": "object",
-                                  "x-kubernetes-map-type": "atomic"
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
                                 },
                                 "secretKeyRef": {
                                   "properties": {
@@ -3401,16 +3594,19 @@
                                     "key"
                                   ],
                                   "type": "object",
-                                  "x-kubernetes-map-type": "atomic"
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
                                 }
                               },
-                              "type": "object"
+                              "type": "object",
+                              "additionalProperties": false
                             }
                           },
                           "required": [
                             "name"
                           ],
-                          "type": "object"
+                          "type": "object",
+                          "additionalProperties": false
                         },
                         "type": "array",
                         "x-kubernetes-list-map-keys": [
@@ -3432,7 +3628,8 @@
                                 }
                               },
                               "type": "object",
-                              "x-kubernetes-map-type": "atomic"
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
                             },
                             "prefix": {
                               "type": "string"
@@ -3448,10 +3645,12 @@
                                 }
                               },
                               "type": "object",
-                              "x-kubernetes-map-type": "atomic"
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
                             }
                           },
-                          "type": "object"
+                          "type": "object",
+                          "additionalProperties": false
                         },
                         "type": "array",
                         "x-kubernetes-list-type": "atomic"
@@ -3476,7 +3675,8 @@
                                     "x-kubernetes-list-type": "atomic"
                                   }
                                 },
-                                "type": "object"
+                                "type": "object",
+                                "additionalProperties": false
                               },
                               "httpGet": {
                                 "properties": {
@@ -3497,7 +3697,8 @@
                                         "name",
                                         "value"
                                       ],
-                                      "type": "object"
+                                      "type": "object",
+                                      "additionalProperties": false
                                     },
                                     "type": "array",
                                     "x-kubernetes-list-type": "atomic"
@@ -3523,7 +3724,8 @@
                                 "required": [
                                   "port"
                                 ],
-                                "type": "object"
+                                "type": "object",
+                                "additionalProperties": false
                               },
                               "sleep": {
                                 "properties": {
@@ -3535,7 +3737,8 @@
                                 "required": [
                                   "seconds"
                                 ],
-                                "type": "object"
+                                "type": "object",
+                                "additionalProperties": false
                               },
                               "tcpSocket": {
                                 "properties": {
@@ -3557,10 +3760,12 @@
                                 "required": [
                                   "port"
                                 ],
-                                "type": "object"
+                                "type": "object",
+                                "additionalProperties": false
                               }
                             },
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "preStop": {
                             "properties": {
@@ -3574,7 +3779,8 @@
                                     "x-kubernetes-list-type": "atomic"
                                   }
                                 },
-                                "type": "object"
+                                "type": "object",
+                                "additionalProperties": false
                               },
                               "httpGet": {
                                 "properties": {
@@ -3595,7 +3801,8 @@
                                         "name",
                                         "value"
                                       ],
-                                      "type": "object"
+                                      "type": "object",
+                                      "additionalProperties": false
                                     },
                                     "type": "array",
                                     "x-kubernetes-list-type": "atomic"
@@ -3621,7 +3828,8 @@
                                 "required": [
                                   "port"
                                 ],
-                                "type": "object"
+                                "type": "object",
+                                "additionalProperties": false
                               },
                               "sleep": {
                                 "properties": {
@@ -3633,7 +3841,8 @@
                                 "required": [
                                   "seconds"
                                 ],
-                                "type": "object"
+                                "type": "object",
+                                "additionalProperties": false
                               },
                               "tcpSocket": {
                                 "properties": {
@@ -3655,16 +3864,19 @@
                                 "required": [
                                   "port"
                                 ],
-                                "type": "object"
+                                "type": "object",
+                                "additionalProperties": false
                               }
                             },
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "stopSignal": {
                             "type": "string"
                           }
                         },
-                        "type": "object"
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "livenessProbe": {
                         "properties": {
@@ -3678,7 +3890,8 @@
                                 "x-kubernetes-list-type": "atomic"
                               }
                             },
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "failureThreshold": {
                             "format": "int32",
@@ -3698,7 +3911,8 @@
                             "required": [
                               "port"
                             ],
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "httpGet": {
                             "properties": {
@@ -3719,7 +3933,8 @@
                                     "name",
                                     "value"
                                   ],
-                                  "type": "object"
+                                  "type": "object",
+                                  "additionalProperties": false
                                 },
                                 "type": "array",
                                 "x-kubernetes-list-type": "atomic"
@@ -3745,7 +3960,8 @@
                             "required": [
                               "port"
                             ],
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "initialDelaySeconds": {
                             "format": "int32",
@@ -3779,7 +3995,8 @@
                             "required": [
                               "port"
                             ],
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "terminationGracePeriodSeconds": {
                             "format": "int64",
@@ -3790,7 +4007,8 @@
                             "type": "integer"
                           }
                         },
-                        "type": "object"
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "name": {
                         "type": "string"
@@ -3820,7 +4038,8 @@
                           "required": [
                             "containerPort"
                           ],
-                          "type": "object"
+                          "type": "object",
+                          "additionalProperties": false
                         },
                         "type": "array",
                         "x-kubernetes-list-map-keys": [
@@ -3841,7 +4060,8 @@
                                 "x-kubernetes-list-type": "atomic"
                               }
                             },
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "failureThreshold": {
                             "format": "int32",
@@ -3861,7 +4081,8 @@
                             "required": [
                               "port"
                             ],
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "httpGet": {
                             "properties": {
@@ -3882,7 +4103,8 @@
                                     "name",
                                     "value"
                                   ],
-                                  "type": "object"
+                                  "type": "object",
+                                  "additionalProperties": false
                                 },
                                 "type": "array",
                                 "x-kubernetes-list-type": "atomic"
@@ -3908,7 +4130,8 @@
                             "required": [
                               "port"
                             ],
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "initialDelaySeconds": {
                             "format": "int32",
@@ -3942,7 +4165,8 @@
                             "required": [
                               "port"
                             ],
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "terminationGracePeriodSeconds": {
                             "format": "int64",
@@ -3953,7 +4177,8 @@
                             "type": "integer"
                           }
                         },
-                        "type": "object"
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "resizePolicy": {
                         "items": {
@@ -3969,7 +4194,8 @@
                             "resourceName",
                             "restartPolicy"
                           ],
-                          "type": "object"
+                          "type": "object",
+                          "additionalProperties": false
                         },
                         "type": "array",
                         "x-kubernetes-list-type": "atomic"
@@ -3989,7 +4215,8 @@
                               "required": [
                                 "name"
                               ],
-                              "type": "object"
+                              "type": "object",
+                              "additionalProperties": false
                             },
                             "type": "array",
                             "x-kubernetes-list-map-keys": [
@@ -4004,7 +4231,8 @@
                             "x-kubernetes-preserve-unknown-fields": true
                           }
                         },
-                        "type": "object"
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "restartPolicy": {
                         "type": "string"
@@ -4032,13 +4260,15 @@
                               "required": [
                                 "operator"
                               ],
-                              "type": "object"
+                              "type": "object",
+                              "additionalProperties": false
                             }
                           },
                           "required": [
                             "action"
                           ],
-                          "type": "object"
+                          "type": "object",
+                          "additionalProperties": false
                         },
                         "type": "array",
                         "x-kubernetes-list-type": "atomic"
@@ -4060,7 +4290,8 @@
                             "required": [
                               "type"
                             ],
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "capabilities": {
                             "properties": {
@@ -4079,7 +4310,8 @@
                                 "x-kubernetes-list-type": "atomic"
                               }
                             },
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "privileged": {
                             "type": "boolean"
@@ -4116,7 +4348,8 @@
                                 "type": "string"
                               }
                             },
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "seccompProfile": {
                             "properties": {
@@ -4130,7 +4363,8 @@
                             "required": [
                               "type"
                             ],
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "windowsOptions": {
                             "properties": {
@@ -4147,10 +4381,12 @@
                                 "type": "string"
                               }
                             },
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           }
                         },
-                        "type": "object"
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "startupProbe": {
                         "properties": {
@@ -4164,7 +4400,8 @@
                                 "x-kubernetes-list-type": "atomic"
                               }
                             },
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "failureThreshold": {
                             "format": "int32",
@@ -4184,7 +4421,8 @@
                             "required": [
                               "port"
                             ],
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "httpGet": {
                             "properties": {
@@ -4205,7 +4443,8 @@
                                     "name",
                                     "value"
                                   ],
-                                  "type": "object"
+                                  "type": "object",
+                                  "additionalProperties": false
                                 },
                                 "type": "array",
                                 "x-kubernetes-list-type": "atomic"
@@ -4231,7 +4470,8 @@
                             "required": [
                               "port"
                             ],
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "initialDelaySeconds": {
                             "format": "int32",
@@ -4265,7 +4505,8 @@
                             "required": [
                               "port"
                             ],
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "terminationGracePeriodSeconds": {
                             "format": "int64",
@@ -4276,7 +4517,8 @@
                             "type": "integer"
                           }
                         },
-                        "type": "object"
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "stdin": {
                         "type": "boolean"
@@ -4310,7 +4552,8 @@
                             "devicePath",
                             "name"
                           ],
-                          "type": "object"
+                          "type": "object",
+                          "additionalProperties": false
                         },
                         "type": "array",
                         "x-kubernetes-list-map-keys": [
@@ -4347,7 +4590,8 @@
                             "mountPath",
                             "name"
                           ],
-                          "type": "object"
+                          "type": "object",
+                          "additionalProperties": false
                         },
                         "type": "array",
                         "x-kubernetes-list-map-keys": [
@@ -4362,7 +4606,8 @@
                     "required": [
                       "name"
                     ],
-                    "type": "object"
+                    "type": "object",
+                    "additionalProperties": false
                   },
                   "type": "array",
                   "x-kubernetes-list-map-keys": [
@@ -4387,7 +4632,8 @@
                     "required": [
                       "ip"
                     ],
-                    "type": "object"
+                    "type": "object",
+                    "additionalProperties": false
                   },
                   "type": "array",
                   "x-kubernetes-list-map-keys": [
@@ -4422,7 +4668,8 @@
                       }
                     },
                     "type": "object",
-                    "x-kubernetes-map-type": "atomic"
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
                   },
                   "type": "array",
                   "x-kubernetes-list-map-keys": [
@@ -4475,7 +4722,8 @@
                                     "key"
                                   ],
                                   "type": "object",
-                                  "x-kubernetes-map-type": "atomic"
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
                                 },
                                 "fieldRef": {
                                   "properties": {
@@ -4490,7 +4738,8 @@
                                     "fieldPath"
                                   ],
                                   "type": "object",
-                                  "x-kubernetes-map-type": "atomic"
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
                                 },
                                 "fileKeyRef": {
                                   "properties": {
@@ -4514,7 +4763,8 @@
                                     "volumeName"
                                   ],
                                   "type": "object",
-                                  "x-kubernetes-map-type": "atomic"
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
                                 },
                                 "resourceFieldRef": {
                                   "properties": {
@@ -4541,7 +4791,8 @@
                                     "resource"
                                   ],
                                   "type": "object",
-                                  "x-kubernetes-map-type": "atomic"
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
                                 },
                                 "secretKeyRef": {
                                   "properties": {
@@ -4560,16 +4811,19 @@
                                     "key"
                                   ],
                                   "type": "object",
-                                  "x-kubernetes-map-type": "atomic"
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
                                 }
                               },
-                              "type": "object"
+                              "type": "object",
+                              "additionalProperties": false
                             }
                           },
                           "required": [
                             "name"
                           ],
-                          "type": "object"
+                          "type": "object",
+                          "additionalProperties": false
                         },
                         "type": "array",
                         "x-kubernetes-list-map-keys": [
@@ -4591,7 +4845,8 @@
                                 }
                               },
                               "type": "object",
-                              "x-kubernetes-map-type": "atomic"
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
                             },
                             "prefix": {
                               "type": "string"
@@ -4607,10 +4862,12 @@
                                 }
                               },
                               "type": "object",
-                              "x-kubernetes-map-type": "atomic"
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
                             }
                           },
-                          "type": "object"
+                          "type": "object",
+                          "additionalProperties": false
                         },
                         "type": "array",
                         "x-kubernetes-list-type": "atomic"
@@ -4635,7 +4892,8 @@
                                     "x-kubernetes-list-type": "atomic"
                                   }
                                 },
-                                "type": "object"
+                                "type": "object",
+                                "additionalProperties": false
                               },
                               "httpGet": {
                                 "properties": {
@@ -4656,7 +4914,8 @@
                                         "name",
                                         "value"
                                       ],
-                                      "type": "object"
+                                      "type": "object",
+                                      "additionalProperties": false
                                     },
                                     "type": "array",
                                     "x-kubernetes-list-type": "atomic"
@@ -4682,7 +4941,8 @@
                                 "required": [
                                   "port"
                                 ],
-                                "type": "object"
+                                "type": "object",
+                                "additionalProperties": false
                               },
                               "sleep": {
                                 "properties": {
@@ -4694,7 +4954,8 @@
                                 "required": [
                                   "seconds"
                                 ],
-                                "type": "object"
+                                "type": "object",
+                                "additionalProperties": false
                               },
                               "tcpSocket": {
                                 "properties": {
@@ -4716,10 +4977,12 @@
                                 "required": [
                                   "port"
                                 ],
-                                "type": "object"
+                                "type": "object",
+                                "additionalProperties": false
                               }
                             },
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "preStop": {
                             "properties": {
@@ -4733,7 +4996,8 @@
                                     "x-kubernetes-list-type": "atomic"
                                   }
                                 },
-                                "type": "object"
+                                "type": "object",
+                                "additionalProperties": false
                               },
                               "httpGet": {
                                 "properties": {
@@ -4754,7 +5018,8 @@
                                         "name",
                                         "value"
                                       ],
-                                      "type": "object"
+                                      "type": "object",
+                                      "additionalProperties": false
                                     },
                                     "type": "array",
                                     "x-kubernetes-list-type": "atomic"
@@ -4780,7 +5045,8 @@
                                 "required": [
                                   "port"
                                 ],
-                                "type": "object"
+                                "type": "object",
+                                "additionalProperties": false
                               },
                               "sleep": {
                                 "properties": {
@@ -4792,7 +5058,8 @@
                                 "required": [
                                   "seconds"
                                 ],
-                                "type": "object"
+                                "type": "object",
+                                "additionalProperties": false
                               },
                               "tcpSocket": {
                                 "properties": {
@@ -4814,16 +5081,19 @@
                                 "required": [
                                   "port"
                                 ],
-                                "type": "object"
+                                "type": "object",
+                                "additionalProperties": false
                               }
                             },
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "stopSignal": {
                             "type": "string"
                           }
                         },
-                        "type": "object"
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "livenessProbe": {
                         "properties": {
@@ -4837,7 +5107,8 @@
                                 "x-kubernetes-list-type": "atomic"
                               }
                             },
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "failureThreshold": {
                             "format": "int32",
@@ -4857,7 +5128,8 @@
                             "required": [
                               "port"
                             ],
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "httpGet": {
                             "properties": {
@@ -4878,7 +5150,8 @@
                                     "name",
                                     "value"
                                   ],
-                                  "type": "object"
+                                  "type": "object",
+                                  "additionalProperties": false
                                 },
                                 "type": "array",
                                 "x-kubernetes-list-type": "atomic"
@@ -4904,7 +5177,8 @@
                             "required": [
                               "port"
                             ],
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "initialDelaySeconds": {
                             "format": "int32",
@@ -4938,7 +5212,8 @@
                             "required": [
                               "port"
                             ],
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "terminationGracePeriodSeconds": {
                             "format": "int64",
@@ -4949,7 +5224,8 @@
                             "type": "integer"
                           }
                         },
-                        "type": "object"
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "name": {
                         "type": "string"
@@ -4979,7 +5255,8 @@
                           "required": [
                             "containerPort"
                           ],
-                          "type": "object"
+                          "type": "object",
+                          "additionalProperties": false
                         },
                         "type": "array",
                         "x-kubernetes-list-map-keys": [
@@ -5000,7 +5277,8 @@
                                 "x-kubernetes-list-type": "atomic"
                               }
                             },
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "failureThreshold": {
                             "format": "int32",
@@ -5020,7 +5298,8 @@
                             "required": [
                               "port"
                             ],
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "httpGet": {
                             "properties": {
@@ -5041,7 +5320,8 @@
                                     "name",
                                     "value"
                                   ],
-                                  "type": "object"
+                                  "type": "object",
+                                  "additionalProperties": false
                                 },
                                 "type": "array",
                                 "x-kubernetes-list-type": "atomic"
@@ -5067,7 +5347,8 @@
                             "required": [
                               "port"
                             ],
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "initialDelaySeconds": {
                             "format": "int32",
@@ -5101,7 +5382,8 @@
                             "required": [
                               "port"
                             ],
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "terminationGracePeriodSeconds": {
                             "format": "int64",
@@ -5112,7 +5394,8 @@
                             "type": "integer"
                           }
                         },
-                        "type": "object"
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "resizePolicy": {
                         "items": {
@@ -5128,7 +5411,8 @@
                             "resourceName",
                             "restartPolicy"
                           ],
-                          "type": "object"
+                          "type": "object",
+                          "additionalProperties": false
                         },
                         "type": "array",
                         "x-kubernetes-list-type": "atomic"
@@ -5148,7 +5432,8 @@
                               "required": [
                                 "name"
                               ],
-                              "type": "object"
+                              "type": "object",
+                              "additionalProperties": false
                             },
                             "type": "array",
                             "x-kubernetes-list-map-keys": [
@@ -5163,7 +5448,8 @@
                             "x-kubernetes-preserve-unknown-fields": true
                           }
                         },
-                        "type": "object"
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "restartPolicy": {
                         "type": "string"
@@ -5191,13 +5477,15 @@
                               "required": [
                                 "operator"
                               ],
-                              "type": "object"
+                              "type": "object",
+                              "additionalProperties": false
                             }
                           },
                           "required": [
                             "action"
                           ],
-                          "type": "object"
+                          "type": "object",
+                          "additionalProperties": false
                         },
                         "type": "array",
                         "x-kubernetes-list-type": "atomic"
@@ -5219,7 +5507,8 @@
                             "required": [
                               "type"
                             ],
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "capabilities": {
                             "properties": {
@@ -5238,7 +5527,8 @@
                                 "x-kubernetes-list-type": "atomic"
                               }
                             },
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "privileged": {
                             "type": "boolean"
@@ -5275,7 +5565,8 @@
                                 "type": "string"
                               }
                             },
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "seccompProfile": {
                             "properties": {
@@ -5289,7 +5580,8 @@
                             "required": [
                               "type"
                             ],
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "windowsOptions": {
                             "properties": {
@@ -5306,10 +5598,12 @@
                                 "type": "string"
                               }
                             },
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           }
                         },
-                        "type": "object"
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "startupProbe": {
                         "properties": {
@@ -5323,7 +5617,8 @@
                                 "x-kubernetes-list-type": "atomic"
                               }
                             },
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "failureThreshold": {
                             "format": "int32",
@@ -5343,7 +5638,8 @@
                             "required": [
                               "port"
                             ],
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "httpGet": {
                             "properties": {
@@ -5364,7 +5660,8 @@
                                     "name",
                                     "value"
                                   ],
-                                  "type": "object"
+                                  "type": "object",
+                                  "additionalProperties": false
                                 },
                                 "type": "array",
                                 "x-kubernetes-list-type": "atomic"
@@ -5390,7 +5687,8 @@
                             "required": [
                               "port"
                             ],
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "initialDelaySeconds": {
                             "format": "int32",
@@ -5424,7 +5722,8 @@
                             "required": [
                               "port"
                             ],
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false
                           },
                           "terminationGracePeriodSeconds": {
                             "format": "int64",
@@ -5435,7 +5734,8 @@
                             "type": "integer"
                           }
                         },
-                        "type": "object"
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "stdin": {
                         "type": "boolean"
@@ -5466,7 +5766,8 @@
                             "devicePath",
                             "name"
                           ],
-                          "type": "object"
+                          "type": "object",
+                          "additionalProperties": false
                         },
                         "type": "array",
                         "x-kubernetes-list-map-keys": [
@@ -5503,7 +5804,8 @@
                             "mountPath",
                             "name"
                           ],
-                          "type": "object"
+                          "type": "object",
+                          "additionalProperties": false
                         },
                         "type": "array",
                         "x-kubernetes-list-map-keys": [
@@ -5518,7 +5820,8 @@
                     "required": [
                       "name"
                     ],
-                    "type": "object"
+                    "type": "object",
+                    "additionalProperties": false
                   },
                   "type": "array",
                   "x-kubernetes-list-map-keys": [
@@ -5545,7 +5848,8 @@
                   "required": [
                     "name"
                   ],
-                  "type": "object"
+                  "type": "object",
+                  "additionalProperties": false
                 },
                 "overhead": {
                   "additionalProperties": {
@@ -5582,7 +5886,8 @@
                     "required": [
                       "conditionType"
                     ],
-                    "type": "object"
+                    "type": "object",
+                    "additionalProperties": false
                   },
                   "type": "array",
                   "x-kubernetes-list-type": "atomic"
@@ -5603,7 +5908,8 @@
                     "required": [
                       "name"
                     ],
-                    "type": "object"
+                    "type": "object",
+                    "additionalProperties": false
                   },
                   "type": "array",
                   "x-kubernetes-list-map-keys": [
@@ -5626,7 +5932,8 @@
                         "required": [
                           "name"
                         ],
-                        "type": "object"
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "type": "array",
                       "x-kubernetes-list-map-keys": [
@@ -5665,7 +5972,8 @@
                       "type": "object"
                     }
                   },
-                  "type": "object"
+                  "type": "object",
+                  "additionalProperties": false
                 },
                 "restartPolicy": {
                   "type": "string"
@@ -5686,7 +5994,8 @@
                     "required": [
                       "name"
                     ],
-                    "type": "object"
+                    "type": "object",
+                    "additionalProperties": false
                   },
                   "type": "array",
                   "x-kubernetes-list-map-keys": [
@@ -5708,7 +6017,8 @@
                       "required": [
                         "type"
                       ],
-                      "type": "object"
+                      "type": "object",
+                      "additionalProperties": false
                     },
                     "fsGroup": {
                       "format": "int64",
@@ -5746,7 +6056,8 @@
                           "type": "string"
                         }
                       },
-                      "type": "object"
+                      "type": "object",
+                      "additionalProperties": false
                     },
                     "seccompProfile": {
                       "properties": {
@@ -5760,7 +6071,8 @@
                       "required": [
                         "type"
                       ],
-                      "type": "object"
+                      "type": "object",
+                      "additionalProperties": false
                     },
                     "supplementalGroups": {
                       "items": {
@@ -5787,7 +6099,8 @@
                           "name",
                           "value"
                         ],
-                        "type": "object"
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "type": "array",
                       "x-kubernetes-list-type": "atomic"
@@ -5807,10 +6120,12 @@
                           "type": "string"
                         }
                       },
-                      "type": "object"
+                      "type": "object",
+                      "additionalProperties": false
                     }
                   },
-                  "type": "object"
+                  "type": "object",
+                  "additionalProperties": false
                 },
                 "serviceAccount": {
                   "type": "string"
@@ -5851,7 +6166,8 @@
                         "type": "string"
                       }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "additionalProperties": false
                   },
                   "type": "array",
                   "x-kubernetes-list-type": "atomic"
@@ -5882,7 +6198,8 @@
                                 "key",
                                 "operator"
                               ],
-                              "type": "object"
+                              "type": "object",
+                              "additionalProperties": false
                             },
                             "type": "array",
                             "x-kubernetes-list-type": "atomic"
@@ -5895,7 +6212,8 @@
                           }
                         },
                         "type": "object",
-                        "x-kubernetes-map-type": "atomic"
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
                       },
                       "matchLabelKeys": {
                         "items": {
@@ -5930,7 +6248,8 @@
                       "topologyKey",
                       "whenUnsatisfiable"
                     ],
-                    "type": "object"
+                    "type": "object",
+                    "additionalProperties": false
                   },
                   "type": "array",
                   "x-kubernetes-list-map-keys": [
@@ -5946,10 +6265,12 @@
               "required": [
                 "containers"
               ],
-              "type": "object"
+              "type": "object",
+              "additionalProperties": false
             }
           },
-          "type": "object"
+          "type": "object",
+          "additionalProperties": false
         },
         "workloadRef": {
           "properties": {
@@ -5966,10 +6287,12 @@
               "type": "string"
             }
           },
-          "type": "object"
+          "type": "object",
+          "additionalProperties": false
         }
       },
-      "type": "object"
+      "type": "object",
+      "additionalProperties": false
     },
     "status": {
       "properties": {
@@ -6002,7 +6325,8 @@
                 "arn",
                 "name"
               ],
-              "type": "object"
+              "type": "object",
+              "additionalProperties": false
             },
             "ingress": {
               "type": "string"
@@ -6023,7 +6347,8 @@
                 "arn",
                 "name"
               ],
-              "type": "object"
+              "type": "object",
+              "additionalProperties": false
             },
             "stableTargetGroup": {
               "properties": {
@@ -6041,10 +6366,12 @@
                 "arn",
                 "name"
               ],
-              "type": "object"
+              "type": "object",
+              "additionalProperties": false
             }
           },
-          "type": "object"
+          "type": "object",
+          "additionalProperties": false
         },
         "albs": {
           "items": {
@@ -6065,7 +6392,8 @@
                   "arn",
                   "name"
                 ],
-                "type": "object"
+                "type": "object",
+                "additionalProperties": false
               },
               "ingress": {
                 "type": "string"
@@ -6086,7 +6414,8 @@
                   "arn",
                   "name"
                 ],
-                "type": "object"
+                "type": "object",
+                "additionalProperties": false
               },
               "stableTargetGroup": {
                 "properties": {
@@ -6104,10 +6433,12 @@
                   "arn",
                   "name"
                 ],
-                "type": "object"
+                "type": "object",
+                "additionalProperties": false
               }
             },
-            "type": "object"
+            "type": "object",
+            "additionalProperties": false
           },
           "type": "array"
         },
@@ -6136,7 +6467,8 @@
                 "name",
                 "status"
               ],
-              "type": "object"
+              "type": "object",
+              "additionalProperties": false
             },
             "prePromotionAnalysisRunStatus": {
               "properties": {
@@ -6154,7 +6486,8 @@
                 "name",
                 "status"
               ],
-              "type": "object"
+              "type": "object",
+              "additionalProperties": false
             },
             "previewSelector": {
               "type": "string"
@@ -6163,7 +6496,8 @@
               "type": "boolean"
             }
           },
-          "type": "object"
+          "type": "object",
+          "additionalProperties": false
         },
         "canary": {
           "properties": {
@@ -6183,7 +6517,8 @@
                 "name",
                 "status"
               ],
-              "type": "object"
+              "type": "object",
+              "additionalProperties": false
             },
             "currentExperiment": {
               "type": "string"
@@ -6204,7 +6539,8 @@
                 "name",
                 "status"
               ],
-              "type": "object"
+              "type": "object",
+              "additionalProperties": false
             },
             "stablePingPong": {
               "type": "string"
@@ -6260,7 +6596,8 @@
                   "name",
                   "operation"
                 ],
-                "type": "object"
+                "type": "object",
+                "additionalProperties": false
               },
               "type": "array"
             },
@@ -6283,7 +6620,8 @@
                     "required": [
                       "weight"
                     ],
-                    "type": "object"
+                    "type": "object",
+                    "additionalProperties": false
                   },
                   "type": "array"
                 },
@@ -6303,7 +6641,8 @@
                   "required": [
                     "weight"
                   ],
-                  "type": "object"
+                  "type": "object",
+                  "additionalProperties": false
                 },
                 "stable": {
                   "properties": {
@@ -6321,7 +6660,8 @@
                   "required": [
                     "weight"
                   ],
-                  "type": "object"
+                  "type": "object",
+                  "additionalProperties": false
                 },
                 "verified": {
                   "type": "boolean"
@@ -6331,10 +6671,12 @@
                 "canary",
                 "stable"
               ],
-              "type": "object"
+              "type": "object",
+              "additionalProperties": false
             }
           },
-          "type": "object"
+          "type": "object",
+          "additionalProperties": false
         },
         "collisionCount": {
           "format": "int32",
@@ -6372,7 +6714,8 @@
               "status",
               "type"
             ],
-            "type": "object"
+            "type": "object",
+            "additionalProperties": false
           },
           "type": "array"
         },
@@ -6410,7 +6753,8 @@
               "reason",
               "startTime"
             ],
-            "type": "object"
+            "type": "object",
+            "additionalProperties": false
           },
           "type": "array"
         },
@@ -6446,7 +6790,8 @@
           "type": "string"
         }
       },
-      "type": "object"
+      "type": "object",
+      "additionalProperties": false
     }
   },
   "required": [


### PR DESCRIPTION
## PR Checklist

- [x] I generated these CRs using the [CRD Extractor tool](https://github.com/datreeio/CRDs-catalog?tab=readme-ov-file#crd-extractor). If I used a different method, I have described the method in this PR.
- [x] I am updating existing schemas and have specified the updated schema version.
- [x] I am adding new schemas and included a link to the GitHub repository that contains the source of these schemas.

---

Updates all argo-rollouts CRD schemas from v1.7.2 to v1.9.0.

### Source CRDs

Schemas extracted from the [argo-rollouts v1.9.0 CRD manifests](https://github.com/argoproj/argo-rollouts/tree/v1.9.0/manifests/crds):

- [`rollout-crd.yaml`](https://github.com/argoproj/argo-rollouts/blob/v1.9.0/manifests/crds/rollout-crd.yaml)
- [`analysis-run-crd.yaml`](https://github.com/argoproj/argo-rollouts/blob/v1.9.0/manifests/crds/analysis-run-crd.yaml)
- [`analysis-template-crd.yaml`](https://github.com/argoproj/argo-rollouts/blob/v1.9.0/manifests/crds/analysis-template-crd.yaml)
- [`cluster-analysis-template-crd.yaml`](https://github.com/argoproj/argo-rollouts/blob/v1.9.0/manifests/crds/cluster-analysis-template-crd.yaml)
- [`experiment-crd.yaml`](https://github.com/argoproj/argo-rollouts/blob/v1.9.0/manifests/crds/experiment-crd.yaml)

### How schemas were generated

```bash
kind create cluster --name argo-rollouts-crd-catalog
kubectl apply --server-side=true --context kind-argo-rollouts-crd-catalog \
  -f https://github.com/argoproj/argo-rollouts/releases/download/v1.9.0/install.yaml
KUBECTL_CONTEXT=kind-argo-rollouts-crd-catalog ./Utilities/crd-extractor.sh
kind delete cluster --name argo-rollouts-crd-catalog
```

### Updated files
- `argoproj.io/rollout_v1alpha1.json`
- `argoproj.io/analysisrun_v1alpha1.json`
- `argoproj.io/analysistemplate_v1alpha1.json`
- `argoproj.io/clusteranalysistemplate_v1alpha1.json`
- `argoproj.io/experiment_v1alpha1.json`

### Notable new fields in v1.9.0
- `spec.strategy.canary.replicaProgressThreshold` — threshold for pod availability before advancing rollout steps

Previous update: #398 (v1.7.2, Oct 2024)