### PR TITLE
fix(traefik): update schemas (new maxResponseBodySize field)

### DIFF
--- a/traefik.io/ingressroute_v1alpha1.json
+++ b/traefik.io/ingressroute_v1alpha1.json
@@ -357,7 +357,7 @@
                 "type": "array"
               },
               "syntax": {
-                "description": "Syntax defines the router's rule syntax.\nMore info: https://doc.traefik.io/traefik/v3.6/reference/routing-configuration/http/routing/rules-and-priority/#rulesyntax\nDeprecated: Please do not use this field and rewrite the router rules to use the v3 syntax.",
+                "description": "Syntax defines the router's rule syntax.\nMore info: https://doc.traefik.io/traefik/v3.6/reference/routing-configuration/http/routing/rules-and-priority/#rulesyntax\n\nDeprecated: Please do not use this field and rewrite the router rules to use the v3 syntax.",
                 "type": "string"
               }
             },

--- a/traefik.io/ingressroutetcp_v1alpha1.json
+++ b/traefik.io/ingressroutetcp_v1alpha1.json
@@ -92,7 +92,7 @@
                       "x-kubernetes-int-or-string": true
                     },
                     "proxyProtocol": {
-                      "description": "ProxyProtocol defines the PROXY protocol configuration.\nMore info: https://doc.traefik.io/traefik/v3.6/reference/routing-configuration/tcp/service/#proxy-protocol\nDeprecated: ProxyProtocol will not be supported in future APIVersions, please use ServersTransport to configure ProxyProtocol instead.",
+                      "description": "ProxyProtocol defines the PROXY protocol configuration.\nMore info: https://doc.traefik.io/traefik/v3.6/reference/routing-configuration/tcp/service/#proxy-protocol\n\nDeprecated: ProxyProtocol will not be supported in future APIVersions, please use ServersTransport to configure ProxyProtocol instead.",
                       "properties": {
                         "version": {
                           "description": "Version defines the PROXY Protocol version to use.",
@@ -109,7 +109,7 @@
                       "type": "string"
                     },
                     "terminationDelay": {
-                      "description": "TerminationDelay defines the deadline that the proxy sets, after one of its connected peers indicates\nit has closed the writing capability of its connection, to close the reading capability as well,\nhence fully terminating the connection.\nIt is a duration in milliseconds, defaulting to 100.\nA negative value means an infinite deadline (i.e. the reading capability is never closed).\nDeprecated: TerminationDelay will not be supported in future APIVersions, please use ServersTransport to configure the TerminationDelay instead.",
+                      "description": "TerminationDelay defines the deadline that the proxy sets, after one of its connected peers indicates\nit has closed the writing capability of its connection, to close the reading capability as well,\nhence fully terminating the connection.\nIt is a duration in milliseconds, defaulting to 100.\nA negative value means an infinite deadline (i.e. the reading capability is never closed).\n\nDeprecated: TerminationDelay will not be supported in future APIVersions, please use ServersTransport to configure the TerminationDelay instead.",
                       "type": "integer"
                     },
                     "tls": {
@@ -132,7 +132,7 @@
                 "type": "array"
               },
               "syntax": {
-                "description": "Syntax defines the router's rule syntax.\nMore info: https://doc.traefik.io/traefik/v3.6/reference/routing-configuration/tcp/routing/rules-and-priority/#rulesyntax\nDeprecated: Please do not use this field and rewrite the router rules to use the v3 syntax.",
+                "description": "Syntax defines the router's rule syntax.\nMore info: https://doc.traefik.io/traefik/v3.6/reference/routing-configuration/tcp/routing/rules-and-priority/#rulesyntax\n\nDeprecated: Please do not use this field and rewrite the router rules to use the v3 syntax.",
                 "enum": [
                   "v3",
                   "v2"

--- a/traefik.io/middleware_v1alpha1.json
+++ b/traefik.io/middleware_v1alpha1.json
@@ -211,7 +211,7 @@
           "description": "ContentType holds the content-type middleware configuration.\nThis middleware exists to enable the correct behavior until at least the default one can be changed in a future version.",
           "properties": {
             "autoDetect": {
-              "description": "AutoDetect specifies whether to let the `Content-Type` header, if it has not been set by the backend,\nbe automatically set to a value derived from the contents of the response.\nDeprecated: AutoDetect option is deprecated, Content-Type middleware is only meant to be used to enable the content-type detection, please remove any usage of this option.",
+              "description": "AutoDetect specifies whether to let the `Content-Type` header, if it has not been set by the backend,\nbe automatically set to a value derived from the contents of the response.\n\nDeprecated: AutoDetect option is deprecated, Content-Type middleware is only meant to be used to enable the content-type detection, please remove any usage of this option.",
               "type": "boolean"
             }
           },
@@ -546,6 +546,11 @@
             },
             "maxBodySize": {
               "description": "MaxBodySize defines the maximum body size in bytes allowed to be forwarded to the authentication server.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "maxResponseBodySize": {
+              "description": "MaxResponseBodySize defines the maximum body size in bytes allowed in the response from the authentication server.",
               "format": "int64",
               "type": "integer"
             },
@@ -1202,7 +1207,7 @@
           "description": "RedirectScheme holds the redirect scheme middleware configuration.\nThis middleware redirects requests from a scheme/port to another.\nMore info: https://doc.traefik.io/traefik/v3.6/middlewares/http/redirectscheme/",
           "properties": {
             "permanent": {
-              "description": "Permanent defines whether the redirection is permanent (308).",
+              "description": "Permanent defines whether the redirection is permanent.\nFor HTTP GET requests a 301 is returned, otherwise a 308 is returned.",
               "type": "boolean"
             },
             "port": {

--- a/traefik.io/middlewaretcp_v1alpha1.json
+++ b/traefik.io/middlewaretcp_v1alpha1.json
@@ -43,7 +43,7 @@
           "additionalProperties": false
         },
         "ipWhiteList": {
-          "description": "IPWhiteList defines the IPWhiteList middleware configuration.\nThis middleware accepts/refuses connections based on the client IP.\nDeprecated: please use IPAllowList instead.\nMore info: https://doc.traefik.io/traefik/v3.6/reference/routing-configuration/tcp/middlewares/ipwhitelist/",
+          "description": "IPWhiteList defines the IPWhiteList middleware configuration.\nThis middleware accepts/refuses connections based on the client IP.\nMore info: https://doc.traefik.io/traefik/v3.6/reference/routing-configuration/tcp/middlewares/ipwhitelist/\n\nDeprecated: please use IPAllowList instead.",
           "properties": {
             "sourceRange": {
               "description": "SourceRange defines the allowed IPs (or ranges of allowed IPs by using CIDR notation).",

--- a/traefik.io/serverstransport_v1alpha1.json
+++ b/traefik.io/serverstransport_v1alpha1.json
@@ -137,7 +137,7 @@
           "type": "array"
         },
         "rootCAsSecrets": {
-          "description": "RootCAsSecrets defines a list of CA secret used to validate self-signed certificate.\nDeprecated: RootCAsSecrets is deprecated, please use the RootCAs option instead.",
+          "description": "RootCAsSecrets defines a list of CA secret used to validate self-signed certificate.\n\nDeprecated: RootCAsSecrets is deprecated, please use the RootCAs option instead.",
           "items": {
             "type": "string"
           },

--- a/traefik.io/serverstransporttcp_v1alpha1.json
+++ b/traefik.io/serverstransporttcp_v1alpha1.json
@@ -111,7 +111,7 @@
               "type": "array"
             },
             "rootCAsSecrets": {
-              "description": "RootCAsSecrets defines a list of CA secret used to validate self-signed certificate.\nDeprecated: RootCAsSecrets is deprecated, please use the RootCAs option instead.",
+              "description": "RootCAsSecrets defines a list of CA secret used to validate self-signed certificate.\n\nDeprecated: RootCAsSecrets is deprecated, please use the RootCAs option instead.",
               "items": {
                 "type": "string"
               },

--- a/traefik.io/tlsoption_v1alpha1.json
+++ b/traefik.io/tlsoption_v1alpha1.json
@@ -74,7 +74,7 @@
           "type": "string"
         },
         "preferServerCipherSuites": {
-          "description": "PreferServerCipherSuites defines whether the server chooses a cipher suite among his own instead of among the client's.\nIt is enabled automatically when minVersion or maxVersion is set.\nDeprecated: https://github.com/golang/go/issues/45430",
+          "description": "PreferServerCipherSuites defines whether the server chooses a cipher suite among his own instead of among the client's.\nIt is enabled automatically when minVersion or maxVersion is set.\n\nDeprecated: https://github.com/golang/go/issues/45430",
           "type": "boolean"
         },
         "sniStrict": {


### PR DESCRIPTION
- Add new `maxResponseBodySize` field to ForwardAuth middleware

## PR Checklist

- [x] I generated these CRs using the [CRD Extractor tool](https://github.com/datreeio/CRDs-catalog?tab=readme-ov-file#crd-extractor). If I used a different method, I have described the method in this PR.
- [x] I am updating existing schemas and have specified the updated schema version.
- [ ] I am adding new schemas and included a link to the GitHub repository that contains the source of these schemas.
