### PR TITLE
Add ClusterOriginIssuer v1 schema

### DIFF
--- a/cert-manager.k8s.cloudflare.com/clusteroriginissuer_v1.json
+++ b/cert-manager.k8s.cloudflare.com/clusteroriginissuer_v1.json
@@ -1,0 +1,154 @@
+{
+  "description": "A ClusterOriginIssuer represents the Cloudflare Origin CA as an external cert-manager issuer.\nIt is scoped to a single namespace, so it can be used only by resources in the same\nnamespace.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Spec is the desired state of the ClusterOriginIssuer resource.",
+      "properties": {
+        "auth": {
+          "description": "Auth configures how to authenticate with the Cloudflare API.",
+          "properties": {
+            "serviceKeyRef": {
+              "description": "ServiceKeyRef authenticates with an API Service Key (the \"Origin CA Key\").\nDeprecated: 2026-03-19.",
+              "properties": {
+                "key": {
+                  "description": "Key of the secret to select from. Must be a valid secret key.",
+                  "type": "string"
+                },
+                "name": {
+                  "description": "Name of the secret in the issuer's namespace to select. If a cluster-scoped\nissuer, the secret is selected from the \"cluster resource namespace\" configured\non the controller.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "key",
+                "name"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "tokenRef": {
+              "description": "TokenRef authenticates with an API Token.",
+              "properties": {
+                "key": {
+                  "description": "Key of the secret to select from. Must be a valid secret key.",
+                  "type": "string"
+                },
+                "name": {
+                  "description": "Name of the secret in the issuer's namespace to select. If a cluster-scoped\nissuer, the secret is selected from the \"cluster resource namespace\" configured\non the controller.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "key",
+                "name"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "x-kubernetes-validations": [
+            {
+              "message": "exactly one of the fields in [serviceKeyRef tokenRef] must be set",
+              "rule": "[has(self.serviceKeyRef),has(self.tokenRef)].filter(x,x==true).size() == 1"
+            }
+          ],
+          "additionalProperties": false
+        },
+        "requestType": {
+          "description": "RequestType is the signature algorithm Cloudflare should use to sign the certificate.",
+          "enum": [
+            "OriginRSA",
+            "OriginECC"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "auth",
+        "requestType"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "Status of the ClusterOriginIssuer. This is set and managed automatically.",
+      "properties": {
+        "conditions": {
+          "description": "List of status conditions to indicate the status of an Issuer.\nKnown condition types are `Ready`.",
+          "items": {
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
+                "maxLength": 32768,
+                "type": "string"
+              },
+              "observedGeneration": {
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
+                "format": "int64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "reason": {
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
+                "maxLength": 1024,
+                "minLength": 1,
+                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
+                "type": "string"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "enum": [
+                  "True",
+                  "False",
+                  "Unknown"
+                ],
+                "type": "string"
+              },
+              "type": {
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
+                "maxLength": 316,
+                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "message",
+              "reason",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "type"
+          ],
+          "x-kubernetes-list-type": "map"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}


### PR DESCRIPTION
Generated from the `origin-ca-issuer` CRD using kubeconform's `openapi2jsonschema.py`. The `OriginIssuer` (namespace-scoped) schema already exists; this adds the cluster-scoped variant, `ClusterOriginIssuer`.

Source CRD: https://github.com/cloudflare/origin-ca-issuer/blob/trunk/deploy/crds/cert-manager.k8s.cloudflare.com_clusteroriginissuers.yaml

## PR Checklist
- [x] I generated these CRs using the [CRD Extractor tool](https://github.com/datreeio/CRDs-catalog?tab=readme-ov-file#crd-extractor). If I used a different method, I have described the method in this PR.
- [ ] I am updating existing schemas and have specified the updated schema version.
- [x] I am adding new schemas and included a link to the GitHub repository that contains the source of these schemas.