### PR TITLE
feat(rke-machine-config.cattle.io): add HetznerConfig v1

### DIFF
--- a/rke-machine-config.cattle.io/hetznerconfig_v1.json
+++ b/rke-machine-config.cattle.io/hetznerconfig_v1.json
@@ -1,0 +1,103 @@
+{
+  "description": "HetznerConfig represents the desired configuration of each machine provisioned within a machine pool associated with a provisioning.cattle.io cluster.",
+  "properties": {
+    "apiToken": {
+      "default": "",
+      "description": "Hetzner Cloud API token",
+      "nullable": true,
+      "type": "string"
+    },
+    "autoCreateFirewallRules": {
+      "default": false,
+      "description": "Automatically create firewall rules for RKE2 inter-node communication",
+      "type": "boolean"
+    },
+    "clusterId": {
+      "default": "",
+      "description": "Cluster identifier for shared firewall and resource labeling",
+      "nullable": true,
+      "type": "string"
+    },
+    "createFirewall": {
+      "default": false,
+      "description": "Create a new firewall for the server",
+      "type": "boolean"
+    },
+    "disablePublicIpv4": {
+      "default": false,
+      "description": "Disable public IPv4 address",
+      "type": "boolean"
+    },
+    "disablePublicIpv6": {
+      "default": false,
+      "description": "Disable public IPv6 address",
+      "type": "boolean"
+    },
+    "existingSshKey": {
+      "default": "",
+      "description": "Use an existing SSH key by name or ID (added alongside the auto-generated key)",
+      "nullable": true,
+      "type": "string"
+    },
+    "firewallName": {
+      "default": "",
+      "description": "Name for the created firewall (default: rancher-<cluster-name>)",
+      "nullable": true,
+      "type": "string"
+    },
+    "firewalls": {
+      "description": "Firewall IDs or names to apply to the server",
+      "items": {
+        "nullable": true,
+        "type": "string"
+      },
+      "nullable": true,
+      "type": "array"
+    },
+    "image": {
+      "default": "ubuntu-24.04",
+      "description": "Hetzner Cloud image name or ID (e.g. ubuntu-24.04, debian-12)",
+      "nullable": true,
+      "type": "string"
+    },
+    "networks": {
+      "description": "Network IDs or names to attach to the server",
+      "items": {
+        "nullable": true,
+        "type": "string"
+      },
+      "nullable": true,
+      "type": "array"
+    },
+    "placementGroup": {
+      "default": "",
+      "description": "Placement group ID or name",
+      "nullable": true,
+      "type": "string"
+    },
+    "serverLocation": {
+      "default": "fsn1",
+      "description": "Hetzner Cloud server location (e.g. fsn1, nbg1, hel1)",
+      "nullable": true,
+      "type": "string"
+    },
+    "serverType": {
+      "default": "cx23",
+      "description": "Hetzner Cloud server type (e.g. cx23, cx33, cx43)",
+      "nullable": true,
+      "type": "string"
+    },
+    "usePrivateNetwork": {
+      "default": false,
+      "description": "Use private network for machine communication",
+      "type": "boolean"
+    },
+    "userData": {
+      "default": "",
+      "description": "Cloud-init user data (string or file path)",
+      "nullable": true,
+      "type": "string"
+    }
+  },
+  "type": "object"
+}


### PR DESCRIPTION
## Summary

Adds JSON schema for **`HetznerConfig`** (API group: `rke-machine-config.cattle.io/v1`) — the machine-pool configuration CRD for Rancher clusters provisioned via the Hetzner Cloud node driver on RKE/RKE2.

## Motivation

Before this schema, running `kubeconform` on rendered Rancher cluster-template manifests that include Hetzner nodepools produced warnings:

```
could not find schema for HetznerConfig
```

This prevented full schema validation in CI for any chart or GitOps repository deploying Rancher clusters on Hetzner Cloud — a common pattern for Open edX, K3s, and general Rancher-based SaaS deployments on Hetzner.

## Source

The schema was extracted from the CRD installed by the upstream Hetzner Node Driver (`zsys-studio/rancher-hetzner-cluster-provider`) on a Rancher 2.x management cluster, then converted via the `openapi2jsonschema.py` script shipped with kubeconform.

```
kubectl get crd hetznerconfigs.rke-machine-config.cattle.io -o yaml > hetznerconfig.crd.yaml
python3 openapi2jsonschema.py hetznerconfig.crd.yaml
```

## Verification

Tested against a rendered Rancher cluster-template Helm output with 4 `HetznerConfig` resources:

**Before** (only `default` + datreeio schema-location):
```
Summary: 18 resources found in 1 file - Valid: 16, Invalid: 0, Errors: 0, Skipped: 2
```

**After** (adding this schema locally):
```
Summary: 18 resources found in 1 file - Valid: 18, Invalid: 0, Errors: 0, Skipped: 0
```

Both `HetznerConfig` resources (control-plane pool + worker pool) are now validated.

## License

Apache-2.0 — matches the CRD source project license and the datreeio/CRDs-catalog license.