### PR TITLE
add: apps.gitlab.com runner_v1beta2

### DIFF
--- a/apps.gitlab.com/runner_v1beta2.json
+++ b/apps.gitlab.com/runner_v1beta2.json
@@ -1,0 +1,284 @@
+{
+  "description": "Runner is the open source project used to run your jobs and send the results back to GitLab",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Specification of the desired behavior of a GitLab Runner instance",
+      "properties": {
+        "azure": {
+          "description": "options used to setup Azure blob\nstorage as GitLab Runner Cache",
+          "properties": {
+            "container": {
+              "description": "Name of the Azure container in which the cache will be stored",
+              "type": "string"
+            },
+            "credentials": {
+              "description": "Credentials secret contains 'accountName' and 'privateKey'\nused to authenticate against Azure blob storage",
+              "type": "string"
+            },
+            "storageDomain": {
+              "description": "The domain name of the Azure blob storage\ne.g. blob.core.windows.net",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "buildImage": {
+          "description": "The name of the default image to use to run\nbuild jobs, when none is specified",
+          "type": "string"
+        },
+        "ca": {
+          "description": "Name of tls secret containing the custom certificate\nauthority (CA) certificates",
+          "type": "string"
+        },
+        "cachePath": {
+          "description": "Path defines the Runner Cache path",
+          "type": "string"
+        },
+        "cacheShared": {
+          "description": "Enable sharing of cache between Runners",
+          "type": "boolean"
+        },
+        "cacheType": {
+          "description": "Type of cache used for Runner artifacts\nOptions are: gcs, s3, azure",
+          "type": "string"
+        },
+        "cloneURL": {
+          "description": "If specified, overrides the default URL used to clone or fetch the Git ref",
+          "type": "string"
+        },
+        "concurrent": {
+          "description": "Option to limit the number of jobs globally that can run concurrently.\nThe operator sets this to 10, if not specified",
+          "format": "int32",
+          "type": "integer"
+        },
+        "config": {
+          "description": "allow user to provide configmap name\ncontaining the user provided config.toml",
+          "type": "string"
+        },
+        "connectionMaxAge": {
+          "description": "The maximum duration a TLS keepalive connection to the GitLab server should remain open before reconnecting. The default value is `15m` for 15 minutes. If set to `0` or lower, the connection persists as long as possible.",
+          "type": "string"
+        },
+        "deploymentSpec": {
+          "description": "DeploymentSpec manipulates the GitLab Runner Manager's deployment by applying [KubernetesSpecPatch]es to it.\nDeploymentSpec patches will be applied before [PodSpec] patches.",
+          "items": {
+            "description": "KubernetesSpecPatch represents the structure expected when adding a custom patches to configure\nthe GitLab Runner Manager.",
+            "properties": {
+              "name": {
+                "description": "Name is the name given to the custom Pod Spec",
+                "type": "string"
+              },
+              "patch": {
+                "description": "A JSON or YAML format string that describes the changes which must be applied\nto the final PodSpec object before it is generated.\nYou cannot set the patch_path and patch in the same pod_spec configuration, otherwise an error occurs.",
+                "type": "string"
+              },
+              "patchFile": {
+                "description": "Path to the file that defines the changes to apply to the final PodSpec object before it is generated.\nThe file must be a JSON or YAML file.\nYou cannot set the patch_path and patch in the same pod_spec configuration, otherwise an error occurs.",
+                "type": "string"
+              },
+              "patchType": {
+                "description": "The strategy the runner uses to apply the specified changes to the PodSpec object generated by GitLab Runner.\nThe accepted values are merge, json, and strategic (default value).",
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "patchType"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "env": {
+          "description": "Accepts configmap name. Provides user mechanism to inject environment\nvariables in the GitLab Runner pod via the key value pairs in the ConfigMap",
+          "type": "string"
+        },
+        "gcs": {
+          "description": "options used to setup GCS (Google\nContainer Storage) as GitLab Runner Cache",
+          "properties": {
+            "bucket": {
+              "description": "Name of the bucket in which the cache will be stored",
+              "type": "string"
+            },
+            "credentials": {
+              "description": "contains the GCS 'access-id' and 'private-key'",
+              "type": "string"
+            },
+            "credentialsFile": {
+              "description": "Takes GCS credentials file, 'keys.json'",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "gitlabUrl": {
+          "description": "The fully qualified domain name for the GitLab instance.\nFor example, https://gitlab.example.com",
+          "type": "string"
+        },
+        "helperImage": {
+          "description": "If specified, overrides the default GitLab Runner helper image",
+          "type": "string"
+        },
+        "imagePullPolicy": {
+          "description": "ImagePullPolicy sets the Image pull policy.\nOne of Always, Never, IfNotPresent.\nDefaults to Always if :latest tag is specified, or IfNotPresent otherwise.\nMore info: https://kubernetes.io/docs/concepts/containers/images#updating-images",
+          "type": "string"
+        },
+        "interval": {
+          "description": "Option to define the number of seconds between checks for new jobs.\nThis is set to a default of 30s by operator if not set",
+          "format": "int32",
+          "type": "integer"
+        },
+        "listenAddr": {
+          "description": "Option to set the metrics listen address for the runner.",
+          "type": "string"
+        },
+        "locked": {
+          "description": "Specify whether the runner should be locked to a specific project. Defaults to false.",
+          "type": "boolean"
+        },
+        "logFormat": {
+          "description": "Specifies the log format. Options are `runner`, `text`, and `json`. The default value is `runner`, which contains ANSI escape codes for coloring.",
+          "type": "string"
+        },
+        "logLevel": {
+          "description": "Option to set the log level for the runner.\nValid values are \"debug\", \"info\", \"warn\", \"error\", \"fatal\", \"panic\"",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "If specified, overrides the namespace where job pods are created",
+          "type": "string"
+        },
+        "podSpec": {
+          "description": "PodSpec manipulates the GitLab Runner Manager's pod by applying [KubernetesSpecPatch]es to it.\nPodSpec patches will be applied after [DeploymentSpec] patches.",
+          "items": {
+            "description": "KubernetesSpecPatch represents the structure expected when adding a custom patches to configure\nthe GitLab Runner Manager.",
+            "properties": {
+              "name": {
+                "description": "Name is the name given to the custom Pod Spec",
+                "type": "string"
+              },
+              "patch": {
+                "description": "A JSON or YAML format string that describes the changes which must be applied\nto the final PodSpec object before it is generated.\nYou cannot set the patch_path and patch in the same pod_spec configuration, otherwise an error occurs.",
+                "type": "string"
+              },
+              "patchFile": {
+                "description": "Path to the file that defines the changes to apply to the final PodSpec object before it is generated.\nThe file must be a JSON or YAML file.\nYou cannot set the patch_path and patch in the same pod_spec configuration, otherwise an error occurs.",
+                "type": "string"
+              },
+              "patchType": {
+                "description": "The strategy the runner uses to apply the specified changes to the PodSpec object generated by GitLab Runner.\nThe accepted values are merge, json, and strategic (default value).",
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "patchType"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "protected": {
+          "description": "Specify whether the runner should only run protected branches. Defaults to false.",
+          "type": "boolean"
+        },
+        "runUntagged": {
+          "description": "Specify if jobs without tags should be run.\nIf not specified, runner will default to true if no tags were specified.\nIn other case it will default to false.",
+          "type": "boolean"
+        },
+        "runnerImage": {
+          "description": "If specified, overrides the default GitLab Runner image. Default is the Runner image the operator was bundled with.",
+          "type": "string"
+        },
+        "s3": {
+          "description": "options used to setup S3\nobject store as GitLab Runner Cache",
+          "properties": {
+            "bucket": {
+              "description": "Name of the bucket in which the cache will be stored",
+              "type": "string"
+            },
+            "credentials": {
+              "description": "Name of the secret containing the\n'accesskey' and 'secretkey' used to access the object storage",
+              "type": "string"
+            },
+            "insecure": {
+              "description": "Use insecure connections or HTTP",
+              "type": "boolean"
+            },
+            "location": {
+              "description": "Name of the S3 region in use",
+              "type": "string"
+            },
+            "server": {
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "sentryDsn": {
+          "description": "Enables tracking of all system level errors to Sentry.\nIf not specified, error tracking with Sentry will be disabled.",
+          "type": "string"
+        },
+        "serviceaccount": {
+          "description": "allow user to override service account\nused by GitLab Runner",
+          "type": "string"
+        },
+        "shutdownTimeout": {
+          "description": "Number of seconds until the forceful shutdown operation times out and exits the process. The default value is `30`. If set to `0` or lower, the default value is used.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "tags": {
+          "description": "List of comma separated tags to be applied to the runner\nMore info: https://docs.gitlab.com/ee/ci/runners/#use-tags-to-limit-the-number-of-jobs-using-the-runner",
+          "type": "string"
+        },
+        "token": {
+          "description": "Name of secret containing the 'runner-registration-token' key used to register the runner",
+          "type": "string"
+        }
+      },
+      "required": [
+        "gitlabUrl",
+        "token"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "Most recently observed status of the GitLab Runner.\nIt is read-only to the user",
+      "properties": {
+        "message": {
+          "description": "Additional information of GitLab Runner registration",
+          "type": "string"
+        },
+        "phase": {
+          "description": "Reports status of the GitLab Runner instance",
+          "type": "string"
+        },
+        "registration": {
+          "description": "Reports status of GitLab Runner registration",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}


### PR DESCRIPTION
Adding new [runner_v1beta2 CRD](https://gitlab.com/gitlab-org/gl-openshift/gitlab-runner-operator/-/blob/c002c4ef3b6465124ed505c14a9742b686eeee40/config/crd/bases/apps.gitlab.com_runners.yaml) for existing _apps.gitlab.com_ group.

## PR Checklist

- [x] I generated these CRs using the [CRD Extractor tool](https://github.com/datreeio/CRDs-catalog?tab=readme-ov-file#crd-extractor). If I used a different method, I have described the method in this PR.
  - I used openapi2jsonschema.py directly against CRD from repository, instead of extracting from cluster
- ~I am updating existing schemas and have specified the updated schema version.~
- [x] I am adding new schemas and included a link to the GitHub repository that contains the source of these schemas.
