### PR TITLE
services.k8s.aws: Add the IAMRoleSelector CRD

### DIFF
--- a/services.k8s.aws/iamroleselector_v1alpha1.json
+++ b/services.k8s.aws/iamroleselector_v1alpha1.json
@@ -1,0 +1,109 @@
+{
+  "description": "IAMRoleSelector is the schema for the IAMRoleSelector API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "properties": {
+        "arn": {
+          "type": "string",
+          "x-kubernetes-validations": [
+            {
+              "message": "Value is immutable once set",
+              "rule": "self == oldSelf"
+            }
+          ]
+        },
+        "namespaceSelector": {
+          "description": "IAMRoleSelectorSpec defines the desired state of IAMRoleSelector",
+          "properties": {
+            "labelSelector": {
+              "description": "LabelSelector is a label query over a set of resources.",
+              "properties": {
+                "matchLabels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                }
+              },
+              "required": [
+                "matchLabels"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "names": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "names"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "resourceLabelSelector": {
+          "description": "LabelSelector is a label query over a set of resources.",
+          "properties": {
+            "matchLabels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            }
+          },
+          "required": [
+            "matchLabels"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "resourceTypeSelector": {
+          "items": {
+            "properties": {
+              "group": {
+                "type": "string"
+              },
+              "kind": {
+                "type": "string"
+              },
+              "version": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "group",
+              "kind",
+              "version"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "arn"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "type": "object"
+    }
+  },
+  "type": "object"
+}


### PR DESCRIPTION
The CRD was retrieved from
https://github.com/aws-controllers-k8s/iam-controller/blob/main/config/crd/common/bases/services.k8s.aws_iamroleselectors.yaml.

## Extraction method

I didn't want to point crd-extractor at a productionc cluster, so I grabbed the CRD from the upstream repository (link above)

```
curl -L -o /tmp/iamroleselectors.services.k8s.aws.yaml https://raw.githubusercontent.com/aws-controllers-k8s/iam-controller/refs/heads/main/config/crd/common/bases/services.k8s.aws_iamroleselectors.yaml
```

and ran `openapi2jsonschema.py` directly

```
cd Utilities
devbox run python3 openapi2jsonschema.py /tmp/iamroleselectors.services.k8s.aws.yaml
```

before moving the resulting file into the correct location

```
mv iamroleselector_v1alpha1.json ../services.k8s.aws/
```

## PR Checklist

- [ ] I generated these CRs using the [CRD Extractor tool](https://github.com/datreeio/CRDs-catalog?tab=readme-ov-file#crd-extractor). If I used a different method, I have described the method in this PR.
- [ ] I am updating existing schemas and have specified the updated schema version.
- [x] I am adding new schemas and included a link to the GitHub repository that contains the source of these schemas.