### PR TITLE
fix: missing external-secrets null byte policy field

### DIFF
--- a/external-secrets.io/externalsecret_v1.json
+++ b/external-secrets.io/externalsecret_v1.json
@@ -56,6 +56,15 @@
                     ],
                     "type": "string"
                   },
+                  "nullBytePolicy": {
+                    "default": "Ignore",
+                    "description": "Controls how ESO handles fetched secret data containing NUL bytes for this source.",
+                    "enum": [
+                      "Ignore",
+                      "Fail"
+                    ],
+                    "type": "string"
+                  },
                   "property": {
                     "description": "Used to select a specific property of the Provider value (if a map), if supported",
                     "type": "string"
@@ -205,6 +214,15 @@
                     ],
                     "type": "string"
                   },
+                  "nullBytePolicy": {
+                    "default": "Ignore",
+                    "description": "Controls how ESO handles fetched secret data containing NUL bytes for this source.",
+                    "enum": [
+                      "Ignore",
+                      "Fail"
+                    ],
+                    "type": "string"
+                  },
                   "property": {
                     "description": "Used to select a specific property of the Provider value (if a map), if supported",
                     "type": "string"
@@ -253,6 +271,15 @@
                     },
                     "type": "object",
                     "additionalProperties": false
+                  },
+                  "nullBytePolicy": {
+                    "default": "Ignore",
+                    "description": "Controls how ESO handles fetched secret data containing NUL bytes for this find source.",
+                    "enum": [
+                      "Ignore",
+                      "Fail"
+                    ],
+                    "type": "string"
                   },
                   "path": {
                     "description": "A root path to start the find operations.",


### PR DESCRIPTION
## PR Checklist

external-secrets introduced a new backward compatible field called nullBytePolicy for how to handle secrets that have no contents.

https://external-secrets.io/main/api/spec/#external-secrets.io/v1.ExternalSecretNullBytePolicy
https://github.com/external-secrets/external-secrets/pull/6194
https://github.com/external-secrets/external-secrets/releases/tag/v2.3.0

- [X] I generated these CRs using the [CRD Extractor tool](https://github.com/datreeio/CRDs-catalog?tab=readme-ov-file#crd-extractor). If I used a different method, I have described the method in this PR.
- [X] I am updating existing schemas and have specified the updated schema version.
- [ ] I am adding new schemas and included a link to the GitHub repository that contains the source of these schemas.
