### PR TITLE
feat(schemas): Add CAPI addons v1alpha1 JSON schemas

### DIFF
--- a/addons.cluster.x-k8s.io/helmchartproxy_v1alpha1.json
+++ b/addons.cluster.x-k8s.io/helmchartproxy_v1alpha1.json
@@ -1,0 +1,382 @@
+{
+  "description": "HelmChartProxy is the Schema for the helmchartproxies API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "HelmChartProxySpec defines the desired state of HelmChartProxy.",
+      "properties": {
+        "chartName": {
+          "description": "ChartName is the name of the Helm chart in the repository.\ne.g. chart-path oci://repo-url/chart-name as chartName: chart-name and https://repo-url/chart-name as chartName: chart-name",
+          "type": "string"
+        },
+        "clusterSelector": {
+          "description": "ClusterSelector selects Clusters in the same namespace with a label that matches the specified label selector. The Helm\nchart will be installed on all selected Clusters. If a Cluster is no longer selected, the Helm release will be uninstalled.",
+          "properties": {
+            "matchExpressions": {
+              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+              "items": {
+                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                "properties": {
+                  "key": {
+                    "description": "key is the label key that the selector applies to.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  }
+                },
+                "required": [
+                  "key",
+                  "operator"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            },
+            "matchLabels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
+        "credentials": {
+          "description": "Credentials is a reference to an object containing the OCI credentials. If it is not specified, no credentials will be used.",
+          "properties": {
+            "key": {
+              "description": "Key is the key in the Secret containing the OCI credentials.",
+              "type": "string"
+            },
+            "secret": {
+              "description": "Secret is a reference to a Secret containing the OCI credentials.",
+              "properties": {
+                "name": {
+                  "description": "name is unique within a namespace to reference a secret resource.",
+                  "type": "string"
+                },
+                "namespace": {
+                  "description": "namespace defines the space within which the secret name must be unique.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "x-kubernetes-map-type": "atomic",
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "key",
+            "secret"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "namespace": {
+          "description": "ReleaseNamespace is the namespace the Helm release will be installed on each selected\nCluster. If it is not specified, it will be set to the default namespace.",
+          "type": "string"
+        },
+        "options": {
+          "description": "Options represents CLI flags passed to Helm operations (i.e. install, upgrade, delete) and\ninclude options such as wait, skipCRDs, timeout, waitForJobs, etc.",
+          "properties": {
+            "atomic": {
+              "description": "Atomic indicates the installation/upgrade process to delete the installation or rollback on failure.\nIf 'Atomic' is set, wait will be enabled automatically during helm install/upgrade operation.",
+              "type": "boolean"
+            },
+            "dependencyUpdate": {
+              "description": "DependencyUpdate indicates the Helm install/upgrade action to get missing dependencies.",
+              "type": "boolean"
+            },
+            "disableHooks": {
+              "description": "DisableHooks prevents hooks from running during the Helm install action.",
+              "type": "boolean"
+            },
+            "disableOpenAPIValidation": {
+              "description": "DisableOpenAPIValidation controls whether OpenAPI validation is enforced.",
+              "type": "boolean"
+            },
+            "enableClientCache": {
+              "default": false,
+              "description": "EnableClientCache is a flag to enable Helm client cache. If it is not specified, it will be set to true.",
+              "type": "boolean"
+            },
+            "install": {
+              "description": "Install represents CLI flags passed to Helm install operation which can be used to control\nbehaviour of helm Install operations via options like wait, skipCrds, timeout, waitForJobs, etc.",
+              "properties": {
+                "createNamespace": {
+                  "default": true,
+                  "description": "CreateNamespace indicates the Helm install/upgrade action to create the\nHelmChartProxySpec.ReleaseNamespace if it does not exist yet.\nOn uninstall, the namespace will not be garbage collected.\nIf it is not specified by user, will be set to default 'true'.",
+                  "type": "boolean"
+                },
+                "includeCRDs": {
+                  "description": "IncludeCRDs determines whether CRDs stored as a part of helm templates directory should be installed.",
+                  "type": "boolean"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "options": {
+              "description": "SubNotes determines whether sub-notes should be rendered in the chart.",
+              "type": "boolean"
+            },
+            "skipCRDs": {
+              "description": "SkipCRDs controls whether CRDs should be installed during install/upgrade operation.\nBy default, CRDs are installed if not already present.\nIf set, no CRDs will be installed.",
+              "type": "boolean"
+            },
+            "timeout": {
+              "description": "Timeout is the time to wait for any individual Kubernetes operation (like\nresource creation, Jobs for hooks, etc.) during the performance of a Helm install action.\nDefaults to '10 min'.",
+              "type": "string"
+            },
+            "uninstall": {
+              "description": "Uninstall represents CLI flags passed to Helm uninstall operation which can be used to control\nbehaviour of helm Uninstall operation via options like wait, timeout, etc.",
+              "properties": {
+                "description": {
+                  "description": "Description represents human readable information to be shown on release uninstall.",
+                  "type": "string"
+                },
+                "keepHistory": {
+                  "description": "KeepHistory defines whether historical revisions of a release should be saved.\nIf it's set, helm uninstall operation will not delete the history of the release.\nThe helm storage backend (secret, configmap, etc) will be retained in the cluster.",
+                  "type": "boolean"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "upgrade": {
+              "description": "Upgrade represents CLI flags passed to Helm upgrade operation which can be used to control\nbehaviour of helm Upgrade operations via options like wait, skipCrds, timeout, waitForJobs, etc.",
+              "properties": {
+                "cleanupOnFail": {
+                  "description": "CleanupOnFail indicates the upgrade action to delete newly-created resources on a failed update operation.",
+                  "type": "boolean"
+                },
+                "force": {
+                  "description": "Force indicates to ignore certain warnings and perform the helm release upgrade anyway.\nThis should be used with caution.",
+                  "type": "boolean"
+                },
+                "maxHistory": {
+                  "default": 10,
+                  "description": "MaxHistory limits the maximum number of revisions saved per release (default is 10).",
+                  "type": "integer"
+                },
+                "recreate": {
+                  "description": "Recreate will (if true) recreate pods after a rollback.",
+                  "type": "boolean"
+                },
+                "resetThenReuseValues": {
+                  "description": "ResetThenReuseValues will reset the values to the chart's built-ins then merge with user's last supplied values.",
+                  "type": "boolean"
+                },
+                "resetValues": {
+                  "description": "ResetValues will reset the values to the chart's built-ins rather than merging with existing.",
+                  "type": "boolean"
+                },
+                "reuseValues": {
+                  "description": "ReuseValues will re-use the user's last supplied values.",
+                  "type": "boolean"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "wait": {
+              "description": "Wait enables the waiting for resources to be ready after a Helm install/upgrade has been performed.",
+              "type": "boolean"
+            },
+            "waitForJobs": {
+              "description": "WaitForJobs enables waiting for jobs to complete after a Helm install/upgrade has been performed.",
+              "type": "boolean"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "reconcileStrategy": {
+          "description": "ReconcileStrategy indicates whether a Helm chart should be continuously installed, updated, and uninstalled on selected Clusters,\nor if it should be reconciled until it is successfully installed on selected Clusters and not otherwise updated or uninstalled.\nIf not specified, the default behavior will be to reconcile continuously. This field is immutable.\nPossible values are `Continuous`, `InstallOnce`, or unset.",
+          "enum": [
+            "",
+            "InstallOnce",
+            "Continuous"
+          ],
+          "type": "string"
+        },
+        "releaseName": {
+          "description": "ReleaseName is the release name of the installed Helm chart. If it is not specified, a name will be generated.",
+          "type": "string"
+        },
+        "repoURL": {
+          "description": "RepoURL is the URL of the Helm chart repository.\ne.g. chart-path oci://repo-url/chart-name as repoURL: oci://repo-url and https://repo-url/chart-name as repoURL: https://repo-url",
+          "type": "string"
+        },
+        "tlsConfig": {
+          "description": "TLSConfig contains the TLS configuration for a HelmChartProxy.",
+          "properties": {
+            "caSecret": {
+              "description": "Secret is a reference to a Secret containing the TLS CA certificate at the key ca.crt.",
+              "properties": {
+                "name": {
+                  "description": "name is unique within a namespace to reference a secret resource.",
+                  "type": "string"
+                },
+                "namespace": {
+                  "description": "namespace defines the space within which the secret name must be unique.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "x-kubernetes-map-type": "atomic",
+              "additionalProperties": false
+            },
+            "insecureSkipTLSVerify": {
+              "description": "InsecureSkipTLSVerify controls whether the Helm client should verify the server's certificate.",
+              "type": "boolean"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "valuesTemplate": {
+          "description": "ValuesTemplate is an inline YAML representing the values for the Helm chart. This YAML supports Go templating to reference\nfields from each selected workload Cluster and programatically create and set values.",
+          "type": "string"
+        },
+        "version": {
+          "description": "Version is the version of the Helm chart. If it is not specified, the chart will use\nand be kept up to date with the latest version.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "chartName",
+        "clusterSelector",
+        "repoURL"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "HelmChartProxyStatus defines the observed state of HelmChartProxy.",
+      "properties": {
+        "conditions": {
+          "description": "Conditions defines current state of the HelmChartProxy.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed. If that is not known, then using the time when\nthe API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message is a human readable message indicating details about the transition.\nThis field may be empty.",
+                "maxLength": 10240,
+                "minLength": 1,
+                "type": "string"
+              },
+              "reason": {
+                "description": "reason is the reason for the condition's last transition in CamelCase.\nThe specific API may choose whether or not this field is considered a guaranteed API.\nThis field may be empty.",
+                "maxLength": 256,
+                "minLength": 1,
+                "type": "string"
+              },
+              "severity": {
+                "description": "severity provides an explicit classification of Reason code, so the users or machines can immediately\nunderstand the current situation and act accordingly.\nThe Severity field MUST be set only when Status=False.",
+                "maxLength": 32,
+                "type": "string"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.\nMany .condition.type values are consistent across resources like Available, but because arbitrary conditions\ncan be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "maxLength": 256,
+                "minLength": 1,
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "matchingClusters": {
+          "description": "MatchingClusters is the list of references to Clusters selected by the ClusterSelector.",
+          "items": {
+            "description": "ObjectReference contains enough information to let you inspect or modify the referred object.",
+            "properties": {
+              "apiVersion": {
+                "description": "API version of the referent.",
+                "type": "string"
+              },
+              "fieldPath": {
+                "description": "If referring to a piece of an object instead of an entire object, this string\nshould contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].\nFor example, if the object reference is to a container within a pod, this would take on a value like:\n\"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered\nthe event) or if no container name is specified \"spec.containers[2]\" (container with\nindex 2 in this pod). This syntax is chosen only to have some well-defined way of\nreferencing a part of an object.",
+                "type": "string"
+              },
+              "kind": {
+                "description": "Kind of the referent.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                "type": "string"
+              },
+              "name": {
+                "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                "type": "string"
+              },
+              "namespace": {
+                "description": "Namespace of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                "type": "string"
+              },
+              "resourceVersion": {
+                "description": "Specific resourceVersion to which this reference is made, if any.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                "type": "string"
+              },
+              "uid": {
+                "description": "UID of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "x-kubernetes-map-type": "atomic",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration is the latest generation observed by the controller.",
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/addons.cluster.x-k8s.io/helmreleaseproxy_v1alpha1.json
+++ b/addons.cluster.x-k8s.io/helmreleaseproxy_v1alpha1.json
@@ -1,0 +1,339 @@
+{
+  "description": "HelmReleaseProxy is the Schema for the helmreleaseproxies API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "HelmReleaseProxySpec defines the desired state of HelmReleaseProxy.",
+      "properties": {
+        "chartName": {
+          "description": "ChartName is the name of the Helm chart in the repository.\ne.g. chart-path oci://repo-url/chart-name as chartName: chart-name and https://repo-url/chart-name as chartName: chart-name",
+          "type": "string"
+        },
+        "clusterRef": {
+          "description": "ClusterRef is a reference to the Cluster to install the Helm release on.",
+          "properties": {
+            "apiVersion": {
+              "description": "API version of the referent.",
+              "type": "string"
+            },
+            "fieldPath": {
+              "description": "If referring to a piece of an object instead of an entire object, this string\nshould contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].\nFor example, if the object reference is to a container within a pod, this would take on a value like:\n\"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered\nthe event) or if no container name is specified \"spec.containers[2]\" (container with\nindex 2 in this pod). This syntax is chosen only to have some well-defined way of\nreferencing a part of an object.",
+              "type": "string"
+            },
+            "kind": {
+              "description": "Kind of the referent.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "Namespace of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+              "type": "string"
+            },
+            "resourceVersion": {
+              "description": "Specific resourceVersion to which this reference is made, if any.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+              "type": "string"
+            },
+            "uid": {
+              "description": "UID of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
+        "credentials": {
+          "description": "Credentials is a reference to an object containing the OCI credentials. If it is not specified, no credentials will be used.",
+          "properties": {
+            "key": {
+              "description": "Key is the key in the Secret containing the OCI credentials.",
+              "type": "string"
+            },
+            "secret": {
+              "description": "Secret is a reference to a Secret containing the OCI credentials.",
+              "properties": {
+                "name": {
+                  "description": "name is unique within a namespace to reference a secret resource.",
+                  "type": "string"
+                },
+                "namespace": {
+                  "description": "namespace defines the space within which the secret name must be unique.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "x-kubernetes-map-type": "atomic",
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "key",
+            "secret"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "namespace": {
+          "description": "ReleaseNamespace is the namespace the Helm release will be installed on the referenced\nCluster. If it is not specified, it will be set to the default namespace.",
+          "type": "string"
+        },
+        "options": {
+          "description": "Options represents the helm setting options which can be used to control behaviour of helm operations(Install, Upgrade, Delete, etc)\nvia options like wait, skipCrds, timeout, waitForJobs, etc.",
+          "properties": {
+            "atomic": {
+              "description": "Atomic indicates the installation/upgrade process to delete the installation or rollback on failure.\nIf 'Atomic' is set, wait will be enabled automatically during helm install/upgrade operation.",
+              "type": "boolean"
+            },
+            "dependencyUpdate": {
+              "description": "DependencyUpdate indicates the Helm install/upgrade action to get missing dependencies.",
+              "type": "boolean"
+            },
+            "disableHooks": {
+              "description": "DisableHooks prevents hooks from running during the Helm install action.",
+              "type": "boolean"
+            },
+            "disableOpenAPIValidation": {
+              "description": "DisableOpenAPIValidation controls whether OpenAPI validation is enforced.",
+              "type": "boolean"
+            },
+            "enableClientCache": {
+              "default": false,
+              "description": "EnableClientCache is a flag to enable Helm client cache. If it is not specified, it will be set to true.",
+              "type": "boolean"
+            },
+            "install": {
+              "description": "Install represents CLI flags passed to Helm install operation which can be used to control\nbehaviour of helm Install operations via options like wait, skipCrds, timeout, waitForJobs, etc.",
+              "properties": {
+                "createNamespace": {
+                  "default": true,
+                  "description": "CreateNamespace indicates the Helm install/upgrade action to create the\nHelmChartProxySpec.ReleaseNamespace if it does not exist yet.\nOn uninstall, the namespace will not be garbage collected.\nIf it is not specified by user, will be set to default 'true'.",
+                  "type": "boolean"
+                },
+                "includeCRDs": {
+                  "description": "IncludeCRDs determines whether CRDs stored as a part of helm templates directory should be installed.",
+                  "type": "boolean"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "options": {
+              "description": "SubNotes determines whether sub-notes should be rendered in the chart.",
+              "type": "boolean"
+            },
+            "skipCRDs": {
+              "description": "SkipCRDs controls whether CRDs should be installed during install/upgrade operation.\nBy default, CRDs are installed if not already present.\nIf set, no CRDs will be installed.",
+              "type": "boolean"
+            },
+            "timeout": {
+              "description": "Timeout is the time to wait for any individual Kubernetes operation (like\nresource creation, Jobs for hooks, etc.) during the performance of a Helm install action.\nDefaults to '10 min'.",
+              "type": "string"
+            },
+            "uninstall": {
+              "description": "Uninstall represents CLI flags passed to Helm uninstall operation which can be used to control\nbehaviour of helm Uninstall operation via options like wait, timeout, etc.",
+              "properties": {
+                "description": {
+                  "description": "Description represents human readable information to be shown on release uninstall.",
+                  "type": "string"
+                },
+                "keepHistory": {
+                  "description": "KeepHistory defines whether historical revisions of a release should be saved.\nIf it's set, helm uninstall operation will not delete the history of the release.\nThe helm storage backend (secret, configmap, etc) will be retained in the cluster.",
+                  "type": "boolean"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "upgrade": {
+              "description": "Upgrade represents CLI flags passed to Helm upgrade operation which can be used to control\nbehaviour of helm Upgrade operations via options like wait, skipCrds, timeout, waitForJobs, etc.",
+              "properties": {
+                "cleanupOnFail": {
+                  "description": "CleanupOnFail indicates the upgrade action to delete newly-created resources on a failed update operation.",
+                  "type": "boolean"
+                },
+                "force": {
+                  "description": "Force indicates to ignore certain warnings and perform the helm release upgrade anyway.\nThis should be used with caution.",
+                  "type": "boolean"
+                },
+                "maxHistory": {
+                  "default": 10,
+                  "description": "MaxHistory limits the maximum number of revisions saved per release (default is 10).",
+                  "type": "integer"
+                },
+                "recreate": {
+                  "description": "Recreate will (if true) recreate pods after a rollback.",
+                  "type": "boolean"
+                },
+                "resetThenReuseValues": {
+                  "description": "ResetThenReuseValues will reset the values to the chart's built-ins then merge with user's last supplied values.",
+                  "type": "boolean"
+                },
+                "resetValues": {
+                  "description": "ResetValues will reset the values to the chart's built-ins rather than merging with existing.",
+                  "type": "boolean"
+                },
+                "reuseValues": {
+                  "description": "ReuseValues will re-use the user's last supplied values.",
+                  "type": "boolean"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "wait": {
+              "description": "Wait enables the waiting for resources to be ready after a Helm install/upgrade has been performed.",
+              "type": "boolean"
+            },
+            "waitForJobs": {
+              "description": "WaitForJobs enables waiting for jobs to complete after a Helm install/upgrade has been performed.",
+              "type": "boolean"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "reconcileStrategy": {
+          "description": "ReconcileStrategy indicates whether a Helm chart should be continuously installed, updated, and uninstalled on the Cluster,\nor if it should be reconciled until it is successfully installed on the Cluster and not otherwise updated or uninstalled.\nIf not specified, the default behavior will be to reconcile continuously. This field is immutable.\nPossible values are `Continuous`, `InstallOnce`, or unset.",
+          "enum": [
+            "",
+            "InstallOnce",
+            "Continuous"
+          ],
+          "type": "string"
+        },
+        "releaseName": {
+          "description": "ReleaseName is the release name of the installed Helm chart. If it is not specified, a name will be generated.",
+          "type": "string"
+        },
+        "repoURL": {
+          "description": "RepoURL is the URL of the Helm chart repository.\ne.g. chart-path oci://repo-url/chart-name as repoURL: oci://repo-url and https://repo-url/chart-name as repoURL: https://repo-url",
+          "type": "string"
+        },
+        "tlsConfig": {
+          "description": "TLSConfig contains the TLS configuration for the HelmReleaseProxy.",
+          "properties": {
+            "caSecret": {
+              "description": "Secret is a reference to a Secret containing the TLS CA certificate at the key ca.crt.",
+              "properties": {
+                "name": {
+                  "description": "name is unique within a namespace to reference a secret resource.",
+                  "type": "string"
+                },
+                "namespace": {
+                  "description": "namespace defines the space within which the secret name must be unique.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "x-kubernetes-map-type": "atomic",
+              "additionalProperties": false
+            },
+            "insecureSkipTLSVerify": {
+              "description": "InsecureSkipTLSVerify controls whether the Helm client should verify the server's certificate.",
+              "type": "boolean"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "values": {
+          "description": "Values is an inline YAML representing the values for the Helm chart. This YAML is the result of the rendered\nGo templating with the values from the referenced workload Cluster.",
+          "type": "string"
+        },
+        "version": {
+          "description": "Version is the version of the Helm chart. If it is not specified, the chart will use\nand be kept up to date with the latest version.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "chartName",
+        "clusterRef",
+        "repoURL"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "HelmReleaseProxyStatus defines the observed state of HelmReleaseProxy.",
+      "properties": {
+        "conditions": {
+          "description": "Conditions defines current state of the HelmReleaseProxy.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed. If that is not known, then using the time when\nthe API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message is a human readable message indicating details about the transition.\nThis field may be empty.",
+                "maxLength": 10240,
+                "minLength": 1,
+                "type": "string"
+              },
+              "reason": {
+                "description": "reason is the reason for the condition's last transition in CamelCase.\nThe specific API may choose whether or not this field is considered a guaranteed API.\nThis field may be empty.",
+                "maxLength": 256,
+                "minLength": 1,
+                "type": "string"
+              },
+              "severity": {
+                "description": "severity provides an explicit classification of Reason code, so the users or machines can immediately\nunderstand the current situation and act accordingly.\nThe Severity field MUST be set only when Status=False.",
+                "maxLength": 32,
+                "type": "string"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.\nMany .condition.type values are consistent across resources like Available, but because arbitrary conditions\ncan be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "maxLength": 256,
+                "minLength": 1,
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration is the latest generation observed by the controller.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "revision": {
+          "description": "Revision is the current revision of the Helm release.",
+          "type": "integer"
+        },
+        "status": {
+          "description": "Status is the current status of the Helm release.",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}


### PR DESCRIPTION
STATE
Missing JSON validation schemas for Cluster API addons HelmChartProxy and HelmReleaseProxy v1alpha1 resources.

SOLUTION
- Add HelmChartProxy v1alpha1 JSON schema with spec fields for chart name, repo URL, cluster selector, credentials, TLS config, helm options, and reconcile strategy
- Add HelmReleaseProxy v1alpha1 JSON schema with spec fields for chart name, repo URL, cluster ref, credentials, TLS config, helm options, values, and reconcile strategy

The Github CRD definition are available [here](https://github.com/kubernetes-sigs/cluster-api-addon-provider-helm/tree/v0.4.2/config/crd/bases)

## PR Checklist

- [X] I generated these CRs using the [CRD Extractor tool](https://github.com/datreeio/CRDs-catalog?tab=readme-ov-file#crd-extractor). If I used a different method, I have described the method in this PR.
- [ ] I am updating existing schemas and have specified the updated schema version.
- [X] I am adding new schemas and included a link to the GitHub repository that contains the source of these schemas.
