### PR TITLE
fix: remove namespace from ImageUpdater spec required fields

### DIFF
--- a/argocd-image-updater.argoproj.io/imageupdater_v1alpha1.json
+++ b/argocd-image-updater.argoproj.io/imageupdater_v1alpha1.json
@@ -364,8 +364,7 @@
         }
       },
       "required": [
-        "applicationRefs",
-        "namespace"
+        "applicationRefs"
       ],
       "type": "object",
       "additionalProperties": false

--- a/argocd-image-updater.argoproj.io/imageupdater_v1alpha1.json
+++ b/argocd-image-updater.argoproj.io/imageupdater_v1alpha1.json
@@ -323,10 +323,6 @@
           "type": "object",
           "additionalProperties": false
         },
-        "namespace": {
-          "description": "Namespace indicates the target namespace of the applications.\nThis is the namespace where the controller will look for Argo CD Applications\nmatching the criteria in ApplicationRefs.",
-          "type": "string"
-        },
         "writeBackConfig": {
           "description": "WriteBackConfig provides global default settings for how and where to write back image updates.\nThis can be overridden at the ApplicationRef level.",
           "properties": {


### PR DESCRIPTION
## Summary

The `imageupdater_v1alpha1.json` schema lists `namespace` as required in `spec.required`:

```json
"required": ["applicationRefs", "namespace"]
```

However, the upstream CRD at [argoproj-labs/argocd-image-updater](https://github.com/argoproj-labs/argocd-image-updater/blob/main/config/crd/bases/argocd-image-updater.argoproj.io_imageupdaters.yaml) only requires `applicationRefs`:

```yaml
required:
- applicationRefs
```

The `namespace` field was deprecated in argocd-image-updater v1.1.1+ in favor of `metadata.namespace` for Application discovery.

This causes kubeconform to reject valid manifests that follow the latest CRD spec.

Fixes #853