### PR TITLE
update: renovate-operator.mogenius.com renovatejob_v1alpha1

### DIFF
--- a/renovate-operator.mogenius.com/renovatejob_v1alpha1.json
+++ b/renovate-operator.mogenius.com/renovatejob_v1alpha1.json
@@ -1,3749 +1,3687 @@
 {
-    "properties": {
-        "apiVersion": {
-            "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
-            "type": "string"
-        },
-        "kind": {
-            "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-            "type": "string"
-        },
-        "metadata": {
-            "type": "object"
-        },
-        "spec": {
-            "description": "RenovateJobSpec defines the desired state of RenovateJob",
-            "properties": {
-                "affinity": {
-                    "description": "Affinity settings for scheduling the resulting pod",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "RenovateJobSpec defines the desired state of RenovateJob",
+      "properties": {
+        "affinity": {
+          "description": "Affinity settings for scheduling the resulting pod",
+          "properties": {
+            "nodeAffinity": {
+              "description": "Describes node affinity scheduling rules for the pod.",
+              "properties": {
+                "preferredDuringSchedulingIgnoredDuringExecution": {
+                  "description": "The scheduler will prefer to schedule pods to nodes that satisfy\nthe affinity expressions specified by this field, but it may choose\na node that violates one or more of the expressions. The node that is\nmost preferred is the one with the greatest sum of weights, i.e.\nfor each node that meets all of the scheduling requirements (resource\nrequest, requiredDuringScheduling affinity expressions, etc.),\ncompute a sum by iterating through the elements of this field and adding\n\"weight\" to the sum if the node matches the corresponding matchExpressions; the\nnode(s) with the highest sum are the most preferred.",
+                  "items": {
+                    "description": "An empty preferred scheduling term matches all objects with implicit weight 0\n(i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).",
                     "properties": {
-                        "nodeAffinity": {
-                            "description": "Describes node affinity scheduling rules for the pod.",
-                            "properties": {
-                                "preferredDuringSchedulingIgnoredDuringExecution": {
-                                    "description": "The scheduler will prefer to schedule pods to nodes that satisfy\nthe affinity expressions specified by this field, but it may choose\na node that violates one or more of the expressions. The node that is\nmost preferred is the one with the greatest sum of weights, i.e.\nfor each node that meets all of the scheduling requirements (resource\nrequest, requiredDuringScheduling affinity expressions, etc.),\ncompute a sum by iterating through the elements of this field and adding\n\"weight\" to the sum if the node matches the corresponding matchExpressions; the\nnode(s) with the highest sum are the most preferred.",
-                                    "items": {
-                                        "description": "An empty preferred scheduling term matches all objects with implicit weight 0\n(i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).",
-                                        "properties": {
-                                            "preference": {
-                                                "description": "A node selector term, associated with the corresponding weight.",
-                                                "properties": {
-                                                    "matchExpressions": {
-                                                        "description": "A list of node selector requirements by node's labels.",
-                                                        "items": {
-                                                            "description": "A node selector requirement is a selector that contains values, a key, and an operator\nthat relates the key and values.",
-                                                            "properties": {
-                                                                "key": {
-                                                                    "description": "The label key that the selector applies to.",
-                                                                    "type": "string"
-                                                                },
-                                                                "operator": {
-                                                                    "description": "Represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
-                                                                    "type": "string"
-                                                                },
-                                                                "values": {
-                                                                    "description": "An array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. If the operator is Gt or Lt, the values\narray must have a single element, which will be interpreted as an integer.\nThis array is replaced during a strategic merge patch.",
-                                                                    "items": {
-                                                                        "type": "string"
-                                                                    },
-                                                                    "type": "array",
-                                                                    "x-kubernetes-list-type": "atomic"
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "key",
-                                                                "operator"
-                                                            ],
-                                                            "type": "object",
-                                                            "additionalProperties": false
-                                                        },
-                                                        "type": "array",
-                                                        "x-kubernetes-list-type": "atomic"
-                                                    },
-                                                    "matchFields": {
-                                                        "description": "A list of node selector requirements by node's fields.",
-                                                        "items": {
-                                                            "description": "A node selector requirement is a selector that contains values, a key, and an operator\nthat relates the key and values.",
-                                                            "properties": {
-                                                                "key": {
-                                                                    "description": "The label key that the selector applies to.",
-                                                                    "type": "string"
-                                                                },
-                                                                "operator": {
-                                                                    "description": "Represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
-                                                                    "type": "string"
-                                                                },
-                                                                "values": {
-                                                                    "description": "An array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. If the operator is Gt or Lt, the values\narray must have a single element, which will be interpreted as an integer.\nThis array is replaced during a strategic merge patch.",
-                                                                    "items": {
-                                                                        "type": "string"
-                                                                    },
-                                                                    "type": "array",
-                                                                    "x-kubernetes-list-type": "atomic"
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "key",
-                                                                "operator"
-                                                            ],
-                                                            "type": "object",
-                                                            "additionalProperties": false
-                                                        },
-                                                        "type": "array",
-                                                        "x-kubernetes-list-type": "atomic"
-                                                    }
-                                                },
-                                                "type": "object",
-                                                "x-kubernetes-map-type": "atomic",
-                                                "additionalProperties": false
-                                            },
-                                            "weight": {
-                                                "description": "Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.",
-                                                "format": "int32",
-                                                "type": "integer",
-                                                "minimum": -2147483648,
-                                                "maximum": 2147483647
-                                            }
-                                        },
-                                        "required": [
-                                            "preference",
-                                            "weight"
-                                        ],
-                                        "type": "object",
-                                        "additionalProperties": false
-                                    },
-                                    "type": "array",
-                                    "x-kubernetes-list-type": "atomic"
+                      "preference": {
+                        "description": "A node selector term, associated with the corresponding weight.",
+                        "properties": {
+                          "matchExpressions": {
+                            "description": "A list of node selector requirements by node's labels.",
+                            "items": {
+                              "description": "A node selector requirement is a selector that contains values, a key, and an operator\nthat relates the key and values.",
+                              "properties": {
+                                "key": {
+                                  "description": "The label key that the selector applies to.",
+                                  "type": "string"
                                 },
-                                "requiredDuringSchedulingIgnoredDuringExecution": {
-                                    "description": "If the affinity requirements specified by this field are not met at\nscheduling time, the pod will not be scheduled onto the node.\nIf the affinity requirements specified by this field cease to be met\nat some point during pod execution (e.g. due to an update), the system\nmay or may not try to eventually evict the pod from its node.",
-                                    "properties": {
-                                        "nodeSelectorTerms": {
-                                            "description": "Required. A list of node selector terms. The terms are ORed.",
-                                            "items": {
-                                                "description": "A null or empty node selector term matches no objects. The requirements of\nthem are ANDed.\nThe TopologySelectorTerm type implements a subset of the NodeSelectorTerm.",
-                                                "properties": {
-                                                    "matchExpressions": {
-                                                        "description": "A list of node selector requirements by node's labels.",
-                                                        "items": {
-                                                            "description": "A node selector requirement is a selector that contains values, a key, and an operator\nthat relates the key and values.",
-                                                            "properties": {
-                                                                "key": {
-                                                                    "description": "The label key that the selector applies to.",
-                                                                    "type": "string"
-                                                                },
-                                                                "operator": {
-                                                                    "description": "Represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
-                                                                    "type": "string"
-                                                                },
-                                                                "values": {
-                                                                    "description": "An array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. If the operator is Gt or Lt, the values\narray must have a single element, which will be interpreted as an integer.\nThis array is replaced during a strategic merge patch.",
-                                                                    "items": {
-                                                                        "type": "string"
-                                                                    },
-                                                                    "type": "array",
-                                                                    "x-kubernetes-list-type": "atomic"
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "key",
-                                                                "operator"
-                                                            ],
-                                                            "type": "object",
-                                                            "additionalProperties": false
-                                                        },
-                                                        "type": "array",
-                                                        "x-kubernetes-list-type": "atomic"
-                                                    },
-                                                    "matchFields": {
-                                                        "description": "A list of node selector requirements by node's fields.",
-                                                        "items": {
-                                                            "description": "A node selector requirement is a selector that contains values, a key, and an operator\nthat relates the key and values.",
-                                                            "properties": {
-                                                                "key": {
-                                                                    "description": "The label key that the selector applies to.",
-                                                                    "type": "string"
-                                                                },
-                                                                "operator": {
-                                                                    "description": "Represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
-                                                                    "type": "string"
-                                                                },
-                                                                "values": {
-                                                                    "description": "An array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. If the operator is Gt or Lt, the values\narray must have a single element, which will be interpreted as an integer.\nThis array is replaced during a strategic merge patch.",
-                                                                    "items": {
-                                                                        "type": "string"
-                                                                    },
-                                                                    "type": "array",
-                                                                    "x-kubernetes-list-type": "atomic"
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "key",
-                                                                "operator"
-                                                            ],
-                                                            "type": "object",
-                                                            "additionalProperties": false
-                                                        },
-                                                        "type": "array",
-                                                        "x-kubernetes-list-type": "atomic"
-                                                    }
-                                                },
-                                                "type": "object",
-                                                "x-kubernetes-map-type": "atomic",
-                                                "additionalProperties": false
-                                            },
-                                            "type": "array",
-                                            "x-kubernetes-list-type": "atomic"
-                                        }
-                                    },
-                                    "required": [
-                                        "nodeSelectorTerms"
-                                    ],
-                                    "type": "object",
-                                    "x-kubernetes-map-type": "atomic",
-                                    "additionalProperties": false
+                                "operator": {
+                                  "description": "Represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "An array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. If the operator is Gt or Lt, the values\narray must have a single element, which will be interpreted as an integer.\nThis array is replaced during a strategic merge patch.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
                             },
-                            "type": "object",
-                            "additionalProperties": false
-                        },
-                        "podAffinity": {
-                            "description": "Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).",
-                            "properties": {
-                                "preferredDuringSchedulingIgnoredDuringExecution": {
-                                    "description": "The scheduler will prefer to schedule pods to nodes that satisfy\nthe affinity expressions specified by this field, but it may choose\na node that violates one or more of the expressions. The node that is\nmost preferred is the one with the greatest sum of weights, i.e.\nfor each node that meets all of the scheduling requirements (resource\nrequest, requiredDuringScheduling affinity expressions, etc.),\ncompute a sum by iterating through the elements of this field and adding\n\"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the\nnode(s) with the highest sum are the most preferred.",
-                                    "items": {
-                                        "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
-                                        "properties": {
-                                            "podAffinityTerm": {
-                                                "description": "Required. A pod affinity term, associated with the corresponding weight.",
-                                                "properties": {
-                                                    "labelSelector": {
-                                                        "description": "A label query over a set of resources, in this case pods.\nIf it's null, this PodAffinityTerm matches with no Pods.",
-                                                        "properties": {
-                                                            "matchExpressions": {
-                                                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
-                                                                "items": {
-                                                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
-                                                                    "properties": {
-                                                                        "key": {
-                                                                            "description": "key is the label key that the selector applies to.",
-                                                                            "type": "string"
-                                                                        },
-                                                                        "operator": {
-                                                                            "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
-                                                                            "type": "string"
-                                                                        },
-                                                                        "values": {
-                                                                            "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
-                                                                            "items": {
-                                                                                "type": "string"
-                                                                            },
-                                                                            "type": "array",
-                                                                            "x-kubernetes-list-type": "atomic"
-                                                                        }
-                                                                    },
-                                                                    "required": [
-                                                                        "key",
-                                                                        "operator"
-                                                                    ],
-                                                                    "type": "object",
-                                                                    "additionalProperties": false
-                                                                },
-                                                                "type": "array",
-                                                                "x-kubernetes-list-type": "atomic"
-                                                            },
-                                                            "matchLabels": {
-                                                                "additionalProperties": {
-                                                                    "type": "string"
-                                                                },
-                                                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                                                                "type": "object"
-                                                            }
-                                                        },
-                                                        "type": "object",
-                                                        "x-kubernetes-map-type": "atomic",
-                                                        "additionalProperties": false
-                                                    },
-                                                    "matchLabelKeys": {
-                                                        "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both matchLabelKeys and labelSelector.\nAlso, matchLabelKeys cannot be set when labelSelector isn't set.",
-                                                        "items": {
-                                                            "type": "string"
-                                                        },
-                                                        "type": "array",
-                                                        "x-kubernetes-list-type": "atomic"
-                                                    },
-                                                    "mismatchLabelKeys": {
-                                                        "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both mismatchLabelKeys and labelSelector.\nAlso, mismatchLabelKeys cannot be set when labelSelector isn't set.",
-                                                        "items": {
-                                                            "type": "string"
-                                                        },
-                                                        "type": "array",
-                                                        "x-kubernetes-list-type": "atomic"
-                                                    },
-                                                    "namespaceSelector": {
-                                                        "description": "A label query over the set of namespaces that the term applies to.\nThe term is applied to the union of the namespaces selected by this field\nand the ones listed in the namespaces field.\nnull selector and null or empty namespaces list means \"this pod's namespace\".\nAn empty selector ({}) matches all namespaces.",
-                                                        "properties": {
-                                                            "matchExpressions": {
-                                                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
-                                                                "items": {
-                                                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
-                                                                    "properties": {
-                                                                        "key": {
-                                                                            "description": "key is the label key that the selector applies to.",
-                                                                            "type": "string"
-                                                                        },
-                                                                        "operator": {
-                                                                            "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
-                                                                            "type": "string"
-                                                                        },
-                                                                        "values": {
-                                                                            "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
-                                                                            "items": {
-                                                                                "type": "string"
-                                                                            },
-                                                                            "type": "array",
-                                                                            "x-kubernetes-list-type": "atomic"
-                                                                        }
-                                                                    },
-                                                                    "required": [
-                                                                        "key",
-                                                                        "operator"
-                                                                    ],
-                                                                    "type": "object",
-                                                                    "additionalProperties": false
-                                                                },
-                                                                "type": "array",
-                                                                "x-kubernetes-list-type": "atomic"
-                                                            },
-                                                            "matchLabels": {
-                                                                "additionalProperties": {
-                                                                    "type": "string"
-                                                                },
-                                                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                                                                "type": "object"
-                                                            }
-                                                        },
-                                                        "type": "object",
-                                                        "x-kubernetes-map-type": "atomic",
-                                                        "additionalProperties": false
-                                                    },
-                                                    "namespaces": {
-                                                        "description": "namespaces specifies a static list of namespace names that the term applies to.\nThe term is applied to the union of the namespaces listed in this field\nand the ones selected by namespaceSelector.\nnull or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
-                                                        "items": {
-                                                            "type": "string"
-                                                        },
-                                                        "type": "array",
-                                                        "x-kubernetes-list-type": "atomic"
-                                                    },
-                                                    "topologyKey": {
-                                                        "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
-                                                        "type": "string"
-                                                    }
-                                                },
-                                                "required": [
-                                                    "topologyKey"
-                                                ],
-                                                "type": "object",
-                                                "additionalProperties": false
-                                            },
-                                            "weight": {
-                                                "description": "weight associated with matching the corresponding podAffinityTerm,\nin the range 1-100.",
-                                                "format": "int32",
-                                                "type": "integer",
-                                                "minimum": -2147483648,
-                                                "maximum": 2147483647
-                                            }
-                                        },
-                                        "required": [
-                                            "podAffinityTerm",
-                                            "weight"
-                                        ],
-                                        "type": "object",
-                                        "additionalProperties": false
-                                    },
-                                    "type": "array",
-                                    "x-kubernetes-list-type": "atomic"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "matchFields": {
+                            "description": "A list of node selector requirements by node's fields.",
+                            "items": {
+                              "description": "A node selector requirement is a selector that contains values, a key, and an operator\nthat relates the key and values.",
+                              "properties": {
+                                "key": {
+                                  "description": "The label key that the selector applies to.",
+                                  "type": "string"
                                 },
-                                "requiredDuringSchedulingIgnoredDuringExecution": {
-                                    "description": "If the affinity requirements specified by this field are not met at\nscheduling time, the pod will not be scheduled onto the node.\nIf the affinity requirements specified by this field cease to be met\nat some point during pod execution (e.g. due to a pod label update), the\nsystem may or may not try to eventually evict the pod from its node.\nWhen there are multiple elements, the lists of nodes corresponding to each\npodAffinityTerm are intersected, i.e. all terms must be satisfied.",
-                                    "items": {
-                                        "description": "Defines a set of pods (namely those matching the labelSelector\nrelative to the given namespace(s)) that this pod should be\nco-located (affinity) or not co-located (anti-affinity) with,\nwhere co-located is defined as running on a node whose value of\nthe label with key <topologyKey> matches that of any node on which\na pod of the set of pods is running",
-                                        "properties": {
-                                            "labelSelector": {
-                                                "description": "A label query over a set of resources, in this case pods.\nIf it's null, this PodAffinityTerm matches with no Pods.",
-                                                "properties": {
-                                                    "matchExpressions": {
-                                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
-                                                        "items": {
-                                                            "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
-                                                            "properties": {
-                                                                "key": {
-                                                                    "description": "key is the label key that the selector applies to.",
-                                                                    "type": "string"
-                                                                },
-                                                                "operator": {
-                                                                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
-                                                                    "type": "string"
-                                                                },
-                                                                "values": {
-                                                                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
-                                                                    "items": {
-                                                                        "type": "string"
-                                                                    },
-                                                                    "type": "array",
-                                                                    "x-kubernetes-list-type": "atomic"
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "key",
-                                                                "operator"
-                                                            ],
-                                                            "type": "object",
-                                                            "additionalProperties": false
-                                                        },
-                                                        "type": "array",
-                                                        "x-kubernetes-list-type": "atomic"
-                                                    },
-                                                    "matchLabels": {
-                                                        "additionalProperties": {
-                                                            "type": "string"
-                                                        },
-                                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                                                        "type": "object"
-                                                    }
-                                                },
-                                                "type": "object",
-                                                "x-kubernetes-map-type": "atomic",
-                                                "additionalProperties": false
-                                            },
-                                            "matchLabelKeys": {
-                                                "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both matchLabelKeys and labelSelector.\nAlso, matchLabelKeys cannot be set when labelSelector isn't set.",
-                                                "items": {
-                                                    "type": "string"
-                                                },
-                                                "type": "array",
-                                                "x-kubernetes-list-type": "atomic"
-                                            },
-                                            "mismatchLabelKeys": {
-                                                "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both mismatchLabelKeys and labelSelector.\nAlso, mismatchLabelKeys cannot be set when labelSelector isn't set.",
-                                                "items": {
-                                                    "type": "string"
-                                                },
-                                                "type": "array",
-                                                "x-kubernetes-list-type": "atomic"
-                                            },
-                                            "namespaceSelector": {
-                                                "description": "A label query over the set of namespaces that the term applies to.\nThe term is applied to the union of the namespaces selected by this field\nand the ones listed in the namespaces field.\nnull selector and null or empty namespaces list means \"this pod's namespace\".\nAn empty selector ({}) matches all namespaces.",
-                                                "properties": {
-                                                    "matchExpressions": {
-                                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
-                                                        "items": {
-                                                            "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
-                                                            "properties": {
-                                                                "key": {
-                                                                    "description": "key is the label key that the selector applies to.",
-                                                                    "type": "string"
-                                                                },
-                                                                "operator": {
-                                                                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
-                                                                    "type": "string"
-                                                                },
-                                                                "values": {
-                                                                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
-                                                                    "items": {
-                                                                        "type": "string"
-                                                                    },
-                                                                    "type": "array",
-                                                                    "x-kubernetes-list-type": "atomic"
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "key",
-                                                                "operator"
-                                                            ],
-                                                            "type": "object",
-                                                            "additionalProperties": false
-                                                        },
-                                                        "type": "array",
-                                                        "x-kubernetes-list-type": "atomic"
-                                                    },
-                                                    "matchLabels": {
-                                                        "additionalProperties": {
-                                                            "type": "string"
-                                                        },
-                                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                                                        "type": "object"
-                                                    }
-                                                },
-                                                "type": "object",
-                                                "x-kubernetes-map-type": "atomic",
-                                                "additionalProperties": false
-                                            },
-                                            "namespaces": {
-                                                "description": "namespaces specifies a static list of namespace names that the term applies to.\nThe term is applied to the union of the namespaces listed in this field\nand the ones selected by namespaceSelector.\nnull or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
-                                                "items": {
-                                                    "type": "string"
-                                                },
-                                                "type": "array",
-                                                "x-kubernetes-list-type": "atomic"
-                                            },
-                                            "topologyKey": {
-                                                "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
-                                                "type": "string"
-                                            }
-                                        },
-                                        "required": [
-                                            "topologyKey"
-                                        ],
-                                        "type": "object",
-                                        "additionalProperties": false
-                                    },
-                                    "type": "array",
-                                    "x-kubernetes-list-type": "atomic"
+                                "operator": {
+                                  "description": "Represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "An array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. If the operator is Gt or Lt, the values\narray must have a single element, which will be interpreted as an integer.\nThis array is replaced during a strategic merge patch.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
                             },
-                            "type": "object",
-                            "additionalProperties": false
-                        },
-                        "podAntiAffinity": {
-                            "description": "Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).",
-                            "properties": {
-                                "preferredDuringSchedulingIgnoredDuringExecution": {
-                                    "description": "The scheduler will prefer to schedule pods to nodes that satisfy\nthe anti-affinity expressions specified by this field, but it may choose\na node that violates one or more of the expressions. The node that is\nmost preferred is the one with the greatest sum of weights, i.e.\nfor each node that meets all of the scheduling requirements (resource\nrequest, requiredDuringScheduling anti-affinity expressions, etc.),\ncompute a sum by iterating through the elements of this field and subtracting\n\"weight\" from the sum if the node has pods which matches the corresponding podAffinityTerm; the\nnode(s) with the highest sum are the most preferred.",
-                                    "items": {
-                                        "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
-                                        "properties": {
-                                            "podAffinityTerm": {
-                                                "description": "Required. A pod affinity term, associated with the corresponding weight.",
-                                                "properties": {
-                                                    "labelSelector": {
-                                                        "description": "A label query over a set of resources, in this case pods.\nIf it's null, this PodAffinityTerm matches with no Pods.",
-                                                        "properties": {
-                                                            "matchExpressions": {
-                                                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
-                                                                "items": {
-                                                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
-                                                                    "properties": {
-                                                                        "key": {
-                                                                            "description": "key is the label key that the selector applies to.",
-                                                                            "type": "string"
-                                                                        },
-                                                                        "operator": {
-                                                                            "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
-                                                                            "type": "string"
-                                                                        },
-                                                                        "values": {
-                                                                            "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
-                                                                            "items": {
-                                                                                "type": "string"
-                                                                            },
-                                                                            "type": "array",
-                                                                            "x-kubernetes-list-type": "atomic"
-                                                                        }
-                                                                    },
-                                                                    "required": [
-                                                                        "key",
-                                                                        "operator"
-                                                                    ],
-                                                                    "type": "object",
-                                                                    "additionalProperties": false
-                                                                },
-                                                                "type": "array",
-                                                                "x-kubernetes-list-type": "atomic"
-                                                            },
-                                                            "matchLabels": {
-                                                                "additionalProperties": {
-                                                                    "type": "string"
-                                                                },
-                                                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                                                                "type": "object"
-                                                            }
-                                                        },
-                                                        "type": "object",
-                                                        "x-kubernetes-map-type": "atomic",
-                                                        "additionalProperties": false
-                                                    },
-                                                    "matchLabelKeys": {
-                                                        "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both matchLabelKeys and labelSelector.\nAlso, matchLabelKeys cannot be set when labelSelector isn't set.",
-                                                        "items": {
-                                                            "type": "string"
-                                                        },
-                                                        "type": "array",
-                                                        "x-kubernetes-list-type": "atomic"
-                                                    },
-                                                    "mismatchLabelKeys": {
-                                                        "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both mismatchLabelKeys and labelSelector.\nAlso, mismatchLabelKeys cannot be set when labelSelector isn't set.",
-                                                        "items": {
-                                                            "type": "string"
-                                                        },
-                                                        "type": "array",
-                                                        "x-kubernetes-list-type": "atomic"
-                                                    },
-                                                    "namespaceSelector": {
-                                                        "description": "A label query over the set of namespaces that the term applies to.\nThe term is applied to the union of the namespaces selected by this field\nand the ones listed in the namespaces field.\nnull selector and null or empty namespaces list means \"this pod's namespace\".\nAn empty selector ({}) matches all namespaces.",
-                                                        "properties": {
-                                                            "matchExpressions": {
-                                                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
-                                                                "items": {
-                                                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
-                                                                    "properties": {
-                                                                        "key": {
-                                                                            "description": "key is the label key that the selector applies to.",
-                                                                            "type": "string"
-                                                                        },
-                                                                        "operator": {
-                                                                            "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
-                                                                            "type": "string"
-                                                                        },
-                                                                        "values": {
-                                                                            "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
-                                                                            "items": {
-                                                                                "type": "string"
-                                                                            },
-                                                                            "type": "array",
-                                                                            "x-kubernetes-list-type": "atomic"
-                                                                        }
-                                                                    },
-                                                                    "required": [
-                                                                        "key",
-                                                                        "operator"
-                                                                    ],
-                                                                    "type": "object",
-                                                                    "additionalProperties": false
-                                                                },
-                                                                "type": "array",
-                                                                "x-kubernetes-list-type": "atomic"
-                                                            },
-                                                            "matchLabels": {
-                                                                "additionalProperties": {
-                                                                    "type": "string"
-                                                                },
-                                                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                                                                "type": "object"
-                                                            }
-                                                        },
-                                                        "type": "object",
-                                                        "x-kubernetes-map-type": "atomic",
-                                                        "additionalProperties": false
-                                                    },
-                                                    "namespaces": {
-                                                        "description": "namespaces specifies a static list of namespace names that the term applies to.\nThe term is applied to the union of the namespaces listed in this field\nand the ones selected by namespaceSelector.\nnull or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
-                                                        "items": {
-                                                            "type": "string"
-                                                        },
-                                                        "type": "array",
-                                                        "x-kubernetes-list-type": "atomic"
-                                                    },
-                                                    "topologyKey": {
-                                                        "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
-                                                        "type": "string"
-                                                    }
-                                                },
-                                                "required": [
-                                                    "topologyKey"
-                                                ],
-                                                "type": "object",
-                                                "additionalProperties": false
-                                            },
-                                            "weight": {
-                                                "description": "weight associated with matching the corresponding podAffinityTerm,\nin the range 1-100.",
-                                                "format": "int32",
-                                                "type": "integer",
-                                                "minimum": -2147483648,
-                                                "maximum": 2147483647
-                                            }
-                                        },
-                                        "required": [
-                                            "podAffinityTerm",
-                                            "weight"
-                                        ],
-                                        "type": "object",
-                                        "additionalProperties": false
-                                    },
-                                    "type": "array",
-                                    "x-kubernetes-list-type": "atomic"
-                                },
-                                "requiredDuringSchedulingIgnoredDuringExecution": {
-                                    "description": "If the anti-affinity requirements specified by this field are not met at\nscheduling time, the pod will not be scheduled onto the node.\nIf the anti-affinity requirements specified by this field cease to be met\nat some point during pod execution (e.g. due to a pod label update), the\nsystem may or may not try to eventually evict the pod from its node.\nWhen there are multiple elements, the lists of nodes corresponding to each\npodAffinityTerm are intersected, i.e. all terms must be satisfied.",
-                                    "items": {
-                                        "description": "Defines a set of pods (namely those matching the labelSelector\nrelative to the given namespace(s)) that this pod should be\nco-located (affinity) or not co-located (anti-affinity) with,\nwhere co-located is defined as running on a node whose value of\nthe label with key <topologyKey> matches that of any node on which\na pod of the set of pods is running",
-                                        "properties": {
-                                            "labelSelector": {
-                                                "description": "A label query over a set of resources, in this case pods.\nIf it's null, this PodAffinityTerm matches with no Pods.",
-                                                "properties": {
-                                                    "matchExpressions": {
-                                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
-                                                        "items": {
-                                                            "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
-                                                            "properties": {
-                                                                "key": {
-                                                                    "description": "key is the label key that the selector applies to.",
-                                                                    "type": "string"
-                                                                },
-                                                                "operator": {
-                                                                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
-                                                                    "type": "string"
-                                                                },
-                                                                "values": {
-                                                                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
-                                                                    "items": {
-                                                                        "type": "string"
-                                                                    },
-                                                                    "type": "array",
-                                                                    "x-kubernetes-list-type": "atomic"
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "key",
-                                                                "operator"
-                                                            ],
-                                                            "type": "object",
-                                                            "additionalProperties": false
-                                                        },
-                                                        "type": "array",
-                                                        "x-kubernetes-list-type": "atomic"
-                                                    },
-                                                    "matchLabels": {
-                                                        "additionalProperties": {
-                                                            "type": "string"
-                                                        },
-                                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                                                        "type": "object"
-                                                    }
-                                                },
-                                                "type": "object",
-                                                "x-kubernetes-map-type": "atomic",
-                                                "additionalProperties": false
-                                            },
-                                            "matchLabelKeys": {
-                                                "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both matchLabelKeys and labelSelector.\nAlso, matchLabelKeys cannot be set when labelSelector isn't set.",
-                                                "items": {
-                                                    "type": "string"
-                                                },
-                                                "type": "array",
-                                                "x-kubernetes-list-type": "atomic"
-                                            },
-                                            "mismatchLabelKeys": {
-                                                "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both mismatchLabelKeys and labelSelector.\nAlso, mismatchLabelKeys cannot be set when labelSelector isn't set.",
-                                                "items": {
-                                                    "type": "string"
-                                                },
-                                                "type": "array",
-                                                "x-kubernetes-list-type": "atomic"
-                                            },
-                                            "namespaceSelector": {
-                                                "description": "A label query over the set of namespaces that the term applies to.\nThe term is applied to the union of the namespaces selected by this field\nand the ones listed in the namespaces field.\nnull selector and null or empty namespaces list means \"this pod's namespace\".\nAn empty selector ({}) matches all namespaces.",
-                                                "properties": {
-                                                    "matchExpressions": {
-                                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
-                                                        "items": {
-                                                            "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
-                                                            "properties": {
-                                                                "key": {
-                                                                    "description": "key is the label key that the selector applies to.",
-                                                                    "type": "string"
-                                                                },
-                                                                "operator": {
-                                                                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
-                                                                    "type": "string"
-                                                                },
-                                                                "values": {
-                                                                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
-                                                                    "items": {
-                                                                        "type": "string"
-                                                                    },
-                                                                    "type": "array",
-                                                                    "x-kubernetes-list-type": "atomic"
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "key",
-                                                                "operator"
-                                                            ],
-                                                            "type": "object",
-                                                            "additionalProperties": false
-                                                        },
-                                                        "type": "array",
-                                                        "x-kubernetes-list-type": "atomic"
-                                                    },
-                                                    "matchLabels": {
-                                                        "additionalProperties": {
-                                                            "type": "string"
-                                                        },
-                                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                                                        "type": "object"
-                                                    }
-                                                },
-                                                "type": "object",
-                                                "x-kubernetes-map-type": "atomic",
-                                                "additionalProperties": false
-                                            },
-                                            "namespaces": {
-                                                "description": "namespaces specifies a static list of namespace names that the term applies to.\nThe term is applied to the union of the namespaces listed in this field\nand the ones selected by namespaceSelector.\nnull or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
-                                                "items": {
-                                                    "type": "string"
-                                                },
-                                                "type": "array",
-                                                "x-kubernetes-list-type": "atomic"
-                                            },
-                                            "topologyKey": {
-                                                "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
-                                                "type": "string"
-                                            }
-                                        },
-                                        "required": [
-                                            "topologyKey"
-                                        ],
-                                        "type": "object",
-                                        "additionalProperties": false
-                                    },
-                                    "type": "array",
-                                    "x-kubernetes-list-type": "atomic"
-                                }
-                            },
-                            "type": "object",
-                            "additionalProperties": false
-                        }
-                    },
-                    "type": "object",
-                    "additionalProperties": false
-                },
-                "allowedGroups": {
-                    "description": "Groups allowed to view this RenovateJob when authentication is enabled.\nIf empty or not set, the job is hidden from all users.",
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                },
-                "discoverTopics": {
-                    "description": "Topics to discover projects from, will be concatenated using , separator",
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                },
-                "discoveryFilters": {
-                    "description": "Filter to select which projects to process, will be concatenated using , separator",
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
-                },
-                "dnsPolicy": {
-                    "description": "DNS Policy for the renovate pods",
-                    "type": "string"
-                },
-                "extraEnv": {
-                    "description": "Additional environment variables to set in the renovate container",
-                    "items": {
-                        "description": "EnvVar represents an environment variable present in a Container.",
-                        "properties": {
-                            "name": {
-                                "description": "Name of the environment variable.\nMay consist of any printable ASCII characters except '='.",
-                                "type": "string"
-                            },
-                            "value": {
-                                "description": "Variable references $(VAR_NAME) are expanded\nusing the previously defined environment variables in the container and\nany service environment variables. If a variable cannot be resolved,\nthe reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.\n\"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\".\nEscaped references will never be expanded, regardless of whether the variable\nexists or not.\nDefaults to \"\".",
-                                "type": "string"
-                            },
-                            "valueFrom": {
-                                "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
-                                "properties": {
-                                    "configMapKeyRef": {
-                                        "description": "Selects a key of a ConfigMap.",
-                                        "properties": {
-                                            "key": {
-                                                "description": "The key to select.",
-                                                "type": "string"
-                                            },
-                                            "name": {
-                                                "default": "",
-                                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
-                                                "type": "string"
-                                            },
-                                            "optional": {
-                                                "description": "Specify whether the ConfigMap or its key must be defined",
-                                                "type": "boolean"
-                                            }
-                                        },
-                                        "required": [
-                                            "key"
-                                        ],
-                                        "type": "object",
-                                        "x-kubernetes-map-type": "atomic",
-                                        "additionalProperties": false
-                                    },
-                                    "fieldRef": {
-                                        "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,\nspec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
-                                        "properties": {
-                                            "apiVersion": {
-                                                "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
-                                                "type": "string"
-                                            },
-                                            "fieldPath": {
-                                                "description": "Path of the field to select in the specified API version.",
-                                                "type": "string"
-                                            }
-                                        },
-                                        "required": [
-                                            "fieldPath"
-                                        ],
-                                        "type": "object",
-                                        "x-kubernetes-map-type": "atomic",
-                                        "additionalProperties": false
-                                    },
-                                    "fileKeyRef": {
-                                        "description": "FileKeyRef selects a key of the env file.\nRequires the EnvFiles feature gate to be enabled.",
-                                        "properties": {
-                                            "key": {
-                                                "description": "The key within the env file. An invalid key will prevent the pod from starting.\nThe keys defined within a source may consist of any printable ASCII characters except '='.\nDuring Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.",
-                                                "type": "string"
-                                            },
-                                            "optional": {
-                                                "default": false,
-                                                "description": "Specify whether the file or its key must be defined. If the file or key\ndoes not exist, then the env var is not published.\nIf optional is set to true and the specified key does not exist,\nthe environment variable will not be set in the Pod's containers.\n\nIf optional is set to false and the specified key does not exist,\nan error will be returned during Pod creation.",
-                                                "type": "boolean"
-                                            },
-                                            "path": {
-                                                "description": "The path within the volume from which to select the file.\nMust be relative and may not contain the '..' path or start with '..'.",
-                                                "type": "string"
-                                            },
-                                            "volumeName": {
-                                                "description": "The name of the volume mount containing the env file.",
-                                                "type": "string"
-                                            }
-                                        },
-                                        "required": [
-                                            "key",
-                                            "path",
-                                            "volumeName"
-                                        ],
-                                        "type": "object",
-                                        "x-kubernetes-map-type": "atomic",
-                                        "additionalProperties": false
-                                    },
-                                    "resourceFieldRef": {
-                                        "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
-                                        "properties": {
-                                            "containerName": {
-                                                "description": "Container name: required for volumes, optional for env vars",
-                                                "type": "string"
-                                            },
-                                            "divisor": {
-                                                "anyOf": [
-                                                    {
-                                                        "type": "integer"
-                                                    },
-                                                    {
-                                                        "type": "string"
-                                                    }
-                                                ],
-                                                "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
-                                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
-                                                "x-kubernetes-int-or-string": true
-                                            },
-                                            "resource": {
-                                                "description": "Required: resource to select",
-                                                "type": "string"
-                                            }
-                                        },
-                                        "required": [
-                                            "resource"
-                                        ],
-                                        "type": "object",
-                                        "x-kubernetes-map-type": "atomic",
-                                        "additionalProperties": false
-                                    },
-                                    "secretKeyRef": {
-                                        "description": "Selects a key of a secret in the pod's namespace",
-                                        "properties": {
-                                            "key": {
-                                                "description": "The key of the secret to select from.  Must be a valid secret key.",
-                                                "type": "string"
-                                            },
-                                            "name": {
-                                                "default": "",
-                                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
-                                                "type": "string"
-                                            },
-                                            "optional": {
-                                                "description": "Specify whether the Secret or its key must be defined",
-                                                "type": "boolean"
-                                            }
-                                        },
-                                        "required": [
-                                            "key"
-                                        ],
-                                        "type": "object",
-                                        "x-kubernetes-map-type": "atomic",
-                                        "additionalProperties": false
-                                    }
-                                },
-                                "type": "object",
-                                "additionalProperties": false
-                            }
-                        },
-                        "required": [
-                            "name"
-                        ],
-                        "type": "object",
-                        "additionalProperties": false
-                    },
-                    "type": "array"
-                },
-                "extraEnvFrom": {
-                    "description": "Additional environment variable sources to set in the renovate container",
-                    "items": {
-                        "description": "EnvFromSource represents the source of a set of ConfigMaps or Secrets",
-                        "properties": {
-                            "configMapRef": {
-                                "description": "The ConfigMap to select from",
-                                "properties": {
-                                    "name": {
-                                        "default": "",
-                                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
-                                        "type": "string"
-                                    },
-                                    "optional": {
-                                        "description": "Specify whether the ConfigMap must be defined",
-                                        "type": "boolean"
-                                    }
-                                },
-                                "type": "object",
-                                "x-kubernetes-map-type": "atomic",
-                                "additionalProperties": false
-                            },
-                            "prefix": {
-                                "description": "Optional text to prepend to the name of each environment variable.\nMay consist of any printable ASCII characters except '='.",
-                                "type": "string"
-                            },
-                            "secretRef": {
-                                "description": "The Secret to select from",
-                                "properties": {
-                                    "name": {
-                                        "default": "",
-                                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
-                                        "type": "string"
-                                    },
-                                    "optional": {
-                                        "description": "Specify whether the Secret must be defined",
-                                        "type": "boolean"
-                                    }
-                                },
-                                "type": "object",
-                                "x-kubernetes-map-type": "atomic",
-                                "additionalProperties": false
-                            }
-                        },
-                        "type": "object",
-                        "additionalProperties": false
-                    },
-                    "type": "array"
-                },
-                "extraVolumeMounts": {
-                    "description": "Additional volume mounts for the renovate pods",
-                    "items": {
-                        "description": "VolumeMount describes a mounting of a Volume within a container.",
-                        "properties": {
-                            "mountPath": {
-                                "description": "Path within the container at which the volume should be mounted.  Must\nnot contain ':'.",
-                                "type": "string"
-                            },
-                            "mountPropagation": {
-                                "description": "mountPropagation determines how mounts are propagated from the host\nto container and the other way around.\nWhen not set, MountPropagationNone is used.\nThis field is beta in 1.10.\nWhen RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified\n(which defaults to None).",
-                                "type": "string"
-                            },
-                            "name": {
-                                "description": "This must match the Name of a Volume.",
-                                "type": "string"
-                            },
-                            "readOnly": {
-                                "description": "Mounted read-only if true, read-write otherwise (false or unspecified).\nDefaults to false.",
-                                "type": "boolean"
-                            },
-                            "recursiveReadOnly": {
-                                "description": "RecursiveReadOnly specifies whether read-only mounts should be handled\nrecursively.\n\nIf ReadOnly is false, this field has no meaning and must be unspecified.\n\nIf ReadOnly is true, and this field is set to Disabled, the mount is not made\nrecursively read-only.  If this field is set to IfPossible, the mount is made\nrecursively read-only, if it is supported by the container runtime.  If this\nfield is set to Enabled, the mount is made recursively read-only if it is\nsupported by the container runtime, otherwise the pod will not be started and\nan error will be generated to indicate the reason.\n\nIf this field is set to IfPossible or Enabled, MountPropagation must be set to\nNone (or be unspecified, which defaults to None).\n\nIf this field is not specified, it is treated as an equivalent of Disabled.",
-                                "type": "string"
-                            },
-                            "subPath": {
-                                "description": "Path within the volume from which the container's volume should be mounted.\nDefaults to \"\" (volume's root).",
-                                "type": "string"
-                            },
-                            "subPathExpr": {
-                                "description": "Expanded path within the volume from which the container's volume should be mounted.\nBehaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.\nDefaults to \"\" (volume's root).\nSubPathExpr and SubPath are mutually exclusive.",
-                                "type": "string"
-                            }
-                        },
-                        "required": [
-                            "mountPath",
-                            "name"
-                        ],
-                        "type": "object",
-                        "additionalProperties": false
-                    },
-                    "type": "array"
-                },
-                "extraVolumes": {
-                    "description": "Additional volumes to mount in the renovate pods",
-                    "items": {
-                        "description": "Volume represents a named volume in a pod that may be accessed by any container in the pod.",
-                        "properties": {
-                            "awsElasticBlockStore": {
-                                "description": "awsElasticBlockStore represents an AWS Disk resource that is attached to a\nkubelet's host machine and then exposed to the pod.\nDeprecated: AWSElasticBlockStore is deprecated. All operations for the in-tree\nawsElasticBlockStore type are redirected to the ebs.csi.aws.com CSI driver.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
-                                "properties": {
-                                    "fsType": {
-                                        "description": "fsType is the filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
-                                        "type": "string"
-                                    },
-                                    "partition": {
-                                        "description": "partition is the partition in the volume that you want to mount.\nIf omitted, the default is to mount by volume name.\nExamples: For volume /dev/sda1, you specify the partition as \"1\".\nSimilarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty).",
-                                        "format": "int32",
-                                        "type": "integer",
-                                        "minimum": -2147483648,
-                                        "maximum": 2147483647
-                                    },
-                                    "readOnly": {
-                                        "description": "readOnly value true will force the readOnly setting in VolumeMounts.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
-                                        "type": "boolean"
-                                    },
-                                    "volumeID": {
-                                        "description": "volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
-                                        "type": "string"
-                                    }
-                                },
-                                "required": [
-                                    "volumeID"
-                                ],
-                                "type": "object",
-                                "additionalProperties": false
-                            },
-                            "azureDisk": {
-                                "description": "azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.\nDeprecated: AzureDisk is deprecated. All operations for the in-tree azureDisk type\nare redirected to the disk.csi.azure.com CSI driver.",
-                                "properties": {
-                                    "cachingMode": {
-                                        "description": "cachingMode is the Host Caching mode: None, Read Only, Read Write.",
-                                        "type": "string"
-                                    },
-                                    "diskName": {
-                                        "description": "diskName is the Name of the data disk in the blob storage",
-                                        "type": "string"
-                                    },
-                                    "diskURI": {
-                                        "description": "diskURI is the URI of data disk in the blob storage",
-                                        "type": "string"
-                                    },
-                                    "fsType": {
-                                        "default": "ext4",
-                                        "description": "fsType is Filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
-                                        "type": "string"
-                                    },
-                                    "kind": {
-                                        "description": "kind expected values are Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared",
-                                        "type": "string"
-                                    },
-                                    "readOnly": {
-                                        "default": false,
-                                        "description": "readOnly Defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
-                                        "type": "boolean"
-                                    }
-                                },
-                                "required": [
-                                    "diskName",
-                                    "diskURI"
-                                ],
-                                "type": "object",
-                                "additionalProperties": false
-                            },
-                            "azureFile": {
-                                "description": "azureFile represents an Azure File Service mount on the host and bind mount to the pod.\nDeprecated: AzureFile is deprecated. All operations for the in-tree azureFile type\nare redirected to the file.csi.azure.com CSI driver.",
-                                "properties": {
-                                    "readOnly": {
-                                        "description": "readOnly defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
-                                        "type": "boolean"
-                                    },
-                                    "secretName": {
-                                        "description": "secretName is the  name of secret that contains Azure Storage Account Name and Key",
-                                        "type": "string"
-                                    },
-                                    "shareName": {
-                                        "description": "shareName is the azure share Name",
-                                        "type": "string"
-                                    }
-                                },
-                                "required": [
-                                    "secretName",
-                                    "shareName"
-                                ],
-                                "type": "object",
-                                "additionalProperties": false
-                            },
-                            "cephfs": {
-                                "description": "cephFS represents a Ceph FS mount on the host that shares a pod's lifetime.\nDeprecated: CephFS is deprecated and the in-tree cephfs type is no longer supported.",
-                                "properties": {
-                                    "monitors": {
-                                        "description": "monitors is Required: Monitors is a collection of Ceph monitors\nMore info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
-                                        "items": {
-                                            "type": "string"
-                                        },
-                                        "type": "array",
-                                        "x-kubernetes-list-type": "atomic"
-                                    },
-                                    "path": {
-                                        "description": "path is Optional: Used as the mounted root, rather than the full Ceph tree, default is /",
-                                        "type": "string"
-                                    },
-                                    "readOnly": {
-                                        "description": "readOnly is Optional: Defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.\nMore info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
-                                        "type": "boolean"
-                                    },
-                                    "secretFile": {
-                                        "description": "secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret\nMore info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
-                                        "type": "string"
-                                    },
-                                    "secretRef": {
-                                        "description": "secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.\nMore info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
-                                        "properties": {
-                                            "name": {
-                                                "default": "",
-                                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
-                                                "type": "string"
-                                            }
-                                        },
-                                        "type": "object",
-                                        "x-kubernetes-map-type": "atomic",
-                                        "additionalProperties": false
-                                    },
-                                    "user": {
-                                        "description": "user is optional: User is the rados user name, default is admin\nMore info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
-                                        "type": "string"
-                                    }
-                                },
-                                "required": [
-                                    "monitors"
-                                ],
-                                "type": "object",
-                                "additionalProperties": false
-                            },
-                            "cinder": {
-                                "description": "cinder represents a cinder volume attached and mounted on kubelets host machine.\nDeprecated: Cinder is deprecated. All operations for the in-tree cinder type\nare redirected to the cinder.csi.openstack.org CSI driver.\nMore info: https://examples.k8s.io/mysql-cinder-pd/README.md",
-                                "properties": {
-                                    "fsType": {
-                                        "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://examples.k8s.io/mysql-cinder-pd/README.md",
-                                        "type": "string"
-                                    },
-                                    "readOnly": {
-                                        "description": "readOnly defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.\nMore info: https://examples.k8s.io/mysql-cinder-pd/README.md",
-                                        "type": "boolean"
-                                    },
-                                    "secretRef": {
-                                        "description": "secretRef is optional: points to a secret object containing parameters used to connect\nto OpenStack.",
-                                        "properties": {
-                                            "name": {
-                                                "default": "",
-                                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
-                                                "type": "string"
-                                            }
-                                        },
-                                        "type": "object",
-                                        "x-kubernetes-map-type": "atomic",
-                                        "additionalProperties": false
-                                    },
-                                    "volumeID": {
-                                        "description": "volumeID used to identify the volume in cinder.\nMore info: https://examples.k8s.io/mysql-cinder-pd/README.md",
-                                        "type": "string"
-                                    }
-                                },
-                                "required": [
-                                    "volumeID"
-                                ],
-                                "type": "object",
-                                "additionalProperties": false
-                            },
-                            "configMap": {
-                                "description": "configMap represents a configMap that should populate this volume",
-                                "properties": {
-                                    "defaultMode": {
-                                        "description": "defaultMode is optional: mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nDefaults to 0644.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
-                                        "format": "int32",
-                                        "type": "integer",
-                                        "minimum": -2147483648,
-                                        "maximum": 2147483647
-                                    },
-                                    "items": {
-                                        "description": "items if unspecified, each key-value pair in the Data field of the referenced\nConfigMap will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the ConfigMap,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
-                                        "items": {
-                                            "description": "Maps a string key to a path within a volume.",
-                                            "properties": {
-                                                "key": {
-                                                    "description": "key is the key to project.",
-                                                    "type": "string"
-                                                },
-                                                "mode": {
-                                                    "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
-                                                    "format": "int32",
-                                                    "type": "integer",
-                                                    "minimum": -2147483648,
-                                                    "maximum": 2147483647
-                                                },
-                                                "path": {
-                                                    "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
-                                                    "type": "string"
-                                                }
-                                            },
-                                            "required": [
-                                                "key",
-                                                "path"
-                                            ],
-                                            "type": "object",
-                                            "additionalProperties": false
-                                        },
-                                        "type": "array",
-                                        "x-kubernetes-list-type": "atomic"
-                                    },
-                                    "name": {
-                                        "default": "",
-                                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
-                                        "type": "string"
-                                    },
-                                    "optional": {
-                                        "description": "optional specify whether the ConfigMap or its keys must be defined",
-                                        "type": "boolean"
-                                    }
-                                },
-                                "type": "object",
-                                "x-kubernetes-map-type": "atomic",
-                                "additionalProperties": false
-                            },
-                            "csi": {
-                                "description": "csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers.",
-                                "properties": {
-                                    "driver": {
-                                        "description": "driver is the name of the CSI driver that handles this volume.\nConsult with your admin for the correct name as registered in the cluster.",
-                                        "type": "string"
-                                    },
-                                    "fsType": {
-                                        "description": "fsType to mount. Ex. \"ext4\", \"xfs\", \"ntfs\".\nIf not provided, the empty value is passed to the associated CSI driver\nwhich will determine the default filesystem to apply.",
-                                        "type": "string"
-                                    },
-                                    "nodePublishSecretRef": {
-                                        "description": "nodePublishSecretRef is a reference to the secret object containing\nsensitive information to pass to the CSI driver to complete the CSI\nNodePublishVolume and NodeUnpublishVolume calls.\nThis field is optional, and  may be empty if no secret is required. If the\nsecret object contains more than one secret, all secret references are passed.",
-                                        "properties": {
-                                            "name": {
-                                                "default": "",
-                                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
-                                                "type": "string"
-                                            }
-                                        },
-                                        "type": "object",
-                                        "x-kubernetes-map-type": "atomic",
-                                        "additionalProperties": false
-                                    },
-                                    "readOnly": {
-                                        "description": "readOnly specifies a read-only configuration for the volume.\nDefaults to false (read/write).",
-                                        "type": "boolean"
-                                    },
-                                    "volumeAttributes": {
-                                        "additionalProperties": {
-                                            "type": "string"
-                                        },
-                                        "description": "volumeAttributes stores driver-specific properties that are passed to the CSI\ndriver. Consult your driver's documentation for supported values.",
-                                        "type": "object"
-                                    }
-                                },
-                                "required": [
-                                    "driver"
-                                ],
-                                "type": "object",
-                                "additionalProperties": false
-                            },
-                            "downwardAPI": {
-                                "description": "downwardAPI represents downward API about the pod that should populate this volume",
-                                "properties": {
-                                    "defaultMode": {
-                                        "description": "Optional: mode bits to use on created files by default. Must be a\nOptional: mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nDefaults to 0644.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
-                                        "format": "int32",
-                                        "type": "integer",
-                                        "minimum": -2147483648,
-                                        "maximum": 2147483647
-                                    },
-                                    "items": {
-                                        "description": "Items is a list of downward API volume file",
-                                        "items": {
-                                            "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
-                                            "properties": {
-                                                "fieldRef": {
-                                                    "description": "Required: Selects a field of the pod: only annotations, labels, name, namespace and uid are supported.",
-                                                    "properties": {
-                                                        "apiVersion": {
-                                                            "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
-                                                            "type": "string"
-                                                        },
-                                                        "fieldPath": {
-                                                            "description": "Path of the field to select in the specified API version.",
-                                                            "type": "string"
-                                                        }
-                                                    },
-                                                    "required": [
-                                                        "fieldPath"
-                                                    ],
-                                                    "type": "object",
-                                                    "x-kubernetes-map-type": "atomic",
-                                                    "additionalProperties": false
-                                                },
-                                                "mode": {
-                                                    "description": "Optional: mode bits used to set permissions on this file, must be an octal value\nbetween 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
-                                                    "format": "int32",
-                                                    "type": "integer",
-                                                    "minimum": -2147483648,
-                                                    "maximum": 2147483647
-                                                },
-                                                "path": {
-                                                    "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'",
-                                                    "type": "string"
-                                                },
-                                                "resourceFieldRef": {
-                                                    "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.",
-                                                    "properties": {
-                                                        "containerName": {
-                                                            "description": "Container name: required for volumes, optional for env vars",
-                                                            "type": "string"
-                                                        },
-                                                        "divisor": {
-                                                            "anyOf": [
-                                                                {
-                                                                    "type": "integer"
-                                                                },
-                                                                {
-                                                                    "type": "string"
-                                                                }
-                                                            ],
-                                                            "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
-                                                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
-                                                            "x-kubernetes-int-or-string": true
-                                                        },
-                                                        "resource": {
-                                                            "description": "Required: resource to select",
-                                                            "type": "string"
-                                                        }
-                                                    },
-                                                    "required": [
-                                                        "resource"
-                                                    ],
-                                                    "type": "object",
-                                                    "x-kubernetes-map-type": "atomic",
-                                                    "additionalProperties": false
-                                                }
-                                            },
-                                            "required": [
-                                                "path"
-                                            ],
-                                            "type": "object",
-                                            "additionalProperties": false
-                                        },
-                                        "type": "array",
-                                        "x-kubernetes-list-type": "atomic"
-                                    }
-                                },
-                                "type": "object",
-                                "additionalProperties": false
-                            },
-                            "emptyDir": {
-                                "description": "emptyDir represents a temporary directory that shares a pod's lifetime.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
-                                "properties": {
-                                    "medium": {
-                                        "description": "medium represents what type of storage medium should back this directory.\nThe default is \"\" which means to use the node's default medium.\nMust be an empty string (default) or Memory.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
-                                        "type": "string"
-                                    },
-                                    "sizeLimit": {
-                                        "anyOf": [
-                                            {
-                                                "type": "integer"
-                                            },
-                                            {
-                                                "type": "string"
-                                            }
-                                        ],
-                                        "description": "sizeLimit is the total amount of local storage required for this EmptyDir volume.\nThe size limit is also applicable for memory medium.\nThe maximum usage on memory medium EmptyDir would be the minimum value between\nthe SizeLimit specified here and the sum of memory limits of all containers in a pod.\nThe default is nil which means that the limit is undefined.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
-                                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
-                                        "x-kubernetes-int-or-string": true
-                                    }
-                                },
-                                "type": "object",
-                                "additionalProperties": false
-                            },
-                            "ephemeral": {
-                                "description": "ephemeral represents a volume that is handled by a cluster storage driver.\nThe volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,\nand deleted when the pod is removed.\n\nUse this if:\na) the volume is only needed while the pod runs,\nb) features of normal volumes like restoring from snapshot or capacity\n   tracking are needed,\nc) the storage driver is specified through a storage class, and\nd) the storage driver supports dynamic volume provisioning through\n   a PersistentVolumeClaim (see EphemeralVolumeSource for more\n   information on the connection between this volume type\n   and PersistentVolumeClaim).\n\nUse PersistentVolumeClaim or one of the vendor-specific\nAPIs for volumes that persist for longer than the lifecycle\nof an individual pod.\n\nUse CSI for light-weight local ephemeral volumes if the CSI driver is meant to\nbe used that way - see the documentation of the driver for\nmore information.\n\nA pod can use both types of ephemeral volumes and\npersistent volumes at the same time.",
-                                "properties": {
-                                    "volumeClaimTemplate": {
-                                        "description": "Will be used to create a stand-alone PVC to provision the volume.\nThe pod in which this EphemeralVolumeSource is embedded will be the\nowner of the PVC, i.e. the PVC will be deleted together with the\npod.  The name of the PVC will be `<pod name>-<volume name>` where\n`<volume name>` is the name from the `PodSpec.Volumes` array\nentry. Pod validation will reject the pod if the concatenated name\nis not valid for a PVC (for example, too long).\n\nAn existing PVC with that name that is not owned by the pod\nwill *not* be used for the pod to avoid using an unrelated\nvolume by mistake. Starting the pod is then blocked until\nthe unrelated PVC is removed. If such a pre-created PVC is\nmeant to be used by the pod, the PVC has to updated with an\nowner reference to the pod once the pod exists. Normally\nthis should not be necessary, but it may be useful when\nmanually reconstructing a broken cluster.\n\nThis field is read-only and no changes will be made by Kubernetes\nto the PVC after it has been created.\n\nRequired, must not be nil.",
-                                        "properties": {
-                                            "metadata": {
-                                                "description": "May contain labels and annotations that will be copied into the PVC\nwhen creating it. No other fields are allowed and will be rejected during\nvalidation.",
-                                                "type": "object"
-                                            },
-                                            "spec": {
-                                                "description": "The specification for the PersistentVolumeClaim. The entire content is\ncopied unchanged into the PVC that gets created from this\ntemplate. The same fields as in a PersistentVolumeClaim\nare also valid here.",
-                                                "properties": {
-                                                    "accessModes": {
-                                                        "description": "accessModes contains the desired access modes the volume should have.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1",
-                                                        "items": {
-                                                            "type": "string"
-                                                        },
-                                                        "type": "array",
-                                                        "x-kubernetes-list-type": "atomic"
-                                                    },
-                                                    "dataSource": {
-                                                        "description": "dataSource field can be used to specify either:\n* An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)\n* An existing PVC (PersistentVolumeClaim)\nIf the provisioner or an external controller can support the specified data source,\nit will create a new volume based on the contents of the specified data source.\nWhen the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,\nand dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.\nIf the namespace is specified, then dataSourceRef will not be copied to dataSource.",
-                                                        "properties": {
-                                                            "apiGroup": {
-                                                                "description": "APIGroup is the group for the resource being referenced.\nIf APIGroup is not specified, the specified Kind must be in the core API group.\nFor any other third-party types, APIGroup is required.",
-                                                                "type": "string"
-                                                            },
-                                                            "kind": {
-                                                                "description": "Kind is the type of resource being referenced",
-                                                                "type": "string"
-                                                            },
-                                                            "name": {
-                                                                "description": "Name is the name of resource being referenced",
-                                                                "type": "string"
-                                                            }
-                                                        },
-                                                        "required": [
-                                                            "kind",
-                                                            "name"
-                                                        ],
-                                                        "type": "object",
-                                                        "x-kubernetes-map-type": "atomic",
-                                                        "additionalProperties": false
-                                                    },
-                                                    "dataSourceRef": {
-                                                        "description": "dataSourceRef specifies the object from which to populate the volume with data, if a non-empty\nvolume is desired. This may be any object from a non-empty API group (non\ncore object) or a PersistentVolumeClaim object.\nWhen this field is specified, volume binding will only succeed if the type of\nthe specified object matches some installed volume populator or dynamic\nprovisioner.\nThis field will replace the functionality of the dataSource field and as such\nif both fields are non-empty, they must have the same value. For backwards\ncompatibility, when namespace isn't specified in dataSourceRef,\nboth fields (dataSource and dataSourceRef) will be set to the same\nvalue automatically if one of them is empty and the other is non-empty.\nWhen namespace is specified in dataSourceRef,\ndataSource isn't set to the same value and must be empty.\nThere are three important differences between dataSource and dataSourceRef:\n* While dataSource only allows two specific types of objects, dataSourceRef\n  allows any non-core object, as well as PersistentVolumeClaim objects.\n* While dataSource ignores disallowed values (dropping them), dataSourceRef\n  preserves all values, and generates an error if a disallowed value is\n  specified.\n* While dataSource only allows local objects, dataSourceRef allows objects\n  in any namespaces.\n(Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.\n(Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.",
-                                                        "properties": {
-                                                            "apiGroup": {
-                                                                "description": "APIGroup is the group for the resource being referenced.\nIf APIGroup is not specified, the specified Kind must be in the core API group.\nFor any other third-party types, APIGroup is required.",
-                                                                "type": "string"
-                                                            },
-                                                            "kind": {
-                                                                "description": "Kind is the type of resource being referenced",
-                                                                "type": "string"
-                                                            },
-                                                            "name": {
-                                                                "description": "Name is the name of resource being referenced",
-                                                                "type": "string"
-                                                            },
-                                                            "namespace": {
-                                                                "description": "Namespace is the namespace of resource being referenced\nNote that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.\n(Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.",
-                                                                "type": "string"
-                                                            }
-                                                        },
-                                                        "required": [
-                                                            "kind",
-                                                            "name"
-                                                        ],
-                                                        "type": "object",
-                                                        "additionalProperties": false
-                                                    },
-                                                    "resources": {
-                                                        "description": "resources represents the minimum resources the volume should have.\nUsers are allowed to specify resource requirements\nthat are lower than previous value but must still be higher than capacity recorded in the\nstatus field of the claim.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources",
-                                                        "properties": {
-                                                            "limits": {
-                                                                "additionalProperties": {
-                                                                    "anyOf": [
-                                                                        {
-                                                                            "type": "integer"
-                                                                        },
-                                                                        {
-                                                                            "type": "string"
-                                                                        }
-                                                                    ],
-                                                                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
-                                                                    "x-kubernetes-int-or-string": true
-                                                                },
-                                                                "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
-                                                                "type": "object"
-                                                            },
-                                                            "requests": {
-                                                                "additionalProperties": {
-                                                                    "anyOf": [
-                                                                        {
-                                                                            "type": "integer"
-                                                                        },
-                                                                        {
-                                                                            "type": "string"
-                                                                        }
-                                                                    ],
-                                                                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
-                                                                    "x-kubernetes-int-or-string": true
-                                                                },
-                                                                "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
-                                                                "type": "object"
-                                                            }
-                                                        },
-                                                        "type": "object",
-                                                        "additionalProperties": false
-                                                    },
-                                                    "selector": {
-                                                        "description": "selector is a label query over volumes to consider for binding.",
-                                                        "properties": {
-                                                            "matchExpressions": {
-                                                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
-                                                                "items": {
-                                                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
-                                                                    "properties": {
-                                                                        "key": {
-                                                                            "description": "key is the label key that the selector applies to.",
-                                                                            "type": "string"
-                                                                        },
-                                                                        "operator": {
-                                                                            "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
-                                                                            "type": "string"
-                                                                        },
-                                                                        "values": {
-                                                                            "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
-                                                                            "items": {
-                                                                                "type": "string"
-                                                                            },
-                                                                            "type": "array",
-                                                                            "x-kubernetes-list-type": "atomic"
-                                                                        }
-                                                                    },
-                                                                    "required": [
-                                                                        "key",
-                                                                        "operator"
-                                                                    ],
-                                                                    "type": "object",
-                                                                    "additionalProperties": false
-                                                                },
-                                                                "type": "array",
-                                                                "x-kubernetes-list-type": "atomic"
-                                                            },
-                                                            "matchLabels": {
-                                                                "additionalProperties": {
-                                                                    "type": "string"
-                                                                },
-                                                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                                                                "type": "object"
-                                                            }
-                                                        },
-                                                        "type": "object",
-                                                        "x-kubernetes-map-type": "atomic",
-                                                        "additionalProperties": false
-                                                    },
-                                                    "storageClassName": {
-                                                        "description": "storageClassName is the name of the StorageClass required by the claim.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1",
-                                                        "type": "string"
-                                                    },
-                                                    "volumeAttributesClassName": {
-                                                        "description": "volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.\nIf specified, the CSI driver will create or update the volume with the attributes defined\nin the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,\nit can be changed after the claim is created. An empty string or nil value indicates that no\nVolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,\nthis field can be reset to its previous value (including nil) to cancel the modification.\nIf the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be\nset to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource\nexists.\nMore info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/",
-                                                        "type": "string"
-                                                    },
-                                                    "volumeMode": {
-                                                        "description": "volumeMode defines what type of volume is required by the claim.\nValue of Filesystem is implied when not included in claim spec.",
-                                                        "type": "string"
-                                                    },
-                                                    "volumeName": {
-                                                        "description": "volumeName is the binding reference to the PersistentVolume backing this claim.",
-                                                        "type": "string"
-                                                    }
-                                                },
-                                                "type": "object",
-                                                "additionalProperties": false
-                                            }
-                                        },
-                                        "required": [
-                                            "spec"
-                                        ],
-                                        "type": "object",
-                                        "additionalProperties": false
-                                    }
-                                },
-                                "type": "object",
-                                "additionalProperties": false
-                            },
-                            "fc": {
-                                "description": "fc represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.",
-                                "properties": {
-                                    "fsType": {
-                                        "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
-                                        "type": "string"
-                                    },
-                                    "lun": {
-                                        "description": "lun is Optional: FC target lun number",
-                                        "format": "int32",
-                                        "type": "integer",
-                                        "minimum": -2147483648,
-                                        "maximum": 2147483647
-                                    },
-                                    "readOnly": {
-                                        "description": "readOnly is Optional: Defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
-                                        "type": "boolean"
-                                    },
-                                    "targetWWNs": {
-                                        "description": "targetWWNs is Optional: FC target worldwide names (WWNs)",
-                                        "items": {
-                                            "type": "string"
-                                        },
-                                        "type": "array",
-                                        "x-kubernetes-list-type": "atomic"
-                                    },
-                                    "wwids": {
-                                        "description": "wwids Optional: FC volume world wide identifiers (wwids)\nEither wwids or combination of targetWWNs and lun must be set, but not both simultaneously.",
-                                        "items": {
-                                            "type": "string"
-                                        },
-                                        "type": "array",
-                                        "x-kubernetes-list-type": "atomic"
-                                    }
-                                },
-                                "type": "object",
-                                "additionalProperties": false
-                            },
-                            "flexVolume": {
-                                "description": "flexVolume represents a generic volume resource that is\nprovisioned/attached using an exec based plugin.\nDeprecated: FlexVolume is deprecated. Consider using a CSIDriver instead.",
-                                "properties": {
-                                    "driver": {
-                                        "description": "driver is the name of the driver to use for this volume.",
-                                        "type": "string"
-                                    },
-                                    "fsType": {
-                                        "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". The default filesystem depends on FlexVolume script.",
-                                        "type": "string"
-                                    },
-                                    "options": {
-                                        "additionalProperties": {
-                                            "type": "string"
-                                        },
-                                        "description": "options is Optional: this field holds extra command options if any.",
-                                        "type": "object"
-                                    },
-                                    "readOnly": {
-                                        "description": "readOnly is Optional: defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
-                                        "type": "boolean"
-                                    },
-                                    "secretRef": {
-                                        "description": "secretRef is Optional: secretRef is reference to the secret object containing\nsensitive information to pass to the plugin scripts. This may be\nempty if no secret object is specified. If the secret object\ncontains more than one secret, all secrets are passed to the plugin\nscripts.",
-                                        "properties": {
-                                            "name": {
-                                                "default": "",
-                                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
-                                                "type": "string"
-                                            }
-                                        },
-                                        "type": "object",
-                                        "x-kubernetes-map-type": "atomic",
-                                        "additionalProperties": false
-                                    }
-                                },
-                                "required": [
-                                    "driver"
-                                ],
-                                "type": "object",
-                                "additionalProperties": false
-                            },
-                            "flocker": {
-                                "description": "flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running.\nDeprecated: Flocker is deprecated and the in-tree flocker type is no longer supported.",
-                                "properties": {
-                                    "datasetName": {
-                                        "description": "datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker\nshould be considered as deprecated",
-                                        "type": "string"
-                                    },
-                                    "datasetUUID": {
-                                        "description": "datasetUUID is the UUID of the dataset. This is unique identifier of a Flocker dataset",
-                                        "type": "string"
-                                    }
-                                },
-                                "type": "object",
-                                "additionalProperties": false
-                            },
-                            "gcePersistentDisk": {
-                                "description": "gcePersistentDisk represents a GCE Disk resource that is attached to a\nkubelet's host machine and then exposed to the pod.\nDeprecated: GCEPersistentDisk is deprecated. All operations for the in-tree\ngcePersistentDisk type are redirected to the pd.csi.storage.gke.io CSI driver.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
-                                "properties": {
-                                    "fsType": {
-                                        "description": "fsType is filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
-                                        "type": "string"
-                                    },
-                                    "partition": {
-                                        "description": "partition is the partition in the volume that you want to mount.\nIf omitted, the default is to mount by volume name.\nExamples: For volume /dev/sda1, you specify the partition as \"1\".\nSimilarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty).\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
-                                        "format": "int32",
-                                        "type": "integer",
-                                        "minimum": -2147483648,
-                                        "maximum": 2147483647
-                                    },
-                                    "pdName": {
-                                        "description": "pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
-                                        "type": "string"
-                                    },
-                                    "readOnly": {
-                                        "description": "readOnly here will force the ReadOnly setting in VolumeMounts.\nDefaults to false.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
-                                        "type": "boolean"
-                                    }
-                                },
-                                "required": [
-                                    "pdName"
-                                ],
-                                "type": "object",
-                                "additionalProperties": false
-                            },
-                            "gitRepo": {
-                                "description": "gitRepo represents a git repository at a particular revision.\nDeprecated: GitRepo is deprecated. To provision a container with a git repo, mount an\nEmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir\ninto the Pod's container.",
-                                "properties": {
-                                    "directory": {
-                                        "description": "directory is the target directory name.\nMust not contain or start with '..'.  If '.' is supplied, the volume directory will be the\ngit repository.  Otherwise, if specified, the volume will contain the git repository in\nthe subdirectory with the given name.",
-                                        "type": "string"
-                                    },
-                                    "repository": {
-                                        "description": "repository is the URL",
-                                        "type": "string"
-                                    },
-                                    "revision": {
-                                        "description": "revision is the commit hash for the specified revision.",
-                                        "type": "string"
-                                    }
-                                },
-                                "required": [
-                                    "repository"
-                                ],
-                                "type": "object",
-                                "additionalProperties": false
-                            },
-                            "glusterfs": {
-                                "description": "glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.\nDeprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.",
-                                "properties": {
-                                    "endpoints": {
-                                        "description": "endpoints is the endpoint name that details Glusterfs topology.",
-                                        "type": "string"
-                                    },
-                                    "path": {
-                                        "description": "path is the Glusterfs volume path.\nMore info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
-                                        "type": "string"
-                                    },
-                                    "readOnly": {
-                                        "description": "readOnly here will force the Glusterfs volume to be mounted with read-only permissions.\nDefaults to false.\nMore info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
-                                        "type": "boolean"
-                                    }
-                                },
-                                "required": [
-                                    "endpoints",
-                                    "path"
-                                ],
-                                "type": "object",
-                                "additionalProperties": false
-                            },
-                            "hostPath": {
-                                "description": "hostPath represents a pre-existing file or directory on the host\nmachine that is directly exposed to the container. This is generally\nused for system agents or other privileged things that are allowed\nto see the host machine. Most containers will NOT need this.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
-                                "properties": {
-                                    "path": {
-                                        "description": "path of the directory on the host.\nIf the path is a symlink, it will follow the link to the real path.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
-                                        "type": "string"
-                                    },
-                                    "type": {
-                                        "description": "type for HostPath Volume\nDefaults to \"\"\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
-                                        "type": "string"
-                                    }
-                                },
-                                "required": [
-                                    "path"
-                                ],
-                                "type": "object",
-                                "additionalProperties": false
-                            },
-                            "image": {
-                                "description": "image represents an OCI object (a container image or artifact) pulled and mounted on the kubelet's host machine.\nThe volume is resolved at pod startup depending on which PullPolicy value is provided:\n\n- Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.\n- Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.\n- IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.\n\nThe volume gets re-resolved if the pod gets deleted and recreated, which means that new remote content will become available on pod recreation.\nA failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.\nThe types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.\nThe OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.\nThe volume will be mounted read-only (ro) and non-executable files (noexec).\nSub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.\nThe field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.",
-                                "properties": {
-                                    "pullPolicy": {
-                                        "description": "Policy for pulling OCI objects. Possible values are:\nAlways: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.\nNever: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.\nIfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.\nDefaults to Always if :latest tag is specified, or IfNotPresent otherwise.",
-                                        "type": "string"
-                                    },
-                                    "reference": {
-                                        "description": "Required: Image or artifact reference to be used.\nBehaves in the same way as pod.spec.containers[*].image.\nPull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.\nMore info: https://kubernetes.io/docs/concepts/containers/images\nThis field is optional to allow higher level config management to default or override\ncontainer images in workload controllers like Deployments and StatefulSets.",
-                                        "type": "string"
-                                    }
-                                },
-                                "type": "object",
-                                "additionalProperties": false
-                            },
-                            "iscsi": {
-                                "description": "iscsi represents an ISCSI Disk resource that is attached to a\nkubelet's host machine and then exposed to the pod.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes/#iscsi",
-                                "properties": {
-                                    "chapAuthDiscovery": {
-                                        "description": "chapAuthDiscovery defines whether support iSCSI Discovery CHAP authentication",
-                                        "type": "boolean"
-                                    },
-                                    "chapAuthSession": {
-                                        "description": "chapAuthSession defines whether support iSCSI Session CHAP authentication",
-                                        "type": "boolean"
-                                    },
-                                    "fsType": {
-                                        "description": "fsType is the filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi",
-                                        "type": "string"
-                                    },
-                                    "initiatorName": {
-                                        "description": "initiatorName is the custom iSCSI Initiator Name.\nIf initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface\n<target portal>:<volume name> will be created for the connection.",
-                                        "type": "string"
-                                    },
-                                    "iqn": {
-                                        "description": "iqn is the target iSCSI Qualified Name.",
-                                        "type": "string"
-                                    },
-                                    "iscsiInterface": {
-                                        "default": "default",
-                                        "description": "iscsiInterface is the interface Name that uses an iSCSI transport.\nDefaults to 'default' (tcp).",
-                                        "type": "string"
-                                    },
-                                    "lun": {
-                                        "description": "lun represents iSCSI Target Lun number.",
-                                        "format": "int32",
-                                        "type": "integer",
-                                        "minimum": -2147483648,
-                                        "maximum": 2147483647
-                                    },
-                                    "portals": {
-                                        "description": "portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port\nis other than default (typically TCP ports 860 and 3260).",
-                                        "items": {
-                                            "type": "string"
-                                        },
-                                        "type": "array",
-                                        "x-kubernetes-list-type": "atomic"
-                                    },
-                                    "readOnly": {
-                                        "description": "readOnly here will force the ReadOnly setting in VolumeMounts.\nDefaults to false.",
-                                        "type": "boolean"
-                                    },
-                                    "secretRef": {
-                                        "description": "secretRef is the CHAP Secret for iSCSI target and initiator authentication",
-                                        "properties": {
-                                            "name": {
-                                                "default": "",
-                                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
-                                                "type": "string"
-                                            }
-                                        },
-                                        "type": "object",
-                                        "x-kubernetes-map-type": "atomic",
-                                        "additionalProperties": false
-                                    },
-                                    "targetPortal": {
-                                        "description": "targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port\nis other than default (typically TCP ports 860 and 3260).",
-                                        "type": "string"
-                                    }
-                                },
-                                "required": [
-                                    "iqn",
-                                    "lun",
-                                    "targetPortal"
-                                ],
-                                "type": "object",
-                                "additionalProperties": false
-                            },
-                            "name": {
-                                "description": "name of the volume.\nMust be a DNS_LABEL and unique within the pod.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
-                                "type": "string"
-                            },
-                            "nfs": {
-                                "description": "nfs represents an NFS mount on the host that shares a pod's lifetime\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
-                                "properties": {
-                                    "path": {
-                                        "description": "path that is exported by the NFS server.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
-                                        "type": "string"
-                                    },
-                                    "readOnly": {
-                                        "description": "readOnly here will force the NFS export to be mounted with read-only permissions.\nDefaults to false.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
-                                        "type": "boolean"
-                                    },
-                                    "server": {
-                                        "description": "server is the hostname or IP address of the NFS server.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
-                                        "type": "string"
-                                    }
-                                },
-                                "required": [
-                                    "path",
-                                    "server"
-                                ],
-                                "type": "object",
-                                "additionalProperties": false
-                            },
-                            "persistentVolumeClaim": {
-                                "description": "persistentVolumeClaimVolumeSource represents a reference to a\nPersistentVolumeClaim in the same namespace.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
-                                "properties": {
-                                    "claimName": {
-                                        "description": "claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
-                                        "type": "string"
-                                    },
-                                    "readOnly": {
-                                        "description": "readOnly Will force the ReadOnly setting in VolumeMounts.\nDefault false.",
-                                        "type": "boolean"
-                                    }
-                                },
-                                "required": [
-                                    "claimName"
-                                ],
-                                "type": "object",
-                                "additionalProperties": false
-                            },
-                            "photonPersistentDisk": {
-                                "description": "photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine.\nDeprecated: PhotonPersistentDisk is deprecated and the in-tree photonPersistentDisk type is no longer supported.",
-                                "properties": {
-                                    "fsType": {
-                                        "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
-                                        "type": "string"
-                                    },
-                                    "pdID": {
-                                        "description": "pdID is the ID that identifies Photon Controller persistent disk",
-                                        "type": "string"
-                                    }
-                                },
-                                "required": [
-                                    "pdID"
-                                ],
-                                "type": "object",
-                                "additionalProperties": false
-                            },
-                            "portworxVolume": {
-                                "description": "portworxVolume represents a portworx volume attached and mounted on kubelets host machine.\nDeprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type\nare redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate\nis on.",
-                                "properties": {
-                                    "fsType": {
-                                        "description": "fSType represents the filesystem type to mount\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\". Implicitly inferred to be \"ext4\" if unspecified.",
-                                        "type": "string"
-                                    },
-                                    "readOnly": {
-                                        "description": "readOnly defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
-                                        "type": "boolean"
-                                    },
-                                    "volumeID": {
-                                        "description": "volumeID uniquely identifies a Portworx volume",
-                                        "type": "string"
-                                    }
-                                },
-                                "required": [
-                                    "volumeID"
-                                ],
-                                "type": "object",
-                                "additionalProperties": false
-                            },
-                            "projected": {
-                                "description": "projected items for all in one resources secrets, configmaps, and downward API",
-                                "properties": {
-                                    "defaultMode": {
-                                        "description": "defaultMode are the mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
-                                        "format": "int32",
-                                        "type": "integer",
-                                        "minimum": -2147483648,
-                                        "maximum": 2147483647
-                                    },
-                                    "sources": {
-                                        "description": "sources is the list of volume projections. Each entry in this list\nhandles one source.",
-                                        "items": {
-                                            "description": "Projection that may be projected along with other supported volume types.\nExactly one of these fields must be set.",
-                                            "properties": {
-                                                "clusterTrustBundle": {
-                                                    "description": "ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field\nof ClusterTrustBundle objects in an auto-updating file.\n\nAlpha, gated by the ClusterTrustBundleProjection feature gate.\n\nClusterTrustBundle objects can either be selected by name, or by the\ncombination of signer name and a label selector.\n\nKubelet performs aggressive normalization of the PEM contents written\ninto the pod filesystem.  Esoteric PEM features such as inter-block\ncomments and block headers are stripped.  Certificates are deduplicated.\nThe ordering of certificates within the file is arbitrary, and Kubelet\nmay change the order over time.",
-                                                    "properties": {
-                                                        "labelSelector": {
-                                                            "description": "Select all ClusterTrustBundles that match this label selector.  Only has\neffect if signerName is set.  Mutually-exclusive with name.  If unset,\ninterpreted as \"match nothing\".  If set but empty, interpreted as \"match\neverything\".",
-                                                            "properties": {
-                                                                "matchExpressions": {
-                                                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
-                                                                    "items": {
-                                                                        "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
-                                                                        "properties": {
-                                                                            "key": {
-                                                                                "description": "key is the label key that the selector applies to.",
-                                                                                "type": "string"
-                                                                            },
-                                                                            "operator": {
-                                                                                "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
-                                                                                "type": "string"
-                                                                            },
-                                                                            "values": {
-                                                                                "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
-                                                                                "items": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "type": "array",
-                                                                                "x-kubernetes-list-type": "atomic"
-                                                                            }
-                                                                        },
-                                                                        "required": [
-                                                                            "key",
-                                                                            "operator"
-                                                                        ],
-                                                                        "type": "object",
-                                                                        "additionalProperties": false
-                                                                    },
-                                                                    "type": "array",
-                                                                    "x-kubernetes-list-type": "atomic"
-                                                                },
-                                                                "matchLabels": {
-                                                                    "additionalProperties": {
-                                                                        "type": "string"
-                                                                    },
-                                                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                                                                    "type": "object"
-                                                                }
-                                                            },
-                                                            "type": "object",
-                                                            "x-kubernetes-map-type": "atomic",
-                                                            "additionalProperties": false
-                                                        },
-                                                        "name": {
-                                                            "description": "Select a single ClusterTrustBundle by object name.  Mutually-exclusive\nwith signerName and labelSelector.",
-                                                            "type": "string"
-                                                        },
-                                                        "optional": {
-                                                            "description": "If true, don't block pod startup if the referenced ClusterTrustBundle(s)\naren't available.  If using name, then the named ClusterTrustBundle is\nallowed not to exist.  If using signerName, then the combination of\nsignerName and labelSelector is allowed to match zero\nClusterTrustBundles.",
-                                                            "type": "boolean"
-                                                        },
-                                                        "path": {
-                                                            "description": "Relative path from the volume root to write the bundle.",
-                                                            "type": "string"
-                                                        },
-                                                        "signerName": {
-                                                            "description": "Select all ClusterTrustBundles that match this signer name.\nMutually-exclusive with name.  The contents of all selected\nClusterTrustBundles will be unified and deduplicated.",
-                                                            "type": "string"
-                                                        }
-                                                    },
-                                                    "required": [
-                                                        "path"
-                                                    ],
-                                                    "type": "object",
-                                                    "additionalProperties": false
-                                                },
-                                                "configMap": {
-                                                    "description": "configMap information about the configMap data to project",
-                                                    "properties": {
-                                                        "items": {
-                                                            "description": "items if unspecified, each key-value pair in the Data field of the referenced\nConfigMap will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the ConfigMap,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
-                                                            "items": {
-                                                                "description": "Maps a string key to a path within a volume.",
-                                                                "properties": {
-                                                                    "key": {
-                                                                        "description": "key is the key to project.",
-                                                                        "type": "string"
-                                                                    },
-                                                                    "mode": {
-                                                                        "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
-                                                                        "format": "int32",
-                                                                        "type": "integer",
-                                                                        "minimum": -2147483648,
-                                                                        "maximum": 2147483647
-                                                                    },
-                                                                    "path": {
-                                                                        "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
-                                                                        "type": "string"
-                                                                    }
-                                                                },
-                                                                "required": [
-                                                                    "key",
-                                                                    "path"
-                                                                ],
-                                                                "type": "object",
-                                                                "additionalProperties": false
-                                                            },
-                                                            "type": "array",
-                                                            "x-kubernetes-list-type": "atomic"
-                                                        },
-                                                        "name": {
-                                                            "default": "",
-                                                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
-                                                            "type": "string"
-                                                        },
-                                                        "optional": {
-                                                            "description": "optional specify whether the ConfigMap or its keys must be defined",
-                                                            "type": "boolean"
-                                                        }
-                                                    },
-                                                    "type": "object",
-                                                    "x-kubernetes-map-type": "atomic",
-                                                    "additionalProperties": false
-                                                },
-                                                "downwardAPI": {
-                                                    "description": "downwardAPI information about the downwardAPI data to project",
-                                                    "properties": {
-                                                        "items": {
-                                                            "description": "Items is a list of DownwardAPIVolume file",
-                                                            "items": {
-                                                                "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
-                                                                "properties": {
-                                                                    "fieldRef": {
-                                                                        "description": "Required: Selects a field of the pod: only annotations, labels, name, namespace and uid are supported.",
-                                                                        "properties": {
-                                                                            "apiVersion": {
-                                                                                "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
-                                                                                "type": "string"
-                                                                            },
-                                                                            "fieldPath": {
-                                                                                "description": "Path of the field to select in the specified API version.",
-                                                                                "type": "string"
-                                                                            }
-                                                                        },
-                                                                        "required": [
-                                                                            "fieldPath"
-                                                                        ],
-                                                                        "type": "object",
-                                                                        "x-kubernetes-map-type": "atomic",
-                                                                        "additionalProperties": false
-                                                                    },
-                                                                    "mode": {
-                                                                        "description": "Optional: mode bits used to set permissions on this file, must be an octal value\nbetween 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
-                                                                        "format": "int32",
-                                                                        "type": "integer",
-                                                                        "minimum": -2147483648,
-                                                                        "maximum": 2147483647
-                                                                    },
-                                                                    "path": {
-                                                                        "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'",
-                                                                        "type": "string"
-                                                                    },
-                                                                    "resourceFieldRef": {
-                                                                        "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.",
-                                                                        "properties": {
-                                                                            "containerName": {
-                                                                                "description": "Container name: required for volumes, optional for env vars",
-                                                                                "type": "string"
-                                                                            },
-                                                                            "divisor": {
-                                                                                "anyOf": [
-                                                                                    {
-                                                                                        "type": "integer"
-                                                                                    },
-                                                                                    {
-                                                                                        "type": "string"
-                                                                                    }
-                                                                                ],
-                                                                                "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
-                                                                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
-                                                                                "x-kubernetes-int-or-string": true
-                                                                            },
-                                                                            "resource": {
-                                                                                "description": "Required: resource to select",
-                                                                                "type": "string"
-                                                                            }
-                                                                        },
-                                                                        "required": [
-                                                                            "resource"
-                                                                        ],
-                                                                        "type": "object",
-                                                                        "x-kubernetes-map-type": "atomic",
-                                                                        "additionalProperties": false
-                                                                    }
-                                                                },
-                                                                "required": [
-                                                                    "path"
-                                                                ],
-                                                                "type": "object",
-                                                                "additionalProperties": false
-                                                            },
-                                                            "type": "array",
-                                                            "x-kubernetes-list-type": "atomic"
-                                                        }
-                                                    },
-                                                    "type": "object",
-                                                    "additionalProperties": false
-                                                },
-                                                "podCertificate": {
-                                                    "description": "Projects an auto-rotating credential bundle (private key and certificate\nchain) that the pod can use either as a TLS client or server.\n\nKubelet generates a private key and uses it to send a\nPodCertificateRequest to the named signer.  Once the signer approves the\nrequest and issues a certificate chain, Kubelet writes the key and\ncertificate chain to the pod filesystem.  The pod does not start until\ncertificates have been issued for each podCertificate projected volume\nsource in its spec.\n\nKubelet will begin trying to rotate the certificate at the time indicated\nby the signer using the PodCertificateRequest.Status.BeginRefreshAt\ntimestamp.\n\nKubelet can write a single file, indicated by the credentialBundlePath\nfield, or separate files, indicated by the keyPath and\ncertificateChainPath fields.\n\nThe credential bundle is a single file in PEM format.  The first PEM\nentry is the private key (in PKCS#8 format), and the remaining PEM\nentries are the certificate chain issued by the signer (typically,\nsigners will return their certificate chain in leaf-to-root order).\n\nPrefer using the credential bundle format, since your application code\ncan read it atomically.  If you use keyPath and certificateChainPath,\nyour application must make two separate file reads. If these coincide\nwith a certificate rotation, it is possible that the private key and leaf\ncertificate you read may not correspond to each other.  Your application\nwill need to check for this condition, and re-read until they are\nconsistent.\n\nThe named signer controls chooses the format of the certificate it\nissues; consult the signer implementation's documentation to learn how to\nuse the certificates it issues.",
-                                                    "properties": {
-                                                        "certificateChainPath": {
-                                                            "description": "Write the certificate chain at this path in the projected volume.\n\nMost applications should use credentialBundlePath.  When using keyPath\nand certificateChainPath, your application needs to check that the key\nand leaf certificate are consistent, because it is possible to read the\nfiles mid-rotation.",
-                                                            "type": "string"
-                                                        },
-                                                        "credentialBundlePath": {
-                                                            "description": "Write the credential bundle at this path in the projected volume.\n\nThe credential bundle is a single file that contains multiple PEM blocks.\nThe first PEM block is a PRIVATE KEY block, containing a PKCS#8 private\nkey.\n\nThe remaining blocks are CERTIFICATE blocks, containing the issued\ncertificate chain from the signer (leaf and any intermediates).\n\nUsing credentialBundlePath lets your Pod's application code make a single\natomic read that retrieves a consistent key and certificate chain.  If you\nproject them to separate files, your application code will need to\nadditionally check that the leaf certificate was issued to the key.",
-                                                            "type": "string"
-                                                        },
-                                                        "keyPath": {
-                                                            "description": "Write the key at this path in the projected volume.\n\nMost applications should use credentialBundlePath.  When using keyPath\nand certificateChainPath, your application needs to check that the key\nand leaf certificate are consistent, because it is possible to read the\nfiles mid-rotation.",
-                                                            "type": "string"
-                                                        },
-                                                        "keyType": {
-                                                            "description": "The type of keypair Kubelet will generate for the pod.\n\nValid values are \"RSA3072\", \"RSA4096\", \"ECDSAP256\", \"ECDSAP384\",\n\"ECDSAP521\", and \"ED25519\".",
-                                                            "type": "string"
-                                                        },
-                                                        "maxExpirationSeconds": {
-                                                            "description": "maxExpirationSeconds is the maximum lifetime permitted for the\ncertificate.\n\nKubelet copies this value verbatim into the PodCertificateRequests it\ngenerates for this projection.\n\nIf omitted, kube-apiserver will set it to 86400(24 hours). kube-apiserver\nwill reject values shorter than 3600 (1 hour).  The maximum allowable\nvalue is 7862400 (91 days).\n\nThe signer implementation is then free to issue a certificate with any\nlifetime *shorter* than MaxExpirationSeconds, but no shorter than 3600\nseconds (1 hour).  This constraint is enforced by kube-apiserver.\n`kubernetes.io` signers will never issue certificates with a lifetime\nlonger than 24 hours.",
-                                                            "format": "int32",
-                                                            "type": "integer",
-                                                            "minimum": -2147483648,
-                                                            "maximum": 2147483647
-                                                        },
-                                                        "signerName": {
-                                                            "description": "Kubelet's generated CSRs will be addressed to this signer.",
-                                                            "type": "string"
-                                                        },
-                                                        "userAnnotations": {
-                                                            "additionalProperties": {
-                                                                "type": "string"
-                                                            },
-                                                            "description": "userAnnotations allow pod authors to pass additional information to\nthe signer implementation.  Kubernetes does not restrict or validate this\nmetadata in any way.\n\nThese values are copied verbatim into the `spec.unverifiedUserAnnotations` field of\nthe PodCertificateRequest objects that Kubelet creates.\n\nEntries are subject to the same validation as object metadata annotations,\nwith the addition that all keys must be domain-prefixed. No restrictions\nare placed on values, except an overall size limitation on the entire field.\n\nSigners should document the keys and values they support. Signers should\ndeny requests that contain keys they do not recognize.",
-                                                            "type": "object"
-                                                        }
-                                                    },
-                                                    "required": [
-                                                        "keyType",
-                                                        "signerName"
-                                                    ],
-                                                    "type": "object",
-                                                    "additionalProperties": false
-                                                },
-                                                "secret": {
-                                                    "description": "secret information about the secret data to project",
-                                                    "properties": {
-                                                        "items": {
-                                                            "description": "items if unspecified, each key-value pair in the Data field of the referenced\nSecret will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the Secret,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
-                                                            "items": {
-                                                                "description": "Maps a string key to a path within a volume.",
-                                                                "properties": {
-                                                                    "key": {
-                                                                        "description": "key is the key to project.",
-                                                                        "type": "string"
-                                                                    },
-                                                                    "mode": {
-                                                                        "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
-                                                                        "format": "int32",
-                                                                        "type": "integer",
-                                                                        "minimum": -2147483648,
-                                                                        "maximum": 2147483647
-                                                                    },
-                                                                    "path": {
-                                                                        "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
-                                                                        "type": "string"
-                                                                    }
-                                                                },
-                                                                "required": [
-                                                                    "key",
-                                                                    "path"
-                                                                ],
-                                                                "type": "object",
-                                                                "additionalProperties": false
-                                                            },
-                                                            "type": "array",
-                                                            "x-kubernetes-list-type": "atomic"
-                                                        },
-                                                        "name": {
-                                                            "default": "",
-                                                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
-                                                            "type": "string"
-                                                        },
-                                                        "optional": {
-                                                            "description": "optional field specify whether the Secret or its key must be defined",
-                                                            "type": "boolean"
-                                                        }
-                                                    },
-                                                    "type": "object",
-                                                    "x-kubernetes-map-type": "atomic",
-                                                    "additionalProperties": false
-                                                },
-                                                "serviceAccountToken": {
-                                                    "description": "serviceAccountToken is information about the serviceAccountToken data to project",
-                                                    "properties": {
-                                                        "audience": {
-                                                            "description": "audience is the intended audience of the token. A recipient of a token\nmust identify itself with an identifier specified in the audience of the\ntoken, and otherwise should reject the token. The audience defaults to the\nidentifier of the apiserver.",
-                                                            "type": "string"
-                                                        },
-                                                        "expirationSeconds": {
-                                                            "description": "expirationSeconds is the requested duration of validity of the service\naccount token. As the token approaches expiration, the kubelet volume\nplugin will proactively rotate the service account token. The kubelet will\nstart trying to rotate the token if the token is older than 80 percent of\nits time to live or if the token is older than 24 hours.Defaults to 1 hour\nand must be at least 10 minutes.",
-                                                            "format": "int64",
-                                                            "type": "integer",
-                                                            "minimum": -9223372036854776000,
-                                                            "maximum": 9223372036854776000
-                                                        },
-                                                        "path": {
-                                                            "description": "path is the path relative to the mount point of the file to project the\ntoken into.",
-                                                            "type": "string"
-                                                        }
-                                                    },
-                                                    "required": [
-                                                        "path"
-                                                    ],
-                                                    "type": "object",
-                                                    "additionalProperties": false
-                                                }
-                                            },
-                                            "type": "object",
-                                            "additionalProperties": false
-                                        },
-                                        "type": "array",
-                                        "x-kubernetes-list-type": "atomic"
-                                    }
-                                },
-                                "type": "object",
-                                "additionalProperties": false
-                            },
-                            "quobyte": {
-                                "description": "quobyte represents a Quobyte mount on the host that shares a pod's lifetime.\nDeprecated: Quobyte is deprecated and the in-tree quobyte type is no longer supported.",
-                                "properties": {
-                                    "group": {
-                                        "description": "group to map volume access to\nDefault is no group",
-                                        "type": "string"
-                                    },
-                                    "readOnly": {
-                                        "description": "readOnly here will force the Quobyte volume to be mounted with read-only permissions.\nDefaults to false.",
-                                        "type": "boolean"
-                                    },
-                                    "registry": {
-                                        "description": "registry represents a single or multiple Quobyte Registry services\nspecified as a string as host:port pair (multiple entries are separated with commas)\nwhich acts as the central registry for volumes",
-                                        "type": "string"
-                                    },
-                                    "tenant": {
-                                        "description": "tenant owning the given Quobyte volume in the Backend\nUsed with dynamically provisioned Quobyte volumes, value is set by the plugin",
-                                        "type": "string"
-                                    },
-                                    "user": {
-                                        "description": "user to map volume access to\nDefaults to serivceaccount user",
-                                        "type": "string"
-                                    },
-                                    "volume": {
-                                        "description": "volume is a string that references an already created Quobyte volume by name.",
-                                        "type": "string"
-                                    }
-                                },
-                                "required": [
-                                    "registry",
-                                    "volume"
-                                ],
-                                "type": "object",
-                                "additionalProperties": false
-                            },
-                            "rbd": {
-                                "description": "rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.\nDeprecated: RBD is deprecated and the in-tree rbd type is no longer supported.",
-                                "properties": {
-                                    "fsType": {
-                                        "description": "fsType is the filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#rbd",
-                                        "type": "string"
-                                    },
-                                    "image": {
-                                        "description": "image is the rados image name.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
-                                        "type": "string"
-                                    },
-                                    "keyring": {
-                                        "default": "/etc/ceph/keyring",
-                                        "description": "keyring is the path to key ring for RBDUser.\nDefault is /etc/ceph/keyring.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
-                                        "type": "string"
-                                    },
-                                    "monitors": {
-                                        "description": "monitors is a collection of Ceph monitors.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
-                                        "items": {
-                                            "type": "string"
-                                        },
-                                        "type": "array",
-                                        "x-kubernetes-list-type": "atomic"
-                                    },
-                                    "pool": {
-                                        "default": "rbd",
-                                        "description": "pool is the rados pool name.\nDefault is rbd.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
-                                        "type": "string"
-                                    },
-                                    "readOnly": {
-                                        "description": "readOnly here will force the ReadOnly setting in VolumeMounts.\nDefaults to false.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
-                                        "type": "boolean"
-                                    },
-                                    "secretRef": {
-                                        "description": "secretRef is name of the authentication secret for RBDUser. If provided\noverrides keyring.\nDefault is nil.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
-                                        "properties": {
-                                            "name": {
-                                                "default": "",
-                                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
-                                                "type": "string"
-                                            }
-                                        },
-                                        "type": "object",
-                                        "x-kubernetes-map-type": "atomic",
-                                        "additionalProperties": false
-                                    },
-                                    "user": {
-                                        "default": "admin",
-                                        "description": "user is the rados user name.\nDefault is admin.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
-                                        "type": "string"
-                                    }
-                                },
-                                "required": [
-                                    "image",
-                                    "monitors"
-                                ],
-                                "type": "object",
-                                "additionalProperties": false
-                            },
-                            "scaleIO": {
-                                "description": "scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.\nDeprecated: ScaleIO is deprecated and the in-tree scaleIO type is no longer supported.",
-                                "properties": {
-                                    "fsType": {
-                                        "default": "xfs",
-                                        "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\".\nDefault is \"xfs\".",
-                                        "type": "string"
-                                    },
-                                    "gateway": {
-                                        "description": "gateway is the host address of the ScaleIO API Gateway.",
-                                        "type": "string"
-                                    },
-                                    "protectionDomain": {
-                                        "description": "protectionDomain is the name of the ScaleIO Protection Domain for the configured storage.",
-                                        "type": "string"
-                                    },
-                                    "readOnly": {
-                                        "description": "readOnly Defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
-                                        "type": "boolean"
-                                    },
-                                    "secretRef": {
-                                        "description": "secretRef references to the secret for ScaleIO user and other\nsensitive information. If this is not provided, Login operation will fail.",
-                                        "properties": {
-                                            "name": {
-                                                "default": "",
-                                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
-                                                "type": "string"
-                                            }
-                                        },
-                                        "type": "object",
-                                        "x-kubernetes-map-type": "atomic",
-                                        "additionalProperties": false
-                                    },
-                                    "sslEnabled": {
-                                        "description": "sslEnabled Flag enable/disable SSL communication with Gateway, default false",
-                                        "type": "boolean"
-                                    },
-                                    "storageMode": {
-                                        "default": "ThinProvisioned",
-                                        "description": "storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.\nDefault is ThinProvisioned.",
-                                        "type": "string"
-                                    },
-                                    "storagePool": {
-                                        "description": "storagePool is the ScaleIO Storage Pool associated with the protection domain.",
-                                        "type": "string"
-                                    },
-                                    "system": {
-                                        "description": "system is the name of the storage system as configured in ScaleIO.",
-                                        "type": "string"
-                                    },
-                                    "volumeName": {
-                                        "description": "volumeName is the name of a volume already created in the ScaleIO system\nthat is associated with this volume source.",
-                                        "type": "string"
-                                    }
-                                },
-                                "required": [
-                                    "gateway",
-                                    "secretRef",
-                                    "system"
-                                ],
-                                "type": "object",
-                                "additionalProperties": false
-                            },
-                            "secret": {
-                                "description": "secret represents a secret that should populate this volume.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
-                                "properties": {
-                                    "defaultMode": {
-                                        "description": "defaultMode is Optional: mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values\nfor mode bits. Defaults to 0644.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
-                                        "format": "int32",
-                                        "type": "integer",
-                                        "minimum": -2147483648,
-                                        "maximum": 2147483647
-                                    },
-                                    "items": {
-                                        "description": "items If unspecified, each key-value pair in the Data field of the referenced\nSecret will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the Secret,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
-                                        "items": {
-                                            "description": "Maps a string key to a path within a volume.",
-                                            "properties": {
-                                                "key": {
-                                                    "description": "key is the key to project.",
-                                                    "type": "string"
-                                                },
-                                                "mode": {
-                                                    "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
-                                                    "format": "int32",
-                                                    "type": "integer",
-                                                    "minimum": -2147483648,
-                                                    "maximum": 2147483647
-                                                },
-                                                "path": {
-                                                    "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
-                                                    "type": "string"
-                                                }
-                                            },
-                                            "required": [
-                                                "key",
-                                                "path"
-                                            ],
-                                            "type": "object",
-                                            "additionalProperties": false
-                                        },
-                                        "type": "array",
-                                        "x-kubernetes-list-type": "atomic"
-                                    },
-                                    "optional": {
-                                        "description": "optional field specify whether the Secret or its keys must be defined",
-                                        "type": "boolean"
-                                    },
-                                    "secretName": {
-                                        "description": "secretName is the name of the secret in the pod's namespace to use.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
-                                        "type": "string"
-                                    }
-                                },
-                                "type": "object",
-                                "additionalProperties": false
-                            },
-                            "storageos": {
-                                "description": "storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.\nDeprecated: StorageOS is deprecated and the in-tree storageos type is no longer supported.",
-                                "properties": {
-                                    "fsType": {
-                                        "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
-                                        "type": "string"
-                                    },
-                                    "readOnly": {
-                                        "description": "readOnly defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
-                                        "type": "boolean"
-                                    },
-                                    "secretRef": {
-                                        "description": "secretRef specifies the secret to use for obtaining the StorageOS API\ncredentials.  If not specified, default values will be attempted.",
-                                        "properties": {
-                                            "name": {
-                                                "default": "",
-                                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
-                                                "type": "string"
-                                            }
-                                        },
-                                        "type": "object",
-                                        "x-kubernetes-map-type": "atomic",
-                                        "additionalProperties": false
-                                    },
-                                    "volumeName": {
-                                        "description": "volumeName is the human-readable name of the StorageOS volume.  Volume\nnames are only unique within a namespace.",
-                                        "type": "string"
-                                    },
-                                    "volumeNamespace": {
-                                        "description": "volumeNamespace specifies the scope of the volume within StorageOS.  If no\nnamespace is specified then the Pod's namespace will be used.  This allows the\nKubernetes name scoping to be mirrored within StorageOS for tighter integration.\nSet VolumeName to any name to override the default behaviour.\nSet to \"default\" if you are not using namespaces within StorageOS.\nNamespaces that do not pre-exist within StorageOS will be created.",
-                                        "type": "string"
-                                    }
-                                },
-                                "type": "object",
-                                "additionalProperties": false
-                            },
-                            "vsphereVolume": {
-                                "description": "vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine.\nDeprecated: VsphereVolume is deprecated. All operations for the in-tree vsphereVolume type\nare redirected to the csi.vsphere.vmware.com CSI driver.",
-                                "properties": {
-                                    "fsType": {
-                                        "description": "fsType is filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
-                                        "type": "string"
-                                    },
-                                    "storagePolicyID": {
-                                        "description": "storagePolicyID is the storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.",
-                                        "type": "string"
-                                    },
-                                    "storagePolicyName": {
-                                        "description": "storagePolicyName is the storage Policy Based Management (SPBM) profile name.",
-                                        "type": "string"
-                                    },
-                                    "volumePath": {
-                                        "description": "volumePath is the path that identifies vSphere volume vmdk",
-                                        "type": "string"
-                                    }
-                                },
-                                "required": [
-                                    "volumePath"
-                                ],
-                                "type": "object",
-                                "additionalProperties": false
-                            }
-                        },
-                        "required": [
-                            "name"
-                        ],
-                        "type": "object",
-                        "additionalProperties": false
-                    },
-                    "type": "array"
-                },
-                "image": {
-                    "description": "Renovate Docker image to use",
-                    "type": "string"
-                },
-                "imagePullSecrets": {
-                    "description": "Image pull secrets for the renovate pods",
-                    "items": {
-                        "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
-                        "properties": {
-                            "name": {
-                                "default": "",
-                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
-                                "type": "string"
-                            }
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          }
                         },
                         "type": "object",
                         "x-kubernetes-map-type": "atomic",
                         "additionalProperties": false
-                    },
-                    "type": "array"
-                },
-                "metadata": {
-                    "description": "Metadata that shall be applied to the resulting pod",
-                    "properties": {
-                        "annotations": {
-                            "additionalProperties": {
-                                "type": "string"
-                            },
-                            "type": "object"
-                        },
-                        "labels": {
-                            "additionalProperties": {
-                                "type": "string"
-                            },
-                            "type": "object"
-                        }
-                    },
-                    "type": "object",
-                    "additionalProperties": false
-                },
-                "nodeSelector": {
-                    "additionalProperties": {
-                        "type": "string"
-                    },
-                    "description": "Node selector for scheduling the resulting pod",
-                    "type": "object"
-                },
-                "parallelism": {
-                    "description": "Maximum number of projects to process in parallel",
-                    "format": "int32",
-                    "type": "integer",
-                    "minimum": -2147483648,
-                    "maximum": 2147483647
-                },
-                "provider": {
-                    "description": "Renovate Provider Information to fill \"RENOVATE_ENDPOINT\" and \"RENOVATE_PLATFORM\" environment variables in the renovate container",
-                    "properties": {
-                        "endpoint": {
-                            "type": "string"
-                        },
-                        "name": {
-                            "type": "string"
-                        }
+                      },
+                      "weight": {
+                        "description": "Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.",
+                        "format": "int32",
+                        "type": "integer"
+                      }
                     },
                     "required": [
-                        "name"
+                      "preference",
+                      "weight"
                     ],
                     "type": "object",
                     "additionalProperties": false
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
                 },
-                "resources": {
-                    "description": "Resource requirements for the renovate container",
-                    "properties": {
-                        "claims": {
-                            "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis field depends on the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
+                "requiredDuringSchedulingIgnoredDuringExecution": {
+                  "description": "If the affinity requirements specified by this field are not met at\nscheduling time, the pod will not be scheduled onto the node.\nIf the affinity requirements specified by this field cease to be met\nat some point during pod execution (e.g. due to an update), the system\nmay or may not try to eventually evict the pod from its node.",
+                  "properties": {
+                    "nodeSelectorTerms": {
+                      "description": "Required. A list of node selector terms. The terms are ORed.",
+                      "items": {
+                        "description": "A null or empty node selector term matches no objects. The requirements of\nthem are ANDed.\nThe TopologySelectorTerm type implements a subset of the NodeSelectorTerm.",
+                        "properties": {
+                          "matchExpressions": {
+                            "description": "A list of node selector requirements by node's labels.",
                             "items": {
-                                "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
-                                "properties": {
-                                    "name": {
-                                        "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
-                                        "type": "string"
-                                    },
-                                    "request": {
-                                        "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
-                                        "type": "string"
-                                    }
+                              "description": "A node selector requirement is a selector that contains values, a key, and an operator\nthat relates the key and values.",
+                              "properties": {
+                                "key": {
+                                  "description": "The label key that the selector applies to.",
+                                  "type": "string"
                                 },
-                                "required": [
-                                    "name"
-                                ],
-                                "type": "object",
-                                "additionalProperties": false
+                                "operator": {
+                                  "description": "Represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "An array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. If the operator is Gt or Lt, the values\narray must have a single element, which will be interpreted as an integer.\nThis array is replaced during a strategic merge patch.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
                             },
                             "type": "array",
-                            "x-kubernetes-list-map-keys": [
-                                "name"
-                            ],
-                            "x-kubernetes-list-type": "map"
-                        },
-                        "limits": {
-                            "additionalProperties": {
-                                "anyOf": [
-                                    {
-                                        "type": "integer"
-                                    },
-                                    {
-                                        "type": "string"
-                                    }
-                                ],
-                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
-                                "x-kubernetes-int-or-string": true
-                            },
-                            "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
-                            "type": "object"
-                        },
-                        "requests": {
-                            "additionalProperties": {
-                                "anyOf": [
-                                    {
-                                        "type": "integer"
-                                    },
-                                    {
-                                        "type": "string"
-                                    }
-                                ],
-                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
-                                "x-kubernetes-int-or-string": true
-                            },
-                            "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
-                            "type": "object"
-                        }
-                    },
-                    "type": "object",
-                    "additionalProperties": false
-                },
-                "schedule": {
-                    "description": "Cron schedule in standard cron format",
-                    "type": "string"
-                },
-                "scratchVolume": {
-                    "description": "Configuration for the scratch volume",
-                    "properties": {
-                        "enabled": {
-                            "default": true,
-                            "description": "If enabled a scratch volume will be created and RENOVATE_BASE_DIR will be set accordingly",
-                            "type": "boolean"
-                        },
-                        "ephemeral": {
-                            "description": "Ephemeral uses a Kubernetes generic ephemeral volume for scratch (volume.ephemeral).\nWhen set, Medium and SizeLimit are ignored.",
-                            "properties": {
-                                "volumeClaimTemplate": {
-                                    "description": "Will be used to create a stand-alone PVC to provision the volume.\nThe pod in which this EphemeralVolumeSource is embedded will be the\nowner of the PVC, i.e. the PVC will be deleted together with the\npod.  The name of the PVC will be `<pod name>-<volume name>` where\n`<volume name>` is the name from the `PodSpec.Volumes` array\nentry. Pod validation will reject the pod if the concatenated name\nis not valid for a PVC (for example, too long).\n\nAn existing PVC with that name that is not owned by the pod\nwill *not* be used for the pod to avoid using an unrelated\nvolume by mistake. Starting the pod is then blocked until\nthe unrelated PVC is removed. If such a pre-created PVC is\nmeant to be used by the pod, the PVC has to updated with an\nowner reference to the pod once the pod exists. Normally\nthis should not be necessary, but it may be useful when\nmanually reconstructing a broken cluster.\n\nThis field is read-only and no changes will be made by Kubernetes\nto the PVC after it has been created.\n\nRequired, must not be nil.",
-                                    "properties": {
-                                        "metadata": {
-                                            "description": "May contain labels and annotations that will be copied into the PVC\nwhen creating it. No other fields are allowed and will be rejected during\nvalidation.",
-                                            "type": "object"
-                                        },
-                                        "spec": {
-                                            "description": "The specification for the PersistentVolumeClaim. The entire content is\ncopied unchanged into the PVC that gets created from this\ntemplate. The same fields as in a PersistentVolumeClaim\nare also valid here.",
-                                            "properties": {
-                                                "accessModes": {
-                                                    "description": "accessModes contains the desired access modes the volume should have.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1",
-                                                    "items": {
-                                                        "type": "string"
-                                                    },
-                                                    "type": "array",
-                                                    "x-kubernetes-list-type": "atomic"
-                                                },
-                                                "dataSource": {
-                                                    "description": "dataSource field can be used to specify either:\n* An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)\n* An existing PVC (PersistentVolumeClaim)\nIf the provisioner or an external controller can support the specified data source,\nit will create a new volume based on the contents of the specified data source.\nWhen the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,\nand dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.\nIf the namespace is specified, then dataSourceRef will not be copied to dataSource.",
-                                                    "properties": {
-                                                        "apiGroup": {
-                                                            "description": "APIGroup is the group for the resource being referenced.\nIf APIGroup is not specified, the specified Kind must be in the core API group.\nFor any other third-party types, APIGroup is required.",
-                                                            "type": "string"
-                                                        },
-                                                        "kind": {
-                                                            "description": "Kind is the type of resource being referenced",
-                                                            "type": "string"
-                                                        },
-                                                        "name": {
-                                                            "description": "Name is the name of resource being referenced",
-                                                            "type": "string"
-                                                        }
-                                                    },
-                                                    "required": [
-                                                        "kind",
-                                                        "name"
-                                                    ],
-                                                    "type": "object",
-                                                    "x-kubernetes-map-type": "atomic",
-                                                    "additionalProperties": false
-                                                },
-                                                "dataSourceRef": {
-                                                    "description": "dataSourceRef specifies the object from which to populate the volume with data, if a non-empty\nvolume is desired. This may be any object from a non-empty API group (non\ncore object) or a PersistentVolumeClaim object.\nWhen this field is specified, volume binding will only succeed if the type of\nthe specified object matches some installed volume populator or dynamic\nprovisioner.\nThis field will replace the functionality of the dataSource field and as such\nif both fields are non-empty, they must have the same value. For backwards\ncompatibility, when namespace isn't specified in dataSourceRef,\nboth fields (dataSource and dataSourceRef) will be set to the same\nvalue automatically if one of them is empty and the other is non-empty.\nWhen namespace is specified in dataSourceRef,\ndataSource isn't set to the same value and must be empty.\nThere are three important differences between dataSource and dataSourceRef:\n* While dataSource only allows two specific types of objects, dataSourceRef\n  allows any non-core object, as well as PersistentVolumeClaim objects.\n* While dataSource ignores disallowed values (dropping them), dataSourceRef\n  preserves all values, and generates an error if a disallowed value is\n  specified.\n* While dataSource only allows local objects, dataSourceRef allows objects\n  in any namespaces.\n(Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.\n(Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.",
-                                                    "properties": {
-                                                        "apiGroup": {
-                                                            "description": "APIGroup is the group for the resource being referenced.\nIf APIGroup is not specified, the specified Kind must be in the core API group.\nFor any other third-party types, APIGroup is required.",
-                                                            "type": "string"
-                                                        },
-                                                        "kind": {
-                                                            "description": "Kind is the type of resource being referenced",
-                                                            "type": "string"
-                                                        },
-                                                        "name": {
-                                                            "description": "Name is the name of resource being referenced",
-                                                            "type": "string"
-                                                        },
-                                                        "namespace": {
-                                                            "description": "Namespace is the namespace of resource being referenced\nNote that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.\n(Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.",
-                                                            "type": "string"
-                                                        }
-                                                    },
-                                                    "required": [
-                                                        "kind",
-                                                        "name"
-                                                    ],
-                                                    "type": "object",
-                                                    "additionalProperties": false
-                                                },
-                                                "resources": {
-                                                    "description": "resources represents the minimum resources the volume should have.\nUsers are allowed to specify resource requirements\nthat are lower than previous value but must still be higher than capacity recorded in the\nstatus field of the claim.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources",
-                                                    "properties": {
-                                                        "limits": {
-                                                            "additionalProperties": {
-                                                                "anyOf": [
-                                                                    {
-                                                                        "type": "integer"
-                                                                    },
-                                                                    {
-                                                                        "type": "string"
-                                                                    }
-                                                                ],
-                                                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
-                                                                "x-kubernetes-int-or-string": true
-                                                            },
-                                                            "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
-                                                            "type": "object"
-                                                        },
-                                                        "requests": {
-                                                            "additionalProperties": {
-                                                                "anyOf": [
-                                                                    {
-                                                                        "type": "integer"
-                                                                    },
-                                                                    {
-                                                                        "type": "string"
-                                                                    }
-                                                                ],
-                                                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
-                                                                "x-kubernetes-int-or-string": true
-                                                            },
-                                                            "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
-                                                            "type": "object"
-                                                        }
-                                                    },
-                                                    "type": "object",
-                                                    "additionalProperties": false
-                                                },
-                                                "selector": {
-                                                    "description": "selector is a label query over volumes to consider for binding.",
-                                                    "properties": {
-                                                        "matchExpressions": {
-                                                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
-                                                            "items": {
-                                                                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
-                                                                "properties": {
-                                                                    "key": {
-                                                                        "description": "key is the label key that the selector applies to.",
-                                                                        "type": "string"
-                                                                    },
-                                                                    "operator": {
-                                                                        "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
-                                                                        "type": "string"
-                                                                    },
-                                                                    "values": {
-                                                                        "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
-                                                                        "items": {
-                                                                            "type": "string"
-                                                                        },
-                                                                        "type": "array",
-                                                                        "x-kubernetes-list-type": "atomic"
-                                                                    }
-                                                                },
-                                                                "required": [
-                                                                    "key",
-                                                                    "operator"
-                                                                ],
-                                                                "type": "object",
-                                                                "additionalProperties": false
-                                                            },
-                                                            "type": "array",
-                                                            "x-kubernetes-list-type": "atomic"
-                                                        },
-                                                        "matchLabels": {
-                                                            "additionalProperties": {
-                                                                "type": "string"
-                                                            },
-                                                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                                                            "type": "object"
-                                                        }
-                                                    },
-                                                    "type": "object",
-                                                    "x-kubernetes-map-type": "atomic",
-                                                    "additionalProperties": false
-                                                },
-                                                "storageClassName": {
-                                                    "description": "storageClassName is the name of the StorageClass required by the claim.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1",
-                                                    "type": "string"
-                                                },
-                                                "volumeAttributesClassName": {
-                                                    "description": "volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.\nIf specified, the CSI driver will create or update the volume with the attributes defined\nin the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,\nit can be changed after the claim is created. An empty string or nil value indicates that no\nVolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,\nthis field can be reset to its previous value (including nil) to cancel the modification.\nIf the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be\nset to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource\nexists.\nMore info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/",
-                                                    "type": "string"
-                                                },
-                                                "volumeMode": {
-                                                    "description": "volumeMode defines what type of volume is required by the claim.\nValue of Filesystem is implied when not included in claim spec.",
-                                                    "type": "string"
-                                                },
-                                                "volumeName": {
-                                                    "description": "volumeName is the binding reference to the PersistentVolume backing this claim.",
-                                                    "type": "string"
-                                                }
-                                            },
-                                            "type": "object",
-                                            "additionalProperties": false
-                                        }
-                                    },
-                                    "required": [
-                                        "spec"
-                                    ],
-                                    "type": "object",
-                                    "additionalProperties": false
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "matchFields": {
+                            "description": "A list of node selector requirements by node's fields.",
+                            "items": {
+                              "description": "A node selector requirement is a selector that contains values, a key, and an operator\nthat relates the key and values.",
+                              "properties": {
+                                "key": {
+                                  "description": "The label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "Represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "An array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. If the operator is Gt or Lt, the values\narray must have a single element, which will be interpreted as an integer.\nThis array is replaced during a strategic merge patch.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
                                 }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
                             },
-                            "type": "object",
-                            "additionalProperties": false
-                        },
-                        "medium": {
-                            "description": "Medium for the emptyDir volume. Ignored when Ephemeral is set.\nEmpty uses the node's default medium; Memory uses a tmpfs (corev1.StorageMediumMemory).",
-                            "type": "string"
-                        },
-                        "path": {
-                            "default": "/tmp",
-                            "description": "Path within the container where the scratch volume will be mounted, RENOVATE_BASE_DIR will be set to this path.",
-                            "type": "string"
-                        },
-                        "sizeLimit": {
-                            "anyOf": [
-                                {
-                                    "type": "integer"
-                                },
-                                {
-                                    "type": "string"
-                                }
-                            ],
-                            "description": "SizeLimit caps how large the emptyDir may grow (Kubernetes emptyDir.sizeLimit). Ignored when Ephemeral is set.",
-                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
-                            "x-kubernetes-int-or-string": true
-                        }
-                    },
-                    "type": "object",
-                    "additionalProperties": false
-                },
-                "secretRef": {
-                    "description": "Reference to the secret containing the renovate config",
-                    "type": "string"
-                },
-                "securityContext": {
-                    "description": "Security context for the resulting pod and container",
-                    "properties": {
-                        "container": {
-                            "description": "SecurityContext holds security configuration that will be applied to a container.\nSome fields are present in both SecurityContext and PodSecurityContext.  When both\nare set, the values in SecurityContext take precedence.",
-                            "properties": {
-                                "allowPrivilegeEscalation": {
-                                    "description": "AllowPrivilegeEscalation controls whether a process can gain more\nprivileges than its parent process. This bool directly controls if\nthe no_new_privs flag will be set on the container process.\nAllowPrivilegeEscalation is true always when the container is:\n1) run as Privileged\n2) has CAP_SYS_ADMIN\nNote that this field cannot be set when spec.os.name is windows.",
-                                    "type": "boolean"
-                                },
-                                "appArmorProfile": {
-                                    "description": "appArmorProfile is the AppArmor options to use by this container. If set, this profile\noverrides the pod's appArmorProfile.\nNote that this field cannot be set when spec.os.name is windows.",
-                                    "properties": {
-                                        "localhostProfile": {
-                                            "description": "localhostProfile indicates a profile loaded on the node that should be used.\nThe profile must be preconfigured on the node to work.\nMust match the loaded name of the profile.\nMust be set if and only if type is \"Localhost\".",
-                                            "type": "string"
-                                        },
-                                        "type": {
-                                            "description": "type indicates which kind of AppArmor profile will be applied.\nValid options are:\n  Localhost - a profile pre-loaded on the node.\n  RuntimeDefault - the container runtime's default profile.\n  Unconfined - no AppArmor enforcement.",
-                                            "type": "string"
-                                        }
-                                    },
-                                    "required": [
-                                        "type"
-                                    ],
-                                    "type": "object",
-                                    "additionalProperties": false
-                                },
-                                "capabilities": {
-                                    "description": "The capabilities to add/drop when running containers.\nDefaults to the default set of capabilities granted by the container runtime.\nNote that this field cannot be set when spec.os.name is windows.",
-                                    "properties": {
-                                        "add": {
-                                            "description": "Added capabilities",
-                                            "items": {
-                                                "description": "Capability represent POSIX capabilities type",
-                                                "type": "string"
-                                            },
-                                            "type": "array",
-                                            "x-kubernetes-list-type": "atomic"
-                                        },
-                                        "drop": {
-                                            "description": "Removed capabilities",
-                                            "items": {
-                                                "description": "Capability represent POSIX capabilities type",
-                                                "type": "string"
-                                            },
-                                            "type": "array",
-                                            "x-kubernetes-list-type": "atomic"
-                                        }
-                                    },
-                                    "type": "object",
-                                    "additionalProperties": false
-                                },
-                                "privileged": {
-                                    "description": "Run container in privileged mode.\nProcesses in privileged containers are essentially equivalent to root on the host.\nDefaults to false.\nNote that this field cannot be set when spec.os.name is windows.",
-                                    "type": "boolean"
-                                },
-                                "procMount": {
-                                    "description": "procMount denotes the type of proc mount to use for the containers.\nThe default value is Default which uses the container runtime defaults for\nreadonly paths and masked paths.\nThis requires the ProcMountType feature flag to be enabled.\nNote that this field cannot be set when spec.os.name is windows.",
-                                    "type": "string"
-                                },
-                                "readOnlyRootFilesystem": {
-                                    "description": "Whether this container has a read-only root filesystem.\nDefault is false.\nNote that this field cannot be set when spec.os.name is windows.",
-                                    "type": "boolean"
-                                },
-                                "runAsGroup": {
-                                    "description": "The GID to run the entrypoint of the container process.\nUses runtime default if unset.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
-                                    "format": "int64",
-                                    "type": "integer",
-                                    "minimum": -9223372036854776000,
-                                    "maximum": 9223372036854776000
-                                },
-                                "runAsNonRoot": {
-                                    "description": "Indicates that the container must run as a non-root user.\nIf true, the Kubelet will validate the image at runtime to ensure that it\ndoes not run as UID 0 (root) and fail to start the container if it does.\nIf unset or false, no such validation will be performed.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
-                                    "type": "boolean"
-                                },
-                                "runAsUser": {
-                                    "description": "The UID to run the entrypoint of the container process.\nDefaults to user specified in image metadata if unspecified.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
-                                    "format": "int64",
-                                    "type": "integer",
-                                    "minimum": -9223372036854776000,
-                                    "maximum": 9223372036854776000
-                                },
-                                "seLinuxOptions": {
-                                    "description": "The SELinux context to be applied to the container.\nIf unspecified, the container runtime will allocate a random SELinux context for each\ncontainer.  May also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
-                                    "properties": {
-                                        "level": {
-                                            "description": "Level is SELinux level label that applies to the container.",
-                                            "type": "string"
-                                        },
-                                        "role": {
-                                            "description": "Role is a SELinux role label that applies to the container.",
-                                            "type": "string"
-                                        },
-                                        "type": {
-                                            "description": "Type is a SELinux type label that applies to the container.",
-                                            "type": "string"
-                                        },
-                                        "user": {
-                                            "description": "User is a SELinux user label that applies to the container.",
-                                            "type": "string"
-                                        }
-                                    },
-                                    "type": "object",
-                                    "additionalProperties": false
-                                },
-                                "seccompProfile": {
-                                    "description": "The seccomp options to use by this container. If seccomp options are\nprovided at both the pod & container level, the container options\noverride the pod options.\nNote that this field cannot be set when spec.os.name is windows.",
-                                    "properties": {
-                                        "localhostProfile": {
-                                            "description": "localhostProfile indicates a profile defined in a file on the node should be used.\nThe profile must be preconfigured on the node to work.\nMust be a descending path, relative to the kubelet's configured seccomp profile location.\nMust be set if type is \"Localhost\". Must NOT be set for any other type.",
-                                            "type": "string"
-                                        },
-                                        "type": {
-                                            "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
-                                            "type": "string"
-                                        }
-                                    },
-                                    "required": [
-                                        "type"
-                                    ],
-                                    "type": "object",
-                                    "additionalProperties": false
-                                },
-                                "windowsOptions": {
-                                    "description": "The Windows specific settings applied to all containers.\nIf unspecified, the options from the PodSecurityContext will be used.\nIf set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is linux.",
-                                    "properties": {
-                                        "gmsaCredentialSpec": {
-                                            "description": "GMSACredentialSpec is where the GMSA admission webhook\n(https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the\nGMSA credential spec named by the GMSACredentialSpecName field.",
-                                            "type": "string"
-                                        },
-                                        "gmsaCredentialSpecName": {
-                                            "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
-                                            "type": "string"
-                                        },
-                                        "hostProcess": {
-                                            "description": "HostProcess determines if a container should be run as a 'Host Process' container.\nAll of a Pod's containers must have the same effective HostProcess value\n(it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).\nIn addition, if HostProcess is true then HostNetwork must also be set to true.",
-                                            "type": "boolean"
-                                        },
-                                        "runAsUserName": {
-                                            "description": "The UserName in Windows to run the entrypoint of the container process.\nDefaults to the user specified in image metadata if unspecified.\nMay also be set in PodSecurityContext. If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
-                                            "type": "string"
-                                        }
-                                    },
-                                    "type": "object",
-                                    "additionalProperties": false
-                                }
-                            },
-                            "type": "object",
-                            "additionalProperties": false
-                        },
-                        "pod": {
-                            "description": "PodSecurityContext holds pod-level security attributes and common container settings.\nSome fields are also present in container.securityContext.  Field values of\ncontainer.securityContext take precedence over field values of PodSecurityContext.",
-                            "properties": {
-                                "appArmorProfile": {
-                                    "description": "appArmorProfile is the AppArmor options to use by the containers in this pod.\nNote that this field cannot be set when spec.os.name is windows.",
-                                    "properties": {
-                                        "localhostProfile": {
-                                            "description": "localhostProfile indicates a profile loaded on the node that should be used.\nThe profile must be preconfigured on the node to work.\nMust match the loaded name of the profile.\nMust be set if and only if type is \"Localhost\".",
-                                            "type": "string"
-                                        },
-                                        "type": {
-                                            "description": "type indicates which kind of AppArmor profile will be applied.\nValid options are:\n  Localhost - a profile pre-loaded on the node.\n  RuntimeDefault - the container runtime's default profile.\n  Unconfined - no AppArmor enforcement.",
-                                            "type": "string"
-                                        }
-                                    },
-                                    "required": [
-                                        "type"
-                                    ],
-                                    "type": "object",
-                                    "additionalProperties": false
-                                },
-                                "fsGroup": {
-                                    "description": "A special supplemental group that applies to all containers in a pod.\nSome volume types allow the Kubelet to change the ownership of that volume\nto be owned by the pod:\n\n1. The owning GID will be the FSGroup\n2. The setgid bit is set (new files created in the volume will be owned by FSGroup)\n3. The permission bits are OR'd with rw-rw----\n\nIf unset, the Kubelet will not modify the ownership and permissions of any volume.\nNote that this field cannot be set when spec.os.name is windows.",
-                                    "format": "int64",
-                                    "type": "integer",
-                                    "minimum": -9223372036854776000,
-                                    "maximum": 9223372036854776000
-                                },
-                                "fsGroupChangePolicy": {
-                                    "description": "fsGroupChangePolicy defines behavior of changing ownership and permission of the volume\nbefore being exposed inside Pod. This field will only apply to\nvolume types which support fsGroup based ownership(and permissions).\nIt will have no effect on ephemeral volume types such as: secret, configmaps\nand emptydir.\nValid values are \"OnRootMismatch\" and \"Always\". If not specified, \"Always\" is used.\nNote that this field cannot be set when spec.os.name is windows.",
-                                    "type": "string"
-                                },
-                                "runAsGroup": {
-                                    "description": "The GID to run the entrypoint of the container process.\nUses runtime default if unset.\nMay also be set in SecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence\nfor that container.\nNote that this field cannot be set when spec.os.name is windows.",
-                                    "format": "int64",
-                                    "type": "integer",
-                                    "minimum": -9223372036854776000,
-                                    "maximum": 9223372036854776000
-                                },
-                                "runAsNonRoot": {
-                                    "description": "Indicates that the container must run as a non-root user.\nIf true, the Kubelet will validate the image at runtime to ensure that it\ndoes not run as UID 0 (root) and fail to start the container if it does.\nIf unset or false, no such validation will be performed.\nMay also be set in SecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
-                                    "type": "boolean"
-                                },
-                                "runAsUser": {
-                                    "description": "The UID to run the entrypoint of the container process.\nDefaults to user specified in image metadata if unspecified.\nMay also be set in SecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence\nfor that container.\nNote that this field cannot be set when spec.os.name is windows.",
-                                    "format": "int64",
-                                    "type": "integer",
-                                    "minimum": -9223372036854776000,
-                                    "maximum": 9223372036854776000
-                                },
-                                "seLinuxChangePolicy": {
-                                    "description": "seLinuxChangePolicy defines how the container's SELinux label is applied to all volumes used by the Pod.\nIt has no effect on nodes that do not support SELinux or to volumes does not support SELinux.\nValid values are \"MountOption\" and \"Recursive\".\n\n\"Recursive\" means relabeling of all files on all Pod volumes by the container runtime.\nThis may be slow for large volumes, but allows mixing privileged and unprivileged Pods sharing the same volume on the same node.\n\n\"MountOption\" mounts all eligible Pod volumes with `-o context` mount option.\nThis requires all Pods that share the same volume to use the same SELinux label.\nIt is not possible to share the same volume among privileged and unprivileged Pods.\nEligible volumes are in-tree FibreChannel and iSCSI volumes, and all CSI volumes\nwhose CSI driver announces SELinux support by setting spec.seLinuxMount: true in their\nCSIDriver instance. Other volumes are always re-labelled recursively.\n\"MountOption\" value is allowed only when SELinuxMount feature gate is enabled.\n\nIf not specified and SELinuxMount feature gate is enabled, \"MountOption\" is used.\nIf not specified and SELinuxMount feature gate is disabled, \"MountOption\" is used for ReadWriteOncePod volumes\nand \"Recursive\" for all other volumes.\n\nThis field affects only Pods that have SELinux label set, either in PodSecurityContext or in SecurityContext of all containers.\n\nAll Pods that use the same volume should use the same seLinuxChangePolicy, otherwise some pods can get stuck in ContainerCreating state.\nNote that this field cannot be set when spec.os.name is windows.",
-                                    "type": "string"
-                                },
-                                "seLinuxOptions": {
-                                    "description": "The SELinux context to be applied to all containers.\nIf unspecified, the container runtime will allocate a random SELinux context for each\ncontainer.  May also be set in SecurityContext.  If set in\nboth SecurityContext and PodSecurityContext, the value specified in SecurityContext\ntakes precedence for that container.\nNote that this field cannot be set when spec.os.name is windows.",
-                                    "properties": {
-                                        "level": {
-                                            "description": "Level is SELinux level label that applies to the container.",
-                                            "type": "string"
-                                        },
-                                        "role": {
-                                            "description": "Role is a SELinux role label that applies to the container.",
-                                            "type": "string"
-                                        },
-                                        "type": {
-                                            "description": "Type is a SELinux type label that applies to the container.",
-                                            "type": "string"
-                                        },
-                                        "user": {
-                                            "description": "User is a SELinux user label that applies to the container.",
-                                            "type": "string"
-                                        }
-                                    },
-                                    "type": "object",
-                                    "additionalProperties": false
-                                },
-                                "seccompProfile": {
-                                    "description": "The seccomp options to use by the containers in this pod.\nNote that this field cannot be set when spec.os.name is windows.",
-                                    "properties": {
-                                        "localhostProfile": {
-                                            "description": "localhostProfile indicates a profile defined in a file on the node should be used.\nThe profile must be preconfigured on the node to work.\nMust be a descending path, relative to the kubelet's configured seccomp profile location.\nMust be set if type is \"Localhost\". Must NOT be set for any other type.",
-                                            "type": "string"
-                                        },
-                                        "type": {
-                                            "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
-                                            "type": "string"
-                                        }
-                                    },
-                                    "required": [
-                                        "type"
-                                    ],
-                                    "type": "object",
-                                    "additionalProperties": false
-                                },
-                                "supplementalGroups": {
-                                    "description": "A list of groups applied to the first process run in each container, in\naddition to the container's primary GID and fsGroup (if specified).  If\nthe SupplementalGroupsPolicy feature is enabled, the\nsupplementalGroupsPolicy field determines whether these are in addition\nto or instead of any group memberships defined in the container image.\nIf unspecified, no additional groups are added, though group memberships\ndefined in the container image may still be used, depending on the\nsupplementalGroupsPolicy field.\nNote that this field cannot be set when spec.os.name is windows.",
-                                    "items": {
-                                        "format": "int64",
-                                        "type": "integer",
-                                        "minimum": -9223372036854776000,
-                                        "maximum": 9223372036854776000
-                                    },
-                                    "type": "array",
-                                    "x-kubernetes-list-type": "atomic"
-                                },
-                                "supplementalGroupsPolicy": {
-                                    "description": "Defines how supplemental groups of the first container processes are calculated.\nValid values are \"Merge\" and \"Strict\". If not specified, \"Merge\" is used.\n(Alpha) Using the field requires the SupplementalGroupsPolicy feature gate to be enabled\nand the container runtime must implement support for this feature.\nNote that this field cannot be set when spec.os.name is windows.",
-                                    "type": "string"
-                                },
-                                "sysctls": {
-                                    "description": "Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported\nsysctls (by the container runtime) might fail to launch.\nNote that this field cannot be set when spec.os.name is windows.",
-                                    "items": {
-                                        "description": "Sysctl defines a kernel parameter to be set",
-                                        "properties": {
-                                            "name": {
-                                                "description": "Name of a property to set",
-                                                "type": "string"
-                                            },
-                                            "value": {
-                                                "description": "Value of a property to set",
-                                                "type": "string"
-                                            }
-                                        },
-                                        "required": [
-                                            "name",
-                                            "value"
-                                        ],
-                                        "type": "object",
-                                        "additionalProperties": false
-                                    },
-                                    "type": "array",
-                                    "x-kubernetes-list-type": "atomic"
-                                },
-                                "windowsOptions": {
-                                    "description": "The Windows specific settings applied to all containers.\nIf unspecified, the options within a container's SecurityContext will be used.\nIf set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is linux.",
-                                    "properties": {
-                                        "gmsaCredentialSpec": {
-                                            "description": "GMSACredentialSpec is where the GMSA admission webhook\n(https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the\nGMSA credential spec named by the GMSACredentialSpecName field.",
-                                            "type": "string"
-                                        },
-                                        "gmsaCredentialSpecName": {
-                                            "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
-                                            "type": "string"
-                                        },
-                                        "hostProcess": {
-                                            "description": "HostProcess determines if a container should be run as a 'Host Process' container.\nAll of a Pod's containers must have the same effective HostProcess value\n(it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).\nIn addition, if HostProcess is true then HostNetwork must also be set to true.",
-                                            "type": "boolean"
-                                        },
-                                        "runAsUserName": {
-                                            "description": "The UserName in Windows to run the entrypoint of the container process.\nDefaults to the user specified in image metadata if unspecified.\nMay also be set in PodSecurityContext. If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
-                                            "type": "string"
-                                        }
-                                    },
-                                    "type": "object",
-                                    "additionalProperties": false
-                                }
-                            },
-                            "type": "object",
-                            "additionalProperties": false
-                        }
-                    },
-                    "type": "object",
-                    "additionalProperties": false
-                },
-                "serviceAccount": {
-                    "description": "Settings for the serviceaccount the renovate pod should use",
-                    "properties": {
-                        "automountServiceAccountToken": {
-                            "type": "boolean"
-                        },
-                        "name": {
-                            "type": "string"
-                        }
-                    },
-                    "type": "object",
-                    "additionalProperties": false
-                },
-                "skipForks": {
-                    "description": "If true, forked repositories discovered during autodiscovery will be excluded by querying the platform API",
-                    "type": "boolean"
-                },
-                "tolerations": {
-                    "description": "Tolerations for scheduling the resulting pod",
-                    "items": {
-                        "description": "The pod this Toleration is attached to tolerates any taint that matches\nthe triple <key,value,effect> using the matching operator <operator>.",
-                        "properties": {
-                            "effect": {
-                                "description": "Effect indicates the taint effect to match. Empty means match all taint effects.\nWhen specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
-                                "type": "string"
-                            },
-                            "key": {
-                                "description": "Key is the taint key that the toleration applies to. Empty means match all taint keys.\nIf the key is empty, operator must be Exists; this combination means to match all values and all keys.",
-                                "type": "string"
-                            },
-                            "operator": {
-                                "description": "Operator represents a key's relationship to the value.\nValid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.\nExists is equivalent to wildcard for value, so that a pod can\ntolerate all taints of a particular category.\nLt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).",
-                                "type": "string"
-                            },
-                            "tolerationSeconds": {
-                                "description": "TolerationSeconds represents the period of time the toleration (which must be\nof effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,\nit is not set, which means tolerate the taint forever (do not evict). Zero and\nnegative values will be treated as 0 (evict immediately) by the system.",
-                                "format": "int64",
-                                "type": "integer",
-                                "minimum": -9223372036854776000,
-                                "maximum": 9223372036854776000
-                            },
-                            "value": {
-                                "description": "Value is the taint value the toleration matches to.\nIf the operator is Exists, the value should be empty, otherwise just a regular string.",
-                                "type": "string"
-                            }
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          }
                         },
                         "type": "object",
+                        "x-kubernetes-map-type": "atomic",
                         "additionalProperties": false
-                    },
-                    "type": "array"
-                },
-                "topologySpreadConstraints": {
-                    "description": "Topology spread constraints for scheduling the resulting pod",
-                    "items": {
-                        "description": "TopologySpreadConstraint specifies how to spread matching pods among the given topology.",
+                      },
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
+                    }
+                  },
+                  "required": [
+                    "nodeSelectorTerms"
+                  ],
+                  "type": "object",
+                  "x-kubernetes-map-type": "atomic",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "podAffinity": {
+              "description": "Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).",
+              "properties": {
+                "preferredDuringSchedulingIgnoredDuringExecution": {
+                  "description": "The scheduler will prefer to schedule pods to nodes that satisfy\nthe affinity expressions specified by this field, but it may choose\na node that violates one or more of the expressions. The node that is\nmost preferred is the one with the greatest sum of weights, i.e.\nfor each node that meets all of the scheduling requirements (resource\nrequest, requiredDuringScheduling affinity expressions, etc.),\ncompute a sum by iterating through the elements of this field and adding\n\"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the\nnode(s) with the highest sum are the most preferred.",
+                  "items": {
+                    "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                    "properties": {
+                      "podAffinityTerm": {
+                        "description": "Required. A pod affinity term, associated with the corresponding weight.",
                         "properties": {
-                            "labelSelector": {
-                                "description": "LabelSelector is used to find matching pods.\nPods that match this label selector are counted to determine the number of pods\nin their corresponding topology domain.",
-                                "properties": {
-                                    "matchExpressions": {
-                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
-                                        "items": {
-                                            "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
-                                            "properties": {
-                                                "key": {
-                                                    "description": "key is the label key that the selector applies to.",
-                                                    "type": "string"
-                                                },
-                                                "operator": {
-                                                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
-                                                    "type": "string"
-                                                },
-                                                "values": {
-                                                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
-                                                    "items": {
-                                                        "type": "string"
-                                                    },
-                                                    "type": "array",
-                                                    "x-kubernetes-list-type": "atomic"
-                                                }
-                                            },
-                                            "required": [
-                                                "key",
-                                                "operator"
-                                            ],
-                                            "type": "object",
-                                            "additionalProperties": false
-                                        },
-                                        "type": "array",
-                                        "x-kubernetes-list-type": "atomic"
-                                    },
-                                    "matchLabels": {
-                                        "additionalProperties": {
-                                            "type": "string"
-                                        },
-                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                                        "type": "object"
-                                    }
-                                },
-                                "type": "object",
-                                "x-kubernetes-map-type": "atomic",
-                                "additionalProperties": false
-                            },
-                            "matchLabelKeys": {
-                                "description": "MatchLabelKeys is a set of pod label keys to select the pods over which\nspreading will be calculated. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are ANDed with labelSelector\nto select the group of existing pods over which spreading will be calculated\nfor the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.\nMatchLabelKeys cannot be set when LabelSelector isn't set.\nKeys that don't exist in the incoming pod labels will\nbe ignored. A null or empty list means only match against labelSelector.\n\nThis is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default).",
+                          "labelSelector": {
+                            "description": "A label query over a set of resources, in this case pods.\nIf it's null, this PodAffinityTerm matches with no Pods.",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
                                 "items": {
-                                    "type": "string"
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "key is the label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
                                 },
                                 "type": "array",
                                 "x-kubernetes-list-type": "atomic"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                "type": "object"
+                              }
                             },
-                            "maxSkew": {
-                                "description": "MaxSkew describes the degree to which pods may be unevenly distributed.\nWhen `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference\nbetween the number of matching pods in the target topology and the global minimum.\nThe global minimum is the minimum number of matching pods in an eligible domain\nor zero if the number of eligible domains is less than MinDomains.\nFor example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same\nlabelSelector spread as 2/2/1:\nIn this case, the global minimum is 1.\n| zone1 | zone2 | zone3 |\n|  P P  |  P P  |   P   |\n- if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2;\nscheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2)\nviolate MaxSkew(1).\n- if MaxSkew is 2, incoming pod can be scheduled onto any zone.\nWhen `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence\nto topologies that satisfy it.\nIt's a required field. Default value is 1 and 0 is not allowed.",
-                                "format": "int32",
-                                "type": "integer",
-                                "minimum": -2147483648,
-                                "maximum": 2147483647
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "matchLabelKeys": {
+                            "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both matchLabelKeys and labelSelector.\nAlso, matchLabelKeys cannot be set when labelSelector isn't set.",
+                            "items": {
+                              "type": "string"
                             },
-                            "minDomains": {
-                                "description": "MinDomains indicates a minimum number of eligible domains.\nWhen the number of eligible domains with matching topology keys is less than minDomains,\nPod Topology Spread treats \"global minimum\" as 0, and then the calculation of Skew is performed.\nAnd when the number of eligible domains with matching topology keys equals or greater than minDomains,\nthis value has no effect on scheduling.\nAs a result, when the number of eligible domains is less than minDomains,\nscheduler won't schedule more than maxSkew Pods to those domains.\nIf value is nil, the constraint behaves as if MinDomains is equal to 1.\nValid values are integers greater than 0.\nWhen value is not nil, WhenUnsatisfiable must be DoNotSchedule.\n\nFor example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same\nlabelSelector spread as 2/2/2:\n| zone1 | zone2 | zone3 |\n|  P P  |  P P  |  P P  |\nThe number of domains is less than 5(MinDomains), so \"global minimum\" is treated as 0.\nIn this situation, new pod with the same labelSelector cannot be scheduled,\nbecause computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones,\nit will violate MaxSkew.",
-                                "format": "int32",
-                                "type": "integer",
-                                "minimum": -2147483648,
-                                "maximum": 2147483647
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "mismatchLabelKeys": {
+                            "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both mismatchLabelKeys and labelSelector.\nAlso, mismatchLabelKeys cannot be set when labelSelector isn't set.",
+                            "items": {
+                              "type": "string"
                             },
-                            "nodeAffinityPolicy": {
-                                "description": "NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector\nwhen calculating pod topology spread skew. Options are:\n- Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.\n- Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.\n\nIf this value is nil, the behavior is equivalent to the Honor policy.",
-                                "type": "string"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "namespaceSelector": {
+                            "description": "A label query over the set of namespaces that the term applies to.\nThe term is applied to the union of the namespaces selected by this field\nand the ones listed in the namespaces field.\nnull selector and null or empty namespaces list means \"this pod's namespace\".\nAn empty selector ({}) matches all namespaces.",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "key is the label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                "type": "object"
+                              }
                             },
-                            "nodeTaintsPolicy": {
-                                "description": "NodeTaintsPolicy indicates how we will treat node taints when calculating\npod topology spread skew. Options are:\n- Honor: nodes without taints, along with tainted nodes for which the incoming pod\nhas a toleration, are included.\n- Ignore: node taints are ignored. All nodes are included.\n\nIf this value is nil, the behavior is equivalent to the Ignore policy.",
-                                "type": "string"
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "namespaces": {
+                            "description": "namespaces specifies a static list of namespace names that the term applies to.\nThe term is applied to the union of the namespaces listed in this field\nand the ones selected by namespaceSelector.\nnull or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                            "items": {
+                              "type": "string"
                             },
-                            "topologyKey": {
-                                "description": "TopologyKey is the key of node labels. Nodes that have a label with this key\nand identical values are considered to be in the same topology.\nWe consider each <key, value> as a \"bucket\", and try to put balanced number\nof pods into each bucket.\nWe define a domain as a particular instance of a topology.\nAlso, we define an eligible domain as a domain whose nodes meet the requirements of\nnodeAffinityPolicy and nodeTaintsPolicy.\ne.g. If TopologyKey is \"kubernetes.io/hostname\", each Node is a domain of that topology.\nAnd, if TopologyKey is \"topology.kubernetes.io/zone\", each zone is a domain of that topology.\nIt's a required field.",
-                                "type": "string"
-                            },
-                            "whenUnsatisfiable": {
-                                "description": "WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy\nthe spread constraint.\n- DoNotSchedule (default) tells the scheduler not to schedule it.\n- ScheduleAnyway tells the scheduler to schedule the pod in any location,\n  but giving higher precedence to topologies that would help reduce the\n  skew.\nA constraint is considered \"Unsatisfiable\" for an incoming pod\nif and only if every possible node assignment for that pod would violate\n\"MaxSkew\" on some topology.\nFor example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same\nlabelSelector spread as 3/1/1:\n| zone1 | zone2 | zone3 |\n| P P P |   P   |   P   |\nIf WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled\nto zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies\nMaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler\nwon't make it *more* imbalanced.\nIt's a required field.",
-                                "type": "string"
-                            }
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "topologyKey": {
+                            "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
+                            "type": "string"
+                          }
                         },
                         "required": [
-                            "maxSkew",
-                            "topologyKey",
-                            "whenUnsatisfiable"
+                          "topologyKey"
                         ],
                         "type": "object",
                         "additionalProperties": false
-                    },
-                    "type": "array"
-                },
-                "webhook": {
-                    "description": "Configuration for webhooks to trigger renovate runs",
-                    "properties": {
-                        "authentication": {
-                            "description": "authentication configuration for webhooks",
-                            "properties": {
-                                "enabled": {
-                                    "type": "boolean"
-                                },
-                                "secretRef": {
-                                    "description": "reference to a secret and key",
-                                    "properties": {
-                                        "key": {
-                                            "type": "string"
-                                        },
-                                        "name": {
-                                            "type": "string"
-                                        }
-                                    },
-                                    "type": "object",
-                                    "additionalProperties": false
-                                }
-                            },
-                            "required": [
-                                "enabled"
-                            ],
-                            "type": "object",
-                            "additionalProperties": false
-                        },
-                        "enabled": {
-                            "type": "boolean"
-                        },
-                        "forgejo": {
-                            "description": "Forgejo-specific webhook configuration",
-                            "properties": {
-                                "sync": {
-                                    "description": "configuration for syncing webhooks to Forgejo repos by topic",
-                                    "properties": {
-                                        "authTokenSecretRef": {
-                                            "description": "reference to a secret and key",
-                                            "properties": {
-                                                "key": {
-                                                    "type": "string"
-                                                },
-                                                "name": {
-                                                    "type": "string"
-                                                }
-                                            },
-                                            "type": "object",
-                                            "additionalProperties": false
-                                        },
-                                        "enabled": {
-                                            "type": "boolean"
-                                        },
-                                        "events": {
-                                            "items": {
-                                                "type": "string"
-                                            },
-                                            "type": "array"
-                                        },
-                                        "tokenSecretRef": {
-                                            "description": "reference to a secret and key",
-                                            "properties": {
-                                                "key": {
-                                                    "type": "string"
-                                                },
-                                                "name": {
-                                                    "type": "string"
-                                                }
-                                            },
-                                            "type": "object",
-                                            "additionalProperties": false
-                                        },
-                                        "topic": {
-                                            "type": "string"
-                                        },
-                                        "webhookURL": {
-                                            "type": "string"
-                                        }
-                                    },
-                                    "required": [
-                                        "enabled",
-                                        "webhookURL"
-                                    ],
-                                    "type": "object",
-                                    "additionalProperties": false
-                                }
-                            },
-                            "type": "object",
-                            "additionalProperties": false
-                        }
+                      },
+                      "weight": {
+                        "description": "weight associated with matching the corresponding podAffinityTerm,\nin the range 1-100.",
+                        "format": "int32",
+                        "type": "integer"
+                      }
                     },
                     "required": [
-                        "enabled"
+                      "podAffinityTerm",
+                      "weight"
                     ],
                     "type": "object",
                     "additionalProperties": false
-                }
-            },
-            "required": [
-                "image",
-                "parallelism",
-                "provider",
-                "schedule"
-            ],
-            "type": "object",
-            "additionalProperties": false
-        },
-        "status": {
-            "description": "RenovateJobStatus defines the observed state of RenovateJob",
-            "properties": {
-                "executionOptions": {
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                },
+                "requiredDuringSchedulingIgnoredDuringExecution": {
+                  "description": "If the affinity requirements specified by this field are not met at\nscheduling time, the pod will not be scheduled onto the node.\nIf the affinity requirements specified by this field cease to be met\nat some point during pod execution (e.g. due to a pod label update), the\nsystem may or may not try to eventually evict the pod from its node.\nWhen there are multiple elements, the lists of nodes corresponding to each\npodAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                  "items": {
+                    "description": "Defines a set of pods (namely those matching the labelSelector\nrelative to the given namespace(s)) that this pod should be\nco-located (affinity) or not co-located (anti-affinity) with,\nwhere co-located is defined as running on a node whose value of\nthe label with key <topologyKey> matches that of any node on which\na pod of the set of pods is running",
                     "properties": {
-                        "debug": {
-                            "description": "If true, the renovate job will be executed with LOG_LEVEL=debug",
-                            "type": "boolean"
-                        }
+                      "labelSelector": {
+                        "description": "A label query over a set of resources, in this case pods.\nIf it's null, this PodAffinityTerm matches with no Pods.",
+                        "properties": {
+                          "matchExpressions": {
+                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                            "items": {
+                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                              "properties": {
+                                "key": {
+                                  "description": "key is the label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "matchLabels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "matchLabelKeys": {
+                        "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both matchLabelKeys and labelSelector.\nAlso, matchLabelKeys cannot be set when labelSelector isn't set.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
+                      },
+                      "mismatchLabelKeys": {
+                        "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both mismatchLabelKeys and labelSelector.\nAlso, mismatchLabelKeys cannot be set when labelSelector isn't set.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
+                      },
+                      "namespaceSelector": {
+                        "description": "A label query over the set of namespaces that the term applies to.\nThe term is applied to the union of the namespaces selected by this field\nand the ones listed in the namespaces field.\nnull selector and null or empty namespaces list means \"this pod's namespace\".\nAn empty selector ({}) matches all namespaces.",
+                        "properties": {
+                          "matchExpressions": {
+                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                            "items": {
+                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                              "properties": {
+                                "key": {
+                                  "description": "key is the label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "matchLabels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "namespaces": {
+                        "description": "namespaces specifies a static list of namespace names that the term applies to.\nThe term is applied to the union of the namespaces listed in this field\nand the ones selected by namespaceSelector.\nnull or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
+                      },
+                      "topologyKey": {
+                        "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
+                        "type": "string"
+                      }
                     },
+                    "required": [
+                      "topologyKey"
+                    ],
                     "type": "object",
                     "additionalProperties": false
-                },
-                "projects": {
-                    "items": {
-                        "description": "Status of a single project within a RenovateJob",
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "podAntiAffinity": {
+              "description": "Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).",
+              "properties": {
+                "preferredDuringSchedulingIgnoredDuringExecution": {
+                  "description": "The scheduler will prefer to schedule pods to nodes that satisfy\nthe anti-affinity expressions specified by this field, but it may choose\na node that violates one or more of the expressions. The node that is\nmost preferred is the one with the greatest sum of weights, i.e.\nfor each node that meets all of the scheduling requirements (resource\nrequest, requiredDuringScheduling anti-affinity expressions, etc.),\ncompute a sum by iterating through the elements of this field and subtracting\n\"weight\" from the sum if the node has pods which matches the corresponding podAffinityTerm; the\nnode(s) with the highest sum are the most preferred.",
+                  "items": {
+                    "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                    "properties": {
+                      "podAffinityTerm": {
+                        "description": "Required. A pod affinity term, associated with the corresponding weight.",
                         "properties": {
-                            "duration": {
-                                "type": "string"
-                            },
-                            "lastRun": {
-                                "format": "date-time",
-                                "type": "string"
-                            },
-                            "logIssues": {
-                                "description": "LogIssues contains aggregate counts and individual issue messages from a Renovate run.",
-                                "properties": {
-                                    "errorCount": {
-                                        "type": "integer"
+                          "labelSelector": {
+                            "description": "A label query over a set of resources, in this case pods.\nIf it's null, this PodAffinityTerm matches with no Pods.",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "key is the label key that the selector applies to.",
+                                      "type": "string"
                                     },
-                                    "issues": {
-                                        "items": {
-                                            "description": "LogIssue represents a single warning or error from Renovate logs.",
-                                            "properties": {
-                                                "level": {
-                                                    "type": "integer"
-                                                },
-                                                "message": {
-                                                    "type": "string"
-                                                }
-                                            },
-                                            "required": [
-                                                "level",
-                                                "message"
-                                            ],
-                                            "type": "object",
-                                            "additionalProperties": false
-                                        },
-                                        "type": "array"
+                                    "operator": {
+                                      "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                      "type": "string"
                                     },
-                                    "truncated": {
-                                        "type": "boolean"
-                                    },
-                                    "warnCount": {
-                                        "type": "integer"
+                                    "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
                                 },
-                                "required": [
-                                    "errorCount",
-                                    "warnCount"
-                                ],
-                                "type": "object",
-                                "additionalProperties": false
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                "type": "object"
+                              }
                             },
-                            "name": {
-                                "type": "string"
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "matchLabelKeys": {
+                            "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both matchLabelKeys and labelSelector.\nAlso, matchLabelKeys cannot be set when labelSelector isn't set.",
+                            "items": {
+                              "type": "string"
                             },
-                            "prActivity": {
-                                "description": "PRActivity contains aggregate counts and individual details of PR activity from a run.",
-                                "properties": {
-                                    "automerged": {
-                                        "type": "integer"
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "mismatchLabelKeys": {
+                            "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both mismatchLabelKeys and labelSelector.\nAlso, mismatchLabelKeys cannot be set when labelSelector isn't set.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "namespaceSelector": {
+                            "description": "A label query over the set of namespaces that the term applies to.\nThe term is applied to the union of the namespaces selected by this field\nand the ones listed in the namespaces field.\nnull selector and null or empty namespaces list means \"this pod's namespace\".\nAn empty selector ({}) matches all namespaces.",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "key is the label key that the selector applies to.",
+                                      "type": "string"
                                     },
-                                    "created": {
-                                        "type": "integer"
+                                    "operator": {
+                                      "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                      "type": "string"
                                     },
-                                    "prs": {
-                                        "items": {
-                                            "description": "PRDetail represents a single PR found in Renovate logs.",
-                                            "properties": {
-                                                "action": {
-                                                    "description": "PRAction represents what happened to a PR in a Renovate run.",
-                                                    "type": "string"
-                                                },
-                                                "branch": {
-                                                    "type": "string"
-                                                },
-                                                "number": {
-                                                    "type": "integer"
-                                                },
-                                                "title": {
-                                                    "type": "string"
-                                                }
-                                            },
-                                            "required": [
-                                                "action",
-                                                "branch"
-                                            ],
-                                            "type": "object",
-                                            "additionalProperties": false
-                                        },
-                                        "type": "array"
-                                    },
-                                    "truncated": {
-                                        "type": "boolean"
-                                    },
-                                    "unchanged": {
-                                        "type": "integer"
-                                    },
-                                    "updated": {
-                                        "type": "integer"
+                                    "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
                                     }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
                                 },
-                                "required": [
-                                    "automerged",
-                                    "created",
-                                    "unchanged",
-                                    "updated"
-                                ],
-                                "type": "object",
-                                "additionalProperties": false
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                "type": "object"
+                              }
                             },
-                            "priority": {
-                                "format": "int32",
-                                "type": "integer",
-                                "minimum": -2147483648,
-                                "maximum": 2147483647
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "namespaces": {
+                            "description": "namespaces specifies a static list of namespace names that the term applies to.\nThe term is applied to the union of the namespaces listed in this field\nand the ones selected by namespaceSelector.\nnull or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                            "items": {
+                              "type": "string"
                             },
-                            "renovateResultStatus": {
-                                "type": "string"
-                            },
-                            "status": {
-                                "type": "string"
-                            }
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "topologyKey": {
+                            "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
+                            "type": "string"
+                          }
                         },
                         "required": [
-                            "lastRun",
-                            "name",
-                            "status"
+                          "topologyKey"
                         ],
                         "type": "object",
                         "additionalProperties": false
+                      },
+                      "weight": {
+                        "description": "weight associated with matching the corresponding podAffinityTerm,\nin the range 1-100.",
+                        "format": "int32",
+                        "type": "integer"
+                      }
                     },
-                    "type": "array"
+                    "required": [
+                      "podAffinityTerm",
+                      "weight"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                },
+                "requiredDuringSchedulingIgnoredDuringExecution": {
+                  "description": "If the anti-affinity requirements specified by this field are not met at\nscheduling time, the pod will not be scheduled onto the node.\nIf the anti-affinity requirements specified by this field cease to be met\nat some point during pod execution (e.g. due to a pod label update), the\nsystem may or may not try to eventually evict the pod from its node.\nWhen there are multiple elements, the lists of nodes corresponding to each\npodAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                  "items": {
+                    "description": "Defines a set of pods (namely those matching the labelSelector\nrelative to the given namespace(s)) that this pod should be\nco-located (affinity) or not co-located (anti-affinity) with,\nwhere co-located is defined as running on a node whose value of\nthe label with key <topologyKey> matches that of any node on which\na pod of the set of pods is running",
+                    "properties": {
+                      "labelSelector": {
+                        "description": "A label query over a set of resources, in this case pods.\nIf it's null, this PodAffinityTerm matches with no Pods.",
+                        "properties": {
+                          "matchExpressions": {
+                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                            "items": {
+                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                              "properties": {
+                                "key": {
+                                  "description": "key is the label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "matchLabels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "matchLabelKeys": {
+                        "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both matchLabelKeys and labelSelector.\nAlso, matchLabelKeys cannot be set when labelSelector isn't set.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
+                      },
+                      "mismatchLabelKeys": {
+                        "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both mismatchLabelKeys and labelSelector.\nAlso, mismatchLabelKeys cannot be set when labelSelector isn't set.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
+                      },
+                      "namespaceSelector": {
+                        "description": "A label query over the set of namespaces that the term applies to.\nThe term is applied to the union of the namespaces selected by this field\nand the ones listed in the namespaces field.\nnull selector and null or empty namespaces list means \"this pod's namespace\".\nAn empty selector ({}) matches all namespaces.",
+                        "properties": {
+                          "matchExpressions": {
+                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                            "items": {
+                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                              "properties": {
+                                "key": {
+                                  "description": "key is the label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "matchLabels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "namespaces": {
+                        "description": "namespaces specifies a static list of namespace names that the term applies to.\nThe term is applied to the union of the namespaces listed in this field\nand the ones selected by namespaceSelector.\nnull or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-type": "atomic"
+                      },
+                      "topologyKey": {
+                        "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "topologyKey"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
                 }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "allowedGroups": {
+          "description": "Groups allowed to view this RenovateJob when authentication is enabled.\nIf empty or not set, the job is hidden from all users.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "discoverTopics": {
+          "description": "Topics to discover projects from, will be concatenated using , separator",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "discoveryFilters": {
+          "description": "Filter to select which projects to process, will be concatenated using , separator",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "dnsPolicy": {
+          "description": "DNS Policy for the renovate pods",
+          "type": "string"
+        },
+        "extraEnv": {
+          "description": "Additional environment variables to set in the renovate container",
+          "items": {
+            "description": "EnvVar represents an environment variable present in a Container.",
+            "properties": {
+              "name": {
+                "description": "Name of the environment variable.\nMay consist of any printable ASCII characters except '='.",
+                "type": "string"
+              },
+              "value": {
+                "description": "Variable references $(VAR_NAME) are expanded\nusing the previously defined environment variables in the container and\nany service environment variables. If a variable cannot be resolved,\nthe reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.\n\"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\".\nEscaped references will never be expanded, regardless of whether the variable\nexists or not.\nDefaults to \"\".",
+                "type": "string"
+              },
+              "valueFrom": {
+                "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
+                "properties": {
+                  "configMapKeyRef": {
+                    "description": "Selects a key of a ConfigMap.",
+                    "properties": {
+                      "key": {
+                        "description": "The key to select.",
+                        "type": "string"
+                      },
+                      "name": {
+                        "default": "",
+                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                        "type": "string"
+                      },
+                      "optional": {
+                        "description": "Specify whether the ConfigMap or its key must be defined",
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "key"
+                    ],
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  },
+                  "fieldRef": {
+                    "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,\nspec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
+                    "properties": {
+                      "apiVersion": {
+                        "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                        "type": "string"
+                      },
+                      "fieldPath": {
+                        "description": "Path of the field to select in the specified API version.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "fieldPath"
+                    ],
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  },
+                  "fileKeyRef": {
+                    "description": "FileKeyRef selects a key of the env file.\nRequires the EnvFiles feature gate to be enabled.",
+                    "properties": {
+                      "key": {
+                        "description": "The key within the env file. An invalid key will prevent the pod from starting.\nThe keys defined within a source may consist of any printable ASCII characters except '='.\nDuring Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.",
+                        "type": "string"
+                      },
+                      "optional": {
+                        "default": false,
+                        "description": "Specify whether the file or its key must be defined. If the file or key\ndoes not exist, then the env var is not published.\nIf optional is set to true and the specified key does not exist,\nthe environment variable will not be set in the Pod's containers.\n\nIf optional is set to false and the specified key does not exist,\nan error will be returned during Pod creation.",
+                        "type": "boolean"
+                      },
+                      "path": {
+                        "description": "The path within the volume from which to select the file.\nMust be relative and may not contain the '..' path or start with '..'.",
+                        "type": "string"
+                      },
+                      "volumeName": {
+                        "description": "The name of the volume mount containing the env file.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "key",
+                      "path",
+                      "volumeName"
+                    ],
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  },
+                  "resourceFieldRef": {
+                    "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
+                    "properties": {
+                      "containerName": {
+                        "description": "Container name: required for volumes, optional for env vars",
+                        "type": "string"
+                      },
+                      "divisor": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "resource": {
+                        "description": "Required: resource to select",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "resource"
+                    ],
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  },
+                  "secretKeyRef": {
+                    "description": "Selects a key of a secret in the pod's namespace",
+                    "properties": {
+                      "key": {
+                        "description": "The key of the secret to select from.  Must be a valid secret key.",
+                        "type": "string"
+                      },
+                      "name": {
+                        "default": "",
+                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                        "type": "string"
+                      },
+                      "optional": {
+                        "description": "Specify whether the Secret or its key must be defined",
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "key"
+                    ],
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "extraEnvFrom": {
+          "description": "Additional environment variable sources to set in the renovate container",
+          "items": {
+            "description": "EnvFromSource represents the source of a set of ConfigMaps or Secrets",
+            "properties": {
+              "configMapRef": {
+                "description": "The ConfigMap to select from",
+                "properties": {
+                  "name": {
+                    "default": "",
+                    "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                    "type": "string"
+                  },
+                  "optional": {
+                    "description": "Specify whether the ConfigMap must be defined",
+                    "type": "boolean"
+                  }
+                },
+                "type": "object",
+                "x-kubernetes-map-type": "atomic",
+                "additionalProperties": false
+              },
+              "prefix": {
+                "description": "Optional text to prepend to the name of each environment variable.\nMay consist of any printable ASCII characters except '='.",
+                "type": "string"
+              },
+              "secretRef": {
+                "description": "The Secret to select from",
+                "properties": {
+                  "name": {
+                    "default": "",
+                    "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                    "type": "string"
+                  },
+                  "optional": {
+                    "description": "Specify whether the Secret must be defined",
+                    "type": "boolean"
+                  }
+                },
+                "type": "object",
+                "x-kubernetes-map-type": "atomic",
+                "additionalProperties": false
+              }
             },
             "type": "object",
             "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "extraVolumeMounts": {
+          "description": "Additional volume mounts for the renovate pods",
+          "items": {
+            "description": "VolumeMount describes a mounting of a Volume within a container.",
+            "properties": {
+              "mountPath": {
+                "description": "Path within the container at which the volume should be mounted.  Must\nnot contain ':'.",
+                "type": "string"
+              },
+              "mountPropagation": {
+                "description": "mountPropagation determines how mounts are propagated from the host\nto container and the other way around.\nWhen not set, MountPropagationNone is used.\nThis field is beta in 1.10.\nWhen RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified\n(which defaults to None).",
+                "type": "string"
+              },
+              "name": {
+                "description": "This must match the Name of a Volume.",
+                "type": "string"
+              },
+              "readOnly": {
+                "description": "Mounted read-only if true, read-write otherwise (false or unspecified).\nDefaults to false.",
+                "type": "boolean"
+              },
+              "recursiveReadOnly": {
+                "description": "RecursiveReadOnly specifies whether read-only mounts should be handled\nrecursively.\n\nIf ReadOnly is false, this field has no meaning and must be unspecified.\n\nIf ReadOnly is true, and this field is set to Disabled, the mount is not made\nrecursively read-only.  If this field is set to IfPossible, the mount is made\nrecursively read-only, if it is supported by the container runtime.  If this\nfield is set to Enabled, the mount is made recursively read-only if it is\nsupported by the container runtime, otherwise the pod will not be started and\nan error will be generated to indicate the reason.\n\nIf this field is set to IfPossible or Enabled, MountPropagation must be set to\nNone (or be unspecified, which defaults to None).\n\nIf this field is not specified, it is treated as an equivalent of Disabled.",
+                "type": "string"
+              },
+              "subPath": {
+                "description": "Path within the volume from which the container's volume should be mounted.\nDefaults to \"\" (volume's root).",
+                "type": "string"
+              },
+              "subPathExpr": {
+                "description": "Expanded path within the volume from which the container's volume should be mounted.\nBehaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.\nDefaults to \"\" (volume's root).\nSubPathExpr and SubPath are mutually exclusive.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "mountPath",
+              "name"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "extraVolumes": {
+          "description": "Additional volumes to mount in the renovate pods",
+          "items": {
+            "description": "Volume represents a named volume in a pod that may be accessed by any container in the pod.",
+            "properties": {
+              "awsElasticBlockStore": {
+                "description": "awsElasticBlockStore represents an AWS Disk resource that is attached to a\nkubelet's host machine and then exposed to the pod.\nDeprecated: AWSElasticBlockStore is deprecated. All operations for the in-tree\nawsElasticBlockStore type are redirected to the ebs.csi.aws.com CSI driver.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                "properties": {
+                  "fsType": {
+                    "description": "fsType is the filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                    "type": "string"
+                  },
+                  "partition": {
+                    "description": "partition is the partition in the volume that you want to mount.\nIf omitted, the default is to mount by volume name.\nExamples: For volume /dev/sda1, you specify the partition as \"1\".\nSimilarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty).",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "readOnly": {
+                    "description": "readOnly value true will force the readOnly setting in VolumeMounts.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                    "type": "boolean"
+                  },
+                  "volumeID": {
+                    "description": "volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "volumeID"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "azureDisk": {
+                "description": "azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.\nDeprecated: AzureDisk is deprecated. All operations for the in-tree azureDisk type\nare redirected to the disk.csi.azure.com CSI driver.",
+                "properties": {
+                  "cachingMode": {
+                    "description": "cachingMode is the Host Caching mode: None, Read Only, Read Write.",
+                    "type": "string"
+                  },
+                  "diskName": {
+                    "description": "diskName is the Name of the data disk in the blob storage",
+                    "type": "string"
+                  },
+                  "diskURI": {
+                    "description": "diskURI is the URI of data disk in the blob storage",
+                    "type": "string"
+                  },
+                  "fsType": {
+                    "default": "ext4",
+                    "description": "fsType is Filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                    "type": "string"
+                  },
+                  "kind": {
+                    "description": "kind expected values are Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared",
+                    "type": "string"
+                  },
+                  "readOnly": {
+                    "default": false,
+                    "description": "readOnly Defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "diskName",
+                  "diskURI"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "azureFile": {
+                "description": "azureFile represents an Azure File Service mount on the host and bind mount to the pod.\nDeprecated: AzureFile is deprecated. All operations for the in-tree azureFile type\nare redirected to the file.csi.azure.com CSI driver.",
+                "properties": {
+                  "readOnly": {
+                    "description": "readOnly defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                    "type": "boolean"
+                  },
+                  "secretName": {
+                    "description": "secretName is the  name of secret that contains Azure Storage Account Name and Key",
+                    "type": "string"
+                  },
+                  "shareName": {
+                    "description": "shareName is the azure share Name",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "secretName",
+                  "shareName"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "cephfs": {
+                "description": "cephFS represents a Ceph FS mount on the host that shares a pod's lifetime.\nDeprecated: CephFS is deprecated and the in-tree cephfs type is no longer supported.",
+                "properties": {
+                  "monitors": {
+                    "description": "monitors is Required: Monitors is a collection of Ceph monitors\nMore info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  },
+                  "path": {
+                    "description": "path is Optional: Used as the mounted root, rather than the full Ceph tree, default is /",
+                    "type": "string"
+                  },
+                  "readOnly": {
+                    "description": "readOnly is Optional: Defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.\nMore info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                    "type": "boolean"
+                  },
+                  "secretFile": {
+                    "description": "secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret\nMore info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                    "type": "string"
+                  },
+                  "secretRef": {
+                    "description": "secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.\nMore info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                    "properties": {
+                      "name": {
+                        "default": "",
+                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  },
+                  "user": {
+                    "description": "user is optional: User is the rados user name, default is admin\nMore info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "monitors"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "cinder": {
+                "description": "cinder represents a cinder volume attached and mounted on kubelets host machine.\nDeprecated: Cinder is deprecated. All operations for the in-tree cinder type\nare redirected to the cinder.csi.openstack.org CSI driver.\nMore info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                "properties": {
+                  "fsType": {
+                    "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                    "type": "string"
+                  },
+                  "readOnly": {
+                    "description": "readOnly defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.\nMore info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                    "type": "boolean"
+                  },
+                  "secretRef": {
+                    "description": "secretRef is optional: points to a secret object containing parameters used to connect\nto OpenStack.",
+                    "properties": {
+                      "name": {
+                        "default": "",
+                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  },
+                  "volumeID": {
+                    "description": "volumeID used to identify the volume in cinder.\nMore info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "volumeID"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "configMap": {
+                "description": "configMap represents a configMap that should populate this volume",
+                "properties": {
+                  "defaultMode": {
+                    "description": "defaultMode is optional: mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nDefaults to 0644.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "items": {
+                    "description": "items if unspecified, each key-value pair in the Data field of the referenced\nConfigMap will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the ConfigMap,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
+                    "items": {
+                      "description": "Maps a string key to a path within a volume.",
+                      "properties": {
+                        "key": {
+                          "description": "key is the key to project.",
+                          "type": "string"
+                        },
+                        "mode": {
+                          "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "path": {
+                          "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "key",
+                        "path"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  },
+                  "name": {
+                    "default": "",
+                    "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                    "type": "string"
+                  },
+                  "optional": {
+                    "description": "optional specify whether the ConfigMap or its keys must be defined",
+                    "type": "boolean"
+                  }
+                },
+                "type": "object",
+                "x-kubernetes-map-type": "atomic",
+                "additionalProperties": false
+              },
+              "csi": {
+                "description": "csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers.",
+                "properties": {
+                  "driver": {
+                    "description": "driver is the name of the CSI driver that handles this volume.\nConsult with your admin for the correct name as registered in the cluster.",
+                    "type": "string"
+                  },
+                  "fsType": {
+                    "description": "fsType to mount. Ex. \"ext4\", \"xfs\", \"ntfs\".\nIf not provided, the empty value is passed to the associated CSI driver\nwhich will determine the default filesystem to apply.",
+                    "type": "string"
+                  },
+                  "nodePublishSecretRef": {
+                    "description": "nodePublishSecretRef is a reference to the secret object containing\nsensitive information to pass to the CSI driver to complete the CSI\nNodePublishVolume and NodeUnpublishVolume calls.\nThis field is optional, and  may be empty if no secret is required. If the\nsecret object contains more than one secret, all secret references are passed.",
+                    "properties": {
+                      "name": {
+                        "default": "",
+                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  },
+                  "readOnly": {
+                    "description": "readOnly specifies a read-only configuration for the volume.\nDefaults to false (read/write).",
+                    "type": "boolean"
+                  },
+                  "volumeAttributes": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "volumeAttributes stores driver-specific properties that are passed to the CSI\ndriver. Consult your driver's documentation for supported values.",
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "driver"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "downwardAPI": {
+                "description": "downwardAPI represents downward API about the pod that should populate this volume",
+                "properties": {
+                  "defaultMode": {
+                    "description": "Optional: mode bits to use on created files by default. Must be a\nOptional: mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nDefaults to 0644.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "items": {
+                    "description": "Items is a list of downward API volume file",
+                    "items": {
+                      "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
+                      "properties": {
+                        "fieldRef": {
+                          "description": "Required: Selects a field of the pod: only annotations, labels, name, namespace and uid are supported.",
+                          "properties": {
+                            "apiVersion": {
+                              "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                              "type": "string"
+                            },
+                            "fieldPath": {
+                              "description": "Path of the field to select in the specified API version.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "fieldPath"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        },
+                        "mode": {
+                          "description": "Optional: mode bits used to set permissions on this file, must be an octal value\nbetween 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "path": {
+                          "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'",
+                          "type": "string"
+                        },
+                        "resourceFieldRef": {
+                          "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.",
+                          "properties": {
+                            "containerName": {
+                              "description": "Container name: required for volumes, optional for env vars",
+                              "type": "string"
+                            },
+                            "divisor": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                              "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "resource": {
+                              "description": "Required: resource to select",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "resource"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "path"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "emptyDir": {
+                "description": "emptyDir represents a temporary directory that shares a pod's lifetime.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+                "properties": {
+                  "medium": {
+                    "description": "medium represents what type of storage medium should back this directory.\nThe default is \"\" which means to use the node's default medium.\nMust be an empty string (default) or Memory.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+                    "type": "string"
+                  },
+                  "sizeLimit": {
+                    "anyOf": [
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ],
+                    "description": "sizeLimit is the total amount of local storage required for this EmptyDir volume.\nThe size limit is also applicable for memory medium.\nThe maximum usage on memory medium EmptyDir would be the minimum value between\nthe SizeLimit specified here and the sum of memory limits of all containers in a pod.\nThe default is nil which means that the limit is undefined.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                    "x-kubernetes-int-or-string": true
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "ephemeral": {
+                "description": "ephemeral represents a volume that is handled by a cluster storage driver.\nThe volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,\nand deleted when the pod is removed.\n\nUse this if:\na) the volume is only needed while the pod runs,\nb) features of normal volumes like restoring from snapshot or capacity\n   tracking are needed,\nc) the storage driver is specified through a storage class, and\nd) the storage driver supports dynamic volume provisioning through\n   a PersistentVolumeClaim (see EphemeralVolumeSource for more\n   information on the connection between this volume type\n   and PersistentVolumeClaim).\n\nUse PersistentVolumeClaim or one of the vendor-specific\nAPIs for volumes that persist for longer than the lifecycle\nof an individual pod.\n\nUse CSI for light-weight local ephemeral volumes if the CSI driver is meant to\nbe used that way - see the documentation of the driver for\nmore information.\n\nA pod can use both types of ephemeral volumes and\npersistent volumes at the same time.",
+                "properties": {
+                  "volumeClaimTemplate": {
+                    "description": "Will be used to create a stand-alone PVC to provision the volume.\nThe pod in which this EphemeralVolumeSource is embedded will be the\nowner of the PVC, i.e. the PVC will be deleted together with the\npod.  The name of the PVC will be `<pod name>-<volume name>` where\n`<volume name>` is the name from the `PodSpec.Volumes` array\nentry. Pod validation will reject the pod if the concatenated name\nis not valid for a PVC (for example, too long).\n\nAn existing PVC with that name that is not owned by the pod\nwill *not* be used for the pod to avoid using an unrelated\nvolume by mistake. Starting the pod is then blocked until\nthe unrelated PVC is removed. If such a pre-created PVC is\nmeant to be used by the pod, the PVC has to updated with an\nowner reference to the pod once the pod exists. Normally\nthis should not be necessary, but it may be useful when\nmanually reconstructing a broken cluster.\n\nThis field is read-only and no changes will be made by Kubernetes\nto the PVC after it has been created.\n\nRequired, must not be nil.",
+                    "properties": {
+                      "metadata": {
+                        "description": "May contain labels and annotations that will be copied into the PVC\nwhen creating it. No other fields are allowed and will be rejected during\nvalidation.",
+                        "type": "object"
+                      },
+                      "spec": {
+                        "description": "The specification for the PersistentVolumeClaim. The entire content is\ncopied unchanged into the PVC that gets created from this\ntemplate. The same fields as in a PersistentVolumeClaim\nare also valid here.",
+                        "properties": {
+                          "accessModes": {
+                            "description": "accessModes contains the desired access modes the volume should have.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "dataSource": {
+                            "description": "dataSource field can be used to specify either:\n* An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)\n* An existing PVC (PersistentVolumeClaim)\nIf the provisioner or an external controller can support the specified data source,\nit will create a new volume based on the contents of the specified data source.\nWhen the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,\nand dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.\nIf the namespace is specified, then dataSourceRef will not be copied to dataSource.",
+                            "properties": {
+                              "apiGroup": {
+                                "description": "APIGroup is the group for the resource being referenced.\nIf APIGroup is not specified, the specified Kind must be in the core API group.\nFor any other third-party types, APIGroup is required.",
+                                "type": "string"
+                              },
+                              "kind": {
+                                "description": "Kind is the type of resource being referenced",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name is the name of resource being referenced",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "kind",
+                              "name"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "dataSourceRef": {
+                            "description": "dataSourceRef specifies the object from which to populate the volume with data, if a non-empty\nvolume is desired. This may be any object from a non-empty API group (non\ncore object) or a PersistentVolumeClaim object.\nWhen this field is specified, volume binding will only succeed if the type of\nthe specified object matches some installed volume populator or dynamic\nprovisioner.\nThis field will replace the functionality of the dataSource field and as such\nif both fields are non-empty, they must have the same value. For backwards\ncompatibility, when namespace isn't specified in dataSourceRef,\nboth fields (dataSource and dataSourceRef) will be set to the same\nvalue automatically if one of them is empty and the other is non-empty.\nWhen namespace is specified in dataSourceRef,\ndataSource isn't set to the same value and must be empty.\nThere are three important differences between dataSource and dataSourceRef:\n* While dataSource only allows two specific types of objects, dataSourceRef\n  allows any non-core object, as well as PersistentVolumeClaim objects.\n* While dataSource ignores disallowed values (dropping them), dataSourceRef\n  preserves all values, and generates an error if a disallowed value is\n  specified.\n* While dataSource only allows local objects, dataSourceRef allows objects\n  in any namespaces.\n(Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.\n(Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.",
+                            "properties": {
+                              "apiGroup": {
+                                "description": "APIGroup is the group for the resource being referenced.\nIf APIGroup is not specified, the specified Kind must be in the core API group.\nFor any other third-party types, APIGroup is required.",
+                                "type": "string"
+                              },
+                              "kind": {
+                                "description": "Kind is the type of resource being referenced",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name is the name of resource being referenced",
+                                "type": "string"
+                              },
+                              "namespace": {
+                                "description": "Namespace is the namespace of resource being referenced\nNote that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.\n(Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "kind",
+                              "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "resources": {
+                            "description": "resources represents the minimum resources the volume should have.\nUsers are allowed to specify resource requirements\nthat are lower than previous value but must still be higher than capacity recorded in the\nstatus field of the claim.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources",
+                            "properties": {
+                              "limits": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                "type": "object"
+                              },
+                              "requests": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "selector": {
+                            "description": "selector is a label query over volumes to consider for binding.",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "key is the label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "storageClassName": {
+                            "description": "storageClassName is the name of the StorageClass required by the claim.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1",
+                            "type": "string"
+                          },
+                          "volumeAttributesClassName": {
+                            "description": "volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.\nIf specified, the CSI driver will create or update the volume with the attributes defined\nin the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,\nit can be changed after the claim is created. An empty string or nil value indicates that no\nVolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,\nthis field can be reset to its previous value (including nil) to cancel the modification.\nIf the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be\nset to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource\nexists.\nMore info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/",
+                            "type": "string"
+                          },
+                          "volumeMode": {
+                            "description": "volumeMode defines what type of volume is required by the claim.\nValue of Filesystem is implied when not included in claim spec.",
+                            "type": "string"
+                          },
+                          "volumeName": {
+                            "description": "volumeName is the binding reference to the PersistentVolume backing this claim.",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "spec"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "fc": {
+                "description": "fc represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.",
+                "properties": {
+                  "fsType": {
+                    "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                    "type": "string"
+                  },
+                  "lun": {
+                    "description": "lun is Optional: FC target lun number",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "readOnly": {
+                    "description": "readOnly is Optional: Defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                    "type": "boolean"
+                  },
+                  "targetWWNs": {
+                    "description": "targetWWNs is Optional: FC target worldwide names (WWNs)",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  },
+                  "wwids": {
+                    "description": "wwids Optional: FC volume world wide identifiers (wwids)\nEither wwids or combination of targetWWNs and lun must be set, but not both simultaneously.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "flexVolume": {
+                "description": "flexVolume represents a generic volume resource that is\nprovisioned/attached using an exec based plugin.\nDeprecated: FlexVolume is deprecated. Consider using a CSIDriver instead.",
+                "properties": {
+                  "driver": {
+                    "description": "driver is the name of the driver to use for this volume.",
+                    "type": "string"
+                  },
+                  "fsType": {
+                    "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". The default filesystem depends on FlexVolume script.",
+                    "type": "string"
+                  },
+                  "options": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "options is Optional: this field holds extra command options if any.",
+                    "type": "object"
+                  },
+                  "readOnly": {
+                    "description": "readOnly is Optional: defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                    "type": "boolean"
+                  },
+                  "secretRef": {
+                    "description": "secretRef is Optional: secretRef is reference to the secret object containing\nsensitive information to pass to the plugin scripts. This may be\nempty if no secret object is specified. If the secret object\ncontains more than one secret, all secrets are passed to the plugin\nscripts.",
+                    "properties": {
+                      "name": {
+                        "default": "",
+                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  }
+                },
+                "required": [
+                  "driver"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "flocker": {
+                "description": "flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running.\nDeprecated: Flocker is deprecated and the in-tree flocker type is no longer supported.",
+                "properties": {
+                  "datasetName": {
+                    "description": "datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker\nshould be considered as deprecated",
+                    "type": "string"
+                  },
+                  "datasetUUID": {
+                    "description": "datasetUUID is the UUID of the dataset. This is unique identifier of a Flocker dataset",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "gcePersistentDisk": {
+                "description": "gcePersistentDisk represents a GCE Disk resource that is attached to a\nkubelet's host machine and then exposed to the pod.\nDeprecated: GCEPersistentDisk is deprecated. All operations for the in-tree\ngcePersistentDisk type are redirected to the pd.csi.storage.gke.io CSI driver.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                "properties": {
+                  "fsType": {
+                    "description": "fsType is filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                    "type": "string"
+                  },
+                  "partition": {
+                    "description": "partition is the partition in the volume that you want to mount.\nIf omitted, the default is to mount by volume name.\nExamples: For volume /dev/sda1, you specify the partition as \"1\".\nSimilarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty).\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "pdName": {
+                    "description": "pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                    "type": "string"
+                  },
+                  "readOnly": {
+                    "description": "readOnly here will force the ReadOnly setting in VolumeMounts.\nDefaults to false.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "pdName"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "gitRepo": {
+                "description": "gitRepo represents a git repository at a particular revision.\nDeprecated: GitRepo is deprecated. To provision a container with a git repo, mount an\nEmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir\ninto the Pod's container.",
+                "properties": {
+                  "directory": {
+                    "description": "directory is the target directory name.\nMust not contain or start with '..'.  If '.' is supplied, the volume directory will be the\ngit repository.  Otherwise, if specified, the volume will contain the git repository in\nthe subdirectory with the given name.",
+                    "type": "string"
+                  },
+                  "repository": {
+                    "description": "repository is the URL",
+                    "type": "string"
+                  },
+                  "revision": {
+                    "description": "revision is the commit hash for the specified revision.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "repository"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "glusterfs": {
+                "description": "glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.\nDeprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.",
+                "properties": {
+                  "endpoints": {
+                    "description": "endpoints is the endpoint name that details Glusterfs topology.",
+                    "type": "string"
+                  },
+                  "path": {
+                    "description": "path is the Glusterfs volume path.\nMore info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+                    "type": "string"
+                  },
+                  "readOnly": {
+                    "description": "readOnly here will force the Glusterfs volume to be mounted with read-only permissions.\nDefaults to false.\nMore info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "endpoints",
+                  "path"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "hostPath": {
+                "description": "hostPath represents a pre-existing file or directory on the host\nmachine that is directly exposed to the container. This is generally\nused for system agents or other privileged things that are allowed\nto see the host machine. Most containers will NOT need this.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+                "properties": {
+                  "path": {
+                    "description": "path of the directory on the host.\nIf the path is a symlink, it will follow the link to the real path.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+                    "type": "string"
+                  },
+                  "type": {
+                    "description": "type for HostPath Volume\nDefaults to \"\"\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "path"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "image": {
+                "description": "image represents an OCI object (a container image or artifact) pulled and mounted on the kubelet's host machine.\nThe volume is resolved at pod startup depending on which PullPolicy value is provided:\n\n- Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.\n- Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.\n- IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.\n\nThe volume gets re-resolved if the pod gets deleted and recreated, which means that new remote content will become available on pod recreation.\nA failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.\nThe types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.\nThe OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.\nThe volume will be mounted read-only (ro) and non-executable files (noexec).\nSub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.\nThe field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.",
+                "properties": {
+                  "pullPolicy": {
+                    "description": "Policy for pulling OCI objects. Possible values are:\nAlways: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.\nNever: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.\nIfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.\nDefaults to Always if :latest tag is specified, or IfNotPresent otherwise.",
+                    "type": "string"
+                  },
+                  "reference": {
+                    "description": "Required: Image or artifact reference to be used.\nBehaves in the same way as pod.spec.containers[*].image.\nPull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.\nMore info: https://kubernetes.io/docs/concepts/containers/images\nThis field is optional to allow higher level config management to default or override\ncontainer images in workload controllers like Deployments and StatefulSets.",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "iscsi": {
+                "description": "iscsi represents an ISCSI Disk resource that is attached to a\nkubelet's host machine and then exposed to the pod.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes/#iscsi",
+                "properties": {
+                  "chapAuthDiscovery": {
+                    "description": "chapAuthDiscovery defines whether support iSCSI Discovery CHAP authentication",
+                    "type": "boolean"
+                  },
+                  "chapAuthSession": {
+                    "description": "chapAuthSession defines whether support iSCSI Session CHAP authentication",
+                    "type": "boolean"
+                  },
+                  "fsType": {
+                    "description": "fsType is the filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi",
+                    "type": "string"
+                  },
+                  "initiatorName": {
+                    "description": "initiatorName is the custom iSCSI Initiator Name.\nIf initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface\n<target portal>:<volume name> will be created for the connection.",
+                    "type": "string"
+                  },
+                  "iqn": {
+                    "description": "iqn is the target iSCSI Qualified Name.",
+                    "type": "string"
+                  },
+                  "iscsiInterface": {
+                    "default": "default",
+                    "description": "iscsiInterface is the interface Name that uses an iSCSI transport.\nDefaults to 'default' (tcp).",
+                    "type": "string"
+                  },
+                  "lun": {
+                    "description": "lun represents iSCSI Target Lun number.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "portals": {
+                    "description": "portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port\nis other than default (typically TCP ports 860 and 3260).",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  },
+                  "readOnly": {
+                    "description": "readOnly here will force the ReadOnly setting in VolumeMounts.\nDefaults to false.",
+                    "type": "boolean"
+                  },
+                  "secretRef": {
+                    "description": "secretRef is the CHAP Secret for iSCSI target and initiator authentication",
+                    "properties": {
+                      "name": {
+                        "default": "",
+                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  },
+                  "targetPortal": {
+                    "description": "targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port\nis other than default (typically TCP ports 860 and 3260).",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "iqn",
+                  "lun",
+                  "targetPortal"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "name": {
+                "description": "name of the volume.\nMust be a DNS_LABEL and unique within the pod.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                "type": "string"
+              },
+              "nfs": {
+                "description": "nfs represents an NFS mount on the host that shares a pod's lifetime\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                "properties": {
+                  "path": {
+                    "description": "path that is exported by the NFS server.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                    "type": "string"
+                  },
+                  "readOnly": {
+                    "description": "readOnly here will force the NFS export to be mounted with read-only permissions.\nDefaults to false.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                    "type": "boolean"
+                  },
+                  "server": {
+                    "description": "server is the hostname or IP address of the NFS server.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "path",
+                  "server"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "persistentVolumeClaim": {
+                "description": "persistentVolumeClaimVolumeSource represents a reference to a\nPersistentVolumeClaim in the same namespace.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
+                "properties": {
+                  "claimName": {
+                    "description": "claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
+                    "type": "string"
+                  },
+                  "readOnly": {
+                    "description": "readOnly Will force the ReadOnly setting in VolumeMounts.\nDefault false.",
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "claimName"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "photonPersistentDisk": {
+                "description": "photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine.\nDeprecated: PhotonPersistentDisk is deprecated and the in-tree photonPersistentDisk type is no longer supported.",
+                "properties": {
+                  "fsType": {
+                    "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                    "type": "string"
+                  },
+                  "pdID": {
+                    "description": "pdID is the ID that identifies Photon Controller persistent disk",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "pdID"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "portworxVolume": {
+                "description": "portworxVolume represents a portworx volume attached and mounted on kubelets host machine.\nDeprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type\nare redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate\nis on.",
+                "properties": {
+                  "fsType": {
+                    "description": "fSType represents the filesystem type to mount\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                    "type": "string"
+                  },
+                  "readOnly": {
+                    "description": "readOnly defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                    "type": "boolean"
+                  },
+                  "volumeID": {
+                    "description": "volumeID uniquely identifies a Portworx volume",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "volumeID"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "projected": {
+                "description": "projected items for all in one resources secrets, configmaps, and downward API",
+                "properties": {
+                  "defaultMode": {
+                    "description": "defaultMode are the mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "sources": {
+                    "description": "sources is the list of volume projections. Each entry in this list\nhandles one source.",
+                    "items": {
+                      "description": "Projection that may be projected along with other supported volume types.\nExactly one of these fields must be set.",
+                      "properties": {
+                        "clusterTrustBundle": {
+                          "description": "ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field\nof ClusterTrustBundle objects in an auto-updating file.\n\nAlpha, gated by the ClusterTrustBundleProjection feature gate.\n\nClusterTrustBundle objects can either be selected by name, or by the\ncombination of signer name and a label selector.\n\nKubelet performs aggressive normalization of the PEM contents written\ninto the pod filesystem.  Esoteric PEM features such as inter-block\ncomments and block headers are stripped.  Certificates are deduplicated.\nThe ordering of certificates within the file is arbitrary, and Kubelet\nmay change the order over time.",
+                          "properties": {
+                            "labelSelector": {
+                              "description": "Select all ClusterTrustBundles that match this label selector.  Only has\neffect if signerName is set.  Mutually-exclusive with name.  If unset,\ninterpreted as \"match nothing\".  If set but empty, interpreted as \"match\neverything\".",
+                              "properties": {
+                                "matchExpressions": {
+                                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                  "items": {
+                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                    "properties": {
+                                      "key": {
+                                        "description": "key is the label key that the selector applies to.",
+                                        "type": "string"
+                                      },
+                                      "operator": {
+                                        "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                        "type": "string"
+                                      },
+                                      "values": {
+                                        "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      }
+                                    },
+                                    "required": [
+                                      "key",
+                                      "operator"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                },
+                                "matchLabels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            },
+                            "name": {
+                              "description": "Select a single ClusterTrustBundle by object name.  Mutually-exclusive\nwith signerName and labelSelector.",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "If true, don't block pod startup if the referenced ClusterTrustBundle(s)\naren't available.  If using name, then the named ClusterTrustBundle is\nallowed not to exist.  If using signerName, then the combination of\nsignerName and labelSelector is allowed to match zero\nClusterTrustBundles.",
+                              "type": "boolean"
+                            },
+                            "path": {
+                              "description": "Relative path from the volume root to write the bundle.",
+                              "type": "string"
+                            },
+                            "signerName": {
+                              "description": "Select all ClusterTrustBundles that match this signer name.\nMutually-exclusive with name.  The contents of all selected\nClusterTrustBundles will be unified and deduplicated.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "path"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "configMap": {
+                          "description": "configMap information about the configMap data to project",
+                          "properties": {
+                            "items": {
+                              "description": "items if unspecified, each key-value pair in the Data field of the referenced\nConfigMap will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the ConfigMap,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
+                              "items": {
+                                "description": "Maps a string key to a path within a volume.",
+                                "properties": {
+                                  "key": {
+                                    "description": "key is the key to project.",
+                                    "type": "string"
+                                  },
+                                  "mode": {
+                                    "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "path": {
+                                    "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "key",
+                                  "path"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
+                            },
+                            "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "optional specify whether the ConfigMap or its keys must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        },
+                        "downwardAPI": {
+                          "description": "downwardAPI information about the downwardAPI data to project",
+                          "properties": {
+                            "items": {
+                              "description": "Items is a list of DownwardAPIVolume file",
+                              "items": {
+                                "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
+                                "properties": {
+                                  "fieldRef": {
+                                    "description": "Required: Selects a field of the pod: only annotations, labels, name, namespace and uid are supported.",
+                                    "properties": {
+                                      "apiVersion": {
+                                        "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                        "type": "string"
+                                      },
+                                      "fieldPath": {
+                                        "description": "Path of the field to select in the specified API version.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "fieldPath"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  },
+                                  "mode": {
+                                    "description": "Optional: mode bits used to set permissions on this file, must be an octal value\nbetween 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "path": {
+                                    "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'",
+                                    "type": "string"
+                                  },
+                                  "resourceFieldRef": {
+                                    "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.",
+                                    "properties": {
+                                      "containerName": {
+                                        "description": "Container name: required for volumes, optional for env vars",
+                                        "type": "string"
+                                      },
+                                      "divisor": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "resource": {
+                                        "description": "Required: resource to select",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "resource"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "required": [
+                                  "path"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "podCertificate": {
+                          "description": "Projects an auto-rotating credential bundle (private key and certificate\nchain) that the pod can use either as a TLS client or server.\n\nKubelet generates a private key and uses it to send a\nPodCertificateRequest to the named signer.  Once the signer approves the\nrequest and issues a certificate chain, Kubelet writes the key and\ncertificate chain to the pod filesystem.  The pod does not start until\ncertificates have been issued for each podCertificate projected volume\nsource in its spec.\n\nKubelet will begin trying to rotate the certificate at the time indicated\nby the signer using the PodCertificateRequest.Status.BeginRefreshAt\ntimestamp.\n\nKubelet can write a single file, indicated by the credentialBundlePath\nfield, or separate files, indicated by the keyPath and\ncertificateChainPath fields.\n\nThe credential bundle is a single file in PEM format.  The first PEM\nentry is the private key (in PKCS#8 format), and the remaining PEM\nentries are the certificate chain issued by the signer (typically,\nsigners will return their certificate chain in leaf-to-root order).\n\nPrefer using the credential bundle format, since your application code\ncan read it atomically.  If you use keyPath and certificateChainPath,\nyour application must make two separate file reads. If these coincide\nwith a certificate rotation, it is possible that the private key and leaf\ncertificate you read may not correspond to each other.  Your application\nwill need to check for this condition, and re-read until they are\nconsistent.\n\nThe named signer controls chooses the format of the certificate it\nissues; consult the signer implementation's documentation to learn how to\nuse the certificates it issues.",
+                          "properties": {
+                            "certificateChainPath": {
+                              "description": "Write the certificate chain at this path in the projected volume.\n\nMost applications should use credentialBundlePath.  When using keyPath\nand certificateChainPath, your application needs to check that the key\nand leaf certificate are consistent, because it is possible to read the\nfiles mid-rotation.",
+                              "type": "string"
+                            },
+                            "credentialBundlePath": {
+                              "description": "Write the credential bundle at this path in the projected volume.\n\nThe credential bundle is a single file that contains multiple PEM blocks.\nThe first PEM block is a PRIVATE KEY block, containing a PKCS#8 private\nkey.\n\nThe remaining blocks are CERTIFICATE blocks, containing the issued\ncertificate chain from the signer (leaf and any intermediates).\n\nUsing credentialBundlePath lets your Pod's application code make a single\natomic read that retrieves a consistent key and certificate chain.  If you\nproject them to separate files, your application code will need to\nadditionally check that the leaf certificate was issued to the key.",
+                              "type": "string"
+                            },
+                            "keyPath": {
+                              "description": "Write the key at this path in the projected volume.\n\nMost applications should use credentialBundlePath.  When using keyPath\nand certificateChainPath, your application needs to check that the key\nand leaf certificate are consistent, because it is possible to read the\nfiles mid-rotation.",
+                              "type": "string"
+                            },
+                            "keyType": {
+                              "description": "The type of keypair Kubelet will generate for the pod.\n\nValid values are \"RSA3072\", \"RSA4096\", \"ECDSAP256\", \"ECDSAP384\",\n\"ECDSAP521\", and \"ED25519\".",
+                              "type": "string"
+                            },
+                            "maxExpirationSeconds": {
+                              "description": "maxExpirationSeconds is the maximum lifetime permitted for the\ncertificate.\n\nKubelet copies this value verbatim into the PodCertificateRequests it\ngenerates for this projection.\n\nIf omitted, kube-apiserver will set it to 86400(24 hours). kube-apiserver\nwill reject values shorter than 3600 (1 hour).  The maximum allowable\nvalue is 7862400 (91 days).\n\nThe signer implementation is then free to issue a certificate with any\nlifetime *shorter* than MaxExpirationSeconds, but no shorter than 3600\nseconds (1 hour).  This constraint is enforced by kube-apiserver.\n`kubernetes.io` signers will never issue certificates with a lifetime\nlonger than 24 hours.",
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "signerName": {
+                              "description": "Kubelet's generated CSRs will be addressed to this signer.",
+                              "type": "string"
+                            },
+                            "userAnnotations": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "description": "userAnnotations allow pod authors to pass additional information to\nthe signer implementation.  Kubernetes does not restrict or validate this\nmetadata in any way.\n\nThese values are copied verbatim into the `spec.unverifiedUserAnnotations` field of\nthe PodCertificateRequest objects that Kubelet creates.\n\nEntries are subject to the same validation as object metadata annotations,\nwith the addition that all keys must be domain-prefixed. No restrictions\nare placed on values, except an overall size limitation on the entire field.\n\nSigners should document the keys and values they support. Signers should\ndeny requests that contain keys they do not recognize.",
+                              "type": "object"
+                            }
+                          },
+                          "required": [
+                            "keyType",
+                            "signerName"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "secret": {
+                          "description": "secret information about the secret data to project",
+                          "properties": {
+                            "items": {
+                              "description": "items if unspecified, each key-value pair in the Data field of the referenced\nSecret will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the Secret,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
+                              "items": {
+                                "description": "Maps a string key to a path within a volume.",
+                                "properties": {
+                                  "key": {
+                                    "description": "key is the key to project.",
+                                    "type": "string"
+                                  },
+                                  "mode": {
+                                    "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "path": {
+                                    "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "key",
+                                  "path"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
+                            },
+                            "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "optional field specify whether the Secret or its key must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        },
+                        "serviceAccountToken": {
+                          "description": "serviceAccountToken is information about the serviceAccountToken data to project",
+                          "properties": {
+                            "audience": {
+                              "description": "audience is the intended audience of the token. A recipient of a token\nmust identify itself with an identifier specified in the audience of the\ntoken, and otherwise should reject the token. The audience defaults to the\nidentifier of the apiserver.",
+                              "type": "string"
+                            },
+                            "expirationSeconds": {
+                              "description": "expirationSeconds is the requested duration of validity of the service\naccount token. As the token approaches expiration, the kubelet volume\nplugin will proactively rotate the service account token. The kubelet will\nstart trying to rotate the token if the token is older than 80 percent of\nits time to live or if the token is older than 24 hours.Defaults to 1 hour\nand must be at least 10 minutes.",
+                              "format": "int64",
+                              "type": "integer"
+                            },
+                            "path": {
+                              "description": "path is the path relative to the mount point of the file to project the\ntoken into.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "path"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "quobyte": {
+                "description": "quobyte represents a Quobyte mount on the host that shares a pod's lifetime.\nDeprecated: Quobyte is deprecated and the in-tree quobyte type is no longer supported.",
+                "properties": {
+                  "group": {
+                    "description": "group to map volume access to\nDefault is no group",
+                    "type": "string"
+                  },
+                  "readOnly": {
+                    "description": "readOnly here will force the Quobyte volume to be mounted with read-only permissions.\nDefaults to false.",
+                    "type": "boolean"
+                  },
+                  "registry": {
+                    "description": "registry represents a single or multiple Quobyte Registry services\nspecified as a string as host:port pair (multiple entries are separated with commas)\nwhich acts as the central registry for volumes",
+                    "type": "string"
+                  },
+                  "tenant": {
+                    "description": "tenant owning the given Quobyte volume in the Backend\nUsed with dynamically provisioned Quobyte volumes, value is set by the plugin",
+                    "type": "string"
+                  },
+                  "user": {
+                    "description": "user to map volume access to\nDefaults to serivceaccount user",
+                    "type": "string"
+                  },
+                  "volume": {
+                    "description": "volume is a string that references an already created Quobyte volume by name.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "registry",
+                  "volume"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "rbd": {
+                "description": "rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.\nDeprecated: RBD is deprecated and the in-tree rbd type is no longer supported.",
+                "properties": {
+                  "fsType": {
+                    "description": "fsType is the filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#rbd",
+                    "type": "string"
+                  },
+                  "image": {
+                    "description": "image is the rados image name.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                    "type": "string"
+                  },
+                  "keyring": {
+                    "default": "/etc/ceph/keyring",
+                    "description": "keyring is the path to key ring for RBDUser.\nDefault is /etc/ceph/keyring.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                    "type": "string"
+                  },
+                  "monitors": {
+                    "description": "monitors is a collection of Ceph monitors.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  },
+                  "pool": {
+                    "default": "rbd",
+                    "description": "pool is the rados pool name.\nDefault is rbd.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                    "type": "string"
+                  },
+                  "readOnly": {
+                    "description": "readOnly here will force the ReadOnly setting in VolumeMounts.\nDefaults to false.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                    "type": "boolean"
+                  },
+                  "secretRef": {
+                    "description": "secretRef is name of the authentication secret for RBDUser. If provided\noverrides keyring.\nDefault is nil.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                    "properties": {
+                      "name": {
+                        "default": "",
+                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  },
+                  "user": {
+                    "default": "admin",
+                    "description": "user is the rados user name.\nDefault is admin.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "image",
+                  "monitors"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "scaleIO": {
+                "description": "scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.\nDeprecated: ScaleIO is deprecated and the in-tree scaleIO type is no longer supported.",
+                "properties": {
+                  "fsType": {
+                    "default": "xfs",
+                    "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\".\nDefault is \"xfs\".",
+                    "type": "string"
+                  },
+                  "gateway": {
+                    "description": "gateway is the host address of the ScaleIO API Gateway.",
+                    "type": "string"
+                  },
+                  "protectionDomain": {
+                    "description": "protectionDomain is the name of the ScaleIO Protection Domain for the configured storage.",
+                    "type": "string"
+                  },
+                  "readOnly": {
+                    "description": "readOnly Defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                    "type": "boolean"
+                  },
+                  "secretRef": {
+                    "description": "secretRef references to the secret for ScaleIO user and other\nsensitive information. If this is not provided, Login operation will fail.",
+                    "properties": {
+                      "name": {
+                        "default": "",
+                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  },
+                  "sslEnabled": {
+                    "description": "sslEnabled Flag enable/disable SSL communication with Gateway, default false",
+                    "type": "boolean"
+                  },
+                  "storageMode": {
+                    "default": "ThinProvisioned",
+                    "description": "storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.\nDefault is ThinProvisioned.",
+                    "type": "string"
+                  },
+                  "storagePool": {
+                    "description": "storagePool is the ScaleIO Storage Pool associated with the protection domain.",
+                    "type": "string"
+                  },
+                  "system": {
+                    "description": "system is the name of the storage system as configured in ScaleIO.",
+                    "type": "string"
+                  },
+                  "volumeName": {
+                    "description": "volumeName is the name of a volume already created in the ScaleIO system\nthat is associated with this volume source.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "gateway",
+                  "secretRef",
+                  "system"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "secret": {
+                "description": "secret represents a secret that should populate this volume.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
+                "properties": {
+                  "defaultMode": {
+                    "description": "defaultMode is Optional: mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values\nfor mode bits. Defaults to 0644.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "items": {
+                    "description": "items If unspecified, each key-value pair in the Data field of the referenced\nSecret will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the Secret,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
+                    "items": {
+                      "description": "Maps a string key to a path within a volume.",
+                      "properties": {
+                        "key": {
+                          "description": "key is the key to project.",
+                          "type": "string"
+                        },
+                        "mode": {
+                          "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "path": {
+                          "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "key",
+                        "path"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  },
+                  "optional": {
+                    "description": "optional field specify whether the Secret or its keys must be defined",
+                    "type": "boolean"
+                  },
+                  "secretName": {
+                    "description": "secretName is the name of the secret in the pod's namespace to use.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "storageos": {
+                "description": "storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.\nDeprecated: StorageOS is deprecated and the in-tree storageos type is no longer supported.",
+                "properties": {
+                  "fsType": {
+                    "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                    "type": "string"
+                  },
+                  "readOnly": {
+                    "description": "readOnly defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                    "type": "boolean"
+                  },
+                  "secretRef": {
+                    "description": "secretRef specifies the secret to use for obtaining the StorageOS API\ncredentials.  If not specified, default values will be attempted.",
+                    "properties": {
+                      "name": {
+                        "default": "",
+                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  },
+                  "volumeName": {
+                    "description": "volumeName is the human-readable name of the StorageOS volume.  Volume\nnames are only unique within a namespace.",
+                    "type": "string"
+                  },
+                  "volumeNamespace": {
+                    "description": "volumeNamespace specifies the scope of the volume within StorageOS.  If no\nnamespace is specified then the Pod's namespace will be used.  This allows the\nKubernetes name scoping to be mirrored within StorageOS for tighter integration.\nSet VolumeName to any name to override the default behaviour.\nSet to \"default\" if you are not using namespaces within StorageOS.\nNamespaces that do not pre-exist within StorageOS will be created.",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "vsphereVolume": {
+                "description": "vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine.\nDeprecated: VsphereVolume is deprecated. All operations for the in-tree vsphereVolume type\nare redirected to the csi.vsphere.vmware.com CSI driver.",
+                "properties": {
+                  "fsType": {
+                    "description": "fsType is filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                    "type": "string"
+                  },
+                  "storagePolicyID": {
+                    "description": "storagePolicyID is the storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.",
+                    "type": "string"
+                  },
+                  "storagePolicyName": {
+                    "description": "storagePolicyName is the storage Policy Based Management (SPBM) profile name.",
+                    "type": "string"
+                  },
+                  "volumePath": {
+                    "description": "volumePath is the path that identifies vSphere volume vmdk",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "volumePath"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "image": {
+          "description": "Renovate Docker image to use",
+          "type": "string"
+        },
+        "imagePullSecrets": {
+          "description": "Image pull secrets for the renovate pods",
+          "items": {
+            "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
+            "properties": {
+              "name": {
+                "default": "",
+                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "x-kubernetes-map-type": "atomic",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "metadata": {
+          "description": "Metadata that shall be applied to the resulting pod",
+          "properties": {
+            "annotations": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "labels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "nodeSelector": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Node selector for scheduling the resulting pod",
+          "type": "object"
+        },
+        "parallelism": {
+          "description": "Maximum number of projects to process in parallel",
+          "format": "int32",
+          "type": "integer"
+        },
+        "provider": {
+          "description": "Renovate Provider Information to fill \"RENOVATE_ENDPOINT\" and \"RENOVATE_PLATFORM\" environment variables in the renovate container",
+          "properties": {
+            "endpoint": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "resources": {
+          "description": "Resource requirements for the renovate container",
+          "properties": {
+            "claims": {
+              "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis field depends on the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
+              "items": {
+                "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                "properties": {
+                  "name": {
+                    "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
+                    "type": "string"
+                  },
+                  "request": {
+                    "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array",
+              "x-kubernetes-list-map-keys": [
+                "name"
+              ],
+              "x-kubernetes-list-type": "map"
+            },
+            "limits": {
+              "additionalProperties": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ],
+                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                "x-kubernetes-int-or-string": true
+              },
+              "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+              "type": "object"
+            },
+            "requests": {
+              "additionalProperties": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ],
+                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                "x-kubernetes-int-or-string": true
+              },
+              "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "schedule": {
+          "description": "Cron schedule in standard cron format",
+          "type": "string"
+        },
+        "scratchVolume": {
+          "description": "Configuration for the scratch volume",
+          "properties": {
+            "enabled": {
+              "default": true,
+              "description": "If enabled a scratch volume will be created and RENOVATE_BASE_DIR will be set accordingly",
+              "type": "boolean"
+            },
+            "ephemeral": {
+              "description": "Ephemeral uses a Kubernetes generic ephemeral volume for scratch (volume.ephemeral).\nWhen set, Medium and SizeLimit are ignored.",
+              "properties": {
+                "volumeClaimTemplate": {
+                  "description": "Will be used to create a stand-alone PVC to provision the volume.\nThe pod in which this EphemeralVolumeSource is embedded will be the\nowner of the PVC, i.e. the PVC will be deleted together with the\npod.  The name of the PVC will be `<pod name>-<volume name>` where\n`<volume name>` is the name from the `PodSpec.Volumes` array\nentry. Pod validation will reject the pod if the concatenated name\nis not valid for a PVC (for example, too long).\n\nAn existing PVC with that name that is not owned by the pod\nwill *not* be used for the pod to avoid using an unrelated\nvolume by mistake. Starting the pod is then blocked until\nthe unrelated PVC is removed. If such a pre-created PVC is\nmeant to be used by the pod, the PVC has to updated with an\nowner reference to the pod once the pod exists. Normally\nthis should not be necessary, but it may be useful when\nmanually reconstructing a broken cluster.\n\nThis field is read-only and no changes will be made by Kubernetes\nto the PVC after it has been created.\n\nRequired, must not be nil.",
+                  "properties": {
+                    "metadata": {
+                      "description": "May contain labels and annotations that will be copied into the PVC\nwhen creating it. No other fields are allowed and will be rejected during\nvalidation.",
+                      "type": "object"
+                    },
+                    "spec": {
+                      "description": "The specification for the PersistentVolumeClaim. The entire content is\ncopied unchanged into the PVC that gets created from this\ntemplate. The same fields as in a PersistentVolumeClaim\nare also valid here.",
+                      "properties": {
+                        "accessModes": {
+                          "description": "accessModes contains the desired access modes the volume should have.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array",
+                          "x-kubernetes-list-type": "atomic"
+                        },
+                        "dataSource": {
+                          "description": "dataSource field can be used to specify either:\n* An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)\n* An existing PVC (PersistentVolumeClaim)\nIf the provisioner or an external controller can support the specified data source,\nit will create a new volume based on the contents of the specified data source.\nWhen the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,\nand dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.\nIf the namespace is specified, then dataSourceRef will not be copied to dataSource.",
+                          "properties": {
+                            "apiGroup": {
+                              "description": "APIGroup is the group for the resource being referenced.\nIf APIGroup is not specified, the specified Kind must be in the core API group.\nFor any other third-party types, APIGroup is required.",
+                              "type": "string"
+                            },
+                            "kind": {
+                              "description": "Kind is the type of resource being referenced",
+                              "type": "string"
+                            },
+                            "name": {
+                              "description": "Name is the name of resource being referenced",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "kind",
+                            "name"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        },
+                        "dataSourceRef": {
+                          "description": "dataSourceRef specifies the object from which to populate the volume with data, if a non-empty\nvolume is desired. This may be any object from a non-empty API group (non\ncore object) or a PersistentVolumeClaim object.\nWhen this field is specified, volume binding will only succeed if the type of\nthe specified object matches some installed volume populator or dynamic\nprovisioner.\nThis field will replace the functionality of the dataSource field and as such\nif both fields are non-empty, they must have the same value. For backwards\ncompatibility, when namespace isn't specified in dataSourceRef,\nboth fields (dataSource and dataSourceRef) will be set to the same\nvalue automatically if one of them is empty and the other is non-empty.\nWhen namespace is specified in dataSourceRef,\ndataSource isn't set to the same value and must be empty.\nThere are three important differences between dataSource and dataSourceRef:\n* While dataSource only allows two specific types of objects, dataSourceRef\n  allows any non-core object, as well as PersistentVolumeClaim objects.\n* While dataSource ignores disallowed values (dropping them), dataSourceRef\n  preserves all values, and generates an error if a disallowed value is\n  specified.\n* While dataSource only allows local objects, dataSourceRef allows objects\n  in any namespaces.\n(Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.\n(Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.",
+                          "properties": {
+                            "apiGroup": {
+                              "description": "APIGroup is the group for the resource being referenced.\nIf APIGroup is not specified, the specified Kind must be in the core API group.\nFor any other third-party types, APIGroup is required.",
+                              "type": "string"
+                            },
+                            "kind": {
+                              "description": "Kind is the type of resource being referenced",
+                              "type": "string"
+                            },
+                            "name": {
+                              "description": "Name is the name of resource being referenced",
+                              "type": "string"
+                            },
+                            "namespace": {
+                              "description": "Namespace is the namespace of resource being referenced\nNote that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.\n(Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "kind",
+                            "name"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "resources": {
+                          "description": "resources represents the minimum resources the volume should have.\nUsers are allowed to specify resource requirements\nthat are lower than previous value but must still be higher than capacity recorded in the\nstatus field of the claim.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources",
+                          "properties": {
+                            "limits": {
+                              "additionalProperties": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                              "type": "object"
+                            },
+                            "requests": {
+                              "additionalProperties": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                              "type": "object"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "selector": {
+                          "description": "selector is a label query over volumes to consider for binding.",
+                          "properties": {
+                            "matchExpressions": {
+                              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                              "items": {
+                                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                "properties": {
+                                  "key": {
+                                    "description": "key is the label key that the selector applies to.",
+                                    "type": "string"
+                                  },
+                                  "operator": {
+                                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                    "type": "string"
+                                  },
+                                  "values": {
+                                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
+                                  }
+                                },
+                                "required": [
+                                  "key",
+                                  "operator"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
+                            },
+                            "matchLabels": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                              "type": "object"
+                            }
+                          },
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        },
+                        "storageClassName": {
+                          "description": "storageClassName is the name of the StorageClass required by the claim.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1",
+                          "type": "string"
+                        },
+                        "volumeAttributesClassName": {
+                          "description": "volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.\nIf specified, the CSI driver will create or update the volume with the attributes defined\nin the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,\nit can be changed after the claim is created. An empty string or nil value indicates that no\nVolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,\nthis field can be reset to its previous value (including nil) to cancel the modification.\nIf the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be\nset to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource\nexists.\nMore info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/",
+                          "type": "string"
+                        },
+                        "volumeMode": {
+                          "description": "volumeMode defines what type of volume is required by the claim.\nValue of Filesystem is implied when not included in claim spec.",
+                          "type": "string"
+                        },
+                        "volumeName": {
+                          "description": "volumeName is the binding reference to the PersistentVolume backing this claim.",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "spec"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "medium": {
+              "description": "Medium for the emptyDir volume. Ignored when Ephemeral is set.\nEmpty uses the node's default medium; Memory uses a tmpfs (corev1.StorageMediumMemory).",
+              "type": "string"
+            },
+            "path": {
+              "default": "/tmp",
+              "description": "Path within the container where the scratch volume will be mounted, RENOVATE_BASE_DIR will be set to this path.",
+              "type": "string"
+            },
+            "sizeLimit": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "string"
+                }
+              ],
+              "description": "SizeLimit caps how large the emptyDir may grow (Kubernetes emptyDir.sizeLimit). Ignored when Ephemeral is set.",
+              "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+              "x-kubernetes-int-or-string": true
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "secretRef": {
+          "description": "Reference to the secret containing the renovate config",
+          "type": "string"
+        },
+        "securityContext": {
+          "description": "Security context for the resulting pod and container",
+          "properties": {
+            "container": {
+              "description": "SecurityContext holds security configuration that will be applied to a container.\nSome fields are present in both SecurityContext and PodSecurityContext.  When both\nare set, the values in SecurityContext take precedence.",
+              "properties": {
+                "allowPrivilegeEscalation": {
+                  "description": "AllowPrivilegeEscalation controls whether a process can gain more\nprivileges than its parent process. This bool directly controls if\nthe no_new_privs flag will be set on the container process.\nAllowPrivilegeEscalation is true always when the container is:\n1) run as Privileged\n2) has CAP_SYS_ADMIN\nNote that this field cannot be set when spec.os.name is windows.",
+                  "type": "boolean"
+                },
+                "appArmorProfile": {
+                  "description": "appArmorProfile is the AppArmor options to use by this container. If set, this profile\noverrides the pod's appArmorProfile.\nNote that this field cannot be set when spec.os.name is windows.",
+                  "properties": {
+                    "localhostProfile": {
+                      "description": "localhostProfile indicates a profile loaded on the node that should be used.\nThe profile must be preconfigured on the node to work.\nMust match the loaded name of the profile.\nMust be set if and only if type is \"Localhost\".",
+                      "type": "string"
+                    },
+                    "type": {
+                      "description": "type indicates which kind of AppArmor profile will be applied.\nValid options are:\n  Localhost - a profile pre-loaded on the node.\n  RuntimeDefault - the container runtime's default profile.\n  Unconfined - no AppArmor enforcement.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "capabilities": {
+                  "description": "The capabilities to add/drop when running containers.\nDefaults to the default set of capabilities granted by the container runtime.\nNote that this field cannot be set when spec.os.name is windows.",
+                  "properties": {
+                    "add": {
+                      "description": "Added capabilities",
+                      "items": {
+                        "description": "Capability represent POSIX capabilities type",
+                        "type": "string"
+                      },
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
+                    },
+                    "drop": {
+                      "description": "Removed capabilities",
+                      "items": {
+                        "description": "Capability represent POSIX capabilities type",
+                        "type": "string"
+                      },
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "privileged": {
+                  "description": "Run container in privileged mode.\nProcesses in privileged containers are essentially equivalent to root on the host.\nDefaults to false.\nNote that this field cannot be set when spec.os.name is windows.",
+                  "type": "boolean"
+                },
+                "procMount": {
+                  "description": "procMount denotes the type of proc mount to use for the containers.\nThe default value is Default which uses the container runtime defaults for\nreadonly paths and masked paths.\nThis requires the ProcMountType feature flag to be enabled.\nNote that this field cannot be set when spec.os.name is windows.",
+                  "type": "string"
+                },
+                "readOnlyRootFilesystem": {
+                  "description": "Whether this container has a read-only root filesystem.\nDefault is false.\nNote that this field cannot be set when spec.os.name is windows.",
+                  "type": "boolean"
+                },
+                "runAsGroup": {
+                  "description": "The GID to run the entrypoint of the container process.\nUses runtime default if unset.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "runAsNonRoot": {
+                  "description": "Indicates that the container must run as a non-root user.\nIf true, the Kubelet will validate the image at runtime to ensure that it\ndoes not run as UID 0 (root) and fail to start the container if it does.\nIf unset or false, no such validation will be performed.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
+                  "type": "boolean"
+                },
+                "runAsUser": {
+                  "description": "The UID to run the entrypoint of the container process.\nDefaults to user specified in image metadata if unspecified.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "seLinuxOptions": {
+                  "description": "The SELinux context to be applied to the container.\nIf unspecified, the container runtime will allocate a random SELinux context for each\ncontainer.  May also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
+                  "properties": {
+                    "level": {
+                      "description": "Level is SELinux level label that applies to the container.",
+                      "type": "string"
+                    },
+                    "role": {
+                      "description": "Role is a SELinux role label that applies to the container.",
+                      "type": "string"
+                    },
+                    "type": {
+                      "description": "Type is a SELinux type label that applies to the container.",
+                      "type": "string"
+                    },
+                    "user": {
+                      "description": "User is a SELinux user label that applies to the container.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "seccompProfile": {
+                  "description": "The seccomp options to use by this container. If seccomp options are\nprovided at both the pod & container level, the container options\noverride the pod options.\nNote that this field cannot be set when spec.os.name is windows.",
+                  "properties": {
+                    "localhostProfile": {
+                      "description": "localhostProfile indicates a profile defined in a file on the node should be used.\nThe profile must be preconfigured on the node to work.\nMust be a descending path, relative to the kubelet's configured seccomp profile location.\nMust be set if type is \"Localhost\". Must NOT be set for any other type.",
+                      "type": "string"
+                    },
+                    "type": {
+                      "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "windowsOptions": {
+                  "description": "The Windows specific settings applied to all containers.\nIf unspecified, the options from the PodSecurityContext will be used.\nIf set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is linux.",
+                  "properties": {
+                    "gmsaCredentialSpec": {
+                      "description": "GMSACredentialSpec is where the GMSA admission webhook\n(https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the\nGMSA credential spec named by the GMSACredentialSpecName field.",
+                      "type": "string"
+                    },
+                    "gmsaCredentialSpecName": {
+                      "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
+                      "type": "string"
+                    },
+                    "hostProcess": {
+                      "description": "HostProcess determines if a container should be run as a 'Host Process' container.\nAll of a Pod's containers must have the same effective HostProcess value\n(it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).\nIn addition, if HostProcess is true then HostNetwork must also be set to true.",
+                      "type": "boolean"
+                    },
+                    "runAsUserName": {
+                      "description": "The UserName in Windows to run the entrypoint of the container process.\nDefaults to the user specified in image metadata if unspecified.\nMay also be set in PodSecurityContext. If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "pod": {
+              "description": "PodSecurityContext holds pod-level security attributes and common container settings.\nSome fields are also present in container.securityContext.  Field values of\ncontainer.securityContext take precedence over field values of PodSecurityContext.",
+              "properties": {
+                "appArmorProfile": {
+                  "description": "appArmorProfile is the AppArmor options to use by the containers in this pod.\nNote that this field cannot be set when spec.os.name is windows.",
+                  "properties": {
+                    "localhostProfile": {
+                      "description": "localhostProfile indicates a profile loaded on the node that should be used.\nThe profile must be preconfigured on the node to work.\nMust match the loaded name of the profile.\nMust be set if and only if type is \"Localhost\".",
+                      "type": "string"
+                    },
+                    "type": {
+                      "description": "type indicates which kind of AppArmor profile will be applied.\nValid options are:\n  Localhost - a profile pre-loaded on the node.\n  RuntimeDefault - the container runtime's default profile.\n  Unconfined - no AppArmor enforcement.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "fsGroup": {
+                  "description": "A special supplemental group that applies to all containers in a pod.\nSome volume types allow the Kubelet to change the ownership of that volume\nto be owned by the pod:\n\n1. The owning GID will be the FSGroup\n2. The setgid bit is set (new files created in the volume will be owned by FSGroup)\n3. The permission bits are OR'd with rw-rw----\n\nIf unset, the Kubelet will not modify the ownership and permissions of any volume.\nNote that this field cannot be set when spec.os.name is windows.",
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "fsGroupChangePolicy": {
+                  "description": "fsGroupChangePolicy defines behavior of changing ownership and permission of the volume\nbefore being exposed inside Pod. This field will only apply to\nvolume types which support fsGroup based ownership(and permissions).\nIt will have no effect on ephemeral volume types such as: secret, configmaps\nand emptydir.\nValid values are \"OnRootMismatch\" and \"Always\". If not specified, \"Always\" is used.\nNote that this field cannot be set when spec.os.name is windows.",
+                  "type": "string"
+                },
+                "runAsGroup": {
+                  "description": "The GID to run the entrypoint of the container process.\nUses runtime default if unset.\nMay also be set in SecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence\nfor that container.\nNote that this field cannot be set when spec.os.name is windows.",
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "runAsNonRoot": {
+                  "description": "Indicates that the container must run as a non-root user.\nIf true, the Kubelet will validate the image at runtime to ensure that it\ndoes not run as UID 0 (root) and fail to start the container if it does.\nIf unset or false, no such validation will be performed.\nMay also be set in SecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
+                  "type": "boolean"
+                },
+                "runAsUser": {
+                  "description": "The UID to run the entrypoint of the container process.\nDefaults to user specified in image metadata if unspecified.\nMay also be set in SecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence\nfor that container.\nNote that this field cannot be set when spec.os.name is windows.",
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "seLinuxChangePolicy": {
+                  "description": "seLinuxChangePolicy defines how the container's SELinux label is applied to all volumes used by the Pod.\nIt has no effect on nodes that do not support SELinux or to volumes does not support SELinux.\nValid values are \"MountOption\" and \"Recursive\".\n\n\"Recursive\" means relabeling of all files on all Pod volumes by the container runtime.\nThis may be slow for large volumes, but allows mixing privileged and unprivileged Pods sharing the same volume on the same node.\n\n\"MountOption\" mounts all eligible Pod volumes with `-o context` mount option.\nThis requires all Pods that share the same volume to use the same SELinux label.\nIt is not possible to share the same volume among privileged and unprivileged Pods.\nEligible volumes are in-tree FibreChannel and iSCSI volumes, and all CSI volumes\nwhose CSI driver announces SELinux support by setting spec.seLinuxMount: true in their\nCSIDriver instance. Other volumes are always re-labelled recursively.\n\"MountOption\" value is allowed only when SELinuxMount feature gate is enabled.\n\nIf not specified and SELinuxMount feature gate is enabled, \"MountOption\" is used.\nIf not specified and SELinuxMount feature gate is disabled, \"MountOption\" is used for ReadWriteOncePod volumes\nand \"Recursive\" for all other volumes.\n\nThis field affects only Pods that have SELinux label set, either in PodSecurityContext or in SecurityContext of all containers.\n\nAll Pods that use the same volume should use the same seLinuxChangePolicy, otherwise some pods can get stuck in ContainerCreating state.\nNote that this field cannot be set when spec.os.name is windows.",
+                  "type": "string"
+                },
+                "seLinuxOptions": {
+                  "description": "The SELinux context to be applied to all containers.\nIf unspecified, the container runtime will allocate a random SELinux context for each\ncontainer.  May also be set in SecurityContext.  If set in\nboth SecurityContext and PodSecurityContext, the value specified in SecurityContext\ntakes precedence for that container.\nNote that this field cannot be set when spec.os.name is windows.",
+                  "properties": {
+                    "level": {
+                      "description": "Level is SELinux level label that applies to the container.",
+                      "type": "string"
+                    },
+                    "role": {
+                      "description": "Role is a SELinux role label that applies to the container.",
+                      "type": "string"
+                    },
+                    "type": {
+                      "description": "Type is a SELinux type label that applies to the container.",
+                      "type": "string"
+                    },
+                    "user": {
+                      "description": "User is a SELinux user label that applies to the container.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "seccompProfile": {
+                  "description": "The seccomp options to use by the containers in this pod.\nNote that this field cannot be set when spec.os.name is windows.",
+                  "properties": {
+                    "localhostProfile": {
+                      "description": "localhostProfile indicates a profile defined in a file on the node should be used.\nThe profile must be preconfigured on the node to work.\nMust be a descending path, relative to the kubelet's configured seccomp profile location.\nMust be set if type is \"Localhost\". Must NOT be set for any other type.",
+                      "type": "string"
+                    },
+                    "type": {
+                      "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "supplementalGroups": {
+                  "description": "A list of groups applied to the first process run in each container, in\naddition to the container's primary GID and fsGroup (if specified).  If\nthe SupplementalGroupsPolicy feature is enabled, the\nsupplementalGroupsPolicy field determines whether these are in addition\nto or instead of any group memberships defined in the container image.\nIf unspecified, no additional groups are added, though group memberships\ndefined in the container image may still be used, depending on the\nsupplementalGroupsPolicy field.\nNote that this field cannot be set when spec.os.name is windows.",
+                  "items": {
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                },
+                "supplementalGroupsPolicy": {
+                  "description": "Defines how supplemental groups of the first container processes are calculated.\nValid values are \"Merge\" and \"Strict\". If not specified, \"Merge\" is used.\n(Alpha) Using the field requires the SupplementalGroupsPolicy feature gate to be enabled\nand the container runtime must implement support for this feature.\nNote that this field cannot be set when spec.os.name is windows.",
+                  "type": "string"
+                },
+                "sysctls": {
+                  "description": "Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported\nsysctls (by the container runtime) might fail to launch.\nNote that this field cannot be set when spec.os.name is windows.",
+                  "items": {
+                    "description": "Sysctl defines a kernel parameter to be set",
+                    "properties": {
+                      "name": {
+                        "description": "Name of a property to set",
+                        "type": "string"
+                      },
+                      "value": {
+                        "description": "Value of a property to set",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "name",
+                      "value"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                },
+                "windowsOptions": {
+                  "description": "The Windows specific settings applied to all containers.\nIf unspecified, the options within a container's SecurityContext will be used.\nIf set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is linux.",
+                  "properties": {
+                    "gmsaCredentialSpec": {
+                      "description": "GMSACredentialSpec is where the GMSA admission webhook\n(https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the\nGMSA credential spec named by the GMSACredentialSpecName field.",
+                      "type": "string"
+                    },
+                    "gmsaCredentialSpecName": {
+                      "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
+                      "type": "string"
+                    },
+                    "hostProcess": {
+                      "description": "HostProcess determines if a container should be run as a 'Host Process' container.\nAll of a Pod's containers must have the same effective HostProcess value\n(it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).\nIn addition, if HostProcess is true then HostNetwork must also be set to true.",
+                      "type": "boolean"
+                    },
+                    "runAsUserName": {
+                      "description": "The UserName in Windows to run the entrypoint of the container process.\nDefaults to the user specified in image metadata if unspecified.\nMay also be set in PodSecurityContext. If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "serviceAccount": {
+          "description": "Settings for the serviceaccount the renovate pod should use",
+          "properties": {
+            "automountServiceAccountToken": {
+              "type": "boolean"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "skipForks": {
+          "description": "If true, forked repositories discovered during autodiscovery will be excluded by querying the platform API",
+          "type": "boolean"
+        },
+        "tolerations": {
+          "description": "Tolerations for scheduling the resulting pod",
+          "items": {
+            "description": "The pod this Toleration is attached to tolerates any taint that matches\nthe triple <key,value,effect> using the matching operator <operator>.",
+            "properties": {
+              "effect": {
+                "description": "Effect indicates the taint effect to match. Empty means match all taint effects.\nWhen specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
+                "type": "string"
+              },
+              "key": {
+                "description": "Key is the taint key that the toleration applies to. Empty means match all taint keys.\nIf the key is empty, operator must be Exists; this combination means to match all values and all keys.",
+                "type": "string"
+              },
+              "operator": {
+                "description": "Operator represents a key's relationship to the value.\nValid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.\nExists is equivalent to wildcard for value, so that a pod can\ntolerate all taints of a particular category.\nLt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).",
+                "type": "string"
+              },
+              "tolerationSeconds": {
+                "description": "TolerationSeconds represents the period of time the toleration (which must be\nof effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,\nit is not set, which means tolerate the taint forever (do not evict). Zero and\nnegative values will be treated as 0 (evict immediately) by the system.",
+                "format": "int64",
+                "type": "integer"
+              },
+              "value": {
+                "description": "Value is the taint value the toleration matches to.\nIf the operator is Exists, the value should be empty, otherwise just a regular string.",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "topologySpreadConstraints": {
+          "description": "Topology spread constraints for scheduling the resulting pod",
+          "items": {
+            "description": "TopologySpreadConstraint specifies how to spread matching pods among the given topology.",
+            "properties": {
+              "labelSelector": {
+                "description": "LabelSelector is used to find matching pods.\nPods that match this label selector are counted to determine the number of pods\nin their corresponding topology domain.",
+                "properties": {
+                  "matchExpressions": {
+                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                    "items": {
+                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                      "properties": {
+                        "key": {
+                          "description": "key is the label key that the selector applies to.",
+                          "type": "string"
+                        },
+                        "operator": {
+                          "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                          "type": "string"
+                        },
+                        "values": {
+                          "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array",
+                          "x-kubernetes-list-type": "atomic"
+                        }
+                      },
+                      "required": [
+                        "key",
+                        "operator"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  },
+                  "matchLabels": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                    "type": "object"
+                  }
+                },
+                "type": "object",
+                "x-kubernetes-map-type": "atomic",
+                "additionalProperties": false
+              },
+              "matchLabelKeys": {
+                "description": "MatchLabelKeys is a set of pod label keys to select the pods over which\nspreading will be calculated. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are ANDed with labelSelector\nto select the group of existing pods over which spreading will be calculated\nfor the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.\nMatchLabelKeys cannot be set when LabelSelector isn't set.\nKeys that don't exist in the incoming pod labels will\nbe ignored. A null or empty list means only match against labelSelector.\n\nThis is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default).",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array",
+                "x-kubernetes-list-type": "atomic"
+              },
+              "maxSkew": {
+                "description": "MaxSkew describes the degree to which pods may be unevenly distributed.\nWhen `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference\nbetween the number of matching pods in the target topology and the global minimum.\nThe global minimum is the minimum number of matching pods in an eligible domain\nor zero if the number of eligible domains is less than MinDomains.\nFor example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same\nlabelSelector spread as 2/2/1:\nIn this case, the global minimum is 1.\n| zone1 | zone2 | zone3 |\n|  P P  |  P P  |   P   |\n- if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2;\nscheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2)\nviolate MaxSkew(1).\n- if MaxSkew is 2, incoming pod can be scheduled onto any zone.\nWhen `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence\nto topologies that satisfy it.\nIt's a required field. Default value is 1 and 0 is not allowed.",
+                "format": "int32",
+                "type": "integer"
+              },
+              "minDomains": {
+                "description": "MinDomains indicates a minimum number of eligible domains.\nWhen the number of eligible domains with matching topology keys is less than minDomains,\nPod Topology Spread treats \"global minimum\" as 0, and then the calculation of Skew is performed.\nAnd when the number of eligible domains with matching topology keys equals or greater than minDomains,\nthis value has no effect on scheduling.\nAs a result, when the number of eligible domains is less than minDomains,\nscheduler won't schedule more than maxSkew Pods to those domains.\nIf value is nil, the constraint behaves as if MinDomains is equal to 1.\nValid values are integers greater than 0.\nWhen value is not nil, WhenUnsatisfiable must be DoNotSchedule.\n\nFor example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same\nlabelSelector spread as 2/2/2:\n| zone1 | zone2 | zone3 |\n|  P P  |  P P  |  P P  |\nThe number of domains is less than 5(MinDomains), so \"global minimum\" is treated as 0.\nIn this situation, new pod with the same labelSelector cannot be scheduled,\nbecause computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones,\nit will violate MaxSkew.",
+                "format": "int32",
+                "type": "integer"
+              },
+              "nodeAffinityPolicy": {
+                "description": "NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector\nwhen calculating pod topology spread skew. Options are:\n- Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.\n- Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.\n\nIf this value is nil, the behavior is equivalent to the Honor policy.",
+                "type": "string"
+              },
+              "nodeTaintsPolicy": {
+                "description": "NodeTaintsPolicy indicates how we will treat node taints when calculating\npod topology spread skew. Options are:\n- Honor: nodes without taints, along with tainted nodes for which the incoming pod\nhas a toleration, are included.\n- Ignore: node taints are ignored. All nodes are included.\n\nIf this value is nil, the behavior is equivalent to the Ignore policy.",
+                "type": "string"
+              },
+              "topologyKey": {
+                "description": "TopologyKey is the key of node labels. Nodes that have a label with this key\nand identical values are considered to be in the same topology.\nWe consider each <key, value> as a \"bucket\", and try to put balanced number\nof pods into each bucket.\nWe define a domain as a particular instance of a topology.\nAlso, we define an eligible domain as a domain whose nodes meet the requirements of\nnodeAffinityPolicy and nodeTaintsPolicy.\ne.g. If TopologyKey is \"kubernetes.io/hostname\", each Node is a domain of that topology.\nAnd, if TopologyKey is \"topology.kubernetes.io/zone\", each zone is a domain of that topology.\nIt's a required field.",
+                "type": "string"
+              },
+              "whenUnsatisfiable": {
+                "description": "WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy\nthe spread constraint.\n- DoNotSchedule (default) tells the scheduler not to schedule it.\n- ScheduleAnyway tells the scheduler to schedule the pod in any location,\n  but giving higher precedence to topologies that would help reduce the\n  skew.\nA constraint is considered \"Unsatisfiable\" for an incoming pod\nif and only if every possible node assignment for that pod would violate\n\"MaxSkew\" on some topology.\nFor example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same\nlabelSelector spread as 3/1/1:\n| zone1 | zone2 | zone3 |\n| P P P |   P   |   P   |\nIf WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled\nto zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies\nMaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler\nwon't make it *more* imbalanced.\nIt's a required field.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "maxSkew",
+              "topologyKey",
+              "whenUnsatisfiable"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "webhook": {
+          "description": "Configuration for webhooks to trigger renovate runs",
+          "properties": {
+            "authentication": {
+              "description": "authentication configuration for webhooks",
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                },
+                "secretRef": {
+                  "description": "reference to a secret and key",
+                  "properties": {
+                    "key": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "required": [
+                "enabled"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "enabled": {
+              "type": "boolean"
+            },
+            "forgejo": {
+              "description": "Forgejo-specific webhook configuration",
+              "properties": {
+                "sync": {
+                  "description": "configuration for syncing webhooks to Forgejo repos by topic",
+                  "properties": {
+                    "authTokenSecretRef": {
+                      "description": "reference to a secret and key",
+                      "properties": {
+                        "key": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "enabled": {
+                      "type": "boolean"
+                    },
+                    "events": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "tokenSecretRef": {
+                      "description": "reference to a secret and key",
+                      "properties": {
+                        "key": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "topic": {
+                      "type": "string"
+                    },
+                    "webhookURL": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "enabled",
+                    "webhookURL"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "enabled"
+          ],
+          "type": "object",
+          "additionalProperties": false
         }
+      },
+      "required": [
+        "image",
+        "parallelism",
+        "provider",
+        "schedule"
+      ],
+      "type": "object",
+      "additionalProperties": false
     },
-    "type": "object",
-    "additionalProperties": false,
-    "$schema": "http://json-schema.org/draft-04/schema#"
+    "status": {
+      "description": "RenovateJobStatus defines the observed state of RenovateJob",
+      "properties": {
+        "executionOptions": {
+          "properties": {
+            "debug": {
+              "description": "If true, the renovate job will be executed with LOG_LEVEL=debug",
+              "type": "boolean"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "projects": {
+          "items": {
+            "description": "Status of a single project within a RenovateJob",
+            "properties": {
+              "duration": {
+                "type": "string"
+              },
+              "lastRun": {
+                "format": "date-time",
+                "type": "string"
+              },
+              "logIssues": {
+                "description": "LogIssues contains aggregate counts and individual issue messages from a Renovate run.",
+                "properties": {
+                  "errorCount": {
+                    "type": "integer"
+                  },
+                  "issues": {
+                    "items": {
+                      "description": "LogIssue represents a single warning or error from Renovate logs.",
+                      "properties": {
+                        "level": {
+                          "type": "integer"
+                        },
+                        "message": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "level",
+                        "message"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
+                  "truncated": {
+                    "type": "boolean"
+                  },
+                  "warnCount": {
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "errorCount",
+                  "warnCount"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "name": {
+                "type": "string"
+              },
+              "prActivity": {
+                "description": "PRActivity contains aggregate counts and individual details of PR activity from a run.",
+                "properties": {
+                  "automerged": {
+                    "type": "integer"
+                  },
+                  "created": {
+                    "type": "integer"
+                  },
+                  "prs": {
+                    "items": {
+                      "description": "PRDetail represents a single PR found in Renovate logs.",
+                      "properties": {
+                        "action": {
+                          "description": "PRAction represents what happened to a PR in a Renovate run.",
+                          "type": "string"
+                        },
+                        "branch": {
+                          "type": "string"
+                        },
+                        "number": {
+                          "type": "integer"
+                        },
+                        "title": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "action",
+                        "branch"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
+                  "truncated": {
+                    "type": "boolean"
+                  },
+                  "unchanged": {
+                    "type": "integer"
+                  },
+                  "updated": {
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "automerged",
+                  "created",
+                  "unchanged",
+                  "updated"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "priority": {
+                "format": "int32",
+                "type": "integer"
+              },
+              "renovateResultStatus": {
+                "type": "string"
+              },
+              "status": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastRun",
+              "name",
+              "status"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
 }

--- a/renovate-operator.mogenius.com/renovatejob_v1alpha1.json
+++ b/renovate-operator.mogenius.com/renovatejob_v1alpha1.json
@@ -1,3195 +1,3749 @@
 {
-  "properties": {
-    "apiVersion": {
-      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
-      "type": "string"
-    },
-    "kind": {
-      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-      "type": "string"
-    },
-    "metadata": {
-      "type": "object"
-    },
-    "spec": {
-      "description": "RenovateJobSpec defines the desired state of RenovateJob",
-      "properties": {
-        "affinity": {
-          "description": "Affinity settings for scheduling the resulting pod",
-          "properties": {
-            "nodeAffinity": {
-              "description": "Describes node affinity scheduling rules for the pod.",
-              "properties": {
-                "preferredDuringSchedulingIgnoredDuringExecution": {
-                  "description": "The scheduler will prefer to schedule pods to nodes that satisfy\nthe affinity expressions specified by this field, but it may choose\na node that violates one or more of the expressions. The node that is\nmost preferred is the one with the greatest sum of weights, i.e.\nfor each node that meets all of the scheduling requirements (resource\nrequest, requiredDuringScheduling affinity expressions, etc.),\ncompute a sum by iterating through the elements of this field and adding\n\"weight\" to the sum if the node matches the corresponding matchExpressions; the\nnode(s) with the highest sum are the most preferred.",
-                  "items": {
-                    "description": "An empty preferred scheduling term matches all objects with implicit weight 0\n(i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).",
-                    "properties": {
-                      "preference": {
-                        "description": "A node selector term, associated with the corresponding weight.",
-                        "properties": {
-                          "matchExpressions": {
-                            "description": "A list of node selector requirements by node's labels.",
-                            "items": {
-                              "description": "A node selector requirement is a selector that contains values, a key, and an operator\nthat relates the key and values.",
-                              "properties": {
-                                "key": {
-                                  "description": "The label key that the selector applies to.",
-                                  "type": "string"
-                                },
-                                "operator": {
-                                  "description": "Represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
-                                  "type": "string"
-                                },
-                                "values": {
-                                  "description": "An array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. If the operator is Gt or Lt, the values\narray must have a single element, which will be interpreted as an integer.\nThis array is replaced during a strategic merge patch.",
-                                  "items": {
-                                    "type": "string"
-                                  },
-                                  "type": "array",
-                                  "x-kubernetes-list-type": "atomic"
-                                }
-                              },
-                              "required": [
-                                "key",
-                                "operator"
-                              ],
-                              "type": "object",
-                              "additionalProperties": false
-                            },
-                            "type": "array",
-                            "x-kubernetes-list-type": "atomic"
-                          },
-                          "matchFields": {
-                            "description": "A list of node selector requirements by node's fields.",
-                            "items": {
-                              "description": "A node selector requirement is a selector that contains values, a key, and an operator\nthat relates the key and values.",
-                              "properties": {
-                                "key": {
-                                  "description": "The label key that the selector applies to.",
-                                  "type": "string"
-                                },
-                                "operator": {
-                                  "description": "Represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
-                                  "type": "string"
-                                },
-                                "values": {
-                                  "description": "An array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. If the operator is Gt or Lt, the values\narray must have a single element, which will be interpreted as an integer.\nThis array is replaced during a strategic merge patch.",
-                                  "items": {
-                                    "type": "string"
-                                  },
-                                  "type": "array",
-                                  "x-kubernetes-list-type": "atomic"
-                                }
-                              },
-                              "required": [
-                                "key",
-                                "operator"
-                              ],
-                              "type": "object",
-                              "additionalProperties": false
-                            },
-                            "type": "array",
-                            "x-kubernetes-list-type": "atomic"
-                          }
-                        },
-                        "type": "object",
-                        "x-kubernetes-map-type": "atomic",
-                        "additionalProperties": false
-                      },
-                      "weight": {
-                        "description": "Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.",
-                        "format": "int32",
-                        "type": "integer"
-                      }
-                    },
-                    "required": [
-                      "preference",
-                      "weight"
-                    ],
-                    "type": "object",
-                    "additionalProperties": false
-                  },
-                  "type": "array",
-                  "x-kubernetes-list-type": "atomic"
-                },
-                "requiredDuringSchedulingIgnoredDuringExecution": {
-                  "description": "If the affinity requirements specified by this field are not met at\nscheduling time, the pod will not be scheduled onto the node.\nIf the affinity requirements specified by this field cease to be met\nat some point during pod execution (e.g. due to an update), the system\nmay or may not try to eventually evict the pod from its node.",
-                  "properties": {
-                    "nodeSelectorTerms": {
-                      "description": "Required. A list of node selector terms. The terms are ORed.",
-                      "items": {
-                        "description": "A null or empty node selector term matches no objects. The requirements of\nthem are ANDed.\nThe TopologySelectorTerm type implements a subset of the NodeSelectorTerm.",
-                        "properties": {
-                          "matchExpressions": {
-                            "description": "A list of node selector requirements by node's labels.",
-                            "items": {
-                              "description": "A node selector requirement is a selector that contains values, a key, and an operator\nthat relates the key and values.",
-                              "properties": {
-                                "key": {
-                                  "description": "The label key that the selector applies to.",
-                                  "type": "string"
-                                },
-                                "operator": {
-                                  "description": "Represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
-                                  "type": "string"
-                                },
-                                "values": {
-                                  "description": "An array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. If the operator is Gt or Lt, the values\narray must have a single element, which will be interpreted as an integer.\nThis array is replaced during a strategic merge patch.",
-                                  "items": {
-                                    "type": "string"
-                                  },
-                                  "type": "array",
-                                  "x-kubernetes-list-type": "atomic"
-                                }
-                              },
-                              "required": [
-                                "key",
-                                "operator"
-                              ],
-                              "type": "object",
-                              "additionalProperties": false
-                            },
-                            "type": "array",
-                            "x-kubernetes-list-type": "atomic"
-                          },
-                          "matchFields": {
-                            "description": "A list of node selector requirements by node's fields.",
-                            "items": {
-                              "description": "A node selector requirement is a selector that contains values, a key, and an operator\nthat relates the key and values.",
-                              "properties": {
-                                "key": {
-                                  "description": "The label key that the selector applies to.",
-                                  "type": "string"
-                                },
-                                "operator": {
-                                  "description": "Represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
-                                  "type": "string"
-                                },
-                                "values": {
-                                  "description": "An array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. If the operator is Gt or Lt, the values\narray must have a single element, which will be interpreted as an integer.\nThis array is replaced during a strategic merge patch.",
-                                  "items": {
-                                    "type": "string"
-                                  },
-                                  "type": "array",
-                                  "x-kubernetes-list-type": "atomic"
-                                }
-                              },
-                              "required": [
-                                "key",
-                                "operator"
-                              ],
-                              "type": "object",
-                              "additionalProperties": false
-                            },
-                            "type": "array",
-                            "x-kubernetes-list-type": "atomic"
-                          }
-                        },
-                        "type": "object",
-                        "x-kubernetes-map-type": "atomic",
-                        "additionalProperties": false
-                      },
-                      "type": "array",
-                      "x-kubernetes-list-type": "atomic"
-                    }
-                  },
-                  "required": [
-                    "nodeSelectorTerms"
-                  ],
-                  "type": "object",
-                  "x-kubernetes-map-type": "atomic",
-                  "additionalProperties": false
-                }
-              },
-              "type": "object",
-              "additionalProperties": false
-            },
-            "podAffinity": {
-              "description": "Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).",
-              "properties": {
-                "preferredDuringSchedulingIgnoredDuringExecution": {
-                  "description": "The scheduler will prefer to schedule pods to nodes that satisfy\nthe affinity expressions specified by this field, but it may choose\na node that violates one or more of the expressions. The node that is\nmost preferred is the one with the greatest sum of weights, i.e.\nfor each node that meets all of the scheduling requirements (resource\nrequest, requiredDuringScheduling affinity expressions, etc.),\ncompute a sum by iterating through the elements of this field and adding\n\"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the\nnode(s) with the highest sum are the most preferred.",
-                  "items": {
-                    "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
-                    "properties": {
-                      "podAffinityTerm": {
-                        "description": "Required. A pod affinity term, associated with the corresponding weight.",
-                        "properties": {
-                          "labelSelector": {
-                            "description": "A label query over a set of resources, in this case pods.\nIf it's null, this PodAffinityTerm matches with no Pods.",
-                            "properties": {
-                              "matchExpressions": {
-                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
-                                "items": {
-                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
-                                  "properties": {
-                                    "key": {
-                                      "description": "key is the label key that the selector applies to.",
-                                      "type": "string"
-                                    },
-                                    "operator": {
-                                      "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
-                                      "type": "string"
-                                    },
-                                    "values": {
-                                      "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
-                                      "items": {
-                                        "type": "string"
-                                      },
-                                      "type": "array",
-                                      "x-kubernetes-list-type": "atomic"
-                                    }
-                                  },
-                                  "required": [
-                                    "key",
-                                    "operator"
-                                  ],
-                                  "type": "object",
-                                  "additionalProperties": false
-                                },
-                                "type": "array",
-                                "x-kubernetes-list-type": "atomic"
-                              },
-                              "matchLabels": {
-                                "additionalProperties": {
-                                  "type": "string"
-                                },
-                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                                "type": "object"
-                              }
-                            },
-                            "type": "object",
-                            "x-kubernetes-map-type": "atomic",
-                            "additionalProperties": false
-                          },
-                          "matchLabelKeys": {
-                            "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both matchLabelKeys and labelSelector.\nAlso, matchLabelKeys cannot be set when labelSelector isn't set.",
-                            "items": {
-                              "type": "string"
-                            },
-                            "type": "array",
-                            "x-kubernetes-list-type": "atomic"
-                          },
-                          "mismatchLabelKeys": {
-                            "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both mismatchLabelKeys and labelSelector.\nAlso, mismatchLabelKeys cannot be set when labelSelector isn't set.",
-                            "items": {
-                              "type": "string"
-                            },
-                            "type": "array",
-                            "x-kubernetes-list-type": "atomic"
-                          },
-                          "namespaceSelector": {
-                            "description": "A label query over the set of namespaces that the term applies to.\nThe term is applied to the union of the namespaces selected by this field\nand the ones listed in the namespaces field.\nnull selector and null or empty namespaces list means \"this pod's namespace\".\nAn empty selector ({}) matches all namespaces.",
-                            "properties": {
-                              "matchExpressions": {
-                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
-                                "items": {
-                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
-                                  "properties": {
-                                    "key": {
-                                      "description": "key is the label key that the selector applies to.",
-                                      "type": "string"
-                                    },
-                                    "operator": {
-                                      "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
-                                      "type": "string"
-                                    },
-                                    "values": {
-                                      "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
-                                      "items": {
-                                        "type": "string"
-                                      },
-                                      "type": "array",
-                                      "x-kubernetes-list-type": "atomic"
-                                    }
-                                  },
-                                  "required": [
-                                    "key",
-                                    "operator"
-                                  ],
-                                  "type": "object",
-                                  "additionalProperties": false
-                                },
-                                "type": "array",
-                                "x-kubernetes-list-type": "atomic"
-                              },
-                              "matchLabels": {
-                                "additionalProperties": {
-                                  "type": "string"
-                                },
-                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                                "type": "object"
-                              }
-                            },
-                            "type": "object",
-                            "x-kubernetes-map-type": "atomic",
-                            "additionalProperties": false
-                          },
-                          "namespaces": {
-                            "description": "namespaces specifies a static list of namespace names that the term applies to.\nThe term is applied to the union of the namespaces listed in this field\nand the ones selected by namespaceSelector.\nnull or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
-                            "items": {
-                              "type": "string"
-                            },
-                            "type": "array",
-                            "x-kubernetes-list-type": "atomic"
-                          },
-                          "topologyKey": {
-                            "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
-                            "type": "string"
-                          }
-                        },
-                        "required": [
-                          "topologyKey"
-                        ],
-                        "type": "object",
-                        "additionalProperties": false
-                      },
-                      "weight": {
-                        "description": "weight associated with matching the corresponding podAffinityTerm,\nin the range 1-100.",
-                        "format": "int32",
-                        "type": "integer"
-                      }
-                    },
-                    "required": [
-                      "podAffinityTerm",
-                      "weight"
-                    ],
-                    "type": "object",
-                    "additionalProperties": false
-                  },
-                  "type": "array",
-                  "x-kubernetes-list-type": "atomic"
-                },
-                "requiredDuringSchedulingIgnoredDuringExecution": {
-                  "description": "If the affinity requirements specified by this field are not met at\nscheduling time, the pod will not be scheduled onto the node.\nIf the affinity requirements specified by this field cease to be met\nat some point during pod execution (e.g. due to a pod label update), the\nsystem may or may not try to eventually evict the pod from its node.\nWhen there are multiple elements, the lists of nodes corresponding to each\npodAffinityTerm are intersected, i.e. all terms must be satisfied.",
-                  "items": {
-                    "description": "Defines a set of pods (namely those matching the labelSelector\nrelative to the given namespace(s)) that this pod should be\nco-located (affinity) or not co-located (anti-affinity) with,\nwhere co-located is defined as running on a node whose value of\nthe label with key <topologyKey> matches that of any node on which\na pod of the set of pods is running",
-                    "properties": {
-                      "labelSelector": {
-                        "description": "A label query over a set of resources, in this case pods.\nIf it's null, this PodAffinityTerm matches with no Pods.",
-                        "properties": {
-                          "matchExpressions": {
-                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
-                            "items": {
-                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
-                              "properties": {
-                                "key": {
-                                  "description": "key is the label key that the selector applies to.",
-                                  "type": "string"
-                                },
-                                "operator": {
-                                  "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
-                                  "type": "string"
-                                },
-                                "values": {
-                                  "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
-                                  "items": {
-                                    "type": "string"
-                                  },
-                                  "type": "array",
-                                  "x-kubernetes-list-type": "atomic"
-                                }
-                              },
-                              "required": [
-                                "key",
-                                "operator"
-                              ],
-                              "type": "object",
-                              "additionalProperties": false
-                            },
-                            "type": "array",
-                            "x-kubernetes-list-type": "atomic"
-                          },
-                          "matchLabels": {
-                            "additionalProperties": {
-                              "type": "string"
-                            },
-                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                            "type": "object"
-                          }
-                        },
-                        "type": "object",
-                        "x-kubernetes-map-type": "atomic",
-                        "additionalProperties": false
-                      },
-                      "matchLabelKeys": {
-                        "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both matchLabelKeys and labelSelector.\nAlso, matchLabelKeys cannot be set when labelSelector isn't set.",
-                        "items": {
-                          "type": "string"
-                        },
-                        "type": "array",
-                        "x-kubernetes-list-type": "atomic"
-                      },
-                      "mismatchLabelKeys": {
-                        "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both mismatchLabelKeys and labelSelector.\nAlso, mismatchLabelKeys cannot be set when labelSelector isn't set.",
-                        "items": {
-                          "type": "string"
-                        },
-                        "type": "array",
-                        "x-kubernetes-list-type": "atomic"
-                      },
-                      "namespaceSelector": {
-                        "description": "A label query over the set of namespaces that the term applies to.\nThe term is applied to the union of the namespaces selected by this field\nand the ones listed in the namespaces field.\nnull selector and null or empty namespaces list means \"this pod's namespace\".\nAn empty selector ({}) matches all namespaces.",
-                        "properties": {
-                          "matchExpressions": {
-                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
-                            "items": {
-                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
-                              "properties": {
-                                "key": {
-                                  "description": "key is the label key that the selector applies to.",
-                                  "type": "string"
-                                },
-                                "operator": {
-                                  "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
-                                  "type": "string"
-                                },
-                                "values": {
-                                  "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
-                                  "items": {
-                                    "type": "string"
-                                  },
-                                  "type": "array",
-                                  "x-kubernetes-list-type": "atomic"
-                                }
-                              },
-                              "required": [
-                                "key",
-                                "operator"
-                              ],
-                              "type": "object",
-                              "additionalProperties": false
-                            },
-                            "type": "array",
-                            "x-kubernetes-list-type": "atomic"
-                          },
-                          "matchLabels": {
-                            "additionalProperties": {
-                              "type": "string"
-                            },
-                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                            "type": "object"
-                          }
-                        },
-                        "type": "object",
-                        "x-kubernetes-map-type": "atomic",
-                        "additionalProperties": false
-                      },
-                      "namespaces": {
-                        "description": "namespaces specifies a static list of namespace names that the term applies to.\nThe term is applied to the union of the namespaces listed in this field\nand the ones selected by namespaceSelector.\nnull or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
-                        "items": {
-                          "type": "string"
-                        },
-                        "type": "array",
-                        "x-kubernetes-list-type": "atomic"
-                      },
-                      "topologyKey": {
-                        "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
-                        "type": "string"
-                      }
-                    },
-                    "required": [
-                      "topologyKey"
-                    ],
-                    "type": "object",
-                    "additionalProperties": false
-                  },
-                  "type": "array",
-                  "x-kubernetes-list-type": "atomic"
-                }
-              },
-              "type": "object",
-              "additionalProperties": false
-            },
-            "podAntiAffinity": {
-              "description": "Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).",
-              "properties": {
-                "preferredDuringSchedulingIgnoredDuringExecution": {
-                  "description": "The scheduler will prefer to schedule pods to nodes that satisfy\nthe anti-affinity expressions specified by this field, but it may choose\na node that violates one or more of the expressions. The node that is\nmost preferred is the one with the greatest sum of weights, i.e.\nfor each node that meets all of the scheduling requirements (resource\nrequest, requiredDuringScheduling anti-affinity expressions, etc.),\ncompute a sum by iterating through the elements of this field and subtracting\n\"weight\" from the sum if the node has pods which matches the corresponding podAffinityTerm; the\nnode(s) with the highest sum are the most preferred.",
-                  "items": {
-                    "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
-                    "properties": {
-                      "podAffinityTerm": {
-                        "description": "Required. A pod affinity term, associated with the corresponding weight.",
-                        "properties": {
-                          "labelSelector": {
-                            "description": "A label query over a set of resources, in this case pods.\nIf it's null, this PodAffinityTerm matches with no Pods.",
-                            "properties": {
-                              "matchExpressions": {
-                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
-                                "items": {
-                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
-                                  "properties": {
-                                    "key": {
-                                      "description": "key is the label key that the selector applies to.",
-                                      "type": "string"
-                                    },
-                                    "operator": {
-                                      "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
-                                      "type": "string"
-                                    },
-                                    "values": {
-                                      "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
-                                      "items": {
-                                        "type": "string"
-                                      },
-                                      "type": "array",
-                                      "x-kubernetes-list-type": "atomic"
-                                    }
-                                  },
-                                  "required": [
-                                    "key",
-                                    "operator"
-                                  ],
-                                  "type": "object",
-                                  "additionalProperties": false
-                                },
-                                "type": "array",
-                                "x-kubernetes-list-type": "atomic"
-                              },
-                              "matchLabels": {
-                                "additionalProperties": {
-                                  "type": "string"
-                                },
-                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                                "type": "object"
-                              }
-                            },
-                            "type": "object",
-                            "x-kubernetes-map-type": "atomic",
-                            "additionalProperties": false
-                          },
-                          "matchLabelKeys": {
-                            "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both matchLabelKeys and labelSelector.\nAlso, matchLabelKeys cannot be set when labelSelector isn't set.",
-                            "items": {
-                              "type": "string"
-                            },
-                            "type": "array",
-                            "x-kubernetes-list-type": "atomic"
-                          },
-                          "mismatchLabelKeys": {
-                            "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both mismatchLabelKeys and labelSelector.\nAlso, mismatchLabelKeys cannot be set when labelSelector isn't set.",
-                            "items": {
-                              "type": "string"
-                            },
-                            "type": "array",
-                            "x-kubernetes-list-type": "atomic"
-                          },
-                          "namespaceSelector": {
-                            "description": "A label query over the set of namespaces that the term applies to.\nThe term is applied to the union of the namespaces selected by this field\nand the ones listed in the namespaces field.\nnull selector and null or empty namespaces list means \"this pod's namespace\".\nAn empty selector ({}) matches all namespaces.",
-                            "properties": {
-                              "matchExpressions": {
-                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
-                                "items": {
-                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
-                                  "properties": {
-                                    "key": {
-                                      "description": "key is the label key that the selector applies to.",
-                                      "type": "string"
-                                    },
-                                    "operator": {
-                                      "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
-                                      "type": "string"
-                                    },
-                                    "values": {
-                                      "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
-                                      "items": {
-                                        "type": "string"
-                                      },
-                                      "type": "array",
-                                      "x-kubernetes-list-type": "atomic"
-                                    }
-                                  },
-                                  "required": [
-                                    "key",
-                                    "operator"
-                                  ],
-                                  "type": "object",
-                                  "additionalProperties": false
-                                },
-                                "type": "array",
-                                "x-kubernetes-list-type": "atomic"
-                              },
-                              "matchLabels": {
-                                "additionalProperties": {
-                                  "type": "string"
-                                },
-                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                                "type": "object"
-                              }
-                            },
-                            "type": "object",
-                            "x-kubernetes-map-type": "atomic",
-                            "additionalProperties": false
-                          },
-                          "namespaces": {
-                            "description": "namespaces specifies a static list of namespace names that the term applies to.\nThe term is applied to the union of the namespaces listed in this field\nand the ones selected by namespaceSelector.\nnull or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
-                            "items": {
-                              "type": "string"
-                            },
-                            "type": "array",
-                            "x-kubernetes-list-type": "atomic"
-                          },
-                          "topologyKey": {
-                            "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
-                            "type": "string"
-                          }
-                        },
-                        "required": [
-                          "topologyKey"
-                        ],
-                        "type": "object",
-                        "additionalProperties": false
-                      },
-                      "weight": {
-                        "description": "weight associated with matching the corresponding podAffinityTerm,\nin the range 1-100.",
-                        "format": "int32",
-                        "type": "integer"
-                      }
-                    },
-                    "required": [
-                      "podAffinityTerm",
-                      "weight"
-                    ],
-                    "type": "object",
-                    "additionalProperties": false
-                  },
-                  "type": "array",
-                  "x-kubernetes-list-type": "atomic"
-                },
-                "requiredDuringSchedulingIgnoredDuringExecution": {
-                  "description": "If the anti-affinity requirements specified by this field are not met at\nscheduling time, the pod will not be scheduled onto the node.\nIf the anti-affinity requirements specified by this field cease to be met\nat some point during pod execution (e.g. due to a pod label update), the\nsystem may or may not try to eventually evict the pod from its node.\nWhen there are multiple elements, the lists of nodes corresponding to each\npodAffinityTerm are intersected, i.e. all terms must be satisfied.",
-                  "items": {
-                    "description": "Defines a set of pods (namely those matching the labelSelector\nrelative to the given namespace(s)) that this pod should be\nco-located (affinity) or not co-located (anti-affinity) with,\nwhere co-located is defined as running on a node whose value of\nthe label with key <topologyKey> matches that of any node on which\na pod of the set of pods is running",
-                    "properties": {
-                      "labelSelector": {
-                        "description": "A label query over a set of resources, in this case pods.\nIf it's null, this PodAffinityTerm matches with no Pods.",
-                        "properties": {
-                          "matchExpressions": {
-                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
-                            "items": {
-                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
-                              "properties": {
-                                "key": {
-                                  "description": "key is the label key that the selector applies to.",
-                                  "type": "string"
-                                },
-                                "operator": {
-                                  "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
-                                  "type": "string"
-                                },
-                                "values": {
-                                  "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
-                                  "items": {
-                                    "type": "string"
-                                  },
-                                  "type": "array",
-                                  "x-kubernetes-list-type": "atomic"
-                                }
-                              },
-                              "required": [
-                                "key",
-                                "operator"
-                              ],
-                              "type": "object",
-                              "additionalProperties": false
-                            },
-                            "type": "array",
-                            "x-kubernetes-list-type": "atomic"
-                          },
-                          "matchLabels": {
-                            "additionalProperties": {
-                              "type": "string"
-                            },
-                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                            "type": "object"
-                          }
-                        },
-                        "type": "object",
-                        "x-kubernetes-map-type": "atomic",
-                        "additionalProperties": false
-                      },
-                      "matchLabelKeys": {
-                        "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both matchLabelKeys and labelSelector.\nAlso, matchLabelKeys cannot be set when labelSelector isn't set.",
-                        "items": {
-                          "type": "string"
-                        },
-                        "type": "array",
-                        "x-kubernetes-list-type": "atomic"
-                      },
-                      "mismatchLabelKeys": {
-                        "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both mismatchLabelKeys and labelSelector.\nAlso, mismatchLabelKeys cannot be set when labelSelector isn't set.",
-                        "items": {
-                          "type": "string"
-                        },
-                        "type": "array",
-                        "x-kubernetes-list-type": "atomic"
-                      },
-                      "namespaceSelector": {
-                        "description": "A label query over the set of namespaces that the term applies to.\nThe term is applied to the union of the namespaces selected by this field\nand the ones listed in the namespaces field.\nnull selector and null or empty namespaces list means \"this pod's namespace\".\nAn empty selector ({}) matches all namespaces.",
-                        "properties": {
-                          "matchExpressions": {
-                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
-                            "items": {
-                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
-                              "properties": {
-                                "key": {
-                                  "description": "key is the label key that the selector applies to.",
-                                  "type": "string"
-                                },
-                                "operator": {
-                                  "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
-                                  "type": "string"
-                                },
-                                "values": {
-                                  "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
-                                  "items": {
-                                    "type": "string"
-                                  },
-                                  "type": "array",
-                                  "x-kubernetes-list-type": "atomic"
-                                }
-                              },
-                              "required": [
-                                "key",
-                                "operator"
-                              ],
-                              "type": "object",
-                              "additionalProperties": false
-                            },
-                            "type": "array",
-                            "x-kubernetes-list-type": "atomic"
-                          },
-                          "matchLabels": {
-                            "additionalProperties": {
-                              "type": "string"
-                            },
-                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                            "type": "object"
-                          }
-                        },
-                        "type": "object",
-                        "x-kubernetes-map-type": "atomic",
-                        "additionalProperties": false
-                      },
-                      "namespaces": {
-                        "description": "namespaces specifies a static list of namespace names that the term applies to.\nThe term is applied to the union of the namespaces listed in this field\nand the ones selected by namespaceSelector.\nnull or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
-                        "items": {
-                          "type": "string"
-                        },
-                        "type": "array",
-                        "x-kubernetes-list-type": "atomic"
-                      },
-                      "topologyKey": {
-                        "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
-                        "type": "string"
-                      }
-                    },
-                    "required": [
-                      "topologyKey"
-                    ],
-                    "type": "object",
-                    "additionalProperties": false
-                  },
-                  "type": "array",
-                  "x-kubernetes-list-type": "atomic"
-                }
-              },
-              "type": "object",
-              "additionalProperties": false
-            }
-          },
-          "type": "object",
-          "additionalProperties": false
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
         },
-        "discoverTopics": {
-          "description": "Topics to discover projects from",
-          "type": "string"
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
         },
-        "discoveryFilter": {
-          "description": "Filter to select which projects to process",
-          "type": "string"
+        "metadata": {
+            "type": "object"
         },
-        "extraEnv": {
-          "description": "Additional environment variables to set in the renovate container",
-          "items": {
-            "description": "EnvVar represents an environment variable present in a Container.",
+        "spec": {
+            "description": "RenovateJobSpec defines the desired state of RenovateJob",
             "properties": {
-              "name": {
-                "description": "Name of the environment variable.\nMay consist of any printable ASCII characters except '='.",
-                "type": "string"
-              },
-              "value": {
-                "description": "Variable references $(VAR_NAME) are expanded\nusing the previously defined environment variables in the container and\nany service environment variables. If a variable cannot be resolved,\nthe reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.\n\"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\".\nEscaped references will never be expanded, regardless of whether the variable\nexists or not.\nDefaults to \"\".",
-                "type": "string"
-              },
-              "valueFrom": {
-                "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
-                "properties": {
-                  "configMapKeyRef": {
-                    "description": "Selects a key of a ConfigMap.",
+                "affinity": {
+                    "description": "Affinity settings for scheduling the resulting pod",
                     "properties": {
-                      "key": {
-                        "description": "The key to select.",
-                        "type": "string"
-                      },
-                      "name": {
-                        "default": "",
-                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
-                        "type": "string"
-                      },
-                      "optional": {
-                        "description": "Specify whether the ConfigMap or its key must be defined",
-                        "type": "boolean"
-                      }
-                    },
-                    "required": [
-                      "key"
-                    ],
-                    "type": "object",
-                    "x-kubernetes-map-type": "atomic",
-                    "additionalProperties": false
-                  },
-                  "fieldRef": {
-                    "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,\nspec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
-                    "properties": {
-                      "apiVersion": {
-                        "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
-                        "type": "string"
-                      },
-                      "fieldPath": {
-                        "description": "Path of the field to select in the specified API version.",
-                        "type": "string"
-                      }
-                    },
-                    "required": [
-                      "fieldPath"
-                    ],
-                    "type": "object",
-                    "x-kubernetes-map-type": "atomic",
-                    "additionalProperties": false
-                  },
-                  "fileKeyRef": {
-                    "description": "FileKeyRef selects a key of the env file.\nRequires the EnvFiles feature gate to be enabled.",
-                    "properties": {
-                      "key": {
-                        "description": "The key within the env file. An invalid key will prevent the pod from starting.\nThe keys defined within a source may consist of any printable ASCII characters except '='.\nDuring Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.",
-                        "type": "string"
-                      },
-                      "optional": {
-                        "default": false,
-                        "description": "Specify whether the file or its key must be defined. If the file or key\ndoes not exist, then the env var is not published.\nIf optional is set to true and the specified key does not exist,\nthe environment variable will not be set in the Pod's containers.\n\nIf optional is set to false and the specified key does not exist,\nan error will be returned during Pod creation.",
-                        "type": "boolean"
-                      },
-                      "path": {
-                        "description": "The path within the volume from which to select the file.\nMust be relative and may not contain the '..' path or start with '..'.",
-                        "type": "string"
-                      },
-                      "volumeName": {
-                        "description": "The name of the volume mount containing the env file.",
-                        "type": "string"
-                      }
-                    },
-                    "required": [
-                      "key",
-                      "path",
-                      "volumeName"
-                    ],
-                    "type": "object",
-                    "x-kubernetes-map-type": "atomic",
-                    "additionalProperties": false
-                  },
-                  "resourceFieldRef": {
-                    "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
-                    "properties": {
-                      "containerName": {
-                        "description": "Container name: required for volumes, optional for env vars",
-                        "type": "string"
-                      },
-                      "divisor": {
-                        "anyOf": [
-                          {
-                            "type": "integer"
-                          },
-                          {
-                            "type": "string"
-                          }
-                        ],
-                        "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
-                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
-                        "x-kubernetes-int-or-string": true
-                      },
-                      "resource": {
-                        "description": "Required: resource to select",
-                        "type": "string"
-                      }
-                    },
-                    "required": [
-                      "resource"
-                    ],
-                    "type": "object",
-                    "x-kubernetes-map-type": "atomic",
-                    "additionalProperties": false
-                  },
-                  "secretKeyRef": {
-                    "description": "Selects a key of a secret in the pod's namespace",
-                    "properties": {
-                      "key": {
-                        "description": "The key of the secret to select from.  Must be a valid secret key.",
-                        "type": "string"
-                      },
-                      "name": {
-                        "default": "",
-                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
-                        "type": "string"
-                      },
-                      "optional": {
-                        "description": "Specify whether the Secret or its key must be defined",
-                        "type": "boolean"
-                      }
-                    },
-                    "required": [
-                      "key"
-                    ],
-                    "type": "object",
-                    "x-kubernetes-map-type": "atomic",
-                    "additionalProperties": false
-                  }
-                },
-                "type": "object",
-                "additionalProperties": false
-              }
-            },
-            "required": [
-              "name"
-            ],
-            "type": "object",
-            "additionalProperties": false
-          },
-          "type": "array"
-        },
-        "extraVolumeMounts": {
-          "description": "Additional volume mounts for the renovate pods",
-          "items": {
-            "description": "VolumeMount describes a mounting of a Volume within a container.",
-            "properties": {
-              "mountPath": {
-                "description": "Path within the container at which the volume should be mounted.  Must\nnot contain ':'.",
-                "type": "string"
-              },
-              "mountPropagation": {
-                "description": "mountPropagation determines how mounts are propagated from the host\nto container and the other way around.\nWhen not set, MountPropagationNone is used.\nThis field is beta in 1.10.\nWhen RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified\n(which defaults to None).",
-                "type": "string"
-              },
-              "name": {
-                "description": "This must match the Name of a Volume.",
-                "type": "string"
-              },
-              "readOnly": {
-                "description": "Mounted read-only if true, read-write otherwise (false or unspecified).\nDefaults to false.",
-                "type": "boolean"
-              },
-              "recursiveReadOnly": {
-                "description": "RecursiveReadOnly specifies whether read-only mounts should be handled\nrecursively.\n\nIf ReadOnly is false, this field has no meaning and must be unspecified.\n\nIf ReadOnly is true, and this field is set to Disabled, the mount is not made\nrecursively read-only.  If this field is set to IfPossible, the mount is made\nrecursively read-only, if it is supported by the container runtime.  If this\nfield is set to Enabled, the mount is made recursively read-only if it is\nsupported by the container runtime, otherwise the pod will not be started and\nan error will be generated to indicate the reason.\n\nIf this field is set to IfPossible or Enabled, MountPropagation must be set to\nNone (or be unspecified, which defaults to None).\n\nIf this field is not specified, it is treated as an equivalent of Disabled.",
-                "type": "string"
-              },
-              "subPath": {
-                "description": "Path within the volume from which the container's volume should be mounted.\nDefaults to \"\" (volume's root).",
-                "type": "string"
-              },
-              "subPathExpr": {
-                "description": "Expanded path within the volume from which the container's volume should be mounted.\nBehaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.\nDefaults to \"\" (volume's root).\nSubPathExpr and SubPath are mutually exclusive.",
-                "type": "string"
-              }
-            },
-            "required": [
-              "mountPath",
-              "name"
-            ],
-            "type": "object",
-            "additionalProperties": false
-          },
-          "type": "array"
-        },
-        "extraVolumes": {
-          "description": "Additional volumes to mount in the renovate pods",
-          "items": {
-            "description": "Volume represents a named volume in a pod that may be accessed by any container in the pod.",
-            "properties": {
-              "awsElasticBlockStore": {
-                "description": "awsElasticBlockStore represents an AWS Disk resource that is attached to a\nkubelet's host machine and then exposed to the pod.\nDeprecated: AWSElasticBlockStore is deprecated. All operations for the in-tree\nawsElasticBlockStore type are redirected to the ebs.csi.aws.com CSI driver.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
-                "properties": {
-                  "fsType": {
-                    "description": "fsType is the filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
-                    "type": "string"
-                  },
-                  "partition": {
-                    "description": "partition is the partition in the volume that you want to mount.\nIf omitted, the default is to mount by volume name.\nExamples: For volume /dev/sda1, you specify the partition as \"1\".\nSimilarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty).",
-                    "format": "int32",
-                    "type": "integer"
-                  },
-                  "readOnly": {
-                    "description": "readOnly value true will force the readOnly setting in VolumeMounts.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
-                    "type": "boolean"
-                  },
-                  "volumeID": {
-                    "description": "volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "volumeID"
-                ],
-                "type": "object",
-                "additionalProperties": false
-              },
-              "azureDisk": {
-                "description": "azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.\nDeprecated: AzureDisk is deprecated. All operations for the in-tree azureDisk type\nare redirected to the disk.csi.azure.com CSI driver.",
-                "properties": {
-                  "cachingMode": {
-                    "description": "cachingMode is the Host Caching mode: None, Read Only, Read Write.",
-                    "type": "string"
-                  },
-                  "diskName": {
-                    "description": "diskName is the Name of the data disk in the blob storage",
-                    "type": "string"
-                  },
-                  "diskURI": {
-                    "description": "diskURI is the URI of data disk in the blob storage",
-                    "type": "string"
-                  },
-                  "fsType": {
-                    "default": "ext4",
-                    "description": "fsType is Filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
-                    "type": "string"
-                  },
-                  "kind": {
-                    "description": "kind expected values are Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared",
-                    "type": "string"
-                  },
-                  "readOnly": {
-                    "default": false,
-                    "description": "readOnly Defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
-                    "type": "boolean"
-                  }
-                },
-                "required": [
-                  "diskName",
-                  "diskURI"
-                ],
-                "type": "object",
-                "additionalProperties": false
-              },
-              "azureFile": {
-                "description": "azureFile represents an Azure File Service mount on the host and bind mount to the pod.\nDeprecated: AzureFile is deprecated. All operations for the in-tree azureFile type\nare redirected to the file.csi.azure.com CSI driver.",
-                "properties": {
-                  "readOnly": {
-                    "description": "readOnly defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
-                    "type": "boolean"
-                  },
-                  "secretName": {
-                    "description": "secretName is the  name of secret that contains Azure Storage Account Name and Key",
-                    "type": "string"
-                  },
-                  "shareName": {
-                    "description": "shareName is the azure share Name",
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "secretName",
-                  "shareName"
-                ],
-                "type": "object",
-                "additionalProperties": false
-              },
-              "cephfs": {
-                "description": "cephFS represents a Ceph FS mount on the host that shares a pod's lifetime.\nDeprecated: CephFS is deprecated and the in-tree cephfs type is no longer supported.",
-                "properties": {
-                  "monitors": {
-                    "description": "monitors is Required: Monitors is a collection of Ceph monitors\nMore info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
-                    "items": {
-                      "type": "string"
-                    },
-                    "type": "array",
-                    "x-kubernetes-list-type": "atomic"
-                  },
-                  "path": {
-                    "description": "path is Optional: Used as the mounted root, rather than the full Ceph tree, default is /",
-                    "type": "string"
-                  },
-                  "readOnly": {
-                    "description": "readOnly is Optional: Defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.\nMore info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
-                    "type": "boolean"
-                  },
-                  "secretFile": {
-                    "description": "secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret\nMore info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
-                    "type": "string"
-                  },
-                  "secretRef": {
-                    "description": "secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.\nMore info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
-                    "properties": {
-                      "name": {
-                        "default": "",
-                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
-                        "type": "string"
-                      }
-                    },
-                    "type": "object",
-                    "x-kubernetes-map-type": "atomic",
-                    "additionalProperties": false
-                  },
-                  "user": {
-                    "description": "user is optional: User is the rados user name, default is admin\nMore info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "monitors"
-                ],
-                "type": "object",
-                "additionalProperties": false
-              },
-              "cinder": {
-                "description": "cinder represents a cinder volume attached and mounted on kubelets host machine.\nDeprecated: Cinder is deprecated. All operations for the in-tree cinder type\nare redirected to the cinder.csi.openstack.org CSI driver.\nMore info: https://examples.k8s.io/mysql-cinder-pd/README.md",
-                "properties": {
-                  "fsType": {
-                    "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://examples.k8s.io/mysql-cinder-pd/README.md",
-                    "type": "string"
-                  },
-                  "readOnly": {
-                    "description": "readOnly defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.\nMore info: https://examples.k8s.io/mysql-cinder-pd/README.md",
-                    "type": "boolean"
-                  },
-                  "secretRef": {
-                    "description": "secretRef is optional: points to a secret object containing parameters used to connect\nto OpenStack.",
-                    "properties": {
-                      "name": {
-                        "default": "",
-                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
-                        "type": "string"
-                      }
-                    },
-                    "type": "object",
-                    "x-kubernetes-map-type": "atomic",
-                    "additionalProperties": false
-                  },
-                  "volumeID": {
-                    "description": "volumeID used to identify the volume in cinder.\nMore info: https://examples.k8s.io/mysql-cinder-pd/README.md",
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "volumeID"
-                ],
-                "type": "object",
-                "additionalProperties": false
-              },
-              "configMap": {
-                "description": "configMap represents a configMap that should populate this volume",
-                "properties": {
-                  "defaultMode": {
-                    "description": "defaultMode is optional: mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nDefaults to 0644.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
-                    "format": "int32",
-                    "type": "integer"
-                  },
-                  "items": {
-                    "description": "items if unspecified, each key-value pair in the Data field of the referenced\nConfigMap will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the ConfigMap,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
-                    "items": {
-                      "description": "Maps a string key to a path within a volume.",
-                      "properties": {
-                        "key": {
-                          "description": "key is the key to project.",
-                          "type": "string"
-                        },
-                        "mode": {
-                          "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
-                          "format": "int32",
-                          "type": "integer"
-                        },
-                        "path": {
-                          "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
-                          "type": "string"
-                        }
-                      },
-                      "required": [
-                        "key",
-                        "path"
-                      ],
-                      "type": "object",
-                      "additionalProperties": false
-                    },
-                    "type": "array",
-                    "x-kubernetes-list-type": "atomic"
-                  },
-                  "name": {
-                    "default": "",
-                    "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
-                    "type": "string"
-                  },
-                  "optional": {
-                    "description": "optional specify whether the ConfigMap or its keys must be defined",
-                    "type": "boolean"
-                  }
-                },
-                "type": "object",
-                "x-kubernetes-map-type": "atomic",
-                "additionalProperties": false
-              },
-              "csi": {
-                "description": "csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers.",
-                "properties": {
-                  "driver": {
-                    "description": "driver is the name of the CSI driver that handles this volume.\nConsult with your admin for the correct name as registered in the cluster.",
-                    "type": "string"
-                  },
-                  "fsType": {
-                    "description": "fsType to mount. Ex. \"ext4\", \"xfs\", \"ntfs\".\nIf not provided, the empty value is passed to the associated CSI driver\nwhich will determine the default filesystem to apply.",
-                    "type": "string"
-                  },
-                  "nodePublishSecretRef": {
-                    "description": "nodePublishSecretRef is a reference to the secret object containing\nsensitive information to pass to the CSI driver to complete the CSI\nNodePublishVolume and NodeUnpublishVolume calls.\nThis field is optional, and  may be empty if no secret is required. If the\nsecret object contains more than one secret, all secret references are passed.",
-                    "properties": {
-                      "name": {
-                        "default": "",
-                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
-                        "type": "string"
-                      }
-                    },
-                    "type": "object",
-                    "x-kubernetes-map-type": "atomic",
-                    "additionalProperties": false
-                  },
-                  "readOnly": {
-                    "description": "readOnly specifies a read-only configuration for the volume.\nDefaults to false (read/write).",
-                    "type": "boolean"
-                  },
-                  "volumeAttributes": {
-                    "additionalProperties": {
-                      "type": "string"
-                    },
-                    "description": "volumeAttributes stores driver-specific properties that are passed to the CSI\ndriver. Consult your driver's documentation for supported values.",
-                    "type": "object"
-                  }
-                },
-                "required": [
-                  "driver"
-                ],
-                "type": "object",
-                "additionalProperties": false
-              },
-              "downwardAPI": {
-                "description": "downwardAPI represents downward API about the pod that should populate this volume",
-                "properties": {
-                  "defaultMode": {
-                    "description": "Optional: mode bits to use on created files by default. Must be a\nOptional: mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nDefaults to 0644.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
-                    "format": "int32",
-                    "type": "integer"
-                  },
-                  "items": {
-                    "description": "Items is a list of downward API volume file",
-                    "items": {
-                      "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
-                      "properties": {
-                        "fieldRef": {
-                          "description": "Required: Selects a field of the pod: only annotations, labels, name, namespace and uid are supported.",
-                          "properties": {
-                            "apiVersion": {
-                              "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
-                              "type": "string"
-                            },
-                            "fieldPath": {
-                              "description": "Path of the field to select in the specified API version.",
-                              "type": "string"
-                            }
-                          },
-                          "required": [
-                            "fieldPath"
-                          ],
-                          "type": "object",
-                          "x-kubernetes-map-type": "atomic",
-                          "additionalProperties": false
-                        },
-                        "mode": {
-                          "description": "Optional: mode bits used to set permissions on this file, must be an octal value\nbetween 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
-                          "format": "int32",
-                          "type": "integer"
-                        },
-                        "path": {
-                          "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'",
-                          "type": "string"
-                        },
-                        "resourceFieldRef": {
-                          "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.",
-                          "properties": {
-                            "containerName": {
-                              "description": "Container name: required for volumes, optional for env vars",
-                              "type": "string"
-                            },
-                            "divisor": {
-                              "anyOf": [
-                                {
-                                  "type": "integer"
-                                },
-                                {
-                                  "type": "string"
-                                }
-                              ],
-                              "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
-                              "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
-                              "x-kubernetes-int-or-string": true
-                            },
-                            "resource": {
-                              "description": "Required: resource to select",
-                              "type": "string"
-                            }
-                          },
-                          "required": [
-                            "resource"
-                          ],
-                          "type": "object",
-                          "x-kubernetes-map-type": "atomic",
-                          "additionalProperties": false
-                        }
-                      },
-                      "required": [
-                        "path"
-                      ],
-                      "type": "object",
-                      "additionalProperties": false
-                    },
-                    "type": "array",
-                    "x-kubernetes-list-type": "atomic"
-                  }
-                },
-                "type": "object",
-                "additionalProperties": false
-              },
-              "emptyDir": {
-                "description": "emptyDir represents a temporary directory that shares a pod's lifetime.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
-                "properties": {
-                  "medium": {
-                    "description": "medium represents what type of storage medium should back this directory.\nThe default is \"\" which means to use the node's default medium.\nMust be an empty string (default) or Memory.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
-                    "type": "string"
-                  },
-                  "sizeLimit": {
-                    "anyOf": [
-                      {
-                        "type": "integer"
-                      },
-                      {
-                        "type": "string"
-                      }
-                    ],
-                    "description": "sizeLimit is the total amount of local storage required for this EmptyDir volume.\nThe size limit is also applicable for memory medium.\nThe maximum usage on memory medium EmptyDir would be the minimum value between\nthe SizeLimit specified here and the sum of memory limits of all containers in a pod.\nThe default is nil which means that the limit is undefined.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
-                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
-                    "x-kubernetes-int-or-string": true
-                  }
-                },
-                "type": "object",
-                "additionalProperties": false
-              },
-              "ephemeral": {
-                "description": "ephemeral represents a volume that is handled by a cluster storage driver.\nThe volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,\nand deleted when the pod is removed.\n\nUse this if:\na) the volume is only needed while the pod runs,\nb) features of normal volumes like restoring from snapshot or capacity\n   tracking are needed,\nc) the storage driver is specified through a storage class, and\nd) the storage driver supports dynamic volume provisioning through\n   a PersistentVolumeClaim (see EphemeralVolumeSource for more\n   information on the connection between this volume type\n   and PersistentVolumeClaim).\n\nUse PersistentVolumeClaim or one of the vendor-specific\nAPIs for volumes that persist for longer than the lifecycle\nof an individual pod.\n\nUse CSI for light-weight local ephemeral volumes if the CSI driver is meant to\nbe used that way - see the documentation of the driver for\nmore information.\n\nA pod can use both types of ephemeral volumes and\npersistent volumes at the same time.",
-                "properties": {
-                  "volumeClaimTemplate": {
-                    "description": "Will be used to create a stand-alone PVC to provision the volume.\nThe pod in which this EphemeralVolumeSource is embedded will be the\nowner of the PVC, i.e. the PVC will be deleted together with the\npod.  The name of the PVC will be `<pod name>-<volume name>` where\n`<volume name>` is the name from the `PodSpec.Volumes` array\nentry. Pod validation will reject the pod if the concatenated name\nis not valid for a PVC (for example, too long).\n\nAn existing PVC with that name that is not owned by the pod\nwill *not* be used for the pod to avoid using an unrelated\nvolume by mistake. Starting the pod is then blocked until\nthe unrelated PVC is removed. If such a pre-created PVC is\nmeant to be used by the pod, the PVC has to updated with an\nowner reference to the pod once the pod exists. Normally\nthis should not be necessary, but it may be useful when\nmanually reconstructing a broken cluster.\n\nThis field is read-only and no changes will be made by Kubernetes\nto the PVC after it has been created.\n\nRequired, must not be nil.",
-                    "properties": {
-                      "metadata": {
-                        "description": "May contain labels and annotations that will be copied into the PVC\nwhen creating it. No other fields are allowed and will be rejected during\nvalidation.",
-                        "type": "object"
-                      },
-                      "spec": {
-                        "description": "The specification for the PersistentVolumeClaim. The entire content is\ncopied unchanged into the PVC that gets created from this\ntemplate. The same fields as in a PersistentVolumeClaim\nare also valid here.",
-                        "properties": {
-                          "accessModes": {
-                            "description": "accessModes contains the desired access modes the volume should have.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1",
-                            "items": {
-                              "type": "string"
-                            },
-                            "type": "array",
-                            "x-kubernetes-list-type": "atomic"
-                          },
-                          "dataSource": {
-                            "description": "dataSource field can be used to specify either:\n* An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)\n* An existing PVC (PersistentVolumeClaim)\nIf the provisioner or an external controller can support the specified data source,\nit will create a new volume based on the contents of the specified data source.\nWhen the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,\nand dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.\nIf the namespace is specified, then dataSourceRef will not be copied to dataSource.",
+                        "nodeAffinity": {
+                            "description": "Describes node affinity scheduling rules for the pod.",
                             "properties": {
-                              "apiGroup": {
-                                "description": "APIGroup is the group for the resource being referenced.\nIf APIGroup is not specified, the specified Kind must be in the core API group.\nFor any other third-party types, APIGroup is required.",
-                                "type": "string"
-                              },
-                              "kind": {
-                                "description": "Kind is the type of resource being referenced",
-                                "type": "string"
-                              },
-                              "name": {
-                                "description": "Name is the name of resource being referenced",
-                                "type": "string"
-                              }
-                            },
-                            "required": [
-                              "kind",
-                              "name"
-                            ],
-                            "type": "object",
-                            "x-kubernetes-map-type": "atomic",
-                            "additionalProperties": false
-                          },
-                          "dataSourceRef": {
-                            "description": "dataSourceRef specifies the object from which to populate the volume with data, if a non-empty\nvolume is desired. This may be any object from a non-empty API group (non\ncore object) or a PersistentVolumeClaim object.\nWhen this field is specified, volume binding will only succeed if the type of\nthe specified object matches some installed volume populator or dynamic\nprovisioner.\nThis field will replace the functionality of the dataSource field and as such\nif both fields are non-empty, they must have the same value. For backwards\ncompatibility, when namespace isn't specified in dataSourceRef,\nboth fields (dataSource and dataSourceRef) will be set to the same\nvalue automatically if one of them is empty and the other is non-empty.\nWhen namespace is specified in dataSourceRef,\ndataSource isn't set to the same value and must be empty.\nThere are three important differences between dataSource and dataSourceRef:\n* While dataSource only allows two specific types of objects, dataSourceRef\n  allows any non-core object, as well as PersistentVolumeClaim objects.\n* While dataSource ignores disallowed values (dropping them), dataSourceRef\n  preserves all values, and generates an error if a disallowed value is\n  specified.\n* While dataSource only allows local objects, dataSourceRef allows objects\n  in any namespaces.\n(Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.\n(Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.",
-                            "properties": {
-                              "apiGroup": {
-                                "description": "APIGroup is the group for the resource being referenced.\nIf APIGroup is not specified, the specified Kind must be in the core API group.\nFor any other third-party types, APIGroup is required.",
-                                "type": "string"
-                              },
-                              "kind": {
-                                "description": "Kind is the type of resource being referenced",
-                                "type": "string"
-                              },
-                              "name": {
-                                "description": "Name is the name of resource being referenced",
-                                "type": "string"
-                              },
-                              "namespace": {
-                                "description": "Namespace is the namespace of resource being referenced\nNote that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.\n(Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.",
-                                "type": "string"
-                              }
-                            },
-                            "required": [
-                              "kind",
-                              "name"
-                            ],
-                            "type": "object",
-                            "additionalProperties": false
-                          },
-                          "resources": {
-                            "description": "resources represents the minimum resources the volume should have.\nIf RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements\nthat are lower than previous value but must still be higher than capacity recorded in the\nstatus field of the claim.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources",
-                            "properties": {
-                              "limits": {
-                                "additionalProperties": {
-                                  "anyOf": [
-                                    {
-                                      "type": "integer"
+                                "preferredDuringSchedulingIgnoredDuringExecution": {
+                                    "description": "The scheduler will prefer to schedule pods to nodes that satisfy\nthe affinity expressions specified by this field, but it may choose\na node that violates one or more of the expressions. The node that is\nmost preferred is the one with the greatest sum of weights, i.e.\nfor each node that meets all of the scheduling requirements (resource\nrequest, requiredDuringScheduling affinity expressions, etc.),\ncompute a sum by iterating through the elements of this field and adding\n\"weight\" to the sum if the node matches the corresponding matchExpressions; the\nnode(s) with the highest sum are the most preferred.",
+                                    "items": {
+                                        "description": "An empty preferred scheduling term matches all objects with implicit weight 0\n(i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).",
+                                        "properties": {
+                                            "preference": {
+                                                "description": "A node selector term, associated with the corresponding weight.",
+                                                "properties": {
+                                                    "matchExpressions": {
+                                                        "description": "A list of node selector requirements by node's labels.",
+                                                        "items": {
+                                                            "description": "A node selector requirement is a selector that contains values, a key, and an operator\nthat relates the key and values.",
+                                                            "properties": {
+                                                                "key": {
+                                                                    "description": "The label key that the selector applies to.",
+                                                                    "type": "string"
+                                                                },
+                                                                "operator": {
+                                                                    "description": "Represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                                    "type": "string"
+                                                                },
+                                                                "values": {
+                                                                    "description": "An array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. If the operator is Gt or Lt, the values\narray must have a single element, which will be interpreted as an integer.\nThis array is replaced during a strategic merge patch.",
+                                                                    "items": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "type": "array",
+                                                                    "x-kubernetes-list-type": "atomic"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "key",
+                                                                "operator"
+                                                            ],
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                        },
+                                                        "type": "array",
+                                                        "x-kubernetes-list-type": "atomic"
+                                                    },
+                                                    "matchFields": {
+                                                        "description": "A list of node selector requirements by node's fields.",
+                                                        "items": {
+                                                            "description": "A node selector requirement is a selector that contains values, a key, and an operator\nthat relates the key and values.",
+                                                            "properties": {
+                                                                "key": {
+                                                                    "description": "The label key that the selector applies to.",
+                                                                    "type": "string"
+                                                                },
+                                                                "operator": {
+                                                                    "description": "Represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                                    "type": "string"
+                                                                },
+                                                                "values": {
+                                                                    "description": "An array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. If the operator is Gt or Lt, the values\narray must have a single element, which will be interpreted as an integer.\nThis array is replaced during a strategic merge patch.",
+                                                                    "items": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "type": "array",
+                                                                    "x-kubernetes-list-type": "atomic"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "key",
+                                                                "operator"
+                                                            ],
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                        },
+                                                        "type": "array",
+                                                        "x-kubernetes-list-type": "atomic"
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "x-kubernetes-map-type": "atomic",
+                                                "additionalProperties": false
+                                            },
+                                            "weight": {
+                                                "description": "Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.",
+                                                "format": "int32",
+                                                "type": "integer",
+                                                "minimum": -2147483648,
+                                                "maximum": 2147483647
+                                            }
+                                        },
+                                        "required": [
+                                            "preference",
+                                            "weight"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
                                     },
-                                    {
-                                      "type": "string"
-                                    }
-                                  ],
-                                  "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
-                                  "x-kubernetes-int-or-string": true
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
                                 },
-                                "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
-                                "type": "object"
-                              },
-                              "requests": {
-                                "additionalProperties": {
-                                  "anyOf": [
-                                    {
-                                      "type": "integer"
-                                    },
-                                    {
-                                      "type": "string"
-                                    }
-                                  ],
-                                  "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
-                                  "x-kubernetes-int-or-string": true
-                                },
-                                "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
-                                "type": "object"
-                              }
-                            },
-                            "type": "object",
-                            "additionalProperties": false
-                          },
-                          "selector": {
-                            "description": "selector is a label query over volumes to consider for binding.",
-                            "properties": {
-                              "matchExpressions": {
-                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
-                                "items": {
-                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
-                                  "properties": {
-                                    "key": {
-                                      "description": "key is the label key that the selector applies to.",
-                                      "type": "string"
-                                    },
-                                    "operator": {
-                                      "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
-                                      "type": "string"
-                                    },
-                                    "values": {
-                                      "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
-                                      "items": {
-                                        "type": "string"
-                                      },
-                                      "type": "array",
-                                      "x-kubernetes-list-type": "atomic"
-                                    }
-                                  },
-                                  "required": [
-                                    "key",
-                                    "operator"
-                                  ],
-                                  "type": "object",
-                                  "additionalProperties": false
-                                },
-                                "type": "array",
-                                "x-kubernetes-list-type": "atomic"
-                              },
-                              "matchLabels": {
-                                "additionalProperties": {
-                                  "type": "string"
-                                },
-                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                                "type": "object"
-                              }
-                            },
-                            "type": "object",
-                            "x-kubernetes-map-type": "atomic",
-                            "additionalProperties": false
-                          },
-                          "storageClassName": {
-                            "description": "storageClassName is the name of the StorageClass required by the claim.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1",
-                            "type": "string"
-                          },
-                          "volumeAttributesClassName": {
-                            "description": "volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.\nIf specified, the CSI driver will create or update the volume with the attributes defined\nin the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,\nit can be changed after the claim is created. An empty string or nil value indicates that no\nVolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,\nthis field can be reset to its previous value (including nil) to cancel the modification.\nIf the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be\nset to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource\nexists.\nMore info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/",
-                            "type": "string"
-                          },
-                          "volumeMode": {
-                            "description": "volumeMode defines what type of volume is required by the claim.\nValue of Filesystem is implied when not included in claim spec.",
-                            "type": "string"
-                          },
-                          "volumeName": {
-                            "description": "volumeName is the binding reference to the PersistentVolume backing this claim.",
-                            "type": "string"
-                          }
-                        },
-                        "type": "object",
-                        "additionalProperties": false
-                      }
-                    },
-                    "required": [
-                      "spec"
-                    ],
-                    "type": "object",
-                    "additionalProperties": false
-                  }
-                },
-                "type": "object",
-                "additionalProperties": false
-              },
-              "fc": {
-                "description": "fc represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.",
-                "properties": {
-                  "fsType": {
-                    "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
-                    "type": "string"
-                  },
-                  "lun": {
-                    "description": "lun is Optional: FC target lun number",
-                    "format": "int32",
-                    "type": "integer"
-                  },
-                  "readOnly": {
-                    "description": "readOnly is Optional: Defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
-                    "type": "boolean"
-                  },
-                  "targetWWNs": {
-                    "description": "targetWWNs is Optional: FC target worldwide names (WWNs)",
-                    "items": {
-                      "type": "string"
-                    },
-                    "type": "array",
-                    "x-kubernetes-list-type": "atomic"
-                  },
-                  "wwids": {
-                    "description": "wwids Optional: FC volume world wide identifiers (wwids)\nEither wwids or combination of targetWWNs and lun must be set, but not both simultaneously.",
-                    "items": {
-                      "type": "string"
-                    },
-                    "type": "array",
-                    "x-kubernetes-list-type": "atomic"
-                  }
-                },
-                "type": "object",
-                "additionalProperties": false
-              },
-              "flexVolume": {
-                "description": "flexVolume represents a generic volume resource that is\nprovisioned/attached using an exec based plugin.\nDeprecated: FlexVolume is deprecated. Consider using a CSIDriver instead.",
-                "properties": {
-                  "driver": {
-                    "description": "driver is the name of the driver to use for this volume.",
-                    "type": "string"
-                  },
-                  "fsType": {
-                    "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". The default filesystem depends on FlexVolume script.",
-                    "type": "string"
-                  },
-                  "options": {
-                    "additionalProperties": {
-                      "type": "string"
-                    },
-                    "description": "options is Optional: this field holds extra command options if any.",
-                    "type": "object"
-                  },
-                  "readOnly": {
-                    "description": "readOnly is Optional: defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
-                    "type": "boolean"
-                  },
-                  "secretRef": {
-                    "description": "secretRef is Optional: secretRef is reference to the secret object containing\nsensitive information to pass to the plugin scripts. This may be\nempty if no secret object is specified. If the secret object\ncontains more than one secret, all secrets are passed to the plugin\nscripts.",
-                    "properties": {
-                      "name": {
-                        "default": "",
-                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
-                        "type": "string"
-                      }
-                    },
-                    "type": "object",
-                    "x-kubernetes-map-type": "atomic",
-                    "additionalProperties": false
-                  }
-                },
-                "required": [
-                  "driver"
-                ],
-                "type": "object",
-                "additionalProperties": false
-              },
-              "flocker": {
-                "description": "flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running.\nDeprecated: Flocker is deprecated and the in-tree flocker type is no longer supported.",
-                "properties": {
-                  "datasetName": {
-                    "description": "datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker\nshould be considered as deprecated",
-                    "type": "string"
-                  },
-                  "datasetUUID": {
-                    "description": "datasetUUID is the UUID of the dataset. This is unique identifier of a Flocker dataset",
-                    "type": "string"
-                  }
-                },
-                "type": "object",
-                "additionalProperties": false
-              },
-              "gcePersistentDisk": {
-                "description": "gcePersistentDisk represents a GCE Disk resource that is attached to a\nkubelet's host machine and then exposed to the pod.\nDeprecated: GCEPersistentDisk is deprecated. All operations for the in-tree\ngcePersistentDisk type are redirected to the pd.csi.storage.gke.io CSI driver.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
-                "properties": {
-                  "fsType": {
-                    "description": "fsType is filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
-                    "type": "string"
-                  },
-                  "partition": {
-                    "description": "partition is the partition in the volume that you want to mount.\nIf omitted, the default is to mount by volume name.\nExamples: For volume /dev/sda1, you specify the partition as \"1\".\nSimilarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty).\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
-                    "format": "int32",
-                    "type": "integer"
-                  },
-                  "pdName": {
-                    "description": "pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
-                    "type": "string"
-                  },
-                  "readOnly": {
-                    "description": "readOnly here will force the ReadOnly setting in VolumeMounts.\nDefaults to false.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
-                    "type": "boolean"
-                  }
-                },
-                "required": [
-                  "pdName"
-                ],
-                "type": "object",
-                "additionalProperties": false
-              },
-              "gitRepo": {
-                "description": "gitRepo represents a git repository at a particular revision.\nDeprecated: GitRepo is deprecated. To provision a container with a git repo, mount an\nEmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir\ninto the Pod's container.",
-                "properties": {
-                  "directory": {
-                    "description": "directory is the target directory name.\nMust not contain or start with '..'.  If '.' is supplied, the volume directory will be the\ngit repository.  Otherwise, if specified, the volume will contain the git repository in\nthe subdirectory with the given name.",
-                    "type": "string"
-                  },
-                  "repository": {
-                    "description": "repository is the URL",
-                    "type": "string"
-                  },
-                  "revision": {
-                    "description": "revision is the commit hash for the specified revision.",
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "repository"
-                ],
-                "type": "object",
-                "additionalProperties": false
-              },
-              "glusterfs": {
-                "description": "glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.\nDeprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.",
-                "properties": {
-                  "endpoints": {
-                    "description": "endpoints is the endpoint name that details Glusterfs topology.",
-                    "type": "string"
-                  },
-                  "path": {
-                    "description": "path is the Glusterfs volume path.\nMore info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
-                    "type": "string"
-                  },
-                  "readOnly": {
-                    "description": "readOnly here will force the Glusterfs volume to be mounted with read-only permissions.\nDefaults to false.\nMore info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
-                    "type": "boolean"
-                  }
-                },
-                "required": [
-                  "endpoints",
-                  "path"
-                ],
-                "type": "object",
-                "additionalProperties": false
-              },
-              "hostPath": {
-                "description": "hostPath represents a pre-existing file or directory on the host\nmachine that is directly exposed to the container. This is generally\nused for system agents or other privileged things that are allowed\nto see the host machine. Most containers will NOT need this.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
-                "properties": {
-                  "path": {
-                    "description": "path of the directory on the host.\nIf the path is a symlink, it will follow the link to the real path.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
-                    "type": "string"
-                  },
-                  "type": {
-                    "description": "type for HostPath Volume\nDefaults to \"\"\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "path"
-                ],
-                "type": "object",
-                "additionalProperties": false
-              },
-              "image": {
-                "description": "image represents an OCI object (a container image or artifact) pulled and mounted on the kubelet's host machine.\nThe volume is resolved at pod startup depending on which PullPolicy value is provided:\n\n- Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.\n- Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.\n- IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.\n\nThe volume gets re-resolved if the pod gets deleted and recreated, which means that new remote content will become available on pod recreation.\nA failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.\nThe types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.\nThe OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.\nThe volume will be mounted read-only (ro) and non-executable files (noexec).\nSub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.\nThe field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.",
-                "properties": {
-                  "pullPolicy": {
-                    "description": "Policy for pulling OCI objects. Possible values are:\nAlways: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.\nNever: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.\nIfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.\nDefaults to Always if :latest tag is specified, or IfNotPresent otherwise.",
-                    "type": "string"
-                  },
-                  "reference": {
-                    "description": "Required: Image or artifact reference to be used.\nBehaves in the same way as pod.spec.containers[*].image.\nPull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.\nMore info: https://kubernetes.io/docs/concepts/containers/images\nThis field is optional to allow higher level config management to default or override\ncontainer images in workload controllers like Deployments and StatefulSets.",
-                    "type": "string"
-                  }
-                },
-                "type": "object",
-                "additionalProperties": false
-              },
-              "iscsi": {
-                "description": "iscsi represents an ISCSI Disk resource that is attached to a\nkubelet's host machine and then exposed to the pod.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes/#iscsi",
-                "properties": {
-                  "chapAuthDiscovery": {
-                    "description": "chapAuthDiscovery defines whether support iSCSI Discovery CHAP authentication",
-                    "type": "boolean"
-                  },
-                  "chapAuthSession": {
-                    "description": "chapAuthSession defines whether support iSCSI Session CHAP authentication",
-                    "type": "boolean"
-                  },
-                  "fsType": {
-                    "description": "fsType is the filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi",
-                    "type": "string"
-                  },
-                  "initiatorName": {
-                    "description": "initiatorName is the custom iSCSI Initiator Name.\nIf initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface\n<target portal>:<volume name> will be created for the connection.",
-                    "type": "string"
-                  },
-                  "iqn": {
-                    "description": "iqn is the target iSCSI Qualified Name.",
-                    "type": "string"
-                  },
-                  "iscsiInterface": {
-                    "default": "default",
-                    "description": "iscsiInterface is the interface Name that uses an iSCSI transport.\nDefaults to 'default' (tcp).",
-                    "type": "string"
-                  },
-                  "lun": {
-                    "description": "lun represents iSCSI Target Lun number.",
-                    "format": "int32",
-                    "type": "integer"
-                  },
-                  "portals": {
-                    "description": "portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port\nis other than default (typically TCP ports 860 and 3260).",
-                    "items": {
-                      "type": "string"
-                    },
-                    "type": "array",
-                    "x-kubernetes-list-type": "atomic"
-                  },
-                  "readOnly": {
-                    "description": "readOnly here will force the ReadOnly setting in VolumeMounts.\nDefaults to false.",
-                    "type": "boolean"
-                  },
-                  "secretRef": {
-                    "description": "secretRef is the CHAP Secret for iSCSI target and initiator authentication",
-                    "properties": {
-                      "name": {
-                        "default": "",
-                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
-                        "type": "string"
-                      }
-                    },
-                    "type": "object",
-                    "x-kubernetes-map-type": "atomic",
-                    "additionalProperties": false
-                  },
-                  "targetPortal": {
-                    "description": "targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port\nis other than default (typically TCP ports 860 and 3260).",
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "iqn",
-                  "lun",
-                  "targetPortal"
-                ],
-                "type": "object",
-                "additionalProperties": false
-              },
-              "name": {
-                "description": "name of the volume.\nMust be a DNS_LABEL and unique within the pod.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
-                "type": "string"
-              },
-              "nfs": {
-                "description": "nfs represents an NFS mount on the host that shares a pod's lifetime\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
-                "properties": {
-                  "path": {
-                    "description": "path that is exported by the NFS server.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
-                    "type": "string"
-                  },
-                  "readOnly": {
-                    "description": "readOnly here will force the NFS export to be mounted with read-only permissions.\nDefaults to false.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
-                    "type": "boolean"
-                  },
-                  "server": {
-                    "description": "server is the hostname or IP address of the NFS server.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "path",
-                  "server"
-                ],
-                "type": "object",
-                "additionalProperties": false
-              },
-              "persistentVolumeClaim": {
-                "description": "persistentVolumeClaimVolumeSource represents a reference to a\nPersistentVolumeClaim in the same namespace.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
-                "properties": {
-                  "claimName": {
-                    "description": "claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
-                    "type": "string"
-                  },
-                  "readOnly": {
-                    "description": "readOnly Will force the ReadOnly setting in VolumeMounts.\nDefault false.",
-                    "type": "boolean"
-                  }
-                },
-                "required": [
-                  "claimName"
-                ],
-                "type": "object",
-                "additionalProperties": false
-              },
-              "photonPersistentDisk": {
-                "description": "photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine.\nDeprecated: PhotonPersistentDisk is deprecated and the in-tree photonPersistentDisk type is no longer supported.",
-                "properties": {
-                  "fsType": {
-                    "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
-                    "type": "string"
-                  },
-                  "pdID": {
-                    "description": "pdID is the ID that identifies Photon Controller persistent disk",
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "pdID"
-                ],
-                "type": "object",
-                "additionalProperties": false
-              },
-              "portworxVolume": {
-                "description": "portworxVolume represents a portworx volume attached and mounted on kubelets host machine.\nDeprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type\nare redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate\nis on.",
-                "properties": {
-                  "fsType": {
-                    "description": "fSType represents the filesystem type to mount\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\". Implicitly inferred to be \"ext4\" if unspecified.",
-                    "type": "string"
-                  },
-                  "readOnly": {
-                    "description": "readOnly defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
-                    "type": "boolean"
-                  },
-                  "volumeID": {
-                    "description": "volumeID uniquely identifies a Portworx volume",
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "volumeID"
-                ],
-                "type": "object",
-                "additionalProperties": false
-              },
-              "projected": {
-                "description": "projected items for all in one resources secrets, configmaps, and downward API",
-                "properties": {
-                  "defaultMode": {
-                    "description": "defaultMode are the mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
-                    "format": "int32",
-                    "type": "integer"
-                  },
-                  "sources": {
-                    "description": "sources is the list of volume projections. Each entry in this list\nhandles one source.",
-                    "items": {
-                      "description": "Projection that may be projected along with other supported volume types.\nExactly one of these fields must be set.",
-                      "properties": {
-                        "clusterTrustBundle": {
-                          "description": "ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field\nof ClusterTrustBundle objects in an auto-updating file.\n\nAlpha, gated by the ClusterTrustBundleProjection feature gate.\n\nClusterTrustBundle objects can either be selected by name, or by the\ncombination of signer name and a label selector.\n\nKubelet performs aggressive normalization of the PEM contents written\ninto the pod filesystem.  Esoteric PEM features such as inter-block\ncomments and block headers are stripped.  Certificates are deduplicated.\nThe ordering of certificates within the file is arbitrary, and Kubelet\nmay change the order over time.",
-                          "properties": {
-                            "labelSelector": {
-                              "description": "Select all ClusterTrustBundles that match this label selector.  Only has\neffect if signerName is set.  Mutually-exclusive with name.  If unset,\ninterpreted as \"match nothing\".  If set but empty, interpreted as \"match\neverything\".",
-                              "properties": {
-                                "matchExpressions": {
-                                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
-                                  "items": {
-                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                "requiredDuringSchedulingIgnoredDuringExecution": {
+                                    "description": "If the affinity requirements specified by this field are not met at\nscheduling time, the pod will not be scheduled onto the node.\nIf the affinity requirements specified by this field cease to be met\nat some point during pod execution (e.g. due to an update), the system\nmay or may not try to eventually evict the pod from its node.",
                                     "properties": {
-                                      "key": {
-                                        "description": "key is the label key that the selector applies to.",
+                                        "nodeSelectorTerms": {
+                                            "description": "Required. A list of node selector terms. The terms are ORed.",
+                                            "items": {
+                                                "description": "A null or empty node selector term matches no objects. The requirements of\nthem are ANDed.\nThe TopologySelectorTerm type implements a subset of the NodeSelectorTerm.",
+                                                "properties": {
+                                                    "matchExpressions": {
+                                                        "description": "A list of node selector requirements by node's labels.",
+                                                        "items": {
+                                                            "description": "A node selector requirement is a selector that contains values, a key, and an operator\nthat relates the key and values.",
+                                                            "properties": {
+                                                                "key": {
+                                                                    "description": "The label key that the selector applies to.",
+                                                                    "type": "string"
+                                                                },
+                                                                "operator": {
+                                                                    "description": "Represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                                    "type": "string"
+                                                                },
+                                                                "values": {
+                                                                    "description": "An array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. If the operator is Gt or Lt, the values\narray must have a single element, which will be interpreted as an integer.\nThis array is replaced during a strategic merge patch.",
+                                                                    "items": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "type": "array",
+                                                                    "x-kubernetes-list-type": "atomic"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "key",
+                                                                "operator"
+                                                            ],
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                        },
+                                                        "type": "array",
+                                                        "x-kubernetes-list-type": "atomic"
+                                                    },
+                                                    "matchFields": {
+                                                        "description": "A list of node selector requirements by node's fields.",
+                                                        "items": {
+                                                            "description": "A node selector requirement is a selector that contains values, a key, and an operator\nthat relates the key and values.",
+                                                            "properties": {
+                                                                "key": {
+                                                                    "description": "The label key that the selector applies to.",
+                                                                    "type": "string"
+                                                                },
+                                                                "operator": {
+                                                                    "description": "Represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                                    "type": "string"
+                                                                },
+                                                                "values": {
+                                                                    "description": "An array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. If the operator is Gt or Lt, the values\narray must have a single element, which will be interpreted as an integer.\nThis array is replaced during a strategic merge patch.",
+                                                                    "items": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "type": "array",
+                                                                    "x-kubernetes-list-type": "atomic"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "key",
+                                                                "operator"
+                                                            ],
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                        },
+                                                        "type": "array",
+                                                        "x-kubernetes-list-type": "atomic"
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "x-kubernetes-map-type": "atomic",
+                                                "additionalProperties": false
+                                            },
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
+                                        }
+                                    },
+                                    "required": [
+                                        "nodeSelectorTerms"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "podAffinity": {
+                            "description": "Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).",
+                            "properties": {
+                                "preferredDuringSchedulingIgnoredDuringExecution": {
+                                    "description": "The scheduler will prefer to schedule pods to nodes that satisfy\nthe affinity expressions specified by this field, but it may choose\na node that violates one or more of the expressions. The node that is\nmost preferred is the one with the greatest sum of weights, i.e.\nfor each node that meets all of the scheduling requirements (resource\nrequest, requiredDuringScheduling affinity expressions, etc.),\ncompute a sum by iterating through the elements of this field and adding\n\"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the\nnode(s) with the highest sum are the most preferred.",
+                                    "items": {
+                                        "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                                        "properties": {
+                                            "podAffinityTerm": {
+                                                "description": "Required. A pod affinity term, associated with the corresponding weight.",
+                                                "properties": {
+                                                    "labelSelector": {
+                                                        "description": "A label query over a set of resources, in this case pods.\nIf it's null, this PodAffinityTerm matches with no Pods.",
+                                                        "properties": {
+                                                            "matchExpressions": {
+                                                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                                "items": {
+                                                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                                                    "properties": {
+                                                                        "key": {
+                                                                            "description": "key is the label key that the selector applies to.",
+                                                                            "type": "string"
+                                                                        },
+                                                                        "operator": {
+                                                                            "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                            "type": "string"
+                                                                        },
+                                                                        "values": {
+                                                                            "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                                                            "items": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "type": "array",
+                                                                            "x-kubernetes-list-type": "atomic"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "key",
+                                                                        "operator"
+                                                                    ],
+                                                                    "type": "object",
+                                                                    "additionalProperties": false
+                                                                },
+                                                                "type": "array",
+                                                                "x-kubernetes-list-type": "atomic"
+                                                            },
+                                                            "matchLabels": {
+                                                                "additionalProperties": {
+                                                                    "type": "string"
+                                                                },
+                                                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                                "type": "object"
+                                                            }
+                                                        },
+                                                        "type": "object",
+                                                        "x-kubernetes-map-type": "atomic",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "matchLabelKeys": {
+                                                        "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both matchLabelKeys and labelSelector.\nAlso, matchLabelKeys cannot be set when labelSelector isn't set.",
+                                                        "items": {
+                                                            "type": "string"
+                                                        },
+                                                        "type": "array",
+                                                        "x-kubernetes-list-type": "atomic"
+                                                    },
+                                                    "mismatchLabelKeys": {
+                                                        "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both mismatchLabelKeys and labelSelector.\nAlso, mismatchLabelKeys cannot be set when labelSelector isn't set.",
+                                                        "items": {
+                                                            "type": "string"
+                                                        },
+                                                        "type": "array",
+                                                        "x-kubernetes-list-type": "atomic"
+                                                    },
+                                                    "namespaceSelector": {
+                                                        "description": "A label query over the set of namespaces that the term applies to.\nThe term is applied to the union of the namespaces selected by this field\nand the ones listed in the namespaces field.\nnull selector and null or empty namespaces list means \"this pod's namespace\".\nAn empty selector ({}) matches all namespaces.",
+                                                        "properties": {
+                                                            "matchExpressions": {
+                                                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                                "items": {
+                                                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                                                    "properties": {
+                                                                        "key": {
+                                                                            "description": "key is the label key that the selector applies to.",
+                                                                            "type": "string"
+                                                                        },
+                                                                        "operator": {
+                                                                            "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                            "type": "string"
+                                                                        },
+                                                                        "values": {
+                                                                            "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                                                            "items": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "type": "array",
+                                                                            "x-kubernetes-list-type": "atomic"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "key",
+                                                                        "operator"
+                                                                    ],
+                                                                    "type": "object",
+                                                                    "additionalProperties": false
+                                                                },
+                                                                "type": "array",
+                                                                "x-kubernetes-list-type": "atomic"
+                                                            },
+                                                            "matchLabels": {
+                                                                "additionalProperties": {
+                                                                    "type": "string"
+                                                                },
+                                                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                                "type": "object"
+                                                            }
+                                                        },
+                                                        "type": "object",
+                                                        "x-kubernetes-map-type": "atomic",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "namespaces": {
+                                                        "description": "namespaces specifies a static list of namespace names that the term applies to.\nThe term is applied to the union of the namespaces listed in this field\nand the ones selected by namespaceSelector.\nnull or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                                        "items": {
+                                                            "type": "string"
+                                                        },
+                                                        "type": "array",
+                                                        "x-kubernetes-list-type": "atomic"
+                                                    },
+                                                    "topologyKey": {
+                                                        "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "topologyKey"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "weight": {
+                                                "description": "weight associated with matching the corresponding podAffinityTerm,\nin the range 1-100.",
+                                                "format": "int32",
+                                                "type": "integer",
+                                                "minimum": -2147483648,
+                                                "maximum": 2147483647
+                                            }
+                                        },
+                                        "required": [
+                                            "podAffinityTerm",
+                                            "weight"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
+                                },
+                                "requiredDuringSchedulingIgnoredDuringExecution": {
+                                    "description": "If the affinity requirements specified by this field are not met at\nscheduling time, the pod will not be scheduled onto the node.\nIf the affinity requirements specified by this field cease to be met\nat some point during pod execution (e.g. due to a pod label update), the\nsystem may or may not try to eventually evict the pod from its node.\nWhen there are multiple elements, the lists of nodes corresponding to each\npodAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                                    "items": {
+                                        "description": "Defines a set of pods (namely those matching the labelSelector\nrelative to the given namespace(s)) that this pod should be\nco-located (affinity) or not co-located (anti-affinity) with,\nwhere co-located is defined as running on a node whose value of\nthe label with key <topologyKey> matches that of any node on which\na pod of the set of pods is running",
+                                        "properties": {
+                                            "labelSelector": {
+                                                "description": "A label query over a set of resources, in this case pods.\nIf it's null, this PodAffinityTerm matches with no Pods.",
+                                                "properties": {
+                                                    "matchExpressions": {
+                                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                        "items": {
+                                                            "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                                            "properties": {
+                                                                "key": {
+                                                                    "description": "key is the label key that the selector applies to.",
+                                                                    "type": "string"
+                                                                },
+                                                                "operator": {
+                                                                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                    "type": "string"
+                                                                },
+                                                                "values": {
+                                                                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                                                    "items": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "type": "array",
+                                                                    "x-kubernetes-list-type": "atomic"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "key",
+                                                                "operator"
+                                                            ],
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                        },
+                                                        "type": "array",
+                                                        "x-kubernetes-list-type": "atomic"
+                                                    },
+                                                    "matchLabels": {
+                                                        "additionalProperties": {
+                                                            "type": "string"
+                                                        },
+                                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                        "type": "object"
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "x-kubernetes-map-type": "atomic",
+                                                "additionalProperties": false
+                                            },
+                                            "matchLabelKeys": {
+                                                "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both matchLabelKeys and labelSelector.\nAlso, matchLabelKeys cannot be set when labelSelector isn't set.",
+                                                "items": {
+                                                    "type": "string"
+                                                },
+                                                "type": "array",
+                                                "x-kubernetes-list-type": "atomic"
+                                            },
+                                            "mismatchLabelKeys": {
+                                                "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both mismatchLabelKeys and labelSelector.\nAlso, mismatchLabelKeys cannot be set when labelSelector isn't set.",
+                                                "items": {
+                                                    "type": "string"
+                                                },
+                                                "type": "array",
+                                                "x-kubernetes-list-type": "atomic"
+                                            },
+                                            "namespaceSelector": {
+                                                "description": "A label query over the set of namespaces that the term applies to.\nThe term is applied to the union of the namespaces selected by this field\nand the ones listed in the namespaces field.\nnull selector and null or empty namespaces list means \"this pod's namespace\".\nAn empty selector ({}) matches all namespaces.",
+                                                "properties": {
+                                                    "matchExpressions": {
+                                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                        "items": {
+                                                            "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                                            "properties": {
+                                                                "key": {
+                                                                    "description": "key is the label key that the selector applies to.",
+                                                                    "type": "string"
+                                                                },
+                                                                "operator": {
+                                                                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                    "type": "string"
+                                                                },
+                                                                "values": {
+                                                                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                                                    "items": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "type": "array",
+                                                                    "x-kubernetes-list-type": "atomic"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "key",
+                                                                "operator"
+                                                            ],
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                        },
+                                                        "type": "array",
+                                                        "x-kubernetes-list-type": "atomic"
+                                                    },
+                                                    "matchLabels": {
+                                                        "additionalProperties": {
+                                                            "type": "string"
+                                                        },
+                                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                        "type": "object"
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "x-kubernetes-map-type": "atomic",
+                                                "additionalProperties": false
+                                            },
+                                            "namespaces": {
+                                                "description": "namespaces specifies a static list of namespace names that the term applies to.\nThe term is applied to the union of the namespaces listed in this field\nand the ones selected by namespaceSelector.\nnull or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                                "items": {
+                                                    "type": "string"
+                                                },
+                                                "type": "array",
+                                                "x-kubernetes-list-type": "atomic"
+                                            },
+                                            "topologyKey": {
+                                                "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "topologyKey"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "podAntiAffinity": {
+                            "description": "Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).",
+                            "properties": {
+                                "preferredDuringSchedulingIgnoredDuringExecution": {
+                                    "description": "The scheduler will prefer to schedule pods to nodes that satisfy\nthe anti-affinity expressions specified by this field, but it may choose\na node that violates one or more of the expressions. The node that is\nmost preferred is the one with the greatest sum of weights, i.e.\nfor each node that meets all of the scheduling requirements (resource\nrequest, requiredDuringScheduling anti-affinity expressions, etc.),\ncompute a sum by iterating through the elements of this field and subtracting\n\"weight\" from the sum if the node has pods which matches the corresponding podAffinityTerm; the\nnode(s) with the highest sum are the most preferred.",
+                                    "items": {
+                                        "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                                        "properties": {
+                                            "podAffinityTerm": {
+                                                "description": "Required. A pod affinity term, associated with the corresponding weight.",
+                                                "properties": {
+                                                    "labelSelector": {
+                                                        "description": "A label query over a set of resources, in this case pods.\nIf it's null, this PodAffinityTerm matches with no Pods.",
+                                                        "properties": {
+                                                            "matchExpressions": {
+                                                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                                "items": {
+                                                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                                                    "properties": {
+                                                                        "key": {
+                                                                            "description": "key is the label key that the selector applies to.",
+                                                                            "type": "string"
+                                                                        },
+                                                                        "operator": {
+                                                                            "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                            "type": "string"
+                                                                        },
+                                                                        "values": {
+                                                                            "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                                                            "items": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "type": "array",
+                                                                            "x-kubernetes-list-type": "atomic"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "key",
+                                                                        "operator"
+                                                                    ],
+                                                                    "type": "object",
+                                                                    "additionalProperties": false
+                                                                },
+                                                                "type": "array",
+                                                                "x-kubernetes-list-type": "atomic"
+                                                            },
+                                                            "matchLabels": {
+                                                                "additionalProperties": {
+                                                                    "type": "string"
+                                                                },
+                                                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                                "type": "object"
+                                                            }
+                                                        },
+                                                        "type": "object",
+                                                        "x-kubernetes-map-type": "atomic",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "matchLabelKeys": {
+                                                        "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both matchLabelKeys and labelSelector.\nAlso, matchLabelKeys cannot be set when labelSelector isn't set.",
+                                                        "items": {
+                                                            "type": "string"
+                                                        },
+                                                        "type": "array",
+                                                        "x-kubernetes-list-type": "atomic"
+                                                    },
+                                                    "mismatchLabelKeys": {
+                                                        "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both mismatchLabelKeys and labelSelector.\nAlso, mismatchLabelKeys cannot be set when labelSelector isn't set.",
+                                                        "items": {
+                                                            "type": "string"
+                                                        },
+                                                        "type": "array",
+                                                        "x-kubernetes-list-type": "atomic"
+                                                    },
+                                                    "namespaceSelector": {
+                                                        "description": "A label query over the set of namespaces that the term applies to.\nThe term is applied to the union of the namespaces selected by this field\nand the ones listed in the namespaces field.\nnull selector and null or empty namespaces list means \"this pod's namespace\".\nAn empty selector ({}) matches all namespaces.",
+                                                        "properties": {
+                                                            "matchExpressions": {
+                                                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                                "items": {
+                                                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                                                    "properties": {
+                                                                        "key": {
+                                                                            "description": "key is the label key that the selector applies to.",
+                                                                            "type": "string"
+                                                                        },
+                                                                        "operator": {
+                                                                            "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                            "type": "string"
+                                                                        },
+                                                                        "values": {
+                                                                            "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                                                            "items": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "type": "array",
+                                                                            "x-kubernetes-list-type": "atomic"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "key",
+                                                                        "operator"
+                                                                    ],
+                                                                    "type": "object",
+                                                                    "additionalProperties": false
+                                                                },
+                                                                "type": "array",
+                                                                "x-kubernetes-list-type": "atomic"
+                                                            },
+                                                            "matchLabels": {
+                                                                "additionalProperties": {
+                                                                    "type": "string"
+                                                                },
+                                                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                                "type": "object"
+                                                            }
+                                                        },
+                                                        "type": "object",
+                                                        "x-kubernetes-map-type": "atomic",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "namespaces": {
+                                                        "description": "namespaces specifies a static list of namespace names that the term applies to.\nThe term is applied to the union of the namespaces listed in this field\nand the ones selected by namespaceSelector.\nnull or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                                        "items": {
+                                                            "type": "string"
+                                                        },
+                                                        "type": "array",
+                                                        "x-kubernetes-list-type": "atomic"
+                                                    },
+                                                    "topologyKey": {
+                                                        "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "topologyKey"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "weight": {
+                                                "description": "weight associated with matching the corresponding podAffinityTerm,\nin the range 1-100.",
+                                                "format": "int32",
+                                                "type": "integer",
+                                                "minimum": -2147483648,
+                                                "maximum": 2147483647
+                                            }
+                                        },
+                                        "required": [
+                                            "podAffinityTerm",
+                                            "weight"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
+                                },
+                                "requiredDuringSchedulingIgnoredDuringExecution": {
+                                    "description": "If the anti-affinity requirements specified by this field are not met at\nscheduling time, the pod will not be scheduled onto the node.\nIf the anti-affinity requirements specified by this field cease to be met\nat some point during pod execution (e.g. due to a pod label update), the\nsystem may or may not try to eventually evict the pod from its node.\nWhen there are multiple elements, the lists of nodes corresponding to each\npodAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                                    "items": {
+                                        "description": "Defines a set of pods (namely those matching the labelSelector\nrelative to the given namespace(s)) that this pod should be\nco-located (affinity) or not co-located (anti-affinity) with,\nwhere co-located is defined as running on a node whose value of\nthe label with key <topologyKey> matches that of any node on which\na pod of the set of pods is running",
+                                        "properties": {
+                                            "labelSelector": {
+                                                "description": "A label query over a set of resources, in this case pods.\nIf it's null, this PodAffinityTerm matches with no Pods.",
+                                                "properties": {
+                                                    "matchExpressions": {
+                                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                        "items": {
+                                                            "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                                            "properties": {
+                                                                "key": {
+                                                                    "description": "key is the label key that the selector applies to.",
+                                                                    "type": "string"
+                                                                },
+                                                                "operator": {
+                                                                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                    "type": "string"
+                                                                },
+                                                                "values": {
+                                                                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                                                    "items": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "type": "array",
+                                                                    "x-kubernetes-list-type": "atomic"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "key",
+                                                                "operator"
+                                                            ],
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                        },
+                                                        "type": "array",
+                                                        "x-kubernetes-list-type": "atomic"
+                                                    },
+                                                    "matchLabels": {
+                                                        "additionalProperties": {
+                                                            "type": "string"
+                                                        },
+                                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                        "type": "object"
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "x-kubernetes-map-type": "atomic",
+                                                "additionalProperties": false
+                                            },
+                                            "matchLabelKeys": {
+                                                "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both matchLabelKeys and labelSelector.\nAlso, matchLabelKeys cannot be set when labelSelector isn't set.",
+                                                "items": {
+                                                    "type": "string"
+                                                },
+                                                "type": "array",
+                                                "x-kubernetes-list-type": "atomic"
+                                            },
+                                            "mismatchLabelKeys": {
+                                                "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both mismatchLabelKeys and labelSelector.\nAlso, mismatchLabelKeys cannot be set when labelSelector isn't set.",
+                                                "items": {
+                                                    "type": "string"
+                                                },
+                                                "type": "array",
+                                                "x-kubernetes-list-type": "atomic"
+                                            },
+                                            "namespaceSelector": {
+                                                "description": "A label query over the set of namespaces that the term applies to.\nThe term is applied to the union of the namespaces selected by this field\nand the ones listed in the namespaces field.\nnull selector and null or empty namespaces list means \"this pod's namespace\".\nAn empty selector ({}) matches all namespaces.",
+                                                "properties": {
+                                                    "matchExpressions": {
+                                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                        "items": {
+                                                            "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                                            "properties": {
+                                                                "key": {
+                                                                    "description": "key is the label key that the selector applies to.",
+                                                                    "type": "string"
+                                                                },
+                                                                "operator": {
+                                                                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                    "type": "string"
+                                                                },
+                                                                "values": {
+                                                                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                                                    "items": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "type": "array",
+                                                                    "x-kubernetes-list-type": "atomic"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "key",
+                                                                "operator"
+                                                            ],
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                        },
+                                                        "type": "array",
+                                                        "x-kubernetes-list-type": "atomic"
+                                                    },
+                                                    "matchLabels": {
+                                                        "additionalProperties": {
+                                                            "type": "string"
+                                                        },
+                                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                        "type": "object"
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "x-kubernetes-map-type": "atomic",
+                                                "additionalProperties": false
+                                            },
+                                            "namespaces": {
+                                                "description": "namespaces specifies a static list of namespace names that the term applies to.\nThe term is applied to the union of the namespaces listed in this field\nand the ones selected by namespaceSelector.\nnull or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                                "items": {
+                                                    "type": "string"
+                                                },
+                                                "type": "array",
+                                                "x-kubernetes-list-type": "atomic"
+                                            },
+                                            "topologyKey": {
+                                                "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "topologyKey"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "allowedGroups": {
+                    "description": "Groups allowed to view this RenovateJob when authentication is enabled.\nIf empty or not set, the job is hidden from all users.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "discoverTopics": {
+                    "description": "Topics to discover projects from, will be concatenated using , separator",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "discoveryFilters": {
+                    "description": "Filter to select which projects to process, will be concatenated using , separator",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "dnsPolicy": {
+                    "description": "DNS Policy for the renovate pods",
+                    "type": "string"
+                },
+                "extraEnv": {
+                    "description": "Additional environment variables to set in the renovate container",
+                    "items": {
+                        "description": "EnvVar represents an environment variable present in a Container.",
+                        "properties": {
+                            "name": {
+                                "description": "Name of the environment variable.\nMay consist of any printable ASCII characters except '='.",
+                                "type": "string"
+                            },
+                            "value": {
+                                "description": "Variable references $(VAR_NAME) are expanded\nusing the previously defined environment variables in the container and\nany service environment variables. If a variable cannot be resolved,\nthe reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.\n\"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\".\nEscaped references will never be expanded, regardless of whether the variable\nexists or not.\nDefaults to \"\".",
+                                "type": "string"
+                            },
+                            "valueFrom": {
+                                "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
+                                "properties": {
+                                    "configMapKeyRef": {
+                                        "description": "Selects a key of a ConfigMap.",
+                                        "properties": {
+                                            "key": {
+                                                "description": "The key to select.",
+                                                "type": "string"
+                                            },
+                                            "name": {
+                                                "default": "",
+                                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                "type": "string"
+                                            },
+                                            "optional": {
+                                                "description": "Specify whether the ConfigMap or its key must be defined",
+                                                "type": "boolean"
+                                            }
+                                        },
+                                        "required": [
+                                            "key"
+                                        ],
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic",
+                                        "additionalProperties": false
+                                    },
+                                    "fieldRef": {
+                                        "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,\nspec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
+                                        "properties": {
+                                            "apiVersion": {
+                                                "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                                "type": "string"
+                                            },
+                                            "fieldPath": {
+                                                "description": "Path of the field to select in the specified API version.",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "fieldPath"
+                                        ],
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic",
+                                        "additionalProperties": false
+                                    },
+                                    "fileKeyRef": {
+                                        "description": "FileKeyRef selects a key of the env file.\nRequires the EnvFiles feature gate to be enabled.",
+                                        "properties": {
+                                            "key": {
+                                                "description": "The key within the env file. An invalid key will prevent the pod from starting.\nThe keys defined within a source may consist of any printable ASCII characters except '='.\nDuring Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.",
+                                                "type": "string"
+                                            },
+                                            "optional": {
+                                                "default": false,
+                                                "description": "Specify whether the file or its key must be defined. If the file or key\ndoes not exist, then the env var is not published.\nIf optional is set to true and the specified key does not exist,\nthe environment variable will not be set in the Pod's containers.\n\nIf optional is set to false and the specified key does not exist,\nan error will be returned during Pod creation.",
+                                                "type": "boolean"
+                                            },
+                                            "path": {
+                                                "description": "The path within the volume from which to select the file.\nMust be relative and may not contain the '..' path or start with '..'.",
+                                                "type": "string"
+                                            },
+                                            "volumeName": {
+                                                "description": "The name of the volume mount containing the env file.",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "key",
+                                            "path",
+                                            "volumeName"
+                                        ],
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic",
+                                        "additionalProperties": false
+                                    },
+                                    "resourceFieldRef": {
+                                        "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
+                                        "properties": {
+                                            "containerName": {
+                                                "description": "Container name: required for volumes, optional for env vars",
+                                                "type": "string"
+                                            },
+                                            "divisor": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "integer"
+                                                    },
+                                                    {
+                                                        "type": "string"
+                                                    }
+                                                ],
+                                                "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                                "x-kubernetes-int-or-string": true
+                                            },
+                                            "resource": {
+                                                "description": "Required: resource to select",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "resource"
+                                        ],
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic",
+                                        "additionalProperties": false
+                                    },
+                                    "secretKeyRef": {
+                                        "description": "Selects a key of a secret in the pod's namespace",
+                                        "properties": {
+                                            "key": {
+                                                "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                                "type": "string"
+                                            },
+                                            "name": {
+                                                "default": "",
+                                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                "type": "string"
+                                            },
+                                            "optional": {
+                                                "description": "Specify whether the Secret or its key must be defined",
+                                                "type": "boolean"
+                                            }
+                                        },
+                                        "required": [
+                                            "key"
+                                        ],
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic",
+                                        "additionalProperties": false
+                                    }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                            }
+                        },
+                        "required": [
+                            "name"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "extraEnvFrom": {
+                    "description": "Additional environment variable sources to set in the renovate container",
+                    "items": {
+                        "description": "EnvFromSource represents the source of a set of ConfigMaps or Secrets",
+                        "properties": {
+                            "configMapRef": {
+                                "description": "The ConfigMap to select from",
+                                "properties": {
+                                    "name": {
+                                        "default": "",
+                                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                         "type": "string"
-                                      },
-                                      "operator": {
-                                        "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                    },
+                                    "optional": {
+                                        "description": "Specify whether the ConfigMap must be defined",
+                                        "type": "boolean"
+                                    }
+                                },
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                            },
+                            "prefix": {
+                                "description": "Optional text to prepend to the name of each environment variable.\nMay consist of any printable ASCII characters except '='.",
+                                "type": "string"
+                            },
+                            "secretRef": {
+                                "description": "The Secret to select from",
+                                "properties": {
+                                    "name": {
+                                        "default": "",
+                                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                         "type": "string"
-                                      },
-                                      "values": {
-                                        "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                    },
+                                    "optional": {
+                                        "description": "Specify whether the Secret must be defined",
+                                        "type": "boolean"
+                                    }
+                                },
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "extraVolumeMounts": {
+                    "description": "Additional volume mounts for the renovate pods",
+                    "items": {
+                        "description": "VolumeMount describes a mounting of a Volume within a container.",
+                        "properties": {
+                            "mountPath": {
+                                "description": "Path within the container at which the volume should be mounted.  Must\nnot contain ':'.",
+                                "type": "string"
+                            },
+                            "mountPropagation": {
+                                "description": "mountPropagation determines how mounts are propagated from the host\nto container and the other way around.\nWhen not set, MountPropagationNone is used.\nThis field is beta in 1.10.\nWhen RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified\n(which defaults to None).",
+                                "type": "string"
+                            },
+                            "name": {
+                                "description": "This must match the Name of a Volume.",
+                                "type": "string"
+                            },
+                            "readOnly": {
+                                "description": "Mounted read-only if true, read-write otherwise (false or unspecified).\nDefaults to false.",
+                                "type": "boolean"
+                            },
+                            "recursiveReadOnly": {
+                                "description": "RecursiveReadOnly specifies whether read-only mounts should be handled\nrecursively.\n\nIf ReadOnly is false, this field has no meaning and must be unspecified.\n\nIf ReadOnly is true, and this field is set to Disabled, the mount is not made\nrecursively read-only.  If this field is set to IfPossible, the mount is made\nrecursively read-only, if it is supported by the container runtime.  If this\nfield is set to Enabled, the mount is made recursively read-only if it is\nsupported by the container runtime, otherwise the pod will not be started and\nan error will be generated to indicate the reason.\n\nIf this field is set to IfPossible or Enabled, MountPropagation must be set to\nNone (or be unspecified, which defaults to None).\n\nIf this field is not specified, it is treated as an equivalent of Disabled.",
+                                "type": "string"
+                            },
+                            "subPath": {
+                                "description": "Path within the volume from which the container's volume should be mounted.\nDefaults to \"\" (volume's root).",
+                                "type": "string"
+                            },
+                            "subPathExpr": {
+                                "description": "Expanded path within the volume from which the container's volume should be mounted.\nBehaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.\nDefaults to \"\" (volume's root).\nSubPathExpr and SubPath are mutually exclusive.",
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "mountPath",
+                            "name"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "extraVolumes": {
+                    "description": "Additional volumes to mount in the renovate pods",
+                    "items": {
+                        "description": "Volume represents a named volume in a pod that may be accessed by any container in the pod.",
+                        "properties": {
+                            "awsElasticBlockStore": {
+                                "description": "awsElasticBlockStore represents an AWS Disk resource that is attached to a\nkubelet's host machine and then exposed to the pod.\nDeprecated: AWSElasticBlockStore is deprecated. All operations for the in-tree\nawsElasticBlockStore type are redirected to the ebs.csi.aws.com CSI driver.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                                "properties": {
+                                    "fsType": {
+                                        "description": "fsType is the filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                                        "type": "string"
+                                    },
+                                    "partition": {
+                                        "description": "partition is the partition in the volume that you want to mount.\nIf omitted, the default is to mount by volume name.\nExamples: For volume /dev/sda1, you specify the partition as \"1\".\nSimilarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty).",
+                                        "format": "int32",
+                                        "type": "integer",
+                                        "minimum": -2147483648,
+                                        "maximum": 2147483647
+                                    },
+                                    "readOnly": {
+                                        "description": "readOnly value true will force the readOnly setting in VolumeMounts.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                                        "type": "boolean"
+                                    },
+                                    "volumeID": {
+                                        "description": "volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "volumeID"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "azureDisk": {
+                                "description": "azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.\nDeprecated: AzureDisk is deprecated. All operations for the in-tree azureDisk type\nare redirected to the disk.csi.azure.com CSI driver.",
+                                "properties": {
+                                    "cachingMode": {
+                                        "description": "cachingMode is the Host Caching mode: None, Read Only, Read Write.",
+                                        "type": "string"
+                                    },
+                                    "diskName": {
+                                        "description": "diskName is the Name of the data disk in the blob storage",
+                                        "type": "string"
+                                    },
+                                    "diskURI": {
+                                        "description": "diskURI is the URI of data disk in the blob storage",
+                                        "type": "string"
+                                    },
+                                    "fsType": {
+                                        "default": "ext4",
+                                        "description": "fsType is Filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                                        "type": "string"
+                                    },
+                                    "kind": {
+                                        "description": "kind expected values are Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared",
+                                        "type": "string"
+                                    },
+                                    "readOnly": {
+                                        "default": false,
+                                        "description": "readOnly Defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                                        "type": "boolean"
+                                    }
+                                },
+                                "required": [
+                                    "diskName",
+                                    "diskURI"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "azureFile": {
+                                "description": "azureFile represents an Azure File Service mount on the host and bind mount to the pod.\nDeprecated: AzureFile is deprecated. All operations for the in-tree azureFile type\nare redirected to the file.csi.azure.com CSI driver.",
+                                "properties": {
+                                    "readOnly": {
+                                        "description": "readOnly defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                                        "type": "boolean"
+                                    },
+                                    "secretName": {
+                                        "description": "secretName is the  name of secret that contains Azure Storage Account Name and Key",
+                                        "type": "string"
+                                    },
+                                    "shareName": {
+                                        "description": "shareName is the azure share Name",
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "secretName",
+                                    "shareName"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "cephfs": {
+                                "description": "cephFS represents a Ceph FS mount on the host that shares a pod's lifetime.\nDeprecated: CephFS is deprecated and the in-tree cephfs type is no longer supported.",
+                                "properties": {
+                                    "monitors": {
+                                        "description": "monitors is Required: Monitors is a collection of Ceph monitors\nMore info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
                                         "items": {
-                                          "type": "string"
+                                            "type": "string"
                                         },
                                         "type": "array",
                                         "x-kubernetes-list-type": "atomic"
-                                      }
                                     },
-                                    "required": [
-                                      "key",
-                                      "operator"
-                                    ],
-                                    "type": "object",
-                                    "additionalProperties": false
-                                  },
-                                  "type": "array",
-                                  "x-kubernetes-list-type": "atomic"
-                                },
-                                "matchLabels": {
-                                  "additionalProperties": {
-                                    "type": "string"
-                                  },
-                                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                                  "type": "object"
-                                }
-                              },
-                              "type": "object",
-                              "x-kubernetes-map-type": "atomic",
-                              "additionalProperties": false
-                            },
-                            "name": {
-                              "description": "Select a single ClusterTrustBundle by object name.  Mutually-exclusive\nwith signerName and labelSelector.",
-                              "type": "string"
-                            },
-                            "optional": {
-                              "description": "If true, don't block pod startup if the referenced ClusterTrustBundle(s)\naren't available.  If using name, then the named ClusterTrustBundle is\nallowed not to exist.  If using signerName, then the combination of\nsignerName and labelSelector is allowed to match zero\nClusterTrustBundles.",
-                              "type": "boolean"
-                            },
-                            "path": {
-                              "description": "Relative path from the volume root to write the bundle.",
-                              "type": "string"
-                            },
-                            "signerName": {
-                              "description": "Select all ClusterTrustBundles that match this signer name.\nMutually-exclusive with name.  The contents of all selected\nClusterTrustBundles will be unified and deduplicated.",
-                              "type": "string"
-                            }
-                          },
-                          "required": [
-                            "path"
-                          ],
-                          "type": "object",
-                          "additionalProperties": false
-                        },
-                        "configMap": {
-                          "description": "configMap information about the configMap data to project",
-                          "properties": {
-                            "items": {
-                              "description": "items if unspecified, each key-value pair in the Data field of the referenced\nConfigMap will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the ConfigMap,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
-                              "items": {
-                                "description": "Maps a string key to a path within a volume.",
-                                "properties": {
-                                  "key": {
-                                    "description": "key is the key to project.",
-                                    "type": "string"
-                                  },
-                                  "mode": {
-                                    "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
-                                    "format": "int32",
-                                    "type": "integer"
-                                  },
-                                  "path": {
-                                    "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
-                                    "type": "string"
-                                  }
+                                    "path": {
+                                        "description": "path is Optional: Used as the mounted root, rather than the full Ceph tree, default is /",
+                                        "type": "string"
+                                    },
+                                    "readOnly": {
+                                        "description": "readOnly is Optional: Defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.\nMore info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                                        "type": "boolean"
+                                    },
+                                    "secretFile": {
+                                        "description": "secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret\nMore info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                                        "type": "string"
+                                    },
+                                    "secretRef": {
+                                        "description": "secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.\nMore info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                                        "properties": {
+                                            "name": {
+                                                "default": "",
+                                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic",
+                                        "additionalProperties": false
+                                    },
+                                    "user": {
+                                        "description": "user is optional: User is the rados user name, default is admin\nMore info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                                        "type": "string"
+                                    }
                                 },
                                 "required": [
-                                  "key",
-                                  "path"
+                                    "monitors"
                                 ],
                                 "type": "object",
                                 "additionalProperties": false
-                              },
-                              "type": "array",
-                              "x-kubernetes-list-type": "atomic"
                             },
-                            "name": {
-                              "default": "",
-                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
-                              "type": "string"
-                            },
-                            "optional": {
-                              "description": "optional specify whether the ConfigMap or its keys must be defined",
-                              "type": "boolean"
-                            }
-                          },
-                          "type": "object",
-                          "x-kubernetes-map-type": "atomic",
-                          "additionalProperties": false
-                        },
-                        "downwardAPI": {
-                          "description": "downwardAPI information about the downwardAPI data to project",
-                          "properties": {
-                            "items": {
-                              "description": "Items is a list of DownwardAPIVolume file",
-                              "items": {
-                                "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
+                            "cinder": {
+                                "description": "cinder represents a cinder volume attached and mounted on kubelets host machine.\nDeprecated: Cinder is deprecated. All operations for the in-tree cinder type\nare redirected to the cinder.csi.openstack.org CSI driver.\nMore info: https://examples.k8s.io/mysql-cinder-pd/README.md",
                                 "properties": {
-                                  "fieldRef": {
-                                    "description": "Required: Selects a field of the pod: only annotations, labels, name, namespace and uid are supported.",
-                                    "properties": {
-                                      "apiVersion": {
-                                        "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                    "fsType": {
+                                        "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://examples.k8s.io/mysql-cinder-pd/README.md",
                                         "type": "string"
-                                      },
-                                      "fieldPath": {
-                                        "description": "Path of the field to select in the specified API version.",
-                                        "type": "string"
-                                      }
                                     },
-                                    "required": [
-                                      "fieldPath"
-                                    ],
-                                    "type": "object",
-                                    "x-kubernetes-map-type": "atomic",
-                                    "additionalProperties": false
-                                  },
-                                  "mode": {
-                                    "description": "Optional: mode bits used to set permissions on this file, must be an octal value\nbetween 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
-                                    "format": "int32",
-                                    "type": "integer"
-                                  },
-                                  "path": {
-                                    "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'",
-                                    "type": "string"
-                                  },
-                                  "resourceFieldRef": {
-                                    "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.",
-                                    "properties": {
-                                      "containerName": {
-                                        "description": "Container name: required for volumes, optional for env vars",
+                                    "readOnly": {
+                                        "description": "readOnly defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.\nMore info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                                        "type": "boolean"
+                                    },
+                                    "secretRef": {
+                                        "description": "secretRef is optional: points to a secret object containing parameters used to connect\nto OpenStack.",
+                                        "properties": {
+                                            "name": {
+                                                "default": "",
+                                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic",
+                                        "additionalProperties": false
+                                    },
+                                    "volumeID": {
+                                        "description": "volumeID used to identify the volume in cinder.\nMore info: https://examples.k8s.io/mysql-cinder-pd/README.md",
                                         "type": "string"
-                                      },
-                                      "divisor": {
-                                        "anyOf": [
-                                          {
-                                            "type": "integer"
-                                          },
-                                          {
+                                    }
+                                },
+                                "required": [
+                                    "volumeID"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "configMap": {
+                                "description": "configMap represents a configMap that should populate this volume",
+                                "properties": {
+                                    "defaultMode": {
+                                        "description": "defaultMode is optional: mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nDefaults to 0644.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                        "format": "int32",
+                                        "type": "integer",
+                                        "minimum": -2147483648,
+                                        "maximum": 2147483647
+                                    },
+                                    "items": {
+                                        "description": "items if unspecified, each key-value pair in the Data field of the referenced\nConfigMap will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the ConfigMap,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
+                                        "items": {
+                                            "description": "Maps a string key to a path within a volume.",
+                                            "properties": {
+                                                "key": {
+                                                    "description": "key is the key to project.",
+                                                    "type": "string"
+                                                },
+                                                "mode": {
+                                                    "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                                    "format": "int32",
+                                                    "type": "integer",
+                                                    "minimum": -2147483648,
+                                                    "maximum": 2147483647
+                                                },
+                                                "path": {
+                                                    "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "key",
+                                                "path"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                    },
+                                    "name": {
+                                        "default": "",
+                                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                        "type": "string"
+                                    },
+                                    "optional": {
+                                        "description": "optional specify whether the ConfigMap or its keys must be defined",
+                                        "type": "boolean"
+                                    }
+                                },
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                            },
+                            "csi": {
+                                "description": "csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers.",
+                                "properties": {
+                                    "driver": {
+                                        "description": "driver is the name of the CSI driver that handles this volume.\nConsult with your admin for the correct name as registered in the cluster.",
+                                        "type": "string"
+                                    },
+                                    "fsType": {
+                                        "description": "fsType to mount. Ex. \"ext4\", \"xfs\", \"ntfs\".\nIf not provided, the empty value is passed to the associated CSI driver\nwhich will determine the default filesystem to apply.",
+                                        "type": "string"
+                                    },
+                                    "nodePublishSecretRef": {
+                                        "description": "nodePublishSecretRef is a reference to the secret object containing\nsensitive information to pass to the CSI driver to complete the CSI\nNodePublishVolume and NodeUnpublishVolume calls.\nThis field is optional, and  may be empty if no secret is required. If the\nsecret object contains more than one secret, all secret references are passed.",
+                                        "properties": {
+                                            "name": {
+                                                "default": "",
+                                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic",
+                                        "additionalProperties": false
+                                    },
+                                    "readOnly": {
+                                        "description": "readOnly specifies a read-only configuration for the volume.\nDefaults to false (read/write).",
+                                        "type": "boolean"
+                                    },
+                                    "volumeAttributes": {
+                                        "additionalProperties": {
                                             "type": "string"
-                                          }
+                                        },
+                                        "description": "volumeAttributes stores driver-specific properties that are passed to the CSI\ndriver. Consult your driver's documentation for supported values.",
+                                        "type": "object"
+                                    }
+                                },
+                                "required": [
+                                    "driver"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "downwardAPI": {
+                                "description": "downwardAPI represents downward API about the pod that should populate this volume",
+                                "properties": {
+                                    "defaultMode": {
+                                        "description": "Optional: mode bits to use on created files by default. Must be a\nOptional: mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nDefaults to 0644.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                        "format": "int32",
+                                        "type": "integer",
+                                        "minimum": -2147483648,
+                                        "maximum": 2147483647
+                                    },
+                                    "items": {
+                                        "description": "Items is a list of downward API volume file",
+                                        "items": {
+                                            "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
+                                            "properties": {
+                                                "fieldRef": {
+                                                    "description": "Required: Selects a field of the pod: only annotations, labels, name, namespace and uid are supported.",
+                                                    "properties": {
+                                                        "apiVersion": {
+                                                            "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                                            "type": "string"
+                                                        },
+                                                        "fieldPath": {
+                                                            "description": "Path of the field to select in the specified API version.",
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "fieldPath"
+                                                    ],
+                                                    "type": "object",
+                                                    "x-kubernetes-map-type": "atomic",
+                                                    "additionalProperties": false
+                                                },
+                                                "mode": {
+                                                    "description": "Optional: mode bits used to set permissions on this file, must be an octal value\nbetween 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                                    "format": "int32",
+                                                    "type": "integer",
+                                                    "minimum": -2147483648,
+                                                    "maximum": 2147483647
+                                                },
+                                                "path": {
+                                                    "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'",
+                                                    "type": "string"
+                                                },
+                                                "resourceFieldRef": {
+                                                    "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.",
+                                                    "properties": {
+                                                        "containerName": {
+                                                            "description": "Container name: required for volumes, optional for env vars",
+                                                            "type": "string"
+                                                        },
+                                                        "divisor": {
+                                                            "anyOf": [
+                                                                {
+                                                                    "type": "integer"
+                                                                },
+                                                                {
+                                                                    "type": "string"
+                                                                }
+                                                            ],
+                                                            "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                                            "x-kubernetes-int-or-string": true
+                                                        },
+                                                        "resource": {
+                                                            "description": "Required: resource to select",
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "resource"
+                                                    ],
+                                                    "type": "object",
+                                                    "x-kubernetes-map-type": "atomic",
+                                                    "additionalProperties": false
+                                                }
+                                            },
+                                            "required": [
+                                                "path"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                    }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "emptyDir": {
+                                "description": "emptyDir represents a temporary directory that shares a pod's lifetime.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+                                "properties": {
+                                    "medium": {
+                                        "description": "medium represents what type of storage medium should back this directory.\nThe default is \"\" which means to use the node's default medium.\nMust be an empty string (default) or Memory.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+                                        "type": "string"
+                                    },
+                                    "sizeLimit": {
+                                        "anyOf": [
+                                            {
+                                                "type": "integer"
+                                            },
+                                            {
+                                                "type": "string"
+                                            }
                                         ],
-                                        "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                        "description": "sizeLimit is the total amount of local storage required for this EmptyDir volume.\nThe size limit is also applicable for memory medium.\nThe maximum usage on memory medium EmptyDir would be the minimum value between\nthe SizeLimit specified here and the sum of memory limits of all containers in a pod.\nThe default is nil which means that the limit is undefined.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
                                         "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                                         "x-kubernetes-int-or-string": true
-                                      },
-                                      "resource": {
-                                        "description": "Required: resource to select",
-                                        "type": "string"
-                                      }
-                                    },
-                                    "required": [
-                                      "resource"
-                                    ],
-                                    "type": "object",
-                                    "x-kubernetes-map-type": "atomic",
-                                    "additionalProperties": false
-                                  }
+                                    }
                                 },
-                                "required": [
-                                  "path"
-                                ],
                                 "type": "object",
                                 "additionalProperties": false
-                              },
-                              "type": "array",
-                              "x-kubernetes-list-type": "atomic"
-                            }
-                          },
-                          "type": "object",
-                          "additionalProperties": false
-                        },
-                        "podCertificate": {
-                          "description": "Projects an auto-rotating credential bundle (private key and certificate\nchain) that the pod can use either as a TLS client or server.\n\nKubelet generates a private key and uses it to send a\nPodCertificateRequest to the named signer.  Once the signer approves the\nrequest and issues a certificate chain, Kubelet writes the key and\ncertificate chain to the pod filesystem.  The pod does not start until\ncertificates have been issued for each podCertificate projected volume\nsource in its spec.\n\nKubelet will begin trying to rotate the certificate at the time indicated\nby the signer using the PodCertificateRequest.Status.BeginRefreshAt\ntimestamp.\n\nKubelet can write a single file, indicated by the credentialBundlePath\nfield, or separate files, indicated by the keyPath and\ncertificateChainPath fields.\n\nThe credential bundle is a single file in PEM format.  The first PEM\nentry is the private key (in PKCS#8 format), and the remaining PEM\nentries are the certificate chain issued by the signer (typically,\nsigners will return their certificate chain in leaf-to-root order).\n\nPrefer using the credential bundle format, since your application code\ncan read it atomically.  If you use keyPath and certificateChainPath,\nyour application must make two separate file reads. If these coincide\nwith a certificate rotation, it is possible that the private key and leaf\ncertificate you read may not correspond to each other.  Your application\nwill need to check for this condition, and re-read until they are\nconsistent.\n\nThe named signer controls chooses the format of the certificate it\nissues; consult the signer implementation's documentation to learn how to\nuse the certificates it issues.",
-                          "properties": {
-                            "certificateChainPath": {
-                              "description": "Write the certificate chain at this path in the projected volume.\n\nMost applications should use credentialBundlePath.  When using keyPath\nand certificateChainPath, your application needs to check that the key\nand leaf certificate are consistent, because it is possible to read the\nfiles mid-rotation.",
-                              "type": "string"
                             },
-                            "credentialBundlePath": {
-                              "description": "Write the credential bundle at this path in the projected volume.\n\nThe credential bundle is a single file that contains multiple PEM blocks.\nThe first PEM block is a PRIVATE KEY block, containing a PKCS#8 private\nkey.\n\nThe remaining blocks are CERTIFICATE blocks, containing the issued\ncertificate chain from the signer (leaf and any intermediates).\n\nUsing credentialBundlePath lets your Pod's application code make a single\natomic read that retrieves a consistent key and certificate chain.  If you\nproject them to separate files, your application code will need to\nadditionally check that the leaf certificate was issued to the key.",
-                              "type": "string"
-                            },
-                            "keyPath": {
-                              "description": "Write the key at this path in the projected volume.\n\nMost applications should use credentialBundlePath.  When using keyPath\nand certificateChainPath, your application needs to check that the key\nand leaf certificate are consistent, because it is possible to read the\nfiles mid-rotation.",
-                              "type": "string"
-                            },
-                            "keyType": {
-                              "description": "The type of keypair Kubelet will generate for the pod.\n\nValid values are \"RSA3072\", \"RSA4096\", \"ECDSAP256\", \"ECDSAP384\",\n\"ECDSAP521\", and \"ED25519\".",
-                              "type": "string"
-                            },
-                            "maxExpirationSeconds": {
-                              "description": "maxExpirationSeconds is the maximum lifetime permitted for the\ncertificate.\n\nKubelet copies this value verbatim into the PodCertificateRequests it\ngenerates for this projection.\n\nIf omitted, kube-apiserver will set it to 86400(24 hours). kube-apiserver\nwill reject values shorter than 3600 (1 hour).  The maximum allowable\nvalue is 7862400 (91 days).\n\nThe signer implementation is then free to issue a certificate with any\nlifetime *shorter* than MaxExpirationSeconds, but no shorter than 3600\nseconds (1 hour).  This constraint is enforced by kube-apiserver.\n`kubernetes.io` signers will never issue certificates with a lifetime\nlonger than 24 hours.",
-                              "format": "int32",
-                              "type": "integer"
-                            },
-                            "signerName": {
-                              "description": "Kubelet's generated CSRs will be addressed to this signer.",
-                              "type": "string"
-                            }
-                          },
-                          "required": [
-                            "keyType",
-                            "signerName"
-                          ],
-                          "type": "object",
-                          "additionalProperties": false
-                        },
-                        "secret": {
-                          "description": "secret information about the secret data to project",
-                          "properties": {
-                            "items": {
-                              "description": "items if unspecified, each key-value pair in the Data field of the referenced\nSecret will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the Secret,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
-                              "items": {
-                                "description": "Maps a string key to a path within a volume.",
+                            "ephemeral": {
+                                "description": "ephemeral represents a volume that is handled by a cluster storage driver.\nThe volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,\nand deleted when the pod is removed.\n\nUse this if:\na) the volume is only needed while the pod runs,\nb) features of normal volumes like restoring from snapshot or capacity\n   tracking are needed,\nc) the storage driver is specified through a storage class, and\nd) the storage driver supports dynamic volume provisioning through\n   a PersistentVolumeClaim (see EphemeralVolumeSource for more\n   information on the connection between this volume type\n   and PersistentVolumeClaim).\n\nUse PersistentVolumeClaim or one of the vendor-specific\nAPIs for volumes that persist for longer than the lifecycle\nof an individual pod.\n\nUse CSI for light-weight local ephemeral volumes if the CSI driver is meant to\nbe used that way - see the documentation of the driver for\nmore information.\n\nA pod can use both types of ephemeral volumes and\npersistent volumes at the same time.",
                                 "properties": {
-                                  "key": {
-                                    "description": "key is the key to project.",
-                                    "type": "string"
-                                  },
-                                  "mode": {
-                                    "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
-                                    "format": "int32",
-                                    "type": "integer"
-                                  },
-                                  "path": {
-                                    "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
-                                    "type": "string"
-                                  }
+                                    "volumeClaimTemplate": {
+                                        "description": "Will be used to create a stand-alone PVC to provision the volume.\nThe pod in which this EphemeralVolumeSource is embedded will be the\nowner of the PVC, i.e. the PVC will be deleted together with the\npod.  The name of the PVC will be `<pod name>-<volume name>` where\n`<volume name>` is the name from the `PodSpec.Volumes` array\nentry. Pod validation will reject the pod if the concatenated name\nis not valid for a PVC (for example, too long).\n\nAn existing PVC with that name that is not owned by the pod\nwill *not* be used for the pod to avoid using an unrelated\nvolume by mistake. Starting the pod is then blocked until\nthe unrelated PVC is removed. If such a pre-created PVC is\nmeant to be used by the pod, the PVC has to updated with an\nowner reference to the pod once the pod exists. Normally\nthis should not be necessary, but it may be useful when\nmanually reconstructing a broken cluster.\n\nThis field is read-only and no changes will be made by Kubernetes\nto the PVC after it has been created.\n\nRequired, must not be nil.",
+                                        "properties": {
+                                            "metadata": {
+                                                "description": "May contain labels and annotations that will be copied into the PVC\nwhen creating it. No other fields are allowed and will be rejected during\nvalidation.",
+                                                "type": "object"
+                                            },
+                                            "spec": {
+                                                "description": "The specification for the PersistentVolumeClaim. The entire content is\ncopied unchanged into the PVC that gets created from this\ntemplate. The same fields as in a PersistentVolumeClaim\nare also valid here.",
+                                                "properties": {
+                                                    "accessModes": {
+                                                        "description": "accessModes contains the desired access modes the volume should have.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1",
+                                                        "items": {
+                                                            "type": "string"
+                                                        },
+                                                        "type": "array",
+                                                        "x-kubernetes-list-type": "atomic"
+                                                    },
+                                                    "dataSource": {
+                                                        "description": "dataSource field can be used to specify either:\n* An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)\n* An existing PVC (PersistentVolumeClaim)\nIf the provisioner or an external controller can support the specified data source,\nit will create a new volume based on the contents of the specified data source.\nWhen the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,\nand dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.\nIf the namespace is specified, then dataSourceRef will not be copied to dataSource.",
+                                                        "properties": {
+                                                            "apiGroup": {
+                                                                "description": "APIGroup is the group for the resource being referenced.\nIf APIGroup is not specified, the specified Kind must be in the core API group.\nFor any other third-party types, APIGroup is required.",
+                                                                "type": "string"
+                                                            },
+                                                            "kind": {
+                                                                "description": "Kind is the type of resource being referenced",
+                                                                "type": "string"
+                                                            },
+                                                            "name": {
+                                                                "description": "Name is the name of resource being referenced",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "kind",
+                                                            "name"
+                                                        ],
+                                                        "type": "object",
+                                                        "x-kubernetes-map-type": "atomic",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "dataSourceRef": {
+                                                        "description": "dataSourceRef specifies the object from which to populate the volume with data, if a non-empty\nvolume is desired. This may be any object from a non-empty API group (non\ncore object) or a PersistentVolumeClaim object.\nWhen this field is specified, volume binding will only succeed if the type of\nthe specified object matches some installed volume populator or dynamic\nprovisioner.\nThis field will replace the functionality of the dataSource field and as such\nif both fields are non-empty, they must have the same value. For backwards\ncompatibility, when namespace isn't specified in dataSourceRef,\nboth fields (dataSource and dataSourceRef) will be set to the same\nvalue automatically if one of them is empty and the other is non-empty.\nWhen namespace is specified in dataSourceRef,\ndataSource isn't set to the same value and must be empty.\nThere are three important differences between dataSource and dataSourceRef:\n* While dataSource only allows two specific types of objects, dataSourceRef\n  allows any non-core object, as well as PersistentVolumeClaim objects.\n* While dataSource ignores disallowed values (dropping them), dataSourceRef\n  preserves all values, and generates an error if a disallowed value is\n  specified.\n* While dataSource only allows local objects, dataSourceRef allows objects\n  in any namespaces.\n(Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.\n(Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.",
+                                                        "properties": {
+                                                            "apiGroup": {
+                                                                "description": "APIGroup is the group for the resource being referenced.\nIf APIGroup is not specified, the specified Kind must be in the core API group.\nFor any other third-party types, APIGroup is required.",
+                                                                "type": "string"
+                                                            },
+                                                            "kind": {
+                                                                "description": "Kind is the type of resource being referenced",
+                                                                "type": "string"
+                                                            },
+                                                            "name": {
+                                                                "description": "Name is the name of resource being referenced",
+                                                                "type": "string"
+                                                            },
+                                                            "namespace": {
+                                                                "description": "Namespace is the namespace of resource being referenced\nNote that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.\n(Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "kind",
+                                                            "name"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "resources": {
+                                                        "description": "resources represents the minimum resources the volume should have.\nUsers are allowed to specify resource requirements\nthat are lower than previous value but must still be higher than capacity recorded in the\nstatus field of the claim.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources",
+                                                        "properties": {
+                                                            "limits": {
+                                                                "additionalProperties": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "integer"
+                                                                        },
+                                                                        {
+                                                                            "type": "string"
+                                                                        }
+                                                                    ],
+                                                                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                                                    "x-kubernetes-int-or-string": true
+                                                                },
+                                                                "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                                                "type": "object"
+                                                            },
+                                                            "requests": {
+                                                                "additionalProperties": {
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "type": "integer"
+                                                                        },
+                                                                        {
+                                                                            "type": "string"
+                                                                        }
+                                                                    ],
+                                                                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                                                    "x-kubernetes-int-or-string": true
+                                                                },
+                                                                "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                                                "type": "object"
+                                                            }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "selector": {
+                                                        "description": "selector is a label query over volumes to consider for binding.",
+                                                        "properties": {
+                                                            "matchExpressions": {
+                                                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                                "items": {
+                                                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                                                    "properties": {
+                                                                        "key": {
+                                                                            "description": "key is the label key that the selector applies to.",
+                                                                            "type": "string"
+                                                                        },
+                                                                        "operator": {
+                                                                            "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                            "type": "string"
+                                                                        },
+                                                                        "values": {
+                                                                            "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                                                            "items": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "type": "array",
+                                                                            "x-kubernetes-list-type": "atomic"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "key",
+                                                                        "operator"
+                                                                    ],
+                                                                    "type": "object",
+                                                                    "additionalProperties": false
+                                                                },
+                                                                "type": "array",
+                                                                "x-kubernetes-list-type": "atomic"
+                                                            },
+                                                            "matchLabels": {
+                                                                "additionalProperties": {
+                                                                    "type": "string"
+                                                                },
+                                                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                                "type": "object"
+                                                            }
+                                                        },
+                                                        "type": "object",
+                                                        "x-kubernetes-map-type": "atomic",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "storageClassName": {
+                                                        "description": "storageClassName is the name of the StorageClass required by the claim.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1",
+                                                        "type": "string"
+                                                    },
+                                                    "volumeAttributesClassName": {
+                                                        "description": "volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.\nIf specified, the CSI driver will create or update the volume with the attributes defined\nin the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,\nit can be changed after the claim is created. An empty string or nil value indicates that no\nVolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,\nthis field can be reset to its previous value (including nil) to cancel the modification.\nIf the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be\nset to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource\nexists.\nMore info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/",
+                                                        "type": "string"
+                                                    },
+                                                    "volumeMode": {
+                                                        "description": "volumeMode defines what type of volume is required by the claim.\nValue of Filesystem is implied when not included in claim spec.",
+                                                        "type": "string"
+                                                    },
+                                                    "volumeName": {
+                                                        "description": "volumeName is the binding reference to the PersistentVolume backing this claim.",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            }
+                                        },
+                                        "required": [
+                                            "spec"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "fc": {
+                                "description": "fc represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.",
+                                "properties": {
+                                    "fsType": {
+                                        "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                                        "type": "string"
+                                    },
+                                    "lun": {
+                                        "description": "lun is Optional: FC target lun number",
+                                        "format": "int32",
+                                        "type": "integer",
+                                        "minimum": -2147483648,
+                                        "maximum": 2147483647
+                                    },
+                                    "readOnly": {
+                                        "description": "readOnly is Optional: Defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                                        "type": "boolean"
+                                    },
+                                    "targetWWNs": {
+                                        "description": "targetWWNs is Optional: FC target worldwide names (WWNs)",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                    },
+                                    "wwids": {
+                                        "description": "wwids Optional: FC volume world wide identifiers (wwids)\nEither wwids or combination of targetWWNs and lun must be set, but not both simultaneously.",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                    }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "flexVolume": {
+                                "description": "flexVolume represents a generic volume resource that is\nprovisioned/attached using an exec based plugin.\nDeprecated: FlexVolume is deprecated. Consider using a CSIDriver instead.",
+                                "properties": {
+                                    "driver": {
+                                        "description": "driver is the name of the driver to use for this volume.",
+                                        "type": "string"
+                                    },
+                                    "fsType": {
+                                        "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". The default filesystem depends on FlexVolume script.",
+                                        "type": "string"
+                                    },
+                                    "options": {
+                                        "additionalProperties": {
+                                            "type": "string"
+                                        },
+                                        "description": "options is Optional: this field holds extra command options if any.",
+                                        "type": "object"
+                                    },
+                                    "readOnly": {
+                                        "description": "readOnly is Optional: defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                                        "type": "boolean"
+                                    },
+                                    "secretRef": {
+                                        "description": "secretRef is Optional: secretRef is reference to the secret object containing\nsensitive information to pass to the plugin scripts. This may be\nempty if no secret object is specified. If the secret object\ncontains more than one secret, all secrets are passed to the plugin\nscripts.",
+                                        "properties": {
+                                            "name": {
+                                                "default": "",
+                                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic",
+                                        "additionalProperties": false
+                                    }
                                 },
                                 "required": [
-                                  "key",
-                                  "path"
+                                    "driver"
                                 ],
                                 "type": "object",
                                 "additionalProperties": false
-                              },
-                              "type": "array",
-                              "x-kubernetes-list-type": "atomic"
+                            },
+                            "flocker": {
+                                "description": "flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running.\nDeprecated: Flocker is deprecated and the in-tree flocker type is no longer supported.",
+                                "properties": {
+                                    "datasetName": {
+                                        "description": "datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker\nshould be considered as deprecated",
+                                        "type": "string"
+                                    },
+                                    "datasetUUID": {
+                                        "description": "datasetUUID is the UUID of the dataset. This is unique identifier of a Flocker dataset",
+                                        "type": "string"
+                                    }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "gcePersistentDisk": {
+                                "description": "gcePersistentDisk represents a GCE Disk resource that is attached to a\nkubelet's host machine and then exposed to the pod.\nDeprecated: GCEPersistentDisk is deprecated. All operations for the in-tree\ngcePersistentDisk type are redirected to the pd.csi.storage.gke.io CSI driver.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                                "properties": {
+                                    "fsType": {
+                                        "description": "fsType is filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                                        "type": "string"
+                                    },
+                                    "partition": {
+                                        "description": "partition is the partition in the volume that you want to mount.\nIf omitted, the default is to mount by volume name.\nExamples: For volume /dev/sda1, you specify the partition as \"1\".\nSimilarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty).\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                                        "format": "int32",
+                                        "type": "integer",
+                                        "minimum": -2147483648,
+                                        "maximum": 2147483647
+                                    },
+                                    "pdName": {
+                                        "description": "pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                                        "type": "string"
+                                    },
+                                    "readOnly": {
+                                        "description": "readOnly here will force the ReadOnly setting in VolumeMounts.\nDefaults to false.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                                        "type": "boolean"
+                                    }
+                                },
+                                "required": [
+                                    "pdName"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "gitRepo": {
+                                "description": "gitRepo represents a git repository at a particular revision.\nDeprecated: GitRepo is deprecated. To provision a container with a git repo, mount an\nEmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir\ninto the Pod's container.",
+                                "properties": {
+                                    "directory": {
+                                        "description": "directory is the target directory name.\nMust not contain or start with '..'.  If '.' is supplied, the volume directory will be the\ngit repository.  Otherwise, if specified, the volume will contain the git repository in\nthe subdirectory with the given name.",
+                                        "type": "string"
+                                    },
+                                    "repository": {
+                                        "description": "repository is the URL",
+                                        "type": "string"
+                                    },
+                                    "revision": {
+                                        "description": "revision is the commit hash for the specified revision.",
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "repository"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "glusterfs": {
+                                "description": "glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.\nDeprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.",
+                                "properties": {
+                                    "endpoints": {
+                                        "description": "endpoints is the endpoint name that details Glusterfs topology.",
+                                        "type": "string"
+                                    },
+                                    "path": {
+                                        "description": "path is the Glusterfs volume path.\nMore info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+                                        "type": "string"
+                                    },
+                                    "readOnly": {
+                                        "description": "readOnly here will force the Glusterfs volume to be mounted with read-only permissions.\nDefaults to false.\nMore info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+                                        "type": "boolean"
+                                    }
+                                },
+                                "required": [
+                                    "endpoints",
+                                    "path"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "hostPath": {
+                                "description": "hostPath represents a pre-existing file or directory on the host\nmachine that is directly exposed to the container. This is generally\nused for system agents or other privileged things that are allowed\nto see the host machine. Most containers will NOT need this.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+                                "properties": {
+                                    "path": {
+                                        "description": "path of the directory on the host.\nIf the path is a symlink, it will follow the link to the real path.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+                                        "type": "string"
+                                    },
+                                    "type": {
+                                        "description": "type for HostPath Volume\nDefaults to \"\"\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "path"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "image": {
+                                "description": "image represents an OCI object (a container image or artifact) pulled and mounted on the kubelet's host machine.\nThe volume is resolved at pod startup depending on which PullPolicy value is provided:\n\n- Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.\n- Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.\n- IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.\n\nThe volume gets re-resolved if the pod gets deleted and recreated, which means that new remote content will become available on pod recreation.\nA failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.\nThe types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.\nThe OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.\nThe volume will be mounted read-only (ro) and non-executable files (noexec).\nSub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.\nThe field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.",
+                                "properties": {
+                                    "pullPolicy": {
+                                        "description": "Policy for pulling OCI objects. Possible values are:\nAlways: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.\nNever: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.\nIfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.\nDefaults to Always if :latest tag is specified, or IfNotPresent otherwise.",
+                                        "type": "string"
+                                    },
+                                    "reference": {
+                                        "description": "Required: Image or artifact reference to be used.\nBehaves in the same way as pod.spec.containers[*].image.\nPull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.\nMore info: https://kubernetes.io/docs/concepts/containers/images\nThis field is optional to allow higher level config management to default or override\ncontainer images in workload controllers like Deployments and StatefulSets.",
+                                        "type": "string"
+                                    }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "iscsi": {
+                                "description": "iscsi represents an ISCSI Disk resource that is attached to a\nkubelet's host machine and then exposed to the pod.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes/#iscsi",
+                                "properties": {
+                                    "chapAuthDiscovery": {
+                                        "description": "chapAuthDiscovery defines whether support iSCSI Discovery CHAP authentication",
+                                        "type": "boolean"
+                                    },
+                                    "chapAuthSession": {
+                                        "description": "chapAuthSession defines whether support iSCSI Session CHAP authentication",
+                                        "type": "boolean"
+                                    },
+                                    "fsType": {
+                                        "description": "fsType is the filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi",
+                                        "type": "string"
+                                    },
+                                    "initiatorName": {
+                                        "description": "initiatorName is the custom iSCSI Initiator Name.\nIf initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface\n<target portal>:<volume name> will be created for the connection.",
+                                        "type": "string"
+                                    },
+                                    "iqn": {
+                                        "description": "iqn is the target iSCSI Qualified Name.",
+                                        "type": "string"
+                                    },
+                                    "iscsiInterface": {
+                                        "default": "default",
+                                        "description": "iscsiInterface is the interface Name that uses an iSCSI transport.\nDefaults to 'default' (tcp).",
+                                        "type": "string"
+                                    },
+                                    "lun": {
+                                        "description": "lun represents iSCSI Target Lun number.",
+                                        "format": "int32",
+                                        "type": "integer",
+                                        "minimum": -2147483648,
+                                        "maximum": 2147483647
+                                    },
+                                    "portals": {
+                                        "description": "portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port\nis other than default (typically TCP ports 860 and 3260).",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                    },
+                                    "readOnly": {
+                                        "description": "readOnly here will force the ReadOnly setting in VolumeMounts.\nDefaults to false.",
+                                        "type": "boolean"
+                                    },
+                                    "secretRef": {
+                                        "description": "secretRef is the CHAP Secret for iSCSI target and initiator authentication",
+                                        "properties": {
+                                            "name": {
+                                                "default": "",
+                                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic",
+                                        "additionalProperties": false
+                                    },
+                                    "targetPortal": {
+                                        "description": "targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port\nis other than default (typically TCP ports 860 and 3260).",
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "iqn",
+                                    "lun",
+                                    "targetPortal"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
                             },
                             "name": {
-                              "default": "",
-                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
-                              "type": "string"
+                                "description": "name of the volume.\nMust be a DNS_LABEL and unique within the pod.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                "type": "string"
                             },
-                            "optional": {
-                              "description": "optional field specify whether the Secret or its key must be defined",
-                              "type": "boolean"
+                            "nfs": {
+                                "description": "nfs represents an NFS mount on the host that shares a pod's lifetime\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                                "properties": {
+                                    "path": {
+                                        "description": "path that is exported by the NFS server.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                                        "type": "string"
+                                    },
+                                    "readOnly": {
+                                        "description": "readOnly here will force the NFS export to be mounted with read-only permissions.\nDefaults to false.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                                        "type": "boolean"
+                                    },
+                                    "server": {
+                                        "description": "server is the hostname or IP address of the NFS server.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "path",
+                                    "server"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "persistentVolumeClaim": {
+                                "description": "persistentVolumeClaimVolumeSource represents a reference to a\nPersistentVolumeClaim in the same namespace.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
+                                "properties": {
+                                    "claimName": {
+                                        "description": "claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
+                                        "type": "string"
+                                    },
+                                    "readOnly": {
+                                        "description": "readOnly Will force the ReadOnly setting in VolumeMounts.\nDefault false.",
+                                        "type": "boolean"
+                                    }
+                                },
+                                "required": [
+                                    "claimName"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "photonPersistentDisk": {
+                                "description": "photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine.\nDeprecated: PhotonPersistentDisk is deprecated and the in-tree photonPersistentDisk type is no longer supported.",
+                                "properties": {
+                                    "fsType": {
+                                        "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                                        "type": "string"
+                                    },
+                                    "pdID": {
+                                        "description": "pdID is the ID that identifies Photon Controller persistent disk",
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "pdID"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "portworxVolume": {
+                                "description": "portworxVolume represents a portworx volume attached and mounted on kubelets host machine.\nDeprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type\nare redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate\nis on.",
+                                "properties": {
+                                    "fsType": {
+                                        "description": "fSType represents the filesystem type to mount\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                                        "type": "string"
+                                    },
+                                    "readOnly": {
+                                        "description": "readOnly defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                                        "type": "boolean"
+                                    },
+                                    "volumeID": {
+                                        "description": "volumeID uniquely identifies a Portworx volume",
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "volumeID"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "projected": {
+                                "description": "projected items for all in one resources secrets, configmaps, and downward API",
+                                "properties": {
+                                    "defaultMode": {
+                                        "description": "defaultMode are the mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                        "format": "int32",
+                                        "type": "integer",
+                                        "minimum": -2147483648,
+                                        "maximum": 2147483647
+                                    },
+                                    "sources": {
+                                        "description": "sources is the list of volume projections. Each entry in this list\nhandles one source.",
+                                        "items": {
+                                            "description": "Projection that may be projected along with other supported volume types.\nExactly one of these fields must be set.",
+                                            "properties": {
+                                                "clusterTrustBundle": {
+                                                    "description": "ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field\nof ClusterTrustBundle objects in an auto-updating file.\n\nAlpha, gated by the ClusterTrustBundleProjection feature gate.\n\nClusterTrustBundle objects can either be selected by name, or by the\ncombination of signer name and a label selector.\n\nKubelet performs aggressive normalization of the PEM contents written\ninto the pod filesystem.  Esoteric PEM features such as inter-block\ncomments and block headers are stripped.  Certificates are deduplicated.\nThe ordering of certificates within the file is arbitrary, and Kubelet\nmay change the order over time.",
+                                                    "properties": {
+                                                        "labelSelector": {
+                                                            "description": "Select all ClusterTrustBundles that match this label selector.  Only has\neffect if signerName is set.  Mutually-exclusive with name.  If unset,\ninterpreted as \"match nothing\".  If set but empty, interpreted as \"match\neverything\".",
+                                                            "properties": {
+                                                                "matchExpressions": {
+                                                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                                    "items": {
+                                                                        "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                                                        "properties": {
+                                                                            "key": {
+                                                                                "description": "key is the label key that the selector applies to.",
+                                                                                "type": "string"
+                                                                            },
+                                                                            "operator": {
+                                                                                "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                                "type": "string"
+                                                                            },
+                                                                            "values": {
+                                                                                "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                                                                "items": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "type": "array",
+                                                                                "x-kubernetes-list-type": "atomic"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "key",
+                                                                            "operator"
+                                                                        ],
+                                                                        "type": "object",
+                                                                        "additionalProperties": false
+                                                                    },
+                                                                    "type": "array",
+                                                                    "x-kubernetes-list-type": "atomic"
+                                                                },
+                                                                "matchLabels": {
+                                                                    "additionalProperties": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                                    "type": "object"
+                                                                }
+                                                            },
+                                                            "type": "object",
+                                                            "x-kubernetes-map-type": "atomic",
+                                                            "additionalProperties": false
+                                                        },
+                                                        "name": {
+                                                            "description": "Select a single ClusterTrustBundle by object name.  Mutually-exclusive\nwith signerName and labelSelector.",
+                                                            "type": "string"
+                                                        },
+                                                        "optional": {
+                                                            "description": "If true, don't block pod startup if the referenced ClusterTrustBundle(s)\naren't available.  If using name, then the named ClusterTrustBundle is\nallowed not to exist.  If using signerName, then the combination of\nsignerName and labelSelector is allowed to match zero\nClusterTrustBundles.",
+                                                            "type": "boolean"
+                                                        },
+                                                        "path": {
+                                                            "description": "Relative path from the volume root to write the bundle.",
+                                                            "type": "string"
+                                                        },
+                                                        "signerName": {
+                                                            "description": "Select all ClusterTrustBundles that match this signer name.\nMutually-exclusive with name.  The contents of all selected\nClusterTrustBundles will be unified and deduplicated.",
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "path"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                },
+                                                "configMap": {
+                                                    "description": "configMap information about the configMap data to project",
+                                                    "properties": {
+                                                        "items": {
+                                                            "description": "items if unspecified, each key-value pair in the Data field of the referenced\nConfigMap will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the ConfigMap,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
+                                                            "items": {
+                                                                "description": "Maps a string key to a path within a volume.",
+                                                                "properties": {
+                                                                    "key": {
+                                                                        "description": "key is the key to project.",
+                                                                        "type": "string"
+                                                                    },
+                                                                    "mode": {
+                                                                        "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                                                        "format": "int32",
+                                                                        "type": "integer",
+                                                                        "minimum": -2147483648,
+                                                                        "maximum": 2147483647
+                                                                    },
+                                                                    "path": {
+                                                                        "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
+                                                                        "type": "string"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "key",
+                                                                    "path"
+                                                                ],
+                                                                "type": "object",
+                                                                "additionalProperties": false
+                                                            },
+                                                            "type": "array",
+                                                            "x-kubernetes-list-type": "atomic"
+                                                        },
+                                                        "name": {
+                                                            "default": "",
+                                                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                            "type": "string"
+                                                        },
+                                                        "optional": {
+                                                            "description": "optional specify whether the ConfigMap or its keys must be defined",
+                                                            "type": "boolean"
+                                                        }
+                                                    },
+                                                    "type": "object",
+                                                    "x-kubernetes-map-type": "atomic",
+                                                    "additionalProperties": false
+                                                },
+                                                "downwardAPI": {
+                                                    "description": "downwardAPI information about the downwardAPI data to project",
+                                                    "properties": {
+                                                        "items": {
+                                                            "description": "Items is a list of DownwardAPIVolume file",
+                                                            "items": {
+                                                                "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
+                                                                "properties": {
+                                                                    "fieldRef": {
+                                                                        "description": "Required: Selects a field of the pod: only annotations, labels, name, namespace and uid are supported.",
+                                                                        "properties": {
+                                                                            "apiVersion": {
+                                                                                "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                                                                "type": "string"
+                                                                            },
+                                                                            "fieldPath": {
+                                                                                "description": "Path of the field to select in the specified API version.",
+                                                                                "type": "string"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "fieldPath"
+                                                                        ],
+                                                                        "type": "object",
+                                                                        "x-kubernetes-map-type": "atomic",
+                                                                        "additionalProperties": false
+                                                                    },
+                                                                    "mode": {
+                                                                        "description": "Optional: mode bits used to set permissions on this file, must be an octal value\nbetween 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                                                        "format": "int32",
+                                                                        "type": "integer",
+                                                                        "minimum": -2147483648,
+                                                                        "maximum": 2147483647
+                                                                    },
+                                                                    "path": {
+                                                                        "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'",
+                                                                        "type": "string"
+                                                                    },
+                                                                    "resourceFieldRef": {
+                                                                        "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.",
+                                                                        "properties": {
+                                                                            "containerName": {
+                                                                                "description": "Container name: required for volumes, optional for env vars",
+                                                                                "type": "string"
+                                                                            },
+                                                                            "divisor": {
+                                                                                "anyOf": [
+                                                                                    {
+                                                                                        "type": "integer"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "string"
+                                                                                    }
+                                                                                ],
+                                                                                "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                                                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                                                                "x-kubernetes-int-or-string": true
+                                                                            },
+                                                                            "resource": {
+                                                                                "description": "Required: resource to select",
+                                                                                "type": "string"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "resource"
+                                                                        ],
+                                                                        "type": "object",
+                                                                        "x-kubernetes-map-type": "atomic",
+                                                                        "additionalProperties": false
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "path"
+                                                                ],
+                                                                "type": "object",
+                                                                "additionalProperties": false
+                                                            },
+                                                            "type": "array",
+                                                            "x-kubernetes-list-type": "atomic"
+                                                        }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                },
+                                                "podCertificate": {
+                                                    "description": "Projects an auto-rotating credential bundle (private key and certificate\nchain) that the pod can use either as a TLS client or server.\n\nKubelet generates a private key and uses it to send a\nPodCertificateRequest to the named signer.  Once the signer approves the\nrequest and issues a certificate chain, Kubelet writes the key and\ncertificate chain to the pod filesystem.  The pod does not start until\ncertificates have been issued for each podCertificate projected volume\nsource in its spec.\n\nKubelet will begin trying to rotate the certificate at the time indicated\nby the signer using the PodCertificateRequest.Status.BeginRefreshAt\ntimestamp.\n\nKubelet can write a single file, indicated by the credentialBundlePath\nfield, or separate files, indicated by the keyPath and\ncertificateChainPath fields.\n\nThe credential bundle is a single file in PEM format.  The first PEM\nentry is the private key (in PKCS#8 format), and the remaining PEM\nentries are the certificate chain issued by the signer (typically,\nsigners will return their certificate chain in leaf-to-root order).\n\nPrefer using the credential bundle format, since your application code\ncan read it atomically.  If you use keyPath and certificateChainPath,\nyour application must make two separate file reads. If these coincide\nwith a certificate rotation, it is possible that the private key and leaf\ncertificate you read may not correspond to each other.  Your application\nwill need to check for this condition, and re-read until they are\nconsistent.\n\nThe named signer controls chooses the format of the certificate it\nissues; consult the signer implementation's documentation to learn how to\nuse the certificates it issues.",
+                                                    "properties": {
+                                                        "certificateChainPath": {
+                                                            "description": "Write the certificate chain at this path in the projected volume.\n\nMost applications should use credentialBundlePath.  When using keyPath\nand certificateChainPath, your application needs to check that the key\nand leaf certificate are consistent, because it is possible to read the\nfiles mid-rotation.",
+                                                            "type": "string"
+                                                        },
+                                                        "credentialBundlePath": {
+                                                            "description": "Write the credential bundle at this path in the projected volume.\n\nThe credential bundle is a single file that contains multiple PEM blocks.\nThe first PEM block is a PRIVATE KEY block, containing a PKCS#8 private\nkey.\n\nThe remaining blocks are CERTIFICATE blocks, containing the issued\ncertificate chain from the signer (leaf and any intermediates).\n\nUsing credentialBundlePath lets your Pod's application code make a single\natomic read that retrieves a consistent key and certificate chain.  If you\nproject them to separate files, your application code will need to\nadditionally check that the leaf certificate was issued to the key.",
+                                                            "type": "string"
+                                                        },
+                                                        "keyPath": {
+                                                            "description": "Write the key at this path in the projected volume.\n\nMost applications should use credentialBundlePath.  When using keyPath\nand certificateChainPath, your application needs to check that the key\nand leaf certificate are consistent, because it is possible to read the\nfiles mid-rotation.",
+                                                            "type": "string"
+                                                        },
+                                                        "keyType": {
+                                                            "description": "The type of keypair Kubelet will generate for the pod.\n\nValid values are \"RSA3072\", \"RSA4096\", \"ECDSAP256\", \"ECDSAP384\",\n\"ECDSAP521\", and \"ED25519\".",
+                                                            "type": "string"
+                                                        },
+                                                        "maxExpirationSeconds": {
+                                                            "description": "maxExpirationSeconds is the maximum lifetime permitted for the\ncertificate.\n\nKubelet copies this value verbatim into the PodCertificateRequests it\ngenerates for this projection.\n\nIf omitted, kube-apiserver will set it to 86400(24 hours). kube-apiserver\nwill reject values shorter than 3600 (1 hour).  The maximum allowable\nvalue is 7862400 (91 days).\n\nThe signer implementation is then free to issue a certificate with any\nlifetime *shorter* than MaxExpirationSeconds, but no shorter than 3600\nseconds (1 hour).  This constraint is enforced by kube-apiserver.\n`kubernetes.io` signers will never issue certificates with a lifetime\nlonger than 24 hours.",
+                                                            "format": "int32",
+                                                            "type": "integer",
+                                                            "minimum": -2147483648,
+                                                            "maximum": 2147483647
+                                                        },
+                                                        "signerName": {
+                                                            "description": "Kubelet's generated CSRs will be addressed to this signer.",
+                                                            "type": "string"
+                                                        },
+                                                        "userAnnotations": {
+                                                            "additionalProperties": {
+                                                                "type": "string"
+                                                            },
+                                                            "description": "userAnnotations allow pod authors to pass additional information to\nthe signer implementation.  Kubernetes does not restrict or validate this\nmetadata in any way.\n\nThese values are copied verbatim into the `spec.unverifiedUserAnnotations` field of\nthe PodCertificateRequest objects that Kubelet creates.\n\nEntries are subject to the same validation as object metadata annotations,\nwith the addition that all keys must be domain-prefixed. No restrictions\nare placed on values, except an overall size limitation on the entire field.\n\nSigners should document the keys and values they support. Signers should\ndeny requests that contain keys they do not recognize.",
+                                                            "type": "object"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "keyType",
+                                                        "signerName"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                },
+                                                "secret": {
+                                                    "description": "secret information about the secret data to project",
+                                                    "properties": {
+                                                        "items": {
+                                                            "description": "items if unspecified, each key-value pair in the Data field of the referenced\nSecret will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the Secret,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
+                                                            "items": {
+                                                                "description": "Maps a string key to a path within a volume.",
+                                                                "properties": {
+                                                                    "key": {
+                                                                        "description": "key is the key to project.",
+                                                                        "type": "string"
+                                                                    },
+                                                                    "mode": {
+                                                                        "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                                                        "format": "int32",
+                                                                        "type": "integer",
+                                                                        "minimum": -2147483648,
+                                                                        "maximum": 2147483647
+                                                                    },
+                                                                    "path": {
+                                                                        "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
+                                                                        "type": "string"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "key",
+                                                                    "path"
+                                                                ],
+                                                                "type": "object",
+                                                                "additionalProperties": false
+                                                            },
+                                                            "type": "array",
+                                                            "x-kubernetes-list-type": "atomic"
+                                                        },
+                                                        "name": {
+                                                            "default": "",
+                                                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                            "type": "string"
+                                                        },
+                                                        "optional": {
+                                                            "description": "optional field specify whether the Secret or its key must be defined",
+                                                            "type": "boolean"
+                                                        }
+                                                    },
+                                                    "type": "object",
+                                                    "x-kubernetes-map-type": "atomic",
+                                                    "additionalProperties": false
+                                                },
+                                                "serviceAccountToken": {
+                                                    "description": "serviceAccountToken is information about the serviceAccountToken data to project",
+                                                    "properties": {
+                                                        "audience": {
+                                                            "description": "audience is the intended audience of the token. A recipient of a token\nmust identify itself with an identifier specified in the audience of the\ntoken, and otherwise should reject the token. The audience defaults to the\nidentifier of the apiserver.",
+                                                            "type": "string"
+                                                        },
+                                                        "expirationSeconds": {
+                                                            "description": "expirationSeconds is the requested duration of validity of the service\naccount token. As the token approaches expiration, the kubelet volume\nplugin will proactively rotate the service account token. The kubelet will\nstart trying to rotate the token if the token is older than 80 percent of\nits time to live or if the token is older than 24 hours.Defaults to 1 hour\nand must be at least 10 minutes.",
+                                                            "format": "int64",
+                                                            "type": "integer",
+                                                            "minimum": -9223372036854776000,
+                                                            "maximum": 9223372036854776000
+                                                        },
+                                                        "path": {
+                                                            "description": "path is the path relative to the mount point of the file to project the\ntoken into.",
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "path"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                    }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "quobyte": {
+                                "description": "quobyte represents a Quobyte mount on the host that shares a pod's lifetime.\nDeprecated: Quobyte is deprecated and the in-tree quobyte type is no longer supported.",
+                                "properties": {
+                                    "group": {
+                                        "description": "group to map volume access to\nDefault is no group",
+                                        "type": "string"
+                                    },
+                                    "readOnly": {
+                                        "description": "readOnly here will force the Quobyte volume to be mounted with read-only permissions.\nDefaults to false.",
+                                        "type": "boolean"
+                                    },
+                                    "registry": {
+                                        "description": "registry represents a single or multiple Quobyte Registry services\nspecified as a string as host:port pair (multiple entries are separated with commas)\nwhich acts as the central registry for volumes",
+                                        "type": "string"
+                                    },
+                                    "tenant": {
+                                        "description": "tenant owning the given Quobyte volume in the Backend\nUsed with dynamically provisioned Quobyte volumes, value is set by the plugin",
+                                        "type": "string"
+                                    },
+                                    "user": {
+                                        "description": "user to map volume access to\nDefaults to serivceaccount user",
+                                        "type": "string"
+                                    },
+                                    "volume": {
+                                        "description": "volume is a string that references an already created Quobyte volume by name.",
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "registry",
+                                    "volume"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "rbd": {
+                                "description": "rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.\nDeprecated: RBD is deprecated and the in-tree rbd type is no longer supported.",
+                                "properties": {
+                                    "fsType": {
+                                        "description": "fsType is the filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#rbd",
+                                        "type": "string"
+                                    },
+                                    "image": {
+                                        "description": "image is the rados image name.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                                        "type": "string"
+                                    },
+                                    "keyring": {
+                                        "default": "/etc/ceph/keyring",
+                                        "description": "keyring is the path to key ring for RBDUser.\nDefault is /etc/ceph/keyring.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                                        "type": "string"
+                                    },
+                                    "monitors": {
+                                        "description": "monitors is a collection of Ceph monitors.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                    },
+                                    "pool": {
+                                        "default": "rbd",
+                                        "description": "pool is the rados pool name.\nDefault is rbd.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                                        "type": "string"
+                                    },
+                                    "readOnly": {
+                                        "description": "readOnly here will force the ReadOnly setting in VolumeMounts.\nDefaults to false.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                                        "type": "boolean"
+                                    },
+                                    "secretRef": {
+                                        "description": "secretRef is name of the authentication secret for RBDUser. If provided\noverrides keyring.\nDefault is nil.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                                        "properties": {
+                                            "name": {
+                                                "default": "",
+                                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic",
+                                        "additionalProperties": false
+                                    },
+                                    "user": {
+                                        "default": "admin",
+                                        "description": "user is the rados user name.\nDefault is admin.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "image",
+                                    "monitors"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "scaleIO": {
+                                "description": "scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.\nDeprecated: ScaleIO is deprecated and the in-tree scaleIO type is no longer supported.",
+                                "properties": {
+                                    "fsType": {
+                                        "default": "xfs",
+                                        "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\".\nDefault is \"xfs\".",
+                                        "type": "string"
+                                    },
+                                    "gateway": {
+                                        "description": "gateway is the host address of the ScaleIO API Gateway.",
+                                        "type": "string"
+                                    },
+                                    "protectionDomain": {
+                                        "description": "protectionDomain is the name of the ScaleIO Protection Domain for the configured storage.",
+                                        "type": "string"
+                                    },
+                                    "readOnly": {
+                                        "description": "readOnly Defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                                        "type": "boolean"
+                                    },
+                                    "secretRef": {
+                                        "description": "secretRef references to the secret for ScaleIO user and other\nsensitive information. If this is not provided, Login operation will fail.",
+                                        "properties": {
+                                            "name": {
+                                                "default": "",
+                                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic",
+                                        "additionalProperties": false
+                                    },
+                                    "sslEnabled": {
+                                        "description": "sslEnabled Flag enable/disable SSL communication with Gateway, default false",
+                                        "type": "boolean"
+                                    },
+                                    "storageMode": {
+                                        "default": "ThinProvisioned",
+                                        "description": "storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.\nDefault is ThinProvisioned.",
+                                        "type": "string"
+                                    },
+                                    "storagePool": {
+                                        "description": "storagePool is the ScaleIO Storage Pool associated with the protection domain.",
+                                        "type": "string"
+                                    },
+                                    "system": {
+                                        "description": "system is the name of the storage system as configured in ScaleIO.",
+                                        "type": "string"
+                                    },
+                                    "volumeName": {
+                                        "description": "volumeName is the name of a volume already created in the ScaleIO system\nthat is associated with this volume source.",
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "gateway",
+                                    "secretRef",
+                                    "system"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "secret": {
+                                "description": "secret represents a secret that should populate this volume.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
+                                "properties": {
+                                    "defaultMode": {
+                                        "description": "defaultMode is Optional: mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values\nfor mode bits. Defaults to 0644.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                        "format": "int32",
+                                        "type": "integer",
+                                        "minimum": -2147483648,
+                                        "maximum": 2147483647
+                                    },
+                                    "items": {
+                                        "description": "items If unspecified, each key-value pair in the Data field of the referenced\nSecret will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the Secret,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
+                                        "items": {
+                                            "description": "Maps a string key to a path within a volume.",
+                                            "properties": {
+                                                "key": {
+                                                    "description": "key is the key to project.",
+                                                    "type": "string"
+                                                },
+                                                "mode": {
+                                                    "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                                    "format": "int32",
+                                                    "type": "integer",
+                                                    "minimum": -2147483648,
+                                                    "maximum": 2147483647
+                                                },
+                                                "path": {
+                                                    "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "key",
+                                                "path"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                    },
+                                    "optional": {
+                                        "description": "optional field specify whether the Secret or its keys must be defined",
+                                        "type": "boolean"
+                                    },
+                                    "secretName": {
+                                        "description": "secretName is the name of the secret in the pod's namespace to use.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
+                                        "type": "string"
+                                    }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "storageos": {
+                                "description": "storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.\nDeprecated: StorageOS is deprecated and the in-tree storageos type is no longer supported.",
+                                "properties": {
+                                    "fsType": {
+                                        "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                                        "type": "string"
+                                    },
+                                    "readOnly": {
+                                        "description": "readOnly defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                                        "type": "boolean"
+                                    },
+                                    "secretRef": {
+                                        "description": "secretRef specifies the secret to use for obtaining the StorageOS API\ncredentials.  If not specified, default values will be attempted.",
+                                        "properties": {
+                                            "name": {
+                                                "default": "",
+                                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic",
+                                        "additionalProperties": false
+                                    },
+                                    "volumeName": {
+                                        "description": "volumeName is the human-readable name of the StorageOS volume.  Volume\nnames are only unique within a namespace.",
+                                        "type": "string"
+                                    },
+                                    "volumeNamespace": {
+                                        "description": "volumeNamespace specifies the scope of the volume within StorageOS.  If no\nnamespace is specified then the Pod's namespace will be used.  This allows the\nKubernetes name scoping to be mirrored within StorageOS for tighter integration.\nSet VolumeName to any name to override the default behaviour.\nSet to \"default\" if you are not using namespaces within StorageOS.\nNamespaces that do not pre-exist within StorageOS will be created.",
+                                        "type": "string"
+                                    }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "vsphereVolume": {
+                                "description": "vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine.\nDeprecated: VsphereVolume is deprecated. All operations for the in-tree vsphereVolume type\nare redirected to the csi.vsphere.vmware.com CSI driver.",
+                                "properties": {
+                                    "fsType": {
+                                        "description": "fsType is filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                                        "type": "string"
+                                    },
+                                    "storagePolicyID": {
+                                        "description": "storagePolicyID is the storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.",
+                                        "type": "string"
+                                    },
+                                    "storagePolicyName": {
+                                        "description": "storagePolicyName is the storage Policy Based Management (SPBM) profile name.",
+                                        "type": "string"
+                                    },
+                                    "volumePath": {
+                                        "description": "volumePath is the path that identifies vSphere volume vmdk",
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "volumePath"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
                             }
-                          },
-                          "type": "object",
-                          "x-kubernetes-map-type": "atomic",
-                          "additionalProperties": false
                         },
-                        "serviceAccountToken": {
-                          "description": "serviceAccountToken is information about the serviceAccountToken data to project",
-                          "properties": {
-                            "audience": {
-                              "description": "audience is the intended audience of the token. A recipient of a token\nmust identify itself with an identifier specified in the audience of the\ntoken, and otherwise should reject the token. The audience defaults to the\nidentifier of the apiserver.",
-                              "type": "string"
-                            },
-                            "expirationSeconds": {
-                              "description": "expirationSeconds is the requested duration of validity of the service\naccount token. As the token approaches expiration, the kubelet volume\nplugin will proactively rotate the service account token. The kubelet will\nstart trying to rotate the token if the token is older than 80 percent of\nits time to live or if the token is older than 24 hours.Defaults to 1 hour\nand must be at least 10 minutes.",
-                              "format": "int64",
-                              "type": "integer"
-                            },
-                            "path": {
-                              "description": "path is the path relative to the mount point of the file to project the\ntoken into.",
-                              "type": "string"
-                            }
-                          },
-                          "required": [
-                            "path"
-                          ],
-                          "type": "object",
-                          "additionalProperties": false
-                        }
-                      },
-                      "type": "object",
-                      "additionalProperties": false
+                        "required": [
+                            "name"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
                     },
-                    "type": "array",
-                    "x-kubernetes-list-type": "atomic"
-                  }
+                    "type": "array"
                 },
-                "type": "object",
-                "additionalProperties": false
-              },
-              "quobyte": {
-                "description": "quobyte represents a Quobyte mount on the host that shares a pod's lifetime.\nDeprecated: Quobyte is deprecated and the in-tree quobyte type is no longer supported.",
-                "properties": {
-                  "group": {
-                    "description": "group to map volume access to\nDefault is no group",
+                "image": {
+                    "description": "Renovate Docker image to use",
                     "type": "string"
-                  },
-                  "readOnly": {
-                    "description": "readOnly here will force the Quobyte volume to be mounted with read-only permissions.\nDefaults to false.",
-                    "type": "boolean"
-                  },
-                  "registry": {
-                    "description": "registry represents a single or multiple Quobyte Registry services\nspecified as a string as host:port pair (multiple entries are separated with commas)\nwhich acts as the central registry for volumes",
-                    "type": "string"
-                  },
-                  "tenant": {
-                    "description": "tenant owning the given Quobyte volume in the Backend\nUsed with dynamically provisioned Quobyte volumes, value is set by the plugin",
-                    "type": "string"
-                  },
-                  "user": {
-                    "description": "user to map volume access to\nDefaults to serivceaccount user",
-                    "type": "string"
-                  },
-                  "volume": {
-                    "description": "volume is a string that references an already created Quobyte volume by name.",
-                    "type": "string"
-                  }
                 },
-                "required": [
-                  "registry",
-                  "volume"
-                ],
-                "type": "object",
-                "additionalProperties": false
-              },
-              "rbd": {
-                "description": "rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.\nDeprecated: RBD is deprecated and the in-tree rbd type is no longer supported.",
-                "properties": {
-                  "fsType": {
-                    "description": "fsType is the filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#rbd",
-                    "type": "string"
-                  },
-                  "image": {
-                    "description": "image is the rados image name.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
-                    "type": "string"
-                  },
-                  "keyring": {
-                    "default": "/etc/ceph/keyring",
-                    "description": "keyring is the path to key ring for RBDUser.\nDefault is /etc/ceph/keyring.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
-                    "type": "string"
-                  },
-                  "monitors": {
-                    "description": "monitors is a collection of Ceph monitors.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                "imagePullSecrets": {
+                    "description": "Image pull secrets for the renovate pods",
                     "items": {
-                      "type": "string"
+                        "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
+                        "properties": {
+                            "name": {
+                                "default": "",
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
                     },
-                    "type": "array",
-                    "x-kubernetes-list-type": "atomic"
-                  },
-                  "pool": {
-                    "default": "rbd",
-                    "description": "pool is the rados pool name.\nDefault is rbd.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
-                    "type": "string"
-                  },
-                  "readOnly": {
-                    "description": "readOnly here will force the ReadOnly setting in VolumeMounts.\nDefaults to false.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
-                    "type": "boolean"
-                  },
-                  "secretRef": {
-                    "description": "secretRef is name of the authentication secret for RBDUser. If provided\noverrides keyring.\nDefault is nil.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                    "type": "array"
+                },
+                "metadata": {
+                    "description": "Metadata that shall be applied to the resulting pod",
                     "properties": {
-                      "name": {
-                        "default": "",
-                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
-                        "type": "string"
-                      }
+                        "annotations": {
+                            "additionalProperties": {
+                                "type": "string"
+                            },
+                            "type": "object"
+                        },
+                        "labels": {
+                            "additionalProperties": {
+                                "type": "string"
+                            },
+                            "type": "object"
+                        }
                     },
                     "type": "object",
-                    "x-kubernetes-map-type": "atomic",
                     "additionalProperties": false
-                  },
-                  "user": {
-                    "default": "admin",
-                    "description": "user is the rados user name.\nDefault is admin.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
-                    "type": "string"
-                  }
                 },
-                "required": [
-                  "image",
-                  "monitors"
-                ],
-                "type": "object",
-                "additionalProperties": false
-              },
-              "scaleIO": {
-                "description": "scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.\nDeprecated: ScaleIO is deprecated and the in-tree scaleIO type is no longer supported.",
-                "properties": {
-                  "fsType": {
-                    "default": "xfs",
-                    "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\".\nDefault is \"xfs\".",
-                    "type": "string"
-                  },
-                  "gateway": {
-                    "description": "gateway is the host address of the ScaleIO API Gateway.",
-                    "type": "string"
-                  },
-                  "protectionDomain": {
-                    "description": "protectionDomain is the name of the ScaleIO Protection Domain for the configured storage.",
-                    "type": "string"
-                  },
-                  "readOnly": {
-                    "description": "readOnly Defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
-                    "type": "boolean"
-                  },
-                  "secretRef": {
-                    "description": "secretRef references to the secret for ScaleIO user and other\nsensitive information. If this is not provided, Login operation will fail.",
-                    "properties": {
-                      "name": {
-                        "default": "",
-                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                "nodeSelector": {
+                    "additionalProperties": {
                         "type": "string"
-                      }
                     },
-                    "type": "object",
-                    "x-kubernetes-map-type": "atomic",
-                    "additionalProperties": false
-                  },
-                  "sslEnabled": {
-                    "description": "sslEnabled Flag enable/disable SSL communication with Gateway, default false",
-                    "type": "boolean"
-                  },
-                  "storageMode": {
-                    "default": "ThinProvisioned",
-                    "description": "storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.\nDefault is ThinProvisioned.",
-                    "type": "string"
-                  },
-                  "storagePool": {
-                    "description": "storagePool is the ScaleIO Storage Pool associated with the protection domain.",
-                    "type": "string"
-                  },
-                  "system": {
-                    "description": "system is the name of the storage system as configured in ScaleIO.",
-                    "type": "string"
-                  },
-                  "volumeName": {
-                    "description": "volumeName is the name of a volume already created in the ScaleIO system\nthat is associated with this volume source.",
-                    "type": "string"
-                  }
+                    "description": "Node selector for scheduling the resulting pod",
+                    "type": "object"
                 },
-                "required": [
-                  "gateway",
-                  "secretRef",
-                  "system"
-                ],
-                "type": "object",
-                "additionalProperties": false
-              },
-              "secret": {
-                "description": "secret represents a secret that should populate this volume.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
-                "properties": {
-                  "defaultMode": {
-                    "description": "defaultMode is Optional: mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values\nfor mode bits. Defaults to 0644.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                "parallelism": {
+                    "description": "Maximum number of projects to process in parallel",
                     "format": "int32",
-                    "type": "integer"
-                  },
-                  "items": {
-                    "description": "items If unspecified, each key-value pair in the Data field of the referenced\nSecret will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the Secret,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
-                    "items": {
-                      "description": "Maps a string key to a path within a volume.",
-                      "properties": {
-                        "key": {
-                          "description": "key is the key to project.",
-                          "type": "string"
+                    "type": "integer",
+                    "minimum": -2147483648,
+                    "maximum": 2147483647
+                },
+                "provider": {
+                    "description": "Renovate Provider Information to fill \"RENOVATE_ENDPOINT\" and \"RENOVATE_PLATFORM\" environment variables in the renovate container",
+                    "properties": {
+                        "endpoint": {
+                            "type": "string"
                         },
-                        "mode": {
-                          "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
-                          "format": "int32",
-                          "type": "integer"
-                        },
-                        "path": {
-                          "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
-                          "type": "string"
+                        "name": {
+                            "type": "string"
                         }
-                      },
-                      "required": [
-                        "key",
-                        "path"
-                      ],
-                      "type": "object",
-                      "additionalProperties": false
-                    },
-                    "type": "array",
-                    "x-kubernetes-list-type": "atomic"
-                  },
-                  "optional": {
-                    "description": "optional field specify whether the Secret or its keys must be defined",
-                    "type": "boolean"
-                  },
-                  "secretName": {
-                    "description": "secretName is the name of the secret in the pod's namespace to use.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
-                    "type": "string"
-                  }
-                },
-                "type": "object",
-                "additionalProperties": false
-              },
-              "storageos": {
-                "description": "storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.\nDeprecated: StorageOS is deprecated and the in-tree storageos type is no longer supported.",
-                "properties": {
-                  "fsType": {
-                    "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
-                    "type": "string"
-                  },
-                  "readOnly": {
-                    "description": "readOnly defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
-                    "type": "boolean"
-                  },
-                  "secretRef": {
-                    "description": "secretRef specifies the secret to use for obtaining the StorageOS API\ncredentials.  If not specified, default values will be attempted.",
-                    "properties": {
-                      "name": {
-                        "default": "",
-                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
-                        "type": "string"
-                      }
-                    },
-                    "type": "object",
-                    "x-kubernetes-map-type": "atomic",
-                    "additionalProperties": false
-                  },
-                  "volumeName": {
-                    "description": "volumeName is the human-readable name of the StorageOS volume.  Volume\nnames are only unique within a namespace.",
-                    "type": "string"
-                  },
-                  "volumeNamespace": {
-                    "description": "volumeNamespace specifies the scope of the volume within StorageOS.  If no\nnamespace is specified then the Pod's namespace will be used.  This allows the\nKubernetes name scoping to be mirrored within StorageOS for tighter integration.\nSet VolumeName to any name to override the default behaviour.\nSet to \"default\" if you are not using namespaces within StorageOS.\nNamespaces that do not pre-exist within StorageOS will be created.",
-                    "type": "string"
-                  }
-                },
-                "type": "object",
-                "additionalProperties": false
-              },
-              "vsphereVolume": {
-                "description": "vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine.\nDeprecated: VsphereVolume is deprecated. All operations for the in-tree vsphereVolume type\nare redirected to the csi.vsphere.vmware.com CSI driver.",
-                "properties": {
-                  "fsType": {
-                    "description": "fsType is filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
-                    "type": "string"
-                  },
-                  "storagePolicyID": {
-                    "description": "storagePolicyID is the storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.",
-                    "type": "string"
-                  },
-                  "storagePolicyName": {
-                    "description": "storagePolicyName is the storage Policy Based Management (SPBM) profile name.",
-                    "type": "string"
-                  },
-                  "volumePath": {
-                    "description": "volumePath is the path that identifies vSphere volume vmdk",
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "volumePath"
-                ],
-                "type": "object",
-                "additionalProperties": false
-              }
-            },
-            "required": [
-              "name"
-            ],
-            "type": "object",
-            "additionalProperties": false
-          },
-          "type": "array"
-        },
-        "image": {
-          "description": "Renovate Docker image to use",
-          "type": "string"
-        },
-        "imagePullSecrets": {
-          "description": "Image pull secrets for the renovate pods",
-          "items": {
-            "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
-            "properties": {
-              "name": {
-                "default": "",
-                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
-                "type": "string"
-              }
-            },
-            "type": "object",
-            "x-kubernetes-map-type": "atomic",
-            "additionalProperties": false
-          },
-          "type": "array"
-        },
-        "metadata": {
-          "description": "Metadata that shall be applied to the resulting pod",
-          "properties": {
-            "annotations": {
-              "additionalProperties": {
-                "type": "string"
-              },
-              "type": "object"
-            },
-            "labels": {
-              "additionalProperties": {
-                "type": "string"
-              },
-              "type": "object"
-            }
-          },
-          "type": "object",
-          "additionalProperties": false
-        },
-        "nodeSelector": {
-          "additionalProperties": {
-            "type": "string"
-          },
-          "description": "Node selector for scheduling the resulting pod",
-          "type": "object"
-        },
-        "parallelism": {
-          "description": "Maximum number of projects to process in parallel",
-          "format": "int32",
-          "type": "integer"
-        },
-        "resources": {
-          "description": "Resource requirements for the renovate container",
-          "properties": {
-            "claims": {
-              "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis field depends on the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
-              "items": {
-                "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
-                "properties": {
-                  "name": {
-                    "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
-                    "type": "string"
-                  },
-                  "request": {
-                    "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "name"
-                ],
-                "type": "object",
-                "additionalProperties": false
-              },
-              "type": "array",
-              "x-kubernetes-list-map-keys": [
-                "name"
-              ],
-              "x-kubernetes-list-type": "map"
-            },
-            "limits": {
-              "additionalProperties": {
-                "anyOf": [
-                  {
-                    "type": "integer"
-                  },
-                  {
-                    "type": "string"
-                  }
-                ],
-                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
-                "x-kubernetes-int-or-string": true
-              },
-              "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
-              "type": "object"
-            },
-            "requests": {
-              "additionalProperties": {
-                "anyOf": [
-                  {
-                    "type": "integer"
-                  },
-                  {
-                    "type": "string"
-                  }
-                ],
-                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
-                "x-kubernetes-int-or-string": true
-              },
-              "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
-              "type": "object"
-            }
-          },
-          "type": "object",
-          "additionalProperties": false
-        },
-        "schedule": {
-          "description": "Cron schedule in standard cron format",
-          "type": "string"
-        },
-        "secretRef": {
-          "description": "Reference to the secret containing the renovate config",
-          "type": "string"
-        },
-        "securityContext": {
-          "description": "Security context for the resulting pod and container",
-          "properties": {
-            "container": {
-              "description": "SecurityContext holds security configuration that will be applied to a container.\nSome fields are present in both SecurityContext and PodSecurityContext.  When both\nare set, the values in SecurityContext take precedence.",
-              "properties": {
-                "allowPrivilegeEscalation": {
-                  "description": "AllowPrivilegeEscalation controls whether a process can gain more\nprivileges than its parent process. This bool directly controls if\nthe no_new_privs flag will be set on the container process.\nAllowPrivilegeEscalation is true always when the container is:\n1) run as Privileged\n2) has CAP_SYS_ADMIN\nNote that this field cannot be set when spec.os.name is windows.",
-                  "type": "boolean"
-                },
-                "appArmorProfile": {
-                  "description": "appArmorProfile is the AppArmor options to use by this container. If set, this profile\noverrides the pod's appArmorProfile.\nNote that this field cannot be set when spec.os.name is windows.",
-                  "properties": {
-                    "localhostProfile": {
-                      "description": "localhostProfile indicates a profile loaded on the node that should be used.\nThe profile must be preconfigured on the node to work.\nMust match the loaded name of the profile.\nMust be set if and only if type is \"Localhost\".",
-                      "type": "string"
-                    },
-                    "type": {
-                      "description": "type indicates which kind of AppArmor profile will be applied.\nValid options are:\n  Localhost - a profile pre-loaded on the node.\n  RuntimeDefault - the container runtime's default profile.\n  Unconfined - no AppArmor enforcement.",
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "type"
-                  ],
-                  "type": "object",
-                  "additionalProperties": false
-                },
-                "capabilities": {
-                  "description": "The capabilities to add/drop when running containers.\nDefaults to the default set of capabilities granted by the container runtime.\nNote that this field cannot be set when spec.os.name is windows.",
-                  "properties": {
-                    "add": {
-                      "description": "Added capabilities",
-                      "items": {
-                        "description": "Capability represent POSIX capabilities type",
-                        "type": "string"
-                      },
-                      "type": "array",
-                      "x-kubernetes-list-type": "atomic"
-                    },
-                    "drop": {
-                      "description": "Removed capabilities",
-                      "items": {
-                        "description": "Capability represent POSIX capabilities type",
-                        "type": "string"
-                      },
-                      "type": "array",
-                      "x-kubernetes-list-type": "atomic"
-                    }
-                  },
-                  "type": "object",
-                  "additionalProperties": false
-                },
-                "privileged": {
-                  "description": "Run container in privileged mode.\nProcesses in privileged containers are essentially equivalent to root on the host.\nDefaults to false.\nNote that this field cannot be set when spec.os.name is windows.",
-                  "type": "boolean"
-                },
-                "procMount": {
-                  "description": "procMount denotes the type of proc mount to use for the containers.\nThe default value is Default which uses the container runtime defaults for\nreadonly paths and masked paths.\nThis requires the ProcMountType feature flag to be enabled.\nNote that this field cannot be set when spec.os.name is windows.",
-                  "type": "string"
-                },
-                "readOnlyRootFilesystem": {
-                  "description": "Whether this container has a read-only root filesystem.\nDefault is false.\nNote that this field cannot be set when spec.os.name is windows.",
-                  "type": "boolean"
-                },
-                "runAsGroup": {
-                  "description": "The GID to run the entrypoint of the container process.\nUses runtime default if unset.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
-                  "format": "int64",
-                  "type": "integer"
-                },
-                "runAsNonRoot": {
-                  "description": "Indicates that the container must run as a non-root user.\nIf true, the Kubelet will validate the image at runtime to ensure that it\ndoes not run as UID 0 (root) and fail to start the container if it does.\nIf unset or false, no such validation will be performed.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
-                  "type": "boolean"
-                },
-                "runAsUser": {
-                  "description": "The UID to run the entrypoint of the container process.\nDefaults to user specified in image metadata if unspecified.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
-                  "format": "int64",
-                  "type": "integer"
-                },
-                "seLinuxOptions": {
-                  "description": "The SELinux context to be applied to the container.\nIf unspecified, the container runtime will allocate a random SELinux context for each\ncontainer.  May also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
-                  "properties": {
-                    "level": {
-                      "description": "Level is SELinux level label that applies to the container.",
-                      "type": "string"
-                    },
-                    "role": {
-                      "description": "Role is a SELinux role label that applies to the container.",
-                      "type": "string"
-                    },
-                    "type": {
-                      "description": "Type is a SELinux type label that applies to the container.",
-                      "type": "string"
-                    },
-                    "user": {
-                      "description": "User is a SELinux user label that applies to the container.",
-                      "type": "string"
-                    }
-                  },
-                  "type": "object",
-                  "additionalProperties": false
-                },
-                "seccompProfile": {
-                  "description": "The seccomp options to use by this container. If seccomp options are\nprovided at both the pod & container level, the container options\noverride the pod options.\nNote that this field cannot be set when spec.os.name is windows.",
-                  "properties": {
-                    "localhostProfile": {
-                      "description": "localhostProfile indicates a profile defined in a file on the node should be used.\nThe profile must be preconfigured on the node to work.\nMust be a descending path, relative to the kubelet's configured seccomp profile location.\nMust be set if type is \"Localhost\". Must NOT be set for any other type.",
-                      "type": "string"
-                    },
-                    "type": {
-                      "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "type"
-                  ],
-                  "type": "object",
-                  "additionalProperties": false
-                },
-                "windowsOptions": {
-                  "description": "The Windows specific settings applied to all containers.\nIf unspecified, the options from the PodSecurityContext will be used.\nIf set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is linux.",
-                  "properties": {
-                    "gmsaCredentialSpec": {
-                      "description": "GMSACredentialSpec is where the GMSA admission webhook\n(https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the\nGMSA credential spec named by the GMSACredentialSpecName field.",
-                      "type": "string"
-                    },
-                    "gmsaCredentialSpecName": {
-                      "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
-                      "type": "string"
-                    },
-                    "hostProcess": {
-                      "description": "HostProcess determines if a container should be run as a 'Host Process' container.\nAll of a Pod's containers must have the same effective HostProcess value\n(it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).\nIn addition, if HostProcess is true then HostNetwork must also be set to true.",
-                      "type": "boolean"
-                    },
-                    "runAsUserName": {
-                      "description": "The UserName in Windows to run the entrypoint of the container process.\nDefaults to the user specified in image metadata if unspecified.\nMay also be set in PodSecurityContext. If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
-                      "type": "string"
-                    }
-                  },
-                  "type": "object",
-                  "additionalProperties": false
-                }
-              },
-              "type": "object",
-              "additionalProperties": false
-            },
-            "pod": {
-              "description": "PodSecurityContext holds pod-level security attributes and common container settings.\nSome fields are also present in container.securityContext.  Field values of\ncontainer.securityContext take precedence over field values of PodSecurityContext.",
-              "properties": {
-                "appArmorProfile": {
-                  "description": "appArmorProfile is the AppArmor options to use by the containers in this pod.\nNote that this field cannot be set when spec.os.name is windows.",
-                  "properties": {
-                    "localhostProfile": {
-                      "description": "localhostProfile indicates a profile loaded on the node that should be used.\nThe profile must be preconfigured on the node to work.\nMust match the loaded name of the profile.\nMust be set if and only if type is \"Localhost\".",
-                      "type": "string"
-                    },
-                    "type": {
-                      "description": "type indicates which kind of AppArmor profile will be applied.\nValid options are:\n  Localhost - a profile pre-loaded on the node.\n  RuntimeDefault - the container runtime's default profile.\n  Unconfined - no AppArmor enforcement.",
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "type"
-                  ],
-                  "type": "object",
-                  "additionalProperties": false
-                },
-                "fsGroup": {
-                  "description": "A special supplemental group that applies to all containers in a pod.\nSome volume types allow the Kubelet to change the ownership of that volume\nto be owned by the pod:\n\n1. The owning GID will be the FSGroup\n2. The setgid bit is set (new files created in the volume will be owned by FSGroup)\n3. The permission bits are OR'd with rw-rw----\n\nIf unset, the Kubelet will not modify the ownership and permissions of any volume.\nNote that this field cannot be set when spec.os.name is windows.",
-                  "format": "int64",
-                  "type": "integer"
-                },
-                "fsGroupChangePolicy": {
-                  "description": "fsGroupChangePolicy defines behavior of changing ownership and permission of the volume\nbefore being exposed inside Pod. This field will only apply to\nvolume types which support fsGroup based ownership(and permissions).\nIt will have no effect on ephemeral volume types such as: secret, configmaps\nand emptydir.\nValid values are \"OnRootMismatch\" and \"Always\". If not specified, \"Always\" is used.\nNote that this field cannot be set when spec.os.name is windows.",
-                  "type": "string"
-                },
-                "runAsGroup": {
-                  "description": "The GID to run the entrypoint of the container process.\nUses runtime default if unset.\nMay also be set in SecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence\nfor that container.\nNote that this field cannot be set when spec.os.name is windows.",
-                  "format": "int64",
-                  "type": "integer"
-                },
-                "runAsNonRoot": {
-                  "description": "Indicates that the container must run as a non-root user.\nIf true, the Kubelet will validate the image at runtime to ensure that it\ndoes not run as UID 0 (root) and fail to start the container if it does.\nIf unset or false, no such validation will be performed.\nMay also be set in SecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
-                  "type": "boolean"
-                },
-                "runAsUser": {
-                  "description": "The UID to run the entrypoint of the container process.\nDefaults to user specified in image metadata if unspecified.\nMay also be set in SecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence\nfor that container.\nNote that this field cannot be set when spec.os.name is windows.",
-                  "format": "int64",
-                  "type": "integer"
-                },
-                "seLinuxChangePolicy": {
-                  "description": "seLinuxChangePolicy defines how the container's SELinux label is applied to all volumes used by the Pod.\nIt has no effect on nodes that do not support SELinux or to volumes does not support SELinux.\nValid values are \"MountOption\" and \"Recursive\".\n\n\"Recursive\" means relabeling of all files on all Pod volumes by the container runtime.\nThis may be slow for large volumes, but allows mixing privileged and unprivileged Pods sharing the same volume on the same node.\n\n\"MountOption\" mounts all eligible Pod volumes with `-o context` mount option.\nThis requires all Pods that share the same volume to use the same SELinux label.\nIt is not possible to share the same volume among privileged and unprivileged Pods.\nEligible volumes are in-tree FibreChannel and iSCSI volumes, and all CSI volumes\nwhose CSI driver announces SELinux support by setting spec.seLinuxMount: true in their\nCSIDriver instance. Other volumes are always re-labelled recursively.\n\"MountOption\" value is allowed only when SELinuxMount feature gate is enabled.\n\nIf not specified and SELinuxMount feature gate is enabled, \"MountOption\" is used.\nIf not specified and SELinuxMount feature gate is disabled, \"MountOption\" is used for ReadWriteOncePod volumes\nand \"Recursive\" for all other volumes.\n\nThis field affects only Pods that have SELinux label set, either in PodSecurityContext or in SecurityContext of all containers.\n\nAll Pods that use the same volume should use the same seLinuxChangePolicy, otherwise some pods can get stuck in ContainerCreating state.\nNote that this field cannot be set when spec.os.name is windows.",
-                  "type": "string"
-                },
-                "seLinuxOptions": {
-                  "description": "The SELinux context to be applied to all containers.\nIf unspecified, the container runtime will allocate a random SELinux context for each\ncontainer.  May also be set in SecurityContext.  If set in\nboth SecurityContext and PodSecurityContext, the value specified in SecurityContext\ntakes precedence for that container.\nNote that this field cannot be set when spec.os.name is windows.",
-                  "properties": {
-                    "level": {
-                      "description": "Level is SELinux level label that applies to the container.",
-                      "type": "string"
-                    },
-                    "role": {
-                      "description": "Role is a SELinux role label that applies to the container.",
-                      "type": "string"
-                    },
-                    "type": {
-                      "description": "Type is a SELinux type label that applies to the container.",
-                      "type": "string"
-                    },
-                    "user": {
-                      "description": "User is a SELinux user label that applies to the container.",
-                      "type": "string"
-                    }
-                  },
-                  "type": "object",
-                  "additionalProperties": false
-                },
-                "seccompProfile": {
-                  "description": "The seccomp options to use by the containers in this pod.\nNote that this field cannot be set when spec.os.name is windows.",
-                  "properties": {
-                    "localhostProfile": {
-                      "description": "localhostProfile indicates a profile defined in a file on the node should be used.\nThe profile must be preconfigured on the node to work.\nMust be a descending path, relative to the kubelet's configured seccomp profile location.\nMust be set if type is \"Localhost\". Must NOT be set for any other type.",
-                      "type": "string"
-                    },
-                    "type": {
-                      "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "type"
-                  ],
-                  "type": "object",
-                  "additionalProperties": false
-                },
-                "supplementalGroups": {
-                  "description": "A list of groups applied to the first process run in each container, in\naddition to the container's primary GID and fsGroup (if specified).  If\nthe SupplementalGroupsPolicy feature is enabled, the\nsupplementalGroupsPolicy field determines whether these are in addition\nto or instead of any group memberships defined in the container image.\nIf unspecified, no additional groups are added, though group memberships\ndefined in the container image may still be used, depending on the\nsupplementalGroupsPolicy field.\nNote that this field cannot be set when spec.os.name is windows.",
-                  "items": {
-                    "format": "int64",
-                    "type": "integer"
-                  },
-                  "type": "array",
-                  "x-kubernetes-list-type": "atomic"
-                },
-                "supplementalGroupsPolicy": {
-                  "description": "Defines how supplemental groups of the first container processes are calculated.\nValid values are \"Merge\" and \"Strict\". If not specified, \"Merge\" is used.\n(Alpha) Using the field requires the SupplementalGroupsPolicy feature gate to be enabled\nand the container runtime must implement support for this feature.\nNote that this field cannot be set when spec.os.name is windows.",
-                  "type": "string"
-                },
-                "sysctls": {
-                  "description": "Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported\nsysctls (by the container runtime) might fail to launch.\nNote that this field cannot be set when spec.os.name is windows.",
-                  "items": {
-                    "description": "Sysctl defines a kernel parameter to be set",
-                    "properties": {
-                      "name": {
-                        "description": "Name of a property to set",
-                        "type": "string"
-                      },
-                      "value": {
-                        "description": "Value of a property to set",
-                        "type": "string"
-                      }
                     },
                     "required": [
-                      "name",
-                      "value"
+                        "name"
                     ],
                     "type": "object",
                     "additionalProperties": false
-                  },
-                  "type": "array",
-                  "x-kubernetes-list-type": "atomic"
                 },
-                "windowsOptions": {
-                  "description": "The Windows specific settings applied to all containers.\nIf unspecified, the options within a container's SecurityContext will be used.\nIf set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is linux.",
-                  "properties": {
-                    "gmsaCredentialSpec": {
-                      "description": "GMSACredentialSpec is where the GMSA admission webhook\n(https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the\nGMSA credential spec named by the GMSACredentialSpecName field.",
-                      "type": "string"
-                    },
-                    "gmsaCredentialSpecName": {
-                      "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
-                      "type": "string"
-                    },
-                    "hostProcess": {
-                      "description": "HostProcess determines if a container should be run as a 'Host Process' container.\nAll of a Pod's containers must have the same effective HostProcess value\n(it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).\nIn addition, if HostProcess is true then HostNetwork must also be set to true.",
-                      "type": "boolean"
-                    },
-                    "runAsUserName": {
-                      "description": "The UserName in Windows to run the entrypoint of the container process.\nDefaults to the user specified in image metadata if unspecified.\nMay also be set in PodSecurityContext. If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
-                      "type": "string"
-                    }
-                  },
-                  "type": "object",
-                  "additionalProperties": false
-                }
-              },
-              "type": "object",
-              "additionalProperties": false
-            }
-          },
-          "type": "object",
-          "additionalProperties": false
-        },
-        "serviceAccount": {
-          "description": "Settings for the serviceaccount the renovate pod should use",
-          "properties": {
-            "automountServiceAccountToken": {
-              "type": "boolean"
-            },
-            "name": {
-              "type": "string"
-            }
-          },
-          "type": "object",
-          "additionalProperties": false
-        },
-        "tolerations": {
-          "description": "Tolerations for scheduling the resulting pod",
-          "items": {
-            "description": "The pod this Toleration is attached to tolerates any taint that matches\nthe triple <key,value,effect> using the matching operator <operator>.",
-            "properties": {
-              "effect": {
-                "description": "Effect indicates the taint effect to match. Empty means match all taint effects.\nWhen specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
-                "type": "string"
-              },
-              "key": {
-                "description": "Key is the taint key that the toleration applies to. Empty means match all taint keys.\nIf the key is empty, operator must be Exists; this combination means to match all values and all keys.",
-                "type": "string"
-              },
-              "operator": {
-                "description": "Operator represents a key's relationship to the value.\nValid operators are Exists and Equal. Defaults to Equal.\nExists is equivalent to wildcard for value, so that a pod can\ntolerate all taints of a particular category.",
-                "type": "string"
-              },
-              "tolerationSeconds": {
-                "description": "TolerationSeconds represents the period of time the toleration (which must be\nof effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,\nit is not set, which means tolerate the taint forever (do not evict). Zero and\nnegative values will be treated as 0 (evict immediately) by the system.",
-                "format": "int64",
-                "type": "integer"
-              },
-              "value": {
-                "description": "Value is the taint value the toleration matches to.\nIf the operator is Exists, the value should be empty, otherwise just a regular string.",
-                "type": "string"
-              }
-            },
-            "type": "object",
-            "additionalProperties": false
-          },
-          "type": "array"
-        },
-        "topologySpreadConstraints": {
-          "description": "Topology spread constraints for scheduling the resulting pod",
-          "items": {
-            "description": "TopologySpreadConstraint specifies how to spread matching pods among the given topology.",
-            "properties": {
-              "labelSelector": {
-                "description": "LabelSelector is used to find matching pods.\nPods that match this label selector are counted to determine the number of pods\nin their corresponding topology domain.",
-                "properties": {
-                  "matchExpressions": {
-                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
-                    "items": {
-                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
-                      "properties": {
-                        "key": {
-                          "description": "key is the label key that the selector applies to.",
-                          "type": "string"
+                "resources": {
+                    "description": "Resource requirements for the renovate container",
+                    "properties": {
+                        "claims": {
+                            "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis field depends on the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
+                            "items": {
+                                "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                                "properties": {
+                                    "name": {
+                                        "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
+                                        "type": "string"
+                                    },
+                                    "request": {
+                                        "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "name"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-map-keys": [
+                                "name"
+                            ],
+                            "x-kubernetes-list-type": "map"
                         },
-                        "operator": {
-                          "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
-                          "type": "string"
+                        "limits": {
+                            "additionalProperties": {
+                                "anyOf": [
+                                    {
+                                        "type": "integer"
+                                    },
+                                    {
+                                        "type": "string"
+                                    }
+                                ],
+                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                "x-kubernetes-int-or-string": true
+                            },
+                            "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                            "type": "object"
                         },
-                        "values": {
-                          "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
-                          "items": {
-                            "type": "string"
-                          },
-                          "type": "array",
-                          "x-kubernetes-list-type": "atomic"
+                        "requests": {
+                            "additionalProperties": {
+                                "anyOf": [
+                                    {
+                                        "type": "integer"
+                                    },
+                                    {
+                                        "type": "string"
+                                    }
+                                ],
+                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                "x-kubernetes-int-or-string": true
+                            },
+                            "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                            "type": "object"
                         }
-                      },
-                      "required": [
-                        "key",
-                        "operator"
-                      ],
-                      "type": "object",
-                      "additionalProperties": false
                     },
-                    "type": "array",
-                    "x-kubernetes-list-type": "atomic"
-                  },
-                  "matchLabels": {
-                    "additionalProperties": {
-                      "type": "string"
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "schedule": {
+                    "description": "Cron schedule in standard cron format",
+                    "type": "string"
+                },
+                "scratchVolume": {
+                    "description": "Configuration for the scratch volume",
+                    "properties": {
+                        "enabled": {
+                            "default": true,
+                            "description": "If enabled a scratch volume will be created and RENOVATE_BASE_DIR will be set accordingly",
+                            "type": "boolean"
+                        },
+                        "ephemeral": {
+                            "description": "Ephemeral uses a Kubernetes generic ephemeral volume for scratch (volume.ephemeral).\nWhen set, Medium and SizeLimit are ignored.",
+                            "properties": {
+                                "volumeClaimTemplate": {
+                                    "description": "Will be used to create a stand-alone PVC to provision the volume.\nThe pod in which this EphemeralVolumeSource is embedded will be the\nowner of the PVC, i.e. the PVC will be deleted together with the\npod.  The name of the PVC will be `<pod name>-<volume name>` where\n`<volume name>` is the name from the `PodSpec.Volumes` array\nentry. Pod validation will reject the pod if the concatenated name\nis not valid for a PVC (for example, too long).\n\nAn existing PVC with that name that is not owned by the pod\nwill *not* be used for the pod to avoid using an unrelated\nvolume by mistake. Starting the pod is then blocked until\nthe unrelated PVC is removed. If such a pre-created PVC is\nmeant to be used by the pod, the PVC has to updated with an\nowner reference to the pod once the pod exists. Normally\nthis should not be necessary, but it may be useful when\nmanually reconstructing a broken cluster.\n\nThis field is read-only and no changes will be made by Kubernetes\nto the PVC after it has been created.\n\nRequired, must not be nil.",
+                                    "properties": {
+                                        "metadata": {
+                                            "description": "May contain labels and annotations that will be copied into the PVC\nwhen creating it. No other fields are allowed and will be rejected during\nvalidation.",
+                                            "type": "object"
+                                        },
+                                        "spec": {
+                                            "description": "The specification for the PersistentVolumeClaim. The entire content is\ncopied unchanged into the PVC that gets created from this\ntemplate. The same fields as in a PersistentVolumeClaim\nare also valid here.",
+                                            "properties": {
+                                                "accessModes": {
+                                                    "description": "accessModes contains the desired access modes the volume should have.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1",
+                                                    "items": {
+                                                        "type": "string"
+                                                    },
+                                                    "type": "array",
+                                                    "x-kubernetes-list-type": "atomic"
+                                                },
+                                                "dataSource": {
+                                                    "description": "dataSource field can be used to specify either:\n* An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)\n* An existing PVC (PersistentVolumeClaim)\nIf the provisioner or an external controller can support the specified data source,\nit will create a new volume based on the contents of the specified data source.\nWhen the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,\nand dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.\nIf the namespace is specified, then dataSourceRef will not be copied to dataSource.",
+                                                    "properties": {
+                                                        "apiGroup": {
+                                                            "description": "APIGroup is the group for the resource being referenced.\nIf APIGroup is not specified, the specified Kind must be in the core API group.\nFor any other third-party types, APIGroup is required.",
+                                                            "type": "string"
+                                                        },
+                                                        "kind": {
+                                                            "description": "Kind is the type of resource being referenced",
+                                                            "type": "string"
+                                                        },
+                                                        "name": {
+                                                            "description": "Name is the name of resource being referenced",
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "kind",
+                                                        "name"
+                                                    ],
+                                                    "type": "object",
+                                                    "x-kubernetes-map-type": "atomic",
+                                                    "additionalProperties": false
+                                                },
+                                                "dataSourceRef": {
+                                                    "description": "dataSourceRef specifies the object from which to populate the volume with data, if a non-empty\nvolume is desired. This may be any object from a non-empty API group (non\ncore object) or a PersistentVolumeClaim object.\nWhen this field is specified, volume binding will only succeed if the type of\nthe specified object matches some installed volume populator or dynamic\nprovisioner.\nThis field will replace the functionality of the dataSource field and as such\nif both fields are non-empty, they must have the same value. For backwards\ncompatibility, when namespace isn't specified in dataSourceRef,\nboth fields (dataSource and dataSourceRef) will be set to the same\nvalue automatically if one of them is empty and the other is non-empty.\nWhen namespace is specified in dataSourceRef,\ndataSource isn't set to the same value and must be empty.\nThere are three important differences between dataSource and dataSourceRef:\n* While dataSource only allows two specific types of objects, dataSourceRef\n  allows any non-core object, as well as PersistentVolumeClaim objects.\n* While dataSource ignores disallowed values (dropping them), dataSourceRef\n  preserves all values, and generates an error if a disallowed value is\n  specified.\n* While dataSource only allows local objects, dataSourceRef allows objects\n  in any namespaces.\n(Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.\n(Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.",
+                                                    "properties": {
+                                                        "apiGroup": {
+                                                            "description": "APIGroup is the group for the resource being referenced.\nIf APIGroup is not specified, the specified Kind must be in the core API group.\nFor any other third-party types, APIGroup is required.",
+                                                            "type": "string"
+                                                        },
+                                                        "kind": {
+                                                            "description": "Kind is the type of resource being referenced",
+                                                            "type": "string"
+                                                        },
+                                                        "name": {
+                                                            "description": "Name is the name of resource being referenced",
+                                                            "type": "string"
+                                                        },
+                                                        "namespace": {
+                                                            "description": "Namespace is the namespace of resource being referenced\nNote that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.\n(Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.",
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "kind",
+                                                        "name"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                },
+                                                "resources": {
+                                                    "description": "resources represents the minimum resources the volume should have.\nUsers are allowed to specify resource requirements\nthat are lower than previous value but must still be higher than capacity recorded in the\nstatus field of the claim.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources",
+                                                    "properties": {
+                                                        "limits": {
+                                                            "additionalProperties": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "integer"
+                                                                    },
+                                                                    {
+                                                                        "type": "string"
+                                                                    }
+                                                                ],
+                                                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                                                "x-kubernetes-int-or-string": true
+                                                            },
+                                                            "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                                            "type": "object"
+                                                        },
+                                                        "requests": {
+                                                            "additionalProperties": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "integer"
+                                                                    },
+                                                                    {
+                                                                        "type": "string"
+                                                                    }
+                                                                ],
+                                                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                                                "x-kubernetes-int-or-string": true
+                                                            },
+                                                            "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                                            "type": "object"
+                                                        }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                },
+                                                "selector": {
+                                                    "description": "selector is a label query over volumes to consider for binding.",
+                                                    "properties": {
+                                                        "matchExpressions": {
+                                                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                            "items": {
+                                                                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                                                "properties": {
+                                                                    "key": {
+                                                                        "description": "key is the label key that the selector applies to.",
+                                                                        "type": "string"
+                                                                    },
+                                                                    "operator": {
+                                                                        "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                        "type": "string"
+                                                                    },
+                                                                    "values": {
+                                                                        "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                                                        "items": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "type": "array",
+                                                                        "x-kubernetes-list-type": "atomic"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "key",
+                                                                    "operator"
+                                                                ],
+                                                                "type": "object",
+                                                                "additionalProperties": false
+                                                            },
+                                                            "type": "array",
+                                                            "x-kubernetes-list-type": "atomic"
+                                                        },
+                                                        "matchLabels": {
+                                                            "additionalProperties": {
+                                                                "type": "string"
+                                                            },
+                                                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                            "type": "object"
+                                                        }
+                                                    },
+                                                    "type": "object",
+                                                    "x-kubernetes-map-type": "atomic",
+                                                    "additionalProperties": false
+                                                },
+                                                "storageClassName": {
+                                                    "description": "storageClassName is the name of the StorageClass required by the claim.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1",
+                                                    "type": "string"
+                                                },
+                                                "volumeAttributesClassName": {
+                                                    "description": "volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.\nIf specified, the CSI driver will create or update the volume with the attributes defined\nin the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,\nit can be changed after the claim is created. An empty string or nil value indicates that no\nVolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,\nthis field can be reset to its previous value (including nil) to cancel the modification.\nIf the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be\nset to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource\nexists.\nMore info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/",
+                                                    "type": "string"
+                                                },
+                                                "volumeMode": {
+                                                    "description": "volumeMode defines what type of volume is required by the claim.\nValue of Filesystem is implied when not included in claim spec.",
+                                                    "type": "string"
+                                                },
+                                                "volumeName": {
+                                                    "description": "volumeName is the binding reference to the PersistentVolume backing this claim.",
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                        }
+                                    },
+                                    "required": [
+                                        "spec"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "medium": {
+                            "description": "Medium for the emptyDir volume. Ignored when Ephemeral is set.\nEmpty uses the node's default medium; Memory uses a tmpfs (corev1.StorageMediumMemory).",
+                            "type": "string"
+                        },
+                        "path": {
+                            "default": "/tmp",
+                            "description": "Path within the container where the scratch volume will be mounted, RENOVATE_BASE_DIR will be set to this path.",
+                            "type": "string"
+                        },
+                        "sizeLimit": {
+                            "anyOf": [
+                                {
+                                    "type": "integer"
+                                },
+                                {
+                                    "type": "string"
+                                }
+                            ],
+                            "description": "SizeLimit caps how large the emptyDir may grow (Kubernetes emptyDir.sizeLimit). Ignored when Ephemeral is set.",
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                            "x-kubernetes-int-or-string": true
+                        }
                     },
-                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-                    "type": "object"
-                  }
-                },
-                "type": "object",
-                "x-kubernetes-map-type": "atomic",
-                "additionalProperties": false
-              },
-              "matchLabelKeys": {
-                "description": "MatchLabelKeys is a set of pod label keys to select the pods over which\nspreading will be calculated. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are ANDed with labelSelector\nto select the group of existing pods over which spreading will be calculated\nfor the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.\nMatchLabelKeys cannot be set when LabelSelector isn't set.\nKeys that don't exist in the incoming pod labels will\nbe ignored. A null or empty list means only match against labelSelector.\n\nThis is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default).",
-                "items": {
-                  "type": "string"
-                },
-                "type": "array",
-                "x-kubernetes-list-type": "atomic"
-              },
-              "maxSkew": {
-                "description": "MaxSkew describes the degree to which pods may be unevenly distributed.\nWhen `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference\nbetween the number of matching pods in the target topology and the global minimum.\nThe global minimum is the minimum number of matching pods in an eligible domain\nor zero if the number of eligible domains is less than MinDomains.\nFor example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same\nlabelSelector spread as 2/2/1:\nIn this case, the global minimum is 1.\n| zone1 | zone2 | zone3 |\n|  P P  |  P P  |   P   |\n- if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2;\nscheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2)\nviolate MaxSkew(1).\n- if MaxSkew is 2, incoming pod can be scheduled onto any zone.\nWhen `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence\nto topologies that satisfy it.\nIt's a required field. Default value is 1 and 0 is not allowed.",
-                "format": "int32",
-                "type": "integer"
-              },
-              "minDomains": {
-                "description": "MinDomains indicates a minimum number of eligible domains.\nWhen the number of eligible domains with matching topology keys is less than minDomains,\nPod Topology Spread treats \"global minimum\" as 0, and then the calculation of Skew is performed.\nAnd when the number of eligible domains with matching topology keys equals or greater than minDomains,\nthis value has no effect on scheduling.\nAs a result, when the number of eligible domains is less than minDomains,\nscheduler won't schedule more than maxSkew Pods to those domains.\nIf value is nil, the constraint behaves as if MinDomains is equal to 1.\nValid values are integers greater than 0.\nWhen value is not nil, WhenUnsatisfiable must be DoNotSchedule.\n\nFor example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same\nlabelSelector spread as 2/2/2:\n| zone1 | zone2 | zone3 |\n|  P P  |  P P  |  P P  |\nThe number of domains is less than 5(MinDomains), so \"global minimum\" is treated as 0.\nIn this situation, new pod with the same labelSelector cannot be scheduled,\nbecause computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones,\nit will violate MaxSkew.",
-                "format": "int32",
-                "type": "integer"
-              },
-              "nodeAffinityPolicy": {
-                "description": "NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector\nwhen calculating pod topology spread skew. Options are:\n- Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.\n- Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.\n\nIf this value is nil, the behavior is equivalent to the Honor policy.",
-                "type": "string"
-              },
-              "nodeTaintsPolicy": {
-                "description": "NodeTaintsPolicy indicates how we will treat node taints when calculating\npod topology spread skew. Options are:\n- Honor: nodes without taints, along with tainted nodes for which the incoming pod\nhas a toleration, are included.\n- Ignore: node taints are ignored. All nodes are included.\n\nIf this value is nil, the behavior is equivalent to the Ignore policy.",
-                "type": "string"
-              },
-              "topologyKey": {
-                "description": "TopologyKey is the key of node labels. Nodes that have a label with this key\nand identical values are considered to be in the same topology.\nWe consider each <key, value> as a \"bucket\", and try to put balanced number\nof pods into each bucket.\nWe define a domain as a particular instance of a topology.\nAlso, we define an eligible domain as a domain whose nodes meet the requirements of\nnodeAffinityPolicy and nodeTaintsPolicy.\ne.g. If TopologyKey is \"kubernetes.io/hostname\", each Node is a domain of that topology.\nAnd, if TopologyKey is \"topology.kubernetes.io/zone\", each zone is a domain of that topology.\nIt's a required field.",
-                "type": "string"
-              },
-              "whenUnsatisfiable": {
-                "description": "WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy\nthe spread constraint.\n- DoNotSchedule (default) tells the scheduler not to schedule it.\n- ScheduleAnyway tells the scheduler to schedule the pod in any location,\n  but giving higher precedence to topologies that would help reduce the\n  skew.\nA constraint is considered \"Unsatisfiable\" for an incoming pod\nif and only if every possible node assignment for that pod would violate\n\"MaxSkew\" on some topology.\nFor example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same\nlabelSelector spread as 3/1/1:\n| zone1 | zone2 | zone3 |\n| P P P |   P   |   P   |\nIf WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled\nto zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies\nMaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler\nwon't make it *more* imbalanced.\nIt's a required field.",
-                "type": "string"
-              }
-            },
-            "required": [
-              "maxSkew",
-              "topologyKey",
-              "whenUnsatisfiable"
-            ],
-            "type": "object",
-            "additionalProperties": false
-          },
-          "type": "array"
-        },
-        "webhook": {
-          "description": "Configuration for webhooks to trigger renovate runs",
-          "properties": {
-            "authentication": {
-              "description": "authentication configuration for webhooks",
-              "properties": {
-                "enabled": {
-                  "type": "boolean"
+                    "type": "object",
+                    "additionalProperties": false
                 },
                 "secretRef": {
-                  "description": "reference to a secret and key",
-                  "properties": {
-                    "key": {
-                      "type": "string"
+                    "description": "Reference to the secret containing the renovate config",
+                    "type": "string"
+                },
+                "securityContext": {
+                    "description": "Security context for the resulting pod and container",
+                    "properties": {
+                        "container": {
+                            "description": "SecurityContext holds security configuration that will be applied to a container.\nSome fields are present in both SecurityContext and PodSecurityContext.  When both\nare set, the values in SecurityContext take precedence.",
+                            "properties": {
+                                "allowPrivilegeEscalation": {
+                                    "description": "AllowPrivilegeEscalation controls whether a process can gain more\nprivileges than its parent process. This bool directly controls if\nthe no_new_privs flag will be set on the container process.\nAllowPrivilegeEscalation is true always when the container is:\n1) run as Privileged\n2) has CAP_SYS_ADMIN\nNote that this field cannot be set when spec.os.name is windows.",
+                                    "type": "boolean"
+                                },
+                                "appArmorProfile": {
+                                    "description": "appArmorProfile is the AppArmor options to use by this container. If set, this profile\noverrides the pod's appArmorProfile.\nNote that this field cannot be set when spec.os.name is windows.",
+                                    "properties": {
+                                        "localhostProfile": {
+                                            "description": "localhostProfile indicates a profile loaded on the node that should be used.\nThe profile must be preconfigured on the node to work.\nMust match the loaded name of the profile.\nMust be set if and only if type is \"Localhost\".",
+                                            "type": "string"
+                                        },
+                                        "type": {
+                                            "description": "type indicates which kind of AppArmor profile will be applied.\nValid options are:\n  Localhost - a profile pre-loaded on the node.\n  RuntimeDefault - the container runtime's default profile.\n  Unconfined - no AppArmor enforcement.",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "type"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                },
+                                "capabilities": {
+                                    "description": "The capabilities to add/drop when running containers.\nDefaults to the default set of capabilities granted by the container runtime.\nNote that this field cannot be set when spec.os.name is windows.",
+                                    "properties": {
+                                        "add": {
+                                            "description": "Added capabilities",
+                                            "items": {
+                                                "description": "Capability represent POSIX capabilities type",
+                                                "type": "string"
+                                            },
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
+                                        },
+                                        "drop": {
+                                            "description": "Removed capabilities",
+                                            "items": {
+                                                "description": "Capability represent POSIX capabilities type",
+                                                "type": "string"
+                                            },
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
+                                        }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                },
+                                "privileged": {
+                                    "description": "Run container in privileged mode.\nProcesses in privileged containers are essentially equivalent to root on the host.\nDefaults to false.\nNote that this field cannot be set when spec.os.name is windows.",
+                                    "type": "boolean"
+                                },
+                                "procMount": {
+                                    "description": "procMount denotes the type of proc mount to use for the containers.\nThe default value is Default which uses the container runtime defaults for\nreadonly paths and masked paths.\nThis requires the ProcMountType feature flag to be enabled.\nNote that this field cannot be set when spec.os.name is windows.",
+                                    "type": "string"
+                                },
+                                "readOnlyRootFilesystem": {
+                                    "description": "Whether this container has a read-only root filesystem.\nDefault is false.\nNote that this field cannot be set when spec.os.name is windows.",
+                                    "type": "boolean"
+                                },
+                                "runAsGroup": {
+                                    "description": "The GID to run the entrypoint of the container process.\nUses runtime default if unset.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
+                                    "format": "int64",
+                                    "type": "integer",
+                                    "minimum": -9223372036854776000,
+                                    "maximum": 9223372036854776000
+                                },
+                                "runAsNonRoot": {
+                                    "description": "Indicates that the container must run as a non-root user.\nIf true, the Kubelet will validate the image at runtime to ensure that it\ndoes not run as UID 0 (root) and fail to start the container if it does.\nIf unset or false, no such validation will be performed.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
+                                    "type": "boolean"
+                                },
+                                "runAsUser": {
+                                    "description": "The UID to run the entrypoint of the container process.\nDefaults to user specified in image metadata if unspecified.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
+                                    "format": "int64",
+                                    "type": "integer",
+                                    "minimum": -9223372036854776000,
+                                    "maximum": 9223372036854776000
+                                },
+                                "seLinuxOptions": {
+                                    "description": "The SELinux context to be applied to the container.\nIf unspecified, the container runtime will allocate a random SELinux context for each\ncontainer.  May also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
+                                    "properties": {
+                                        "level": {
+                                            "description": "Level is SELinux level label that applies to the container.",
+                                            "type": "string"
+                                        },
+                                        "role": {
+                                            "description": "Role is a SELinux role label that applies to the container.",
+                                            "type": "string"
+                                        },
+                                        "type": {
+                                            "description": "Type is a SELinux type label that applies to the container.",
+                                            "type": "string"
+                                        },
+                                        "user": {
+                                            "description": "User is a SELinux user label that applies to the container.",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                },
+                                "seccompProfile": {
+                                    "description": "The seccomp options to use by this container. If seccomp options are\nprovided at both the pod & container level, the container options\noverride the pod options.\nNote that this field cannot be set when spec.os.name is windows.",
+                                    "properties": {
+                                        "localhostProfile": {
+                                            "description": "localhostProfile indicates a profile defined in a file on the node should be used.\nThe profile must be preconfigured on the node to work.\nMust be a descending path, relative to the kubelet's configured seccomp profile location.\nMust be set if type is \"Localhost\". Must NOT be set for any other type.",
+                                            "type": "string"
+                                        },
+                                        "type": {
+                                            "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "type"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                },
+                                "windowsOptions": {
+                                    "description": "The Windows specific settings applied to all containers.\nIf unspecified, the options from the PodSecurityContext will be used.\nIf set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is linux.",
+                                    "properties": {
+                                        "gmsaCredentialSpec": {
+                                            "description": "GMSACredentialSpec is where the GMSA admission webhook\n(https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the\nGMSA credential spec named by the GMSACredentialSpecName field.",
+                                            "type": "string"
+                                        },
+                                        "gmsaCredentialSpecName": {
+                                            "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
+                                            "type": "string"
+                                        },
+                                        "hostProcess": {
+                                            "description": "HostProcess determines if a container should be run as a 'Host Process' container.\nAll of a Pod's containers must have the same effective HostProcess value\n(it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).\nIn addition, if HostProcess is true then HostNetwork must also be set to true.",
+                                            "type": "boolean"
+                                        },
+                                        "runAsUserName": {
+                                            "description": "The UserName in Windows to run the entrypoint of the container process.\nDefaults to the user specified in image metadata if unspecified.\nMay also be set in PodSecurityContext. If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "pod": {
+                            "description": "PodSecurityContext holds pod-level security attributes and common container settings.\nSome fields are also present in container.securityContext.  Field values of\ncontainer.securityContext take precedence over field values of PodSecurityContext.",
+                            "properties": {
+                                "appArmorProfile": {
+                                    "description": "appArmorProfile is the AppArmor options to use by the containers in this pod.\nNote that this field cannot be set when spec.os.name is windows.",
+                                    "properties": {
+                                        "localhostProfile": {
+                                            "description": "localhostProfile indicates a profile loaded on the node that should be used.\nThe profile must be preconfigured on the node to work.\nMust match the loaded name of the profile.\nMust be set if and only if type is \"Localhost\".",
+                                            "type": "string"
+                                        },
+                                        "type": {
+                                            "description": "type indicates which kind of AppArmor profile will be applied.\nValid options are:\n  Localhost - a profile pre-loaded on the node.\n  RuntimeDefault - the container runtime's default profile.\n  Unconfined - no AppArmor enforcement.",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "type"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                },
+                                "fsGroup": {
+                                    "description": "A special supplemental group that applies to all containers in a pod.\nSome volume types allow the Kubelet to change the ownership of that volume\nto be owned by the pod:\n\n1. The owning GID will be the FSGroup\n2. The setgid bit is set (new files created in the volume will be owned by FSGroup)\n3. The permission bits are OR'd with rw-rw----\n\nIf unset, the Kubelet will not modify the ownership and permissions of any volume.\nNote that this field cannot be set when spec.os.name is windows.",
+                                    "format": "int64",
+                                    "type": "integer",
+                                    "minimum": -9223372036854776000,
+                                    "maximum": 9223372036854776000
+                                },
+                                "fsGroupChangePolicy": {
+                                    "description": "fsGroupChangePolicy defines behavior of changing ownership and permission of the volume\nbefore being exposed inside Pod. This field will only apply to\nvolume types which support fsGroup based ownership(and permissions).\nIt will have no effect on ephemeral volume types such as: secret, configmaps\nand emptydir.\nValid values are \"OnRootMismatch\" and \"Always\". If not specified, \"Always\" is used.\nNote that this field cannot be set when spec.os.name is windows.",
+                                    "type": "string"
+                                },
+                                "runAsGroup": {
+                                    "description": "The GID to run the entrypoint of the container process.\nUses runtime default if unset.\nMay also be set in SecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence\nfor that container.\nNote that this field cannot be set when spec.os.name is windows.",
+                                    "format": "int64",
+                                    "type": "integer",
+                                    "minimum": -9223372036854776000,
+                                    "maximum": 9223372036854776000
+                                },
+                                "runAsNonRoot": {
+                                    "description": "Indicates that the container must run as a non-root user.\nIf true, the Kubelet will validate the image at runtime to ensure that it\ndoes not run as UID 0 (root) and fail to start the container if it does.\nIf unset or false, no such validation will be performed.\nMay also be set in SecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
+                                    "type": "boolean"
+                                },
+                                "runAsUser": {
+                                    "description": "The UID to run the entrypoint of the container process.\nDefaults to user specified in image metadata if unspecified.\nMay also be set in SecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence\nfor that container.\nNote that this field cannot be set when spec.os.name is windows.",
+                                    "format": "int64",
+                                    "type": "integer",
+                                    "minimum": -9223372036854776000,
+                                    "maximum": 9223372036854776000
+                                },
+                                "seLinuxChangePolicy": {
+                                    "description": "seLinuxChangePolicy defines how the container's SELinux label is applied to all volumes used by the Pod.\nIt has no effect on nodes that do not support SELinux or to volumes does not support SELinux.\nValid values are \"MountOption\" and \"Recursive\".\n\n\"Recursive\" means relabeling of all files on all Pod volumes by the container runtime.\nThis may be slow for large volumes, but allows mixing privileged and unprivileged Pods sharing the same volume on the same node.\n\n\"MountOption\" mounts all eligible Pod volumes with `-o context` mount option.\nThis requires all Pods that share the same volume to use the same SELinux label.\nIt is not possible to share the same volume among privileged and unprivileged Pods.\nEligible volumes are in-tree FibreChannel and iSCSI volumes, and all CSI volumes\nwhose CSI driver announces SELinux support by setting spec.seLinuxMount: true in their\nCSIDriver instance. Other volumes are always re-labelled recursively.\n\"MountOption\" value is allowed only when SELinuxMount feature gate is enabled.\n\nIf not specified and SELinuxMount feature gate is enabled, \"MountOption\" is used.\nIf not specified and SELinuxMount feature gate is disabled, \"MountOption\" is used for ReadWriteOncePod volumes\nand \"Recursive\" for all other volumes.\n\nThis field affects only Pods that have SELinux label set, either in PodSecurityContext or in SecurityContext of all containers.\n\nAll Pods that use the same volume should use the same seLinuxChangePolicy, otherwise some pods can get stuck in ContainerCreating state.\nNote that this field cannot be set when spec.os.name is windows.",
+                                    "type": "string"
+                                },
+                                "seLinuxOptions": {
+                                    "description": "The SELinux context to be applied to all containers.\nIf unspecified, the container runtime will allocate a random SELinux context for each\ncontainer.  May also be set in SecurityContext.  If set in\nboth SecurityContext and PodSecurityContext, the value specified in SecurityContext\ntakes precedence for that container.\nNote that this field cannot be set when spec.os.name is windows.",
+                                    "properties": {
+                                        "level": {
+                                            "description": "Level is SELinux level label that applies to the container.",
+                                            "type": "string"
+                                        },
+                                        "role": {
+                                            "description": "Role is a SELinux role label that applies to the container.",
+                                            "type": "string"
+                                        },
+                                        "type": {
+                                            "description": "Type is a SELinux type label that applies to the container.",
+                                            "type": "string"
+                                        },
+                                        "user": {
+                                            "description": "User is a SELinux user label that applies to the container.",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                },
+                                "seccompProfile": {
+                                    "description": "The seccomp options to use by the containers in this pod.\nNote that this field cannot be set when spec.os.name is windows.",
+                                    "properties": {
+                                        "localhostProfile": {
+                                            "description": "localhostProfile indicates a profile defined in a file on the node should be used.\nThe profile must be preconfigured on the node to work.\nMust be a descending path, relative to the kubelet's configured seccomp profile location.\nMust be set if type is \"Localhost\". Must NOT be set for any other type.",
+                                            "type": "string"
+                                        },
+                                        "type": {
+                                            "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "type"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                },
+                                "supplementalGroups": {
+                                    "description": "A list of groups applied to the first process run in each container, in\naddition to the container's primary GID and fsGroup (if specified).  If\nthe SupplementalGroupsPolicy feature is enabled, the\nsupplementalGroupsPolicy field determines whether these are in addition\nto or instead of any group memberships defined in the container image.\nIf unspecified, no additional groups are added, though group memberships\ndefined in the container image may still be used, depending on the\nsupplementalGroupsPolicy field.\nNote that this field cannot be set when spec.os.name is windows.",
+                                    "items": {
+                                        "format": "int64",
+                                        "type": "integer",
+                                        "minimum": -9223372036854776000,
+                                        "maximum": 9223372036854776000
+                                    },
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
+                                },
+                                "supplementalGroupsPolicy": {
+                                    "description": "Defines how supplemental groups of the first container processes are calculated.\nValid values are \"Merge\" and \"Strict\". If not specified, \"Merge\" is used.\n(Alpha) Using the field requires the SupplementalGroupsPolicy feature gate to be enabled\nand the container runtime must implement support for this feature.\nNote that this field cannot be set when spec.os.name is windows.",
+                                    "type": "string"
+                                },
+                                "sysctls": {
+                                    "description": "Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported\nsysctls (by the container runtime) might fail to launch.\nNote that this field cannot be set when spec.os.name is windows.",
+                                    "items": {
+                                        "description": "Sysctl defines a kernel parameter to be set",
+                                        "properties": {
+                                            "name": {
+                                                "description": "Name of a property to set",
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "description": "Value of a property to set",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "name",
+                                            "value"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
+                                },
+                                "windowsOptions": {
+                                    "description": "The Windows specific settings applied to all containers.\nIf unspecified, the options within a container's SecurityContext will be used.\nIf set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is linux.",
+                                    "properties": {
+                                        "gmsaCredentialSpec": {
+                                            "description": "GMSACredentialSpec is where the GMSA admission webhook\n(https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the\nGMSA credential spec named by the GMSACredentialSpecName field.",
+                                            "type": "string"
+                                        },
+                                        "gmsaCredentialSpecName": {
+                                            "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
+                                            "type": "string"
+                                        },
+                                        "hostProcess": {
+                                            "description": "HostProcess determines if a container should be run as a 'Host Process' container.\nAll of a Pod's containers must have the same effective HostProcess value\n(it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).\nIn addition, if HostProcess is true then HostNetwork must also be set to true.",
+                                            "type": "boolean"
+                                        },
+                                        "runAsUserName": {
+                                            "description": "The UserName in Windows to run the entrypoint of the container process.\nDefaults to the user specified in image metadata if unspecified.\nMay also be set in PodSecurityContext. If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        }
                     },
-                    "name": {
-                      "type": "string"
-                    }
-                  },
-                  "type": "object",
-                  "additionalProperties": false
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "serviceAccount": {
+                    "description": "Settings for the serviceaccount the renovate pod should use",
+                    "properties": {
+                        "automountServiceAccountToken": {
+                            "type": "boolean"
+                        },
+                        "name": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "skipForks": {
+                    "description": "If true, forked repositories discovered during autodiscovery will be excluded by querying the platform API",
+                    "type": "boolean"
+                },
+                "tolerations": {
+                    "description": "Tolerations for scheduling the resulting pod",
+                    "items": {
+                        "description": "The pod this Toleration is attached to tolerates any taint that matches\nthe triple <key,value,effect> using the matching operator <operator>.",
+                        "properties": {
+                            "effect": {
+                                "description": "Effect indicates the taint effect to match. Empty means match all taint effects.\nWhen specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
+                                "type": "string"
+                            },
+                            "key": {
+                                "description": "Key is the taint key that the toleration applies to. Empty means match all taint keys.\nIf the key is empty, operator must be Exists; this combination means to match all values and all keys.",
+                                "type": "string"
+                            },
+                            "operator": {
+                                "description": "Operator represents a key's relationship to the value.\nValid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.\nExists is equivalent to wildcard for value, so that a pod can\ntolerate all taints of a particular category.\nLt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).",
+                                "type": "string"
+                            },
+                            "tolerationSeconds": {
+                                "description": "TolerationSeconds represents the period of time the toleration (which must be\nof effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,\nit is not set, which means tolerate the taint forever (do not evict). Zero and\nnegative values will be treated as 0 (evict immediately) by the system.",
+                                "format": "int64",
+                                "type": "integer",
+                                "minimum": -9223372036854776000,
+                                "maximum": 9223372036854776000
+                            },
+                            "value": {
+                                "description": "Value is the taint value the toleration matches to.\nIf the operator is Exists, the value should be empty, otherwise just a regular string.",
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "topologySpreadConstraints": {
+                    "description": "Topology spread constraints for scheduling the resulting pod",
+                    "items": {
+                        "description": "TopologySpreadConstraint specifies how to spread matching pods among the given topology.",
+                        "properties": {
+                            "labelSelector": {
+                                "description": "LabelSelector is used to find matching pods.\nPods that match this label selector are counted to determine the number of pods\nin their corresponding topology domain.",
+                                "properties": {
+                                    "matchExpressions": {
+                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                        "items": {
+                                            "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                            "properties": {
+                                                "key": {
+                                                    "description": "key is the label key that the selector applies to.",
+                                                    "type": "string"
+                                                },
+                                                "operator": {
+                                                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                                    "type": "string"
+                                                },
+                                                "values": {
+                                                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                                    "items": {
+                                                        "type": "string"
+                                                    },
+                                                    "type": "array",
+                                                    "x-kubernetes-list-type": "atomic"
+                                                }
+                                            },
+                                            "required": [
+                                                "key",
+                                                "operator"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                    },
+                                    "matchLabels": {
+                                        "additionalProperties": {
+                                            "type": "string"
+                                        },
+                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                        "type": "object"
+                                    }
+                                },
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                            },
+                            "matchLabelKeys": {
+                                "description": "MatchLabelKeys is a set of pod label keys to select the pods over which\nspreading will be calculated. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are ANDed with labelSelector\nto select the group of existing pods over which spreading will be calculated\nfor the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.\nMatchLabelKeys cannot be set when LabelSelector isn't set.\nKeys that don't exist in the incoming pod labels will\nbe ignored. A null or empty list means only match against labelSelector.\n\nThis is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default).",
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                            },
+                            "maxSkew": {
+                                "description": "MaxSkew describes the degree to which pods may be unevenly distributed.\nWhen `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference\nbetween the number of matching pods in the target topology and the global minimum.\nThe global minimum is the minimum number of matching pods in an eligible domain\nor zero if the number of eligible domains is less than MinDomains.\nFor example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same\nlabelSelector spread as 2/2/1:\nIn this case, the global minimum is 1.\n| zone1 | zone2 | zone3 |\n|  P P  |  P P  |   P   |\n- if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2;\nscheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2)\nviolate MaxSkew(1).\n- if MaxSkew is 2, incoming pod can be scheduled onto any zone.\nWhen `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence\nto topologies that satisfy it.\nIt's a required field. Default value is 1 and 0 is not allowed.",
+                                "format": "int32",
+                                "type": "integer",
+                                "minimum": -2147483648,
+                                "maximum": 2147483647
+                            },
+                            "minDomains": {
+                                "description": "MinDomains indicates a minimum number of eligible domains.\nWhen the number of eligible domains with matching topology keys is less than minDomains,\nPod Topology Spread treats \"global minimum\" as 0, and then the calculation of Skew is performed.\nAnd when the number of eligible domains with matching topology keys equals or greater than minDomains,\nthis value has no effect on scheduling.\nAs a result, when the number of eligible domains is less than minDomains,\nscheduler won't schedule more than maxSkew Pods to those domains.\nIf value is nil, the constraint behaves as if MinDomains is equal to 1.\nValid values are integers greater than 0.\nWhen value is not nil, WhenUnsatisfiable must be DoNotSchedule.\n\nFor example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same\nlabelSelector spread as 2/2/2:\n| zone1 | zone2 | zone3 |\n|  P P  |  P P  |  P P  |\nThe number of domains is less than 5(MinDomains), so \"global minimum\" is treated as 0.\nIn this situation, new pod with the same labelSelector cannot be scheduled,\nbecause computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones,\nit will violate MaxSkew.",
+                                "format": "int32",
+                                "type": "integer",
+                                "minimum": -2147483648,
+                                "maximum": 2147483647
+                            },
+                            "nodeAffinityPolicy": {
+                                "description": "NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector\nwhen calculating pod topology spread skew. Options are:\n- Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.\n- Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.\n\nIf this value is nil, the behavior is equivalent to the Honor policy.",
+                                "type": "string"
+                            },
+                            "nodeTaintsPolicy": {
+                                "description": "NodeTaintsPolicy indicates how we will treat node taints when calculating\npod topology spread skew. Options are:\n- Honor: nodes without taints, along with tainted nodes for which the incoming pod\nhas a toleration, are included.\n- Ignore: node taints are ignored. All nodes are included.\n\nIf this value is nil, the behavior is equivalent to the Ignore policy.",
+                                "type": "string"
+                            },
+                            "topologyKey": {
+                                "description": "TopologyKey is the key of node labels. Nodes that have a label with this key\nand identical values are considered to be in the same topology.\nWe consider each <key, value> as a \"bucket\", and try to put balanced number\nof pods into each bucket.\nWe define a domain as a particular instance of a topology.\nAlso, we define an eligible domain as a domain whose nodes meet the requirements of\nnodeAffinityPolicy and nodeTaintsPolicy.\ne.g. If TopologyKey is \"kubernetes.io/hostname\", each Node is a domain of that topology.\nAnd, if TopologyKey is \"topology.kubernetes.io/zone\", each zone is a domain of that topology.\nIt's a required field.",
+                                "type": "string"
+                            },
+                            "whenUnsatisfiable": {
+                                "description": "WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy\nthe spread constraint.\n- DoNotSchedule (default) tells the scheduler not to schedule it.\n- ScheduleAnyway tells the scheduler to schedule the pod in any location,\n  but giving higher precedence to topologies that would help reduce the\n  skew.\nA constraint is considered \"Unsatisfiable\" for an incoming pod\nif and only if every possible node assignment for that pod would violate\n\"MaxSkew\" on some topology.\nFor example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same\nlabelSelector spread as 3/1/1:\n| zone1 | zone2 | zone3 |\n| P P P |   P   |   P   |\nIf WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled\nto zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies\nMaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler\nwon't make it *more* imbalanced.\nIt's a required field.",
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "maxSkew",
+                            "topologyKey",
+                            "whenUnsatisfiable"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "webhook": {
+                    "description": "Configuration for webhooks to trigger renovate runs",
+                    "properties": {
+                        "authentication": {
+                            "description": "authentication configuration for webhooks",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean"
+                                },
+                                "secretRef": {
+                                    "description": "reference to a secret and key",
+                                    "properties": {
+                                        "key": {
+                                            "type": "string"
+                                        },
+                                        "name": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                }
+                            },
+                            "required": [
+                                "enabled"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "forgejo": {
+                            "description": "Forgejo-specific webhook configuration",
+                            "properties": {
+                                "sync": {
+                                    "description": "configuration for syncing webhooks to Forgejo repos by topic",
+                                    "properties": {
+                                        "authTokenSecretRef": {
+                                            "description": "reference to a secret and key",
+                                            "properties": {
+                                                "key": {
+                                                    "type": "string"
+                                                },
+                                                "name": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                        },
+                                        "enabled": {
+                                            "type": "boolean"
+                                        },
+                                        "events": {
+                                            "items": {
+                                                "type": "string"
+                                            },
+                                            "type": "array"
+                                        },
+                                        "tokenSecretRef": {
+                                            "description": "reference to a secret and key",
+                                            "properties": {
+                                                "key": {
+                                                    "type": "string"
+                                                },
+                                                "name": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                        },
+                                        "topic": {
+                                            "type": "string"
+                                        },
+                                        "webhookURL": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "enabled",
+                                        "webhookURL"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        }
+                    },
+                    "required": [
+                        "enabled"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
                 }
-              },
-              "required": [
-                "enabled"
-              ],
-              "type": "object",
-              "additionalProperties": false
-            },
-            "enabled": {
-              "type": "boolean"
-            }
-          },
-          "required": [
-            "enabled"
-          ],
-          "type": "object",
-          "additionalProperties": false
-        }
-      },
-      "required": [
-        "parallelism",
-        "schedule"
-      ],
-      "type": "object",
-      "additionalProperties": false
-    },
-    "status": {
-      "description": "RenovateJobStatus defines the observed state of RenovateJob",
-      "properties": {
-        "projects": {
-          "items": {
-            "description": "Status of a single project within a RenovateJob",
-            "properties": {
-              "lastRun": {
-                "format": "date-time",
-                "type": "string"
-              },
-              "name": {
-                "type": "string"
-              },
-              "status": {
-                "type": "string"
-              }
             },
             "required": [
-              "lastRun",
-              "name",
-              "status"
+                "image",
+                "parallelism",
+                "provider",
+                "schedule"
             ],
             "type": "object",
             "additionalProperties": false
-          },
-          "type": "array"
+        },
+        "status": {
+            "description": "RenovateJobStatus defines the observed state of RenovateJob",
+            "properties": {
+                "executionOptions": {
+                    "properties": {
+                        "debug": {
+                            "description": "If true, the renovate job will be executed with LOG_LEVEL=debug",
+                            "type": "boolean"
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "projects": {
+                    "items": {
+                        "description": "Status of a single project within a RenovateJob",
+                        "properties": {
+                            "duration": {
+                                "type": "string"
+                            },
+                            "lastRun": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "logIssues": {
+                                "description": "LogIssues contains aggregate counts and individual issue messages from a Renovate run.",
+                                "properties": {
+                                    "errorCount": {
+                                        "type": "integer"
+                                    },
+                                    "issues": {
+                                        "items": {
+                                            "description": "LogIssue represents a single warning or error from Renovate logs.",
+                                            "properties": {
+                                                "level": {
+                                                    "type": "integer"
+                                                },
+                                                "message": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "level",
+                                                "message"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                    },
+                                    "truncated": {
+                                        "type": "boolean"
+                                    },
+                                    "warnCount": {
+                                        "type": "integer"
+                                    }
+                                },
+                                "required": [
+                                    "errorCount",
+                                    "warnCount"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "name": {
+                                "type": "string"
+                            },
+                            "prActivity": {
+                                "description": "PRActivity contains aggregate counts and individual details of PR activity from a run.",
+                                "properties": {
+                                    "automerged": {
+                                        "type": "integer"
+                                    },
+                                    "created": {
+                                        "type": "integer"
+                                    },
+                                    "prs": {
+                                        "items": {
+                                            "description": "PRDetail represents a single PR found in Renovate logs.",
+                                            "properties": {
+                                                "action": {
+                                                    "description": "PRAction represents what happened to a PR in a Renovate run.",
+                                                    "type": "string"
+                                                },
+                                                "branch": {
+                                                    "type": "string"
+                                                },
+                                                "number": {
+                                                    "type": "integer"
+                                                },
+                                                "title": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "action",
+                                                "branch"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                    },
+                                    "truncated": {
+                                        "type": "boolean"
+                                    },
+                                    "unchanged": {
+                                        "type": "integer"
+                                    },
+                                    "updated": {
+                                        "type": "integer"
+                                    }
+                                },
+                                "required": [
+                                    "automerged",
+                                    "created",
+                                    "unchanged",
+                                    "updated"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "priority": {
+                                "format": "int32",
+                                "type": "integer",
+                                "minimum": -2147483648,
+                                "maximum": 2147483647
+                            },
+                            "renovateResultStatus": {
+                                "type": "string"
+                            },
+                            "status": {
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "lastRun",
+                            "name",
+                            "status"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
         }
-      },
-      "type": "object",
-      "additionalProperties": false
-    }
-  },
-  "type": "object"
+    },
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
 }


### PR DESCRIPTION
The [CRD for renovatejob_v1alpha1.json](https://github.com/mogenius/renovate-operator/blob/c84827d9d2b79c4211dae5134e5ec3c0b2ef2204/charts/renovate-operator/crd/renovate-operator.mogenius.com_renovatejobs.yaml) changed; I noticed because validating against this repository failed, expecting `discoveryFilter` as string, instead of a `discoveryFilters` list.

## PR Checklist

- [x] I generated these CRs using the [CRD Extractor tool](https://github.com/datreeio/CRDs-catalog?tab=readme-ov-file#crd-extractor). If I used a different method, I have described the method in this PR.
  - I used openapi2jsonschema.py directly against CRD from Helm chart, instead of extracting from cluster
- [x] I am updating existing schemas and have specified the updated schema version.
  - updating RenovateJob v1alpha1 with incompatible changes
- ~I am adding new schemas and included a link to the GitHub repository that contains the source of these schemas.~
