### PR TITLE
feat(schemas): Add CAPI for the OutScale provider

### DIFF
--- a/infrastructure.cluster.x-k8s.io/osccluster_v1beta1.json
+++ b/infrastructure.cluster.x-k8s.io/osccluster_v1beta1.json
@@ -1,0 +1,1152 @@
+{
+  "description": "OscCluster is the Schema for the oscclusters API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "OscClusterSpec defines the desired state of OscCluster",
+      "properties": {
+        "controlPlaneEndpoint": {
+          "description": "APIEndpoint represents a reachable Kubernetes API endpoint.",
+          "properties": {
+            "host": {
+              "description": "host is the hostname on which the API server is serving.",
+              "maxLength": 512,
+              "type": "string"
+            },
+            "port": {
+              "description": "port is the port on which the API server is serving.",
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "host",
+            "port"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "credentials": {
+          "properties": {
+            "fromFile": {
+              "description": "Load credentials from this file instead of the env.",
+              "type": "string"
+            },
+            "fromSecret": {
+              "description": "Load credentials from this secret instead of the env.",
+              "type": "string"
+            },
+            "profile": {
+              "description": "Name of profile stored in file (unused using fromSecret, \"default\" by default).",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "network": {
+          "properties": {
+            "additionalSecurityRules": {
+              "description": "Additional rules to add to the automatic security groups",
+              "items": {
+                "properties": {
+                  "roles": {
+                    "description": "The roles of automatic securityGroup to add rules to.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "rules": {
+                    "description": "The rules to add.",
+                    "items": {
+                      "properties": {
+                        "flow": {
+                          "description": "The flow of the security group (inbound or outbound)",
+                          "type": "string"
+                        },
+                        "fromPortRange": {
+                          "description": "The beginning of the port range",
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "ipProtocol": {
+                          "description": "The ip protocol name (tcp, udp, icmp or -1)",
+                          "type": "string"
+                        },
+                        "ipRange": {
+                          "description": "The ip range of the security group rule (deprecated, use ipRanges)",
+                          "type": "string"
+                        },
+                        "ipRanges": {
+                          "description": "The list of ip ranges of the security group rule",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "name": {
+                          "description": "The tag name associate with the security group",
+                          "type": "string"
+                        },
+                        "resourceId": {
+                          "description": "The security group rule id",
+                          "type": "string"
+                        },
+                        "toPortRange": {
+                          "description": "The end of the port range",
+                          "format": "int32",
+                          "type": "integer"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "allowFromIPRanges": {
+              "description": "The list of IP ranges (in CIDR notation) to restrict bastion/Kubernetes API access to.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "allowToIPRanges": {
+              "description": "The list of IP ranges (in CIDR notation) the nodes can talk to (\"0.0.0.0/0\" if not set).",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "bastion": {
+              "description": "The bastion configuration",
+              "properties": {
+                "PublicIpId": {
+                  "description": "The ID of an existing public IP to use for this VM.",
+                  "type": "string"
+                },
+                "clusterName": {
+                  "description": "unused",
+                  "type": "string"
+                },
+                "deviceName": {
+                  "description": "unused",
+                  "type": "string"
+                },
+                "enable": {
+                  "type": "boolean"
+                },
+                "imageAccountId": {
+                  "type": "string"
+                },
+                "imageId": {
+                  "type": "string"
+                },
+                "imageName": {
+                  "type": "string"
+                },
+                "keypairName": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "privateIps": {
+                  "items": {
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "privateIp": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "publicIpName": {
+                  "description": "unused",
+                  "type": "string"
+                },
+                "resourceId": {
+                  "description": "the vm id (deprecated, not set anymore)",
+                  "type": "string"
+                },
+                "rootDisk": {
+                  "properties": {
+                    "rootDiskIops": {
+                      "description": "The root disk iops (io1 volumes only) (1500 by default)",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "rootDiskSize": {
+                      "description": "The volume size in gibibytes (GiB) (60 by default)",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "rootDiskType": {
+                      "description": "The volume type (io1, gp2 or standard) (io1 by default)",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "securityGroupNames": {
+                  "description": "The list of security groups (deprecated use bastion role in security groups)",
+                  "items": {
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "subnetName": {
+                  "description": "The subnet of the vm (deprecated use bastion role in subnets)",
+                  "type": "string"
+                },
+                "subregionName": {
+                  "description": "unused",
+                  "type": "string"
+                },
+                "vmType": {
+                  "description": "The type of VM (tinav6.c1r1p2 by default)",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "clusterName": {
+              "description": "The name of the cluster (unused)",
+              "type": "string"
+            },
+            "controlPlaneSubnets": {
+              "description": "List of subnet to spread controlPlane nodes (deprecated, add controlplane role to subnets)",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "disable": {
+              "description": "List of disabled features (internet = no internet service, no nat services)",
+              "items": {
+                "enum": [
+                  "internet",
+                  "loadbalancer"
+                ],
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "extraSecurityGroupRule": {
+              "description": "(unused)",
+              "type": "boolean"
+            },
+            "image": {
+              "description": "The image configuration (unused)",
+              "properties": {
+                "accountId": {
+                  "description": "The image account owner ID.",
+                  "type": "string"
+                },
+                "name": {
+                  "description": "The image name.",
+                  "type": "string"
+                },
+                "outscaleOpenSource": {
+                  "description": "Use an \"Outscale Opensource\" image",
+                  "type": "boolean"
+                },
+                "resourceId": {
+                  "description": "unused",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "internetService": {
+              "description": "The Internet Service configuration",
+              "properties": {
+                "clusterName": {
+                  "description": "the name of the cluster (unused)",
+                  "type": "string"
+                },
+                "name": {
+                  "description": "The name of the Internet service",
+                  "type": "string"
+                },
+                "resourceId": {
+                  "description": "the Internet Service resource id (unused)",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "loadBalancer": {
+              "description": "The Load Balancer configuration",
+              "properties": {
+                "clusterName": {
+                  "description": "unused",
+                  "type": "string"
+                },
+                "healthCheck": {
+                  "description": "The healthCheck configuration of the Load Balancer",
+                  "properties": {
+                    "checkinterval": {
+                      "description": "the time in second between two pings",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "healthythreshold": {
+                      "description": "the consecutive number of pings which are successful to consider the vm healthy",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "port": {
+                      "description": "the HealthCheck port number",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "protocol": {
+                      "description": "The HealthCheck protocol ('HTTP'|'TCP')",
+                      "type": "string"
+                    },
+                    "timeout": {
+                      "description": "the Timeout to consider VM unhealthy",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "unhealthythreshold": {
+                      "description": "the consecutive number of pings which are failed to consider the vm unhealthy",
+                      "format": "int32",
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "listener": {
+                  "description": "The Listener configuration of the loadBalancer",
+                  "properties": {
+                    "backendport": {
+                      "description": "The port on which the backend VMs will listen",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "backendprotocol": {
+                      "description": "The protocol ('HTTP'|'TCP') to route the traffic to the backend vm",
+                      "type": "string"
+                    },
+                    "loadbalancerport": {
+                      "description": "The port on which the loadbalancer will listen",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "loadbalancerprotocol": {
+                      "description": "the routing protocol ('HTTP'|'TCP')",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "loadbalancername": {
+                  "description": "The Load Balancer unique name",
+                  "type": "string"
+                },
+                "loadbalancertype": {
+                  "description": "The Load Balancer type (internet-facing or internal)",
+                  "type": "string"
+                },
+                "securitygroupname": {
+                  "description": "The security group name for the load-balancer (deprecated, add loadbalancer role to a security group)",
+                  "type": "string"
+                },
+                "subnetname": {
+                  "description": "The subnet name where to add the load balancer (deprecated, add loadbalancer role to a subnet)",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "natPublicIpPool": {
+              "description": "The IP Pool storing the Nat Services public IPs",
+              "type": "string"
+            },
+            "natService": {
+              "description": "The Nat Service configuration",
+              "properties": {
+                "clusterName": {
+                  "description": "The name of the cluster (unused)",
+                  "type": "string"
+                },
+                "name": {
+                  "description": "The name of the Nat Service",
+                  "type": "string"
+                },
+                "publicipname": {
+                  "description": "The Public Ip name (unused)",
+                  "type": "string"
+                },
+                "resourceId": {
+                  "description": "The resource id (unused)",
+                  "type": "string"
+                },
+                "subnetname": {
+                  "description": "The name of the Subnet to which the Nat Service will be attached (deprecated, add nat role to subnets)",
+                  "type": "string"
+                },
+                "subregionName": {
+                  "description": "The name of the Subregion to which the Nat Service will be attached, unless a subnet has been defined (unused)",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "natServices": {
+              "description": "The Nat Services configuration",
+              "items": {
+                "properties": {
+                  "clusterName": {
+                    "description": "The name of the cluster (unused)",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "The name of the Nat Service",
+                    "type": "string"
+                  },
+                  "publicipname": {
+                    "description": "The Public Ip name (unused)",
+                    "type": "string"
+                  },
+                  "resourceId": {
+                    "description": "The resource id (unused)",
+                    "type": "string"
+                  },
+                  "subnetname": {
+                    "description": "The name of the Subnet to which the Nat Service will be attached (deprecated, add nat role to subnets)",
+                    "type": "string"
+                  },
+                  "subregionName": {
+                    "description": "The name of the Subregion to which the Nat Service will be attached, unless a subnet has been defined (unused)",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "net": {
+              "description": "The Net configuration",
+              "properties": {
+                "clusterName": {
+                  "description": "the name of the cluster (unused)",
+                  "type": "string"
+                },
+                "ipRange": {
+                  "description": "the ip range in CIDR notation of the Net",
+                  "type": "string"
+                },
+                "name": {
+                  "description": "the network name",
+                  "type": "string"
+                },
+                "resourceId": {
+                  "description": "The Id of the Net to reuse (if useExisting.net is set)",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "netAccessPoints": {
+              "description": "The NetAccessPoints configuration, required if internet is disabled.",
+              "items": {
+                "enum": [
+                  "api",
+                  "directlink",
+                  "eim",
+                  "kms",
+                  "lbu",
+                  "oos"
+                ],
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "netPeering": {
+              "description": "The NetPeering configuration, required if the load balancer is internal, and management and workload clusters are on separate VPCs.",
+              "properties": {
+                "enable": {
+                  "description": "Create a NetPeering between the management and workload VPCs.",
+                  "type": "boolean"
+                },
+                "managementAccountId": {
+                  "description": "The management cluster account ID (optional, fetched from the metadata server if not set).",
+                  "type": "string"
+                },
+                "managementCredentials": {
+                  "description": "The credentials of the management cluster account. Required if management and workload cluster are not in the same account.",
+                  "properties": {
+                    "fromFile": {
+                      "description": "Load credentials from this file instead of the env.",
+                      "type": "string"
+                    },
+                    "fromSecret": {
+                      "description": "Load credentials from this secret instead of the env.",
+                      "type": "string"
+                    },
+                    "profile": {
+                      "description": "Name of profile stored in file (unused using fromSecret, \"default\" by default).",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "managementNetId": {
+                  "description": "The management cluster net ID (optional, fetched from the metadata server if not set).",
+                  "type": "string"
+                },
+                "managementSubnetId": {
+                  "description": "By default, all subnets of managementNetId are routed to the netPeering. If set, only the specified subnet will be routed.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "publicIps": {
+              "description": "The Public Ip configuration (unused)",
+              "items": {
+                "properties": {
+                  "clusterName": {
+                    "description": "unused",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "The tag name associate with the Public Ip (unused)",
+                    "type": "string"
+                  },
+                  "resourceId": {
+                    "description": "The Public Ip Id response (unused)",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "reconciliationRules": {
+              "description": "Reconciliation rules (default: {securityGroup, random, 10%}, {*, onChange}). Only the first matching rule applies.",
+              "items": {
+                "properties": {
+                  "appliesTo": {
+                    "description": "The list of items this rule applies to (bastion, net, netPeering, netPeering/routes, subnet, internetService, netAccessPoint, natService, routeTable, securityGroup, loadbalancer, vm or * for all)",
+                    "items": {
+                      "enum": [
+                        "bastion",
+                        "net",
+                        "netPeering",
+                        "netPeering/routes",
+                        "subnet",
+                        "internetService",
+                        "netAccessPoint",
+                        "natService",
+                        "routeTable",
+                        "securityGroup",
+                        "loadbalancer",
+                        "vm",
+                        "*"
+                      ],
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "mode": {
+                    "description": "The mode of reconciliation: onChange (only when the spec change, default), always, random (onChange + randomPercent% chance)",
+                    "enum": [
+                      "onChange",
+                      "always",
+                      "random"
+                    ],
+                    "type": "string"
+                  },
+                  "reconciliationChance": {
+                    "description": "The chance (in percent, 1-100) of a reconcilation happening when no change have been detected (when mode=random)",
+                    "type": "integer"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "routeTables": {
+              "description": "The Route Table configuration",
+              "items": {
+                "properties": {
+                  "name": {
+                    "description": "The tag name associate with the Route Table",
+                    "type": "string"
+                  },
+                  "resourceId": {
+                    "description": "The resource id (unused)",
+                    "type": "string"
+                  },
+                  "role": {
+                    "description": "The role for this route table",
+                    "type": "string"
+                  },
+                  "routes": {
+                    "description": "The Route configuration",
+                    "items": {
+                      "properties": {
+                        "destination": {
+                          "description": "the destination match Ip range with CIDR notation",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "The tag name associate with the Route",
+                          "type": "string"
+                        },
+                        "resourceId": {
+                          "description": "The Route Id response",
+                          "type": "string"
+                        },
+                        "targetName": {
+                          "description": "The tag name associate with the target resource type",
+                          "type": "string"
+                        },
+                        "targetType": {
+                          "description": "The target resource type which can be Internet Service (gateway) or Nat Service (nat-service)",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
+                  "subnets": {
+                    "description": "The subnet tag name associate with a Subnet (deprecated, use roles)",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "subregionName": {
+                    "description": "The subregion for this route table",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "securityGroups": {
+              "description": "The Security Groups configuration.",
+              "items": {
+                "properties": {
+                  "authoritative": {
+                    "description": "Is the Security Group configuration authoritative ? (if yes, all rules not found in configuration will be deleted).",
+                    "type": "boolean"
+                  },
+                  "description": {
+                    "description": "The description of the security group",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "The name of the security group",
+                    "type": "string"
+                  },
+                  "resourceId": {
+                    "description": "When useExisting.securityGroup is set, the id of an existing securityGroup to use.",
+                    "type": "string"
+                  },
+                  "roles": {
+                    "description": "The roles the securityGroup applies to.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "securityGroupRules": {
+                    "description": "The list of rules for this securityGroup.",
+                    "items": {
+                      "properties": {
+                        "flow": {
+                          "description": "The flow of the security group (inbound or outbound)",
+                          "type": "string"
+                        },
+                        "fromPortRange": {
+                          "description": "The beginning of the port range",
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "ipProtocol": {
+                          "description": "The ip protocol name (tcp, udp, icmp or -1)",
+                          "type": "string"
+                        },
+                        "ipRange": {
+                          "description": "The ip range of the security group rule (deprecated, use ipRanges)",
+                          "type": "string"
+                        },
+                        "ipRanges": {
+                          "description": "The list of ip ranges of the security group rule",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "name": {
+                          "description": "The tag name associate with the security group",
+                          "type": "string"
+                        },
+                        "resourceId": {
+                          "description": "The security group rule id",
+                          "type": "string"
+                        },
+                        "toPortRange": {
+                          "description": "The end of the port range",
+                          "format": "int32",
+                          "type": "integer"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
+                  "tag": {
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "subnets": {
+              "description": "The Subnets configuration",
+              "items": {
+                "properties": {
+                  "ipSubnetRange": {
+                    "description": "the Ip range in CIDR notation of the Subnet",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "The name of the Subnet",
+                    "type": "string"
+                  },
+                  "resourceId": {
+                    "description": "The id of the Subnet to reuse (if useExisting.net is set)",
+                    "type": "string"
+                  },
+                  "roles": {
+                    "description": "The role of the Subnet (controlplane, worker, loadbalancer, bastion or nat)",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "subregionName": {
+                    "description": "The subregion name of the Subnet",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "subregionName": {
+              "description": "The default subregion name (deprecated, use subregions)",
+              "type": "string"
+            },
+            "subregions": {
+              "description": "The list of subregions where to deploy this cluster",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "useExisting": {
+              "description": "Reuse externally managed resources ?",
+              "properties": {
+                "net": {
+                  "description": "If set, net, subnets, internet service, nat services and route tables are externally managed",
+                  "type": "boolean"
+                },
+                "securityGroups": {
+                  "description": "If set, security groups are externally managed.",
+                  "type": "boolean"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "OscClusterStatus defines the observed state of OscCluster",
+      "properties": {
+        "conditions": {
+          "description": "Conditions provide observations of the operational state of a Cluster API resource.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed. If that is not known, then using the time when\nthe API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message is a human readable message indicating details about the transition.\nThis field may be empty.",
+                "maxLength": 10240,
+                "minLength": 1,
+                "type": "string"
+              },
+              "reason": {
+                "description": "reason is the reason for the condition's last transition in CamelCase.\nThe specific API may choose whether or not this field is considered a guaranteed API.\nThis field may be empty.",
+                "maxLength": 256,
+                "minLength": 1,
+                "type": "string"
+              },
+              "severity": {
+                "description": "severity provides an explicit classification of Reason code, so the users or machines can immediately\nunderstand the current situation and act accordingly.\nThe Severity field MUST be set only when Status=False.",
+                "maxLength": 32,
+                "type": "string"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.\nMany .condition.type values are consistent across resources like Available, but because arbitrary conditions\ncan be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "maxLength": 256,
+                "minLength": 1,
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "failureDomains": {
+          "additionalProperties": {
+            "description": "FailureDomainSpec is the Schema for Cluster API failure domains.\nIt allows controllers to understand how many failure domains a cluster can optionally span across.",
+            "properties": {
+              "attributes": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "description": "attributes is a free form map of attributes an infrastructure provider might use or require.",
+                "type": "object"
+              },
+              "controlPlane": {
+                "description": "controlPlane determines if this failure domain is suitable for use by control plane machines.",
+                "type": "boolean"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "description": "FailureDomains is a slice of FailureDomains.",
+          "type": "object"
+        },
+        "network": {
+          "description": "deprecated, replaced by resources",
+          "properties": {
+            "LoadbalancerRef": {
+              "description": "Map between LoadbalancerId and LoadbalancerName (not set anymore)",
+              "properties": {
+                "resourceMap": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "bastionref": {
+              "description": "Map between InstanceId  and BastionName (not set anymore)",
+              "properties": {
+                "resourceMap": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "internetserviceref": {
+              "description": "Map between InternetServiceId  and InternetServiceName (not set anymore)",
+              "properties": {
+                "resourceMap": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "linkPublicIpRef": {
+              "description": "Map between LinkPublicIpId  and PublicIpName (not set anymore)",
+              "properties": {
+                "resourceMap": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "linkroutetableref": {
+              "additionalProperties": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "description": "Map between LinkRouteTableId and RouteTablesName (not set anymore)",
+              "type": "object"
+            },
+            "natref": {
+              "description": "Map between NatServiceId  and NatServiceName (not set anymore)",
+              "properties": {
+                "resourceMap": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "netref": {
+              "description": "Map between NetId  and NetName (not set anymore)",
+              "properties": {
+                "resourceMap": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "publicipref": {
+              "description": "Map between PublicIpId  and PublicIpName (not set anymore)",
+              "properties": {
+                "resourceMap": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "routeref": {
+              "description": "Map between RouteId  and RouteName (not set anymore)",
+              "properties": {
+                "resourceMap": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "routetableref": {
+              "description": "Map between RouteTablesId  and RouteTablesName (not set anymore)",
+              "properties": {
+                "resourceMap": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "securitygroupref": {
+              "description": "Map between SecurityGroupId  and SecurityGroupName (not set anymore)",
+              "properties": {
+                "resourceMap": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "securitygroupruleref": {
+              "description": "Map between SecurityGroupRuleId  and SecurityGroupName (not set anymore)",
+              "properties": {
+                "resourceMap": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "subnetref": {
+              "description": "Map between SubnetId  and SubnetName (not set anymore)",
+              "properties": {
+                "resourceMap": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "ready": {
+          "type": "boolean"
+        },
+        "reconcilerGeneration": {
+          "additionalProperties": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "type": "object"
+        },
+        "resources": {
+          "properties": {
+            "bastion": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "internetService": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "natService": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "net": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "netAccessPoint": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "netPeering": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "publicIps": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "securityGroup": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "subnet": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "vmState": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/oscclustertemplate_v1beta1.json
+++ b/infrastructure.cluster.x-k8s.io/oscclustertemplate_v1beta1.json
@@ -1,0 +1,869 @@
+{
+  "description": "OscClusterTemplate is the Schema for the oscclustertemplates API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "OscClusterTemplateSpec defines the desired state of OscClusterTemplate",
+      "properties": {
+        "template": {
+          "properties": {
+            "metadata": {
+              "description": "ObjectMeta is metadata that all persisted resources must have, which includes all objects\nusers must create. This is a copy of customizable fields from metav1.ObjectMeta.\n\nObjectMeta is embedded in `Machine.Spec`, `MachineDeployment.Template` and `MachineSet.Template`,\nwhich are not top-level Kubernetes objects. Given that metav1.ObjectMeta has lots of special cases\nand read-only fields which end up in the generated CRD validation, having it as a subset simplifies\nthe API and some issues that can impact user experience.\n\nDuring the [upgrade to controller-tools@v2](https://github.com/kubernetes-sigs/cluster-api/pull/1054)\nfor v1alpha2, we noticed a failure would occur running Cluster API test suite against the new CRDs,\nspecifically `spec.metadata.creationTimestamp in body must be of type string: \"null\"`.\nThe investigation showed that `controller-tools@v2` behaves differently than its previous version\nwhen handling types from [metav1](k8s.io/apimachinery/pkg/apis/meta/v1) package.\n\nIn more details, we found that embedded (non-top level) types that embedded `metav1.ObjectMeta`\nhad validation properties, including for `creationTimestamp` (metav1.Time).\nThe `metav1.Time` type specifies a custom json marshaller that, when IsZero() is true, returns `null`\nwhich breaks validation because the field isn't marked as nullable.\n\nIn future versions, controller-tools@v2 might allow overriding the type and validation for embedded\ntypes. When that happens, this hack should be revisited.",
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "annotations is an unstructured key value map stored with a resource that may be\nset by external tools to store and retrieve arbitrary metadata. They are not\nqueryable and should be preserved when modifying objects.\nMore info: http://kubernetes.io/docs/user-guide/annotations",
+                  "type": "object"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "labels is a map of string keys and values that can be used to organize and categorize\n(scope and select) objects. May match selectors of replication controllers\nand services.\nMore info: http://kubernetes.io/docs/user-guide/labels",
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "spec": {
+              "description": "OscClusterSpec defines the desired state of OscCluster",
+              "properties": {
+                "controlPlaneEndpoint": {
+                  "description": "APIEndpoint represents a reachable Kubernetes API endpoint.",
+                  "properties": {
+                    "host": {
+                      "description": "host is the hostname on which the API server is serving.",
+                      "maxLength": 512,
+                      "type": "string"
+                    },
+                    "port": {
+                      "description": "port is the port on which the API server is serving.",
+                      "format": "int32",
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "host",
+                    "port"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "credentials": {
+                  "properties": {
+                    "fromFile": {
+                      "description": "Load credentials from this file instead of the env.",
+                      "type": "string"
+                    },
+                    "fromSecret": {
+                      "description": "Load credentials from this secret instead of the env.",
+                      "type": "string"
+                    },
+                    "profile": {
+                      "description": "Name of profile stored in file (unused using fromSecret, \"default\" by default).",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "network": {
+                  "properties": {
+                    "additionalSecurityRules": {
+                      "description": "Additional rules to add to the automatic security groups",
+                      "items": {
+                        "properties": {
+                          "roles": {
+                            "description": "The roles of automatic securityGroup to add rules to.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "rules": {
+                            "description": "The rules to add.",
+                            "items": {
+                              "properties": {
+                                "flow": {
+                                  "description": "The flow of the security group (inbound or outbound)",
+                                  "type": "string"
+                                },
+                                "fromPortRange": {
+                                  "description": "The beginning of the port range",
+                                  "format": "int32",
+                                  "type": "integer"
+                                },
+                                "ipProtocol": {
+                                  "description": "The ip protocol name (tcp, udp, icmp or -1)",
+                                  "type": "string"
+                                },
+                                "ipRange": {
+                                  "description": "The ip range of the security group rule (deprecated, use ipRanges)",
+                                  "type": "string"
+                                },
+                                "ipRanges": {
+                                  "description": "The list of ip ranges of the security group rule",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "name": {
+                                  "description": "The tag name associate with the security group",
+                                  "type": "string"
+                                },
+                                "resourceId": {
+                                  "description": "The security group rule id",
+                                  "type": "string"
+                                },
+                                "toPortRange": {
+                                  "description": "The end of the port range",
+                                  "format": "int32",
+                                  "type": "integer"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "allowFromIPRanges": {
+                      "description": "The list of IP ranges (in CIDR notation) to restrict bastion/Kubernetes API access to.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "allowToIPRanges": {
+                      "description": "The list of IP ranges (in CIDR notation) the nodes can talk to (\"0.0.0.0/0\" if not set).",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "bastion": {
+                      "description": "The bastion configuration",
+                      "properties": {
+                        "PublicIpId": {
+                          "description": "The ID of an existing public IP to use for this VM.",
+                          "type": "string"
+                        },
+                        "clusterName": {
+                          "description": "unused",
+                          "type": "string"
+                        },
+                        "deviceName": {
+                          "description": "unused",
+                          "type": "string"
+                        },
+                        "enable": {
+                          "type": "boolean"
+                        },
+                        "imageAccountId": {
+                          "type": "string"
+                        },
+                        "imageId": {
+                          "type": "string"
+                        },
+                        "imageName": {
+                          "type": "string"
+                        },
+                        "keypairName": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "privateIps": {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "privateIp": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "publicIpName": {
+                          "description": "unused",
+                          "type": "string"
+                        },
+                        "resourceId": {
+                          "description": "the vm id (deprecated, not set anymore)",
+                          "type": "string"
+                        },
+                        "rootDisk": {
+                          "properties": {
+                            "rootDiskIops": {
+                              "description": "The root disk iops (io1 volumes only) (1500 by default)",
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "rootDiskSize": {
+                              "description": "The volume size in gibibytes (GiB) (60 by default)",
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "rootDiskType": {
+                              "description": "The volume type (io1, gp2 or standard) (io1 by default)",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "securityGroupNames": {
+                          "description": "The list of security groups (deprecated use bastion role in security groups)",
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "subnetName": {
+                          "description": "The subnet of the vm (deprecated use bastion role in subnets)",
+                          "type": "string"
+                        },
+                        "subregionName": {
+                          "description": "unused",
+                          "type": "string"
+                        },
+                        "vmType": {
+                          "description": "The type of VM (tinav6.c1r1p2 by default)",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "clusterName": {
+                      "description": "The name of the cluster (unused)",
+                      "type": "string"
+                    },
+                    "controlPlaneSubnets": {
+                      "description": "List of subnet to spread controlPlane nodes (deprecated, add controlplane role to subnets)",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "disable": {
+                      "description": "List of disabled features (internet = no internet service, no nat services)",
+                      "items": {
+                        "enum": [
+                          "internet",
+                          "loadbalancer"
+                        ],
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "extraSecurityGroupRule": {
+                      "description": "(unused)",
+                      "type": "boolean"
+                    },
+                    "image": {
+                      "description": "The image configuration (unused)",
+                      "properties": {
+                        "accountId": {
+                          "description": "The image account owner ID.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "The image name.",
+                          "type": "string"
+                        },
+                        "outscaleOpenSource": {
+                          "description": "Use an \"Outscale Opensource\" image",
+                          "type": "boolean"
+                        },
+                        "resourceId": {
+                          "description": "unused",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "internetService": {
+                      "description": "The Internet Service configuration",
+                      "properties": {
+                        "clusterName": {
+                          "description": "the name of the cluster (unused)",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "The name of the Internet service",
+                          "type": "string"
+                        },
+                        "resourceId": {
+                          "description": "the Internet Service resource id (unused)",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "loadBalancer": {
+                      "description": "The Load Balancer configuration",
+                      "properties": {
+                        "clusterName": {
+                          "description": "unused",
+                          "type": "string"
+                        },
+                        "healthCheck": {
+                          "description": "The healthCheck configuration of the Load Balancer",
+                          "properties": {
+                            "checkinterval": {
+                              "description": "the time in second between two pings",
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "healthythreshold": {
+                              "description": "the consecutive number of pings which are successful to consider the vm healthy",
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "port": {
+                              "description": "the HealthCheck port number",
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "protocol": {
+                              "description": "The HealthCheck protocol ('HTTP'|'TCP')",
+                              "type": "string"
+                            },
+                            "timeout": {
+                              "description": "the Timeout to consider VM unhealthy",
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "unhealthythreshold": {
+                              "description": "the consecutive number of pings which are failed to consider the vm unhealthy",
+                              "format": "int32",
+                              "type": "integer"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "listener": {
+                          "description": "The Listener configuration of the loadBalancer",
+                          "properties": {
+                            "backendport": {
+                              "description": "The port on which the backend VMs will listen",
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "backendprotocol": {
+                              "description": "The protocol ('HTTP'|'TCP') to route the traffic to the backend vm",
+                              "type": "string"
+                            },
+                            "loadbalancerport": {
+                              "description": "The port on which the loadbalancer will listen",
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "loadbalancerprotocol": {
+                              "description": "the routing protocol ('HTTP'|'TCP')",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "loadbalancername": {
+                          "description": "The Load Balancer unique name",
+                          "type": "string"
+                        },
+                        "loadbalancertype": {
+                          "description": "The Load Balancer type (internet-facing or internal)",
+                          "type": "string"
+                        },
+                        "securitygroupname": {
+                          "description": "The security group name for the load-balancer (deprecated, add loadbalancer role to a security group)",
+                          "type": "string"
+                        },
+                        "subnetname": {
+                          "description": "The subnet name where to add the load balancer (deprecated, add loadbalancer role to a subnet)",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "natPublicIpPool": {
+                      "description": "The IP Pool storing the Nat Services public IPs",
+                      "type": "string"
+                    },
+                    "natService": {
+                      "description": "The Nat Service configuration",
+                      "properties": {
+                        "clusterName": {
+                          "description": "The name of the cluster (unused)",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "The name of the Nat Service",
+                          "type": "string"
+                        },
+                        "publicipname": {
+                          "description": "The Public Ip name (unused)",
+                          "type": "string"
+                        },
+                        "resourceId": {
+                          "description": "The resource id (unused)",
+                          "type": "string"
+                        },
+                        "subnetname": {
+                          "description": "The name of the Subnet to which the Nat Service will be attached (deprecated, add nat role to subnets)",
+                          "type": "string"
+                        },
+                        "subregionName": {
+                          "description": "The name of the Subregion to which the Nat Service will be attached, unless a subnet has been defined (unused)",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "natServices": {
+                      "description": "The Nat Services configuration",
+                      "items": {
+                        "properties": {
+                          "clusterName": {
+                            "description": "The name of the cluster (unused)",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "The name of the Nat Service",
+                            "type": "string"
+                          },
+                          "publicipname": {
+                            "description": "The Public Ip name (unused)",
+                            "type": "string"
+                          },
+                          "resourceId": {
+                            "description": "The resource id (unused)",
+                            "type": "string"
+                          },
+                          "subnetname": {
+                            "description": "The name of the Subnet to which the Nat Service will be attached (deprecated, add nat role to subnets)",
+                            "type": "string"
+                          },
+                          "subregionName": {
+                            "description": "The name of the Subregion to which the Nat Service will be attached, unless a subnet has been defined (unused)",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "net": {
+                      "description": "The Net configuration",
+                      "properties": {
+                        "clusterName": {
+                          "description": "the name of the cluster (unused)",
+                          "type": "string"
+                        },
+                        "ipRange": {
+                          "description": "the ip range in CIDR notation of the Net",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "the network name",
+                          "type": "string"
+                        },
+                        "resourceId": {
+                          "description": "The Id of the Net to reuse (if useExisting.net is set)",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "netAccessPoints": {
+                      "description": "The NetAccessPoints configuration, required if internet is disabled.",
+                      "items": {
+                        "enum": [
+                          "api",
+                          "directlink",
+                          "eim",
+                          "kms",
+                          "lbu",
+                          "oos"
+                        ],
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "netPeering": {
+                      "description": "The NetPeering configuration, required if the load balancer is internal, and management and workload clusters are on separate VPCs.",
+                      "properties": {
+                        "enable": {
+                          "description": "Create a NetPeering between the management and workload VPCs.",
+                          "type": "boolean"
+                        },
+                        "managementAccountId": {
+                          "description": "The management cluster account ID (optional, fetched from the metadata server if not set).",
+                          "type": "string"
+                        },
+                        "managementCredentials": {
+                          "description": "The credentials of the management cluster account. Required if management and workload cluster are not in the same account.",
+                          "properties": {
+                            "fromFile": {
+                              "description": "Load credentials from this file instead of the env.",
+                              "type": "string"
+                            },
+                            "fromSecret": {
+                              "description": "Load credentials from this secret instead of the env.",
+                              "type": "string"
+                            },
+                            "profile": {
+                              "description": "Name of profile stored in file (unused using fromSecret, \"default\" by default).",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "managementNetId": {
+                          "description": "The management cluster net ID (optional, fetched from the metadata server if not set).",
+                          "type": "string"
+                        },
+                        "managementSubnetId": {
+                          "description": "By default, all subnets of managementNetId are routed to the netPeering. If set, only the specified subnet will be routed.",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "publicIps": {
+                      "description": "The Public Ip configuration (unused)",
+                      "items": {
+                        "properties": {
+                          "clusterName": {
+                            "description": "unused",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "The tag name associate with the Public Ip (unused)",
+                            "type": "string"
+                          },
+                          "resourceId": {
+                            "description": "The Public Ip Id response (unused)",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "reconciliationRules": {
+                      "description": "Reconciliation rules (default: {securityGroup, random, 10%}, {*, onChange}). Only the first matching rule applies.",
+                      "items": {
+                        "properties": {
+                          "appliesTo": {
+                            "description": "The list of items this rule applies to (bastion, net, netPeering, netPeering/routes, subnet, internetService, netAccessPoint, natService, routeTable, securityGroup, loadbalancer, vm or * for all)",
+                            "items": {
+                              "enum": [
+                                "bastion",
+                                "net",
+                                "netPeering",
+                                "netPeering/routes",
+                                "subnet",
+                                "internetService",
+                                "netAccessPoint",
+                                "natService",
+                                "routeTable",
+                                "securityGroup",
+                                "loadbalancer",
+                                "vm",
+                                "*"
+                              ],
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "mode": {
+                            "description": "The mode of reconciliation: onChange (only when the spec change, default), always, random (onChange + randomPercent% chance)",
+                            "enum": [
+                              "onChange",
+                              "always",
+                              "random"
+                            ],
+                            "type": "string"
+                          },
+                          "reconciliationChance": {
+                            "description": "The chance (in percent, 1-100) of a reconcilation happening when no change have been detected (when mode=random)",
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "routeTables": {
+                      "description": "The Route Table configuration",
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "description": "The tag name associate with the Route Table",
+                            "type": "string"
+                          },
+                          "resourceId": {
+                            "description": "The resource id (unused)",
+                            "type": "string"
+                          },
+                          "role": {
+                            "description": "The role for this route table",
+                            "type": "string"
+                          },
+                          "routes": {
+                            "description": "The Route configuration",
+                            "items": {
+                              "properties": {
+                                "destination": {
+                                  "description": "the destination match Ip range with CIDR notation",
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "description": "The tag name associate with the Route",
+                                  "type": "string"
+                                },
+                                "resourceId": {
+                                  "description": "The Route Id response",
+                                  "type": "string"
+                                },
+                                "targetName": {
+                                  "description": "The tag name associate with the target resource type",
+                                  "type": "string"
+                                },
+                                "targetType": {
+                                  "description": "The target resource type which can be Internet Service (gateway) or Nat Service (nat-service)",
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "subnets": {
+                            "description": "The subnet tag name associate with a Subnet (deprecated, use roles)",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "subregionName": {
+                            "description": "The subregion for this route table",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "securityGroups": {
+                      "description": "The Security Groups configuration.",
+                      "items": {
+                        "properties": {
+                          "authoritative": {
+                            "description": "Is the Security Group configuration authoritative ? (if yes, all rules not found in configuration will be deleted).",
+                            "type": "boolean"
+                          },
+                          "description": {
+                            "description": "The description of the security group",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "The name of the security group",
+                            "type": "string"
+                          },
+                          "resourceId": {
+                            "description": "When useExisting.securityGroup is set, the id of an existing securityGroup to use.",
+                            "type": "string"
+                          },
+                          "roles": {
+                            "description": "The roles the securityGroup applies to.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "securityGroupRules": {
+                            "description": "The list of rules for this securityGroup.",
+                            "items": {
+                              "properties": {
+                                "flow": {
+                                  "description": "The flow of the security group (inbound or outbound)",
+                                  "type": "string"
+                                },
+                                "fromPortRange": {
+                                  "description": "The beginning of the port range",
+                                  "format": "int32",
+                                  "type": "integer"
+                                },
+                                "ipProtocol": {
+                                  "description": "The ip protocol name (tcp, udp, icmp or -1)",
+                                  "type": "string"
+                                },
+                                "ipRange": {
+                                  "description": "The ip range of the security group rule (deprecated, use ipRanges)",
+                                  "type": "string"
+                                },
+                                "ipRanges": {
+                                  "description": "The list of ip ranges of the security group rule",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "name": {
+                                  "description": "The tag name associate with the security group",
+                                  "type": "string"
+                                },
+                                "resourceId": {
+                                  "description": "The security group rule id",
+                                  "type": "string"
+                                },
+                                "toPortRange": {
+                                  "description": "The end of the port range",
+                                  "format": "int32",
+                                  "type": "integer"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "tag": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "subnets": {
+                      "description": "The Subnets configuration",
+                      "items": {
+                        "properties": {
+                          "ipSubnetRange": {
+                            "description": "the Ip range in CIDR notation of the Subnet",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "The name of the Subnet",
+                            "type": "string"
+                          },
+                          "resourceId": {
+                            "description": "The id of the Subnet to reuse (if useExisting.net is set)",
+                            "type": "string"
+                          },
+                          "roles": {
+                            "description": "The role of the Subnet (controlplane, worker, loadbalancer, bastion or nat)",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "subregionName": {
+                            "description": "The subregion name of the Subnet",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "subregionName": {
+                      "description": "The default subregion name (deprecated, use subregions)",
+                      "type": "string"
+                    },
+                    "subregions": {
+                      "description": "The list of subregions where to deploy this cluster",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "useExisting": {
+                      "description": "Reuse externally managed resources ?",
+                      "properties": {
+                        "net": {
+                          "description": "If set, net, subnets, internet service, nat services and route tables are externally managed",
+                          "type": "boolean"
+                        },
+                        "securityGroups": {
+                          "description": "If set, security groups are externally managed.",
+                          "type": "boolean"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "spec"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "template"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/oscmachine_v1beta1.json
+++ b/infrastructure.cluster.x-k8s.io/oscmachine_v1beta1.json
@@ -1,0 +1,558 @@
+{
+  "description": "OscMachine is the Schema for the oscmachines API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "OscMachineSpec defines the desired state of OscMachine",
+      "properties": {
+        "node": {
+          "properties": {
+            "clusterName": {
+              "description": "unused",
+              "type": "string"
+            },
+            "image": {
+              "properties": {
+                "accountId": {
+                  "description": "The image account owner ID.",
+                  "type": "string"
+                },
+                "name": {
+                  "description": "The image name.",
+                  "type": "string"
+                },
+                "outscaleOpenSource": {
+                  "description": "Use an \"Outscale Opensource\" image",
+                  "type": "boolean"
+                },
+                "resourceId": {
+                  "description": "unused",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "keypair": {
+              "description": "deprecated, use vm.keypairName",
+              "properties": {
+                "clusterName": {
+                  "description": "Deprecated",
+                  "type": "string"
+                },
+                "deleteKeypair": {
+                  "description": "Deprecated",
+                  "type": "boolean"
+                },
+                "name": {
+                  "description": "Deprecated",
+                  "type": "string"
+                },
+                "publicKey": {
+                  "description": "Deprecated",
+                  "type": "string"
+                },
+                "resourceId": {
+                  "description": "Deprecated",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "reconciliationRule": {
+              "description": "Reconciliation rules (default: {*, onChange})",
+              "properties": {
+                "appliesTo": {
+                  "description": "The list of items this rule applies to (bastion, net, netPeering, netPeering/routes, subnet, internetService, netAccessPoint, natService, routeTable, securityGroup, loadbalancer, vm or * for all)",
+                  "items": {
+                    "enum": [
+                      "bastion",
+                      "net",
+                      "netPeering",
+                      "netPeering/routes",
+                      "subnet",
+                      "internetService",
+                      "netAccessPoint",
+                      "natService",
+                      "routeTable",
+                      "securityGroup",
+                      "loadbalancer",
+                      "vm",
+                      "*"
+                    ],
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "mode": {
+                  "description": "The mode of reconciliation: onChange (only when the spec change, default), always, random (onChange + randomPercent% chance)",
+                  "enum": [
+                    "onChange",
+                    "always",
+                    "random"
+                  ],
+                  "type": "string"
+                },
+                "reconciliationChance": {
+                  "description": "The chance (in percent, 1-100) of a reconcilation happening when no change have been detected (when mode=random)",
+                  "type": "integer"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "vm": {
+              "properties": {
+                "clusterName": {
+                  "description": "unused",
+                  "type": "string"
+                },
+                "deviceName": {
+                  "description": "unused",
+                  "type": "string"
+                },
+                "imageId": {
+                  "type": "string"
+                },
+                "keypairName": {
+                  "description": "The keypair name",
+                  "type": "string"
+                },
+                "loadBalancerName": {
+                  "description": "unused",
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "placement": {
+                  "description": "VM placement constraints.",
+                  "properties": {
+                    "attractCluster": {
+                      "description": "Try to put VMs with the same attractCluster value on the same cluster.",
+                      "type": "string"
+                    },
+                    "attractServer": {
+                      "description": "Try to put VMs with the same attractServer value on the same physical server.",
+                      "type": "string"
+                    },
+                    "clusterStrict": {
+                      "description": "clusterStrict makes repulseCluster/attractCluster mandatory. CreateVm will fail if VM placement is not possible.",
+                      "type": "boolean"
+                    },
+                    "repulseCluster": {
+                      "description": "Try to put VMs with the same repulseCluster value on different clusters. Not set by default.",
+                      "type": "string"
+                    },
+                    "repulseServer": {
+                      "description": "Try to put VMs with the same repulseServer value on different physical servers. For workers, set by default to the MachineDeployment name unless RepulseCluster is set.\nDefine to an empty string if you want to disable.",
+                      "type": "string"
+                    },
+                    "serverStrict": {
+                      "description": "serverStrict makes repulseServer/attractServer mandatory. CreateVm will fail if VM placement is not possible.",
+                      "type": "boolean"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "privateIps": {
+                  "items": {
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "privateIp": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "publicIp": {
+                  "description": "If set, a public IP will be configured.",
+                  "type": "boolean"
+                },
+                "publicIpName": {
+                  "description": "unused",
+                  "type": "string"
+                },
+                "publicIpPool": {
+                  "description": "The name of the pool from which public IPs will be picked.",
+                  "type": "string"
+                },
+                "replica": {
+                  "description": "unused",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "resourceId": {
+                  "description": "The resource id of the vm (not set anymore)",
+                  "type": "string"
+                },
+                "role": {
+                  "description": "The node role (controlplane or worker, worker by default).",
+                  "type": "string"
+                },
+                "rootDisk": {
+                  "properties": {
+                    "rootDiskIops": {
+                      "description": "The root disk iops (io1 volumes only) (1500 by default)",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "rootDiskSize": {
+                      "description": "The volume size in gibibytes (GiB) (60 by default)",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "rootDiskType": {
+                      "description": "The volume type (io1, gp2 or standard) (io1 by default)",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "securityGroupNames": {
+                  "description": "The list of security groups to use (deprecated, use controlplane and/or worker roles on security groups)",
+                  "items": {
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "subnetName": {
+                  "description": "The subnet of the node (deprecated, use controlplane and/or worker roles on subnets)",
+                  "type": "string"
+                },
+                "subregionName": {
+                  "description": "The subregion where the machine needs to be placed (deprecated, use subregionNames).",
+                  "type": "string"
+                },
+                "subregionNames": {
+                  "description": "The subregions where the machines needs to be placed.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "tags": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Tags to add to the VM.",
+                  "type": "object"
+                },
+                "vmType": {
+                  "description": "The type of vm (tinav6.c4r8p1 by default)",
+                  "type": "string"
+                },
+                "volumeDeviceName": {
+                  "description": "unused",
+                  "type": "string"
+                },
+                "volumeName": {
+                  "description": "unused",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "keypairName"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "volumes": {
+              "items": {
+                "properties": {
+                  "device": {
+                    "description": "The volume device (/dev/xvdX)",
+                    "type": "string"
+                  },
+                  "fromSnapshot": {
+                    "description": "The id of a snapshot to use as a volume source.",
+                    "type": "string"
+                  },
+                  "iops": {
+                    "description": "The volume iops (io1 volumes only)",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "name": {
+                    "description": "The volume name.",
+                    "type": "string"
+                  },
+                  "resourceId": {
+                    "description": "(unused)",
+                    "type": "string"
+                  },
+                  "size": {
+                    "description": "The volume size in gibibytes (GiB)",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "subregionName": {
+                    "description": "(unused)",
+                    "type": "string"
+                  },
+                  "volumeType": {
+                    "description": "The volume type (io1, gp2 or standard)",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "device"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "providerID": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "OscMachineStatus defines the observed state of OscMachine",
+      "properties": {
+        "addresses": {
+          "items": {
+            "description": "NodeAddress contains information for the node's address.",
+            "properties": {
+              "address": {
+                "description": "The node address.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Node address type, one of Hostname, ExternalIP or InternalIP.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "address",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "conditions": {
+          "description": "Conditions provide observations of the operational state of a Cluster API resource.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed. If that is not known, then using the time when\nthe API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message is a human readable message indicating details about the transition.\nThis field may be empty.",
+                "maxLength": 10240,
+                "minLength": 1,
+                "type": "string"
+              },
+              "reason": {
+                "description": "reason is the reason for the condition's last transition in CamelCase.\nThe specific API may choose whether or not this field is considered a guaranteed API.\nThis field may be empty.",
+                "maxLength": 256,
+                "minLength": 1,
+                "type": "string"
+              },
+              "severity": {
+                "description": "severity provides an explicit classification of Reason code, so the users or machines can immediately\nunderstand the current situation and act accordingly.\nThe Severity field MUST be set only when Status=False.",
+                "maxLength": 32,
+                "type": "string"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.\nMany .condition.type values are consistent across resources like Available, but because arbitrary conditions\ncan be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "maxLength": 256,
+                "minLength": 1,
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "failureDomain": {
+          "type": "string"
+        },
+        "failureMessage": {
+          "type": "string"
+        },
+        "failureReason": {
+          "description": "MachineStatusError defines errors states for Machine objects.",
+          "type": "string"
+        },
+        "node": {
+          "description": "deprecated, replaced by resources",
+          "properties": {
+            "imageRef": {
+              "description": "Image references (not set anymore)",
+              "properties": {
+                "resourceMap": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "keypairRef": {
+              "description": "Keypair references (not set anymore)",
+              "properties": {
+                "resourceMap": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "linkPublicIpRef": {
+              "description": "LinkPublicIp references (not set anymore)",
+              "properties": {
+                "resourceMap": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "publicIpIdRef": {
+              "description": "PublicIp references (not set anymore)",
+              "properties": {
+                "resourceMap": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "vmRef": {
+              "description": "Vm references (not set anymore)",
+              "properties": {
+                "resourceMap": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "volumeRef": {
+              "description": "Volume references (not set anymore)",
+              "properties": {
+                "resourceMap": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "ready": {
+          "type": "boolean"
+        },
+        "reconcilerGeneration": {
+          "additionalProperties": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "type": "object"
+        },
+        "resources": {
+          "properties": {
+            "image": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "publicIps": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "vm": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "volumes": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "vmState": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/infrastructure.cluster.x-k8s.io/oscmachinetemplate_v1beta1.json
+++ b/infrastructure.cluster.x-k8s.io/oscmachinetemplate_v1beta1.json
@@ -1,0 +1,454 @@
+{
+  "description": "OscMachineTemplate is the Schema for the OscMachineTemplate API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "OscMachineTemplateSpec define oscMachine template",
+      "properties": {
+        "template": {
+          "description": "OscMachineTemplateResource is the Schema for the OscMachineTemplate api",
+          "properties": {
+            "metadata": {
+              "description": "ObjectMeta is metadata that all persisted resources must have, which includes all objects\nusers must create. This is a copy of customizable fields from metav1.ObjectMeta.\n\nObjectMeta is embedded in `Machine.Spec`, `MachineDeployment.Template` and `MachineSet.Template`,\nwhich are not top-level Kubernetes objects. Given that metav1.ObjectMeta has lots of special cases\nand read-only fields which end up in the generated CRD validation, having it as a subset simplifies\nthe API and some issues that can impact user experience.\n\nDuring the [upgrade to controller-tools@v2](https://github.com/kubernetes-sigs/cluster-api/pull/1054)\nfor v1alpha2, we noticed a failure would occur running Cluster API test suite against the new CRDs,\nspecifically `spec.metadata.creationTimestamp in body must be of type string: \"null\"`.\nThe investigation showed that `controller-tools@v2` behaves differently than its previous version\nwhen handling types from [metav1](k8s.io/apimachinery/pkg/apis/meta/v1) package.\n\nIn more details, we found that embedded (non-top level) types that embedded `metav1.ObjectMeta`\nhad validation properties, including for `creationTimestamp` (metav1.Time).\nThe `metav1.Time` type specifies a custom json marshaller that, when IsZero() is true, returns `null`\nwhich breaks validation because the field isn't marked as nullable.\n\nIn future versions, controller-tools@v2 might allow overriding the type and validation for embedded\ntypes. When that happens, this hack should be revisited.",
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "annotations is an unstructured key value map stored with a resource that may be\nset by external tools to store and retrieve arbitrary metadata. They are not\nqueryable and should be preserved when modifying objects.\nMore info: http://kubernetes.io/docs/user-guide/annotations",
+                  "type": "object"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "labels is a map of string keys and values that can be used to organize and categorize\n(scope and select) objects. May match selectors of replication controllers\nand services.\nMore info: http://kubernetes.io/docs/user-guide/labels",
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "spec": {
+              "description": "OscMachineSpec defines the desired state of OscMachine",
+              "properties": {
+                "node": {
+                  "properties": {
+                    "clusterName": {
+                      "description": "unused",
+                      "type": "string"
+                    },
+                    "image": {
+                      "properties": {
+                        "accountId": {
+                          "description": "The image account owner ID.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "The image name.",
+                          "type": "string"
+                        },
+                        "outscaleOpenSource": {
+                          "description": "Use an \"Outscale Opensource\" image",
+                          "type": "boolean"
+                        },
+                        "resourceId": {
+                          "description": "unused",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "keypair": {
+                      "description": "deprecated, use vm.keypairName",
+                      "properties": {
+                        "clusterName": {
+                          "description": "Deprecated",
+                          "type": "string"
+                        },
+                        "deleteKeypair": {
+                          "description": "Deprecated",
+                          "type": "boolean"
+                        },
+                        "name": {
+                          "description": "Deprecated",
+                          "type": "string"
+                        },
+                        "publicKey": {
+                          "description": "Deprecated",
+                          "type": "string"
+                        },
+                        "resourceId": {
+                          "description": "Deprecated",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "reconciliationRule": {
+                      "description": "Reconciliation rules (default: {*, onChange})",
+                      "properties": {
+                        "appliesTo": {
+                          "description": "The list of items this rule applies to (bastion, net, netPeering, netPeering/routes, subnet, internetService, netAccessPoint, natService, routeTable, securityGroup, loadbalancer, vm or * for all)",
+                          "items": {
+                            "enum": [
+                              "bastion",
+                              "net",
+                              "netPeering",
+                              "netPeering/routes",
+                              "subnet",
+                              "internetService",
+                              "netAccessPoint",
+                              "natService",
+                              "routeTable",
+                              "securityGroup",
+                              "loadbalancer",
+                              "vm",
+                              "*"
+                            ],
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "mode": {
+                          "description": "The mode of reconciliation: onChange (only when the spec change, default), always, random (onChange + randomPercent% chance)",
+                          "enum": [
+                            "onChange",
+                            "always",
+                            "random"
+                          ],
+                          "type": "string"
+                        },
+                        "reconciliationChance": {
+                          "description": "The chance (in percent, 1-100) of a reconcilation happening when no change have been detected (when mode=random)",
+                          "type": "integer"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "vm": {
+                      "properties": {
+                        "clusterName": {
+                          "description": "unused",
+                          "type": "string"
+                        },
+                        "deviceName": {
+                          "description": "unused",
+                          "type": "string"
+                        },
+                        "imageId": {
+                          "type": "string"
+                        },
+                        "keypairName": {
+                          "description": "The keypair name",
+                          "type": "string"
+                        },
+                        "loadBalancerName": {
+                          "description": "unused",
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "placement": {
+                          "description": "VM placement constraints.",
+                          "properties": {
+                            "attractCluster": {
+                              "description": "Try to put VMs with the same attractCluster value on the same cluster.",
+                              "type": "string"
+                            },
+                            "attractServer": {
+                              "description": "Try to put VMs with the same attractServer value on the same physical server.",
+                              "type": "string"
+                            },
+                            "clusterStrict": {
+                              "description": "clusterStrict makes repulseCluster/attractCluster mandatory. CreateVm will fail if VM placement is not possible.",
+                              "type": "boolean"
+                            },
+                            "repulseCluster": {
+                              "description": "Try to put VMs with the same repulseCluster value on different clusters. Not set by default.",
+                              "type": "string"
+                            },
+                            "repulseServer": {
+                              "description": "Try to put VMs with the same repulseServer value on different physical servers. For workers, set by default to the MachineDeployment name unless RepulseCluster is set.\nDefine to an empty string if you want to disable.",
+                              "type": "string"
+                            },
+                            "serverStrict": {
+                              "description": "serverStrict makes repulseServer/attractServer mandatory. CreateVm will fail if VM placement is not possible.",
+                              "type": "boolean"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "privateIps": {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "privateIp": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "publicIp": {
+                          "description": "If set, a public IP will be configured.",
+                          "type": "boolean"
+                        },
+                        "publicIpName": {
+                          "description": "unused",
+                          "type": "string"
+                        },
+                        "publicIpPool": {
+                          "description": "The name of the pool from which public IPs will be picked.",
+                          "type": "string"
+                        },
+                        "replica": {
+                          "description": "unused",
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "resourceId": {
+                          "description": "The resource id of the vm (not set anymore)",
+                          "type": "string"
+                        },
+                        "role": {
+                          "description": "The node role (controlplane or worker, worker by default).",
+                          "type": "string"
+                        },
+                        "rootDisk": {
+                          "properties": {
+                            "rootDiskIops": {
+                              "description": "The root disk iops (io1 volumes only) (1500 by default)",
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "rootDiskSize": {
+                              "description": "The volume size in gibibytes (GiB) (60 by default)",
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "rootDiskType": {
+                              "description": "The volume type (io1, gp2 or standard) (io1 by default)",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "securityGroupNames": {
+                          "description": "The list of security groups to use (deprecated, use controlplane and/or worker roles on security groups)",
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "subnetName": {
+                          "description": "The subnet of the node (deprecated, use controlplane and/or worker roles on subnets)",
+                          "type": "string"
+                        },
+                        "subregionName": {
+                          "description": "The subregion where the machine needs to be placed (deprecated, use subregionNames).",
+                          "type": "string"
+                        },
+                        "subregionNames": {
+                          "description": "The subregions where the machines needs to be placed.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "tags": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Tags to add to the VM.",
+                          "type": "object"
+                        },
+                        "vmType": {
+                          "description": "The type of vm (tinav6.c4r8p1 by default)",
+                          "type": "string"
+                        },
+                        "volumeDeviceName": {
+                          "description": "unused",
+                          "type": "string"
+                        },
+                        "volumeName": {
+                          "description": "unused",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "keypairName"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "volumes": {
+                      "items": {
+                        "properties": {
+                          "device": {
+                            "description": "The volume device (/dev/xvdX)",
+                            "type": "string"
+                          },
+                          "fromSnapshot": {
+                            "description": "The id of a snapshot to use as a volume source.",
+                            "type": "string"
+                          },
+                          "iops": {
+                            "description": "The volume iops (io1 volumes only)",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "name": {
+                            "description": "The volume name.",
+                            "type": "string"
+                          },
+                          "resourceId": {
+                            "description": "(unused)",
+                            "type": "string"
+                          },
+                          "size": {
+                            "description": "The volume size in gibibytes (GiB)",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "subregionName": {
+                            "description": "(unused)",
+                            "type": "string"
+                          },
+                          "volumeType": {
+                            "description": "The volume type (io1, gp2 or standard)",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "device"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "providerID": {
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "spec"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "template"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "properties": {
+        "capacity": {
+          "additionalProperties": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "string"
+              }
+            ],
+            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+            "x-kubernetes-int-or-string": true
+          },
+          "description": "ResourceList is a set of (resource name, quantity) pairs.",
+          "type": "object"
+        },
+        "conditions": {
+          "description": "Conditions provide observations of the operational state of a Cluster API resource.",
+          "items": {
+            "description": "Condition defines an observation of a Cluster API resource operational state.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed. If that is not known, then using the time when\nthe API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message is a human readable message indicating details about the transition.\nThis field may be empty.",
+                "maxLength": 10240,
+                "minLength": 1,
+                "type": "string"
+              },
+              "reason": {
+                "description": "reason is the reason for the condition's last transition in CamelCase.\nThe specific API may choose whether or not this field is considered a guaranteed API.\nThis field may be empty.",
+                "maxLength": 256,
+                "minLength": 1,
+                "type": "string"
+              },
+              "severity": {
+                "description": "severity provides an explicit classification of Reason code, so the users or machines can immediately\nunderstand the current situation and act accordingly.\nThe Severity field MUST be set only when Status=False.",
+                "maxLength": 32,
+                "type": "string"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.\nMany .condition.type values are consistent across resources like Available, but because arbitrary conditions\ncan be useful (see .node.status.conditions), the ability to deconflict is important.",
+                "maxLength": 256,
+                "minLength": 1,
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}


### PR DESCRIPTION
Here is the [schema definition](https://github.com/outscale/cluster-api-provider-outscale/tree/v1.4.0/config/crd/bases) on GitHub

## PR Checklist

- [x] I generated these CRs using the [CRD Extractor tool](https://github.com/datreeio/CRDs-catalog?tab=readme-ov-file#crd-extractor). If I used a different method, I have described the method in this PR.
- [ ] I am updating existing schemas and have specified the updated schema version.
- [x] I am adding new schemas and included a link to the GitHub repository that contains the source of these schemas.
