### PR TITLE
Add metadata field to feature flag specification

### DIFF
--- a/core.openfeature.dev/featureflag_v1beta1.json
+++ b/core.openfeature.dev/featureflag_v1beta1.json
@@ -18,6 +18,10 @@
         "flagSpec": {
           "description": "FlagSpec is the structured representation of the feature flag specification",
           "properties": {
+            "metadata": {
+              "type": "object",
+              "x-kubernetes-preserve-unknown-fields": true
+            },
             "$evaluators": {
               "type": "object",
               "x-kubernetes-preserve-unknown-fields": true


### PR DESCRIPTION
according to official go type definition https://github.com/open-feature/open-feature-operator/blob/main/api/core/v1beta1/featureflag_types.go#L33 and the kubernetes spec https://github.com/open-feature/open-feature-operator/blob/097bc22264a0a0d6724d6e7d2c75c50d37760907/config/crd/bases/core.openfeature.dev_featureflags.yaml#L80

## PR Checklist

- [X] I generated these CRs using the [CRD Extractor tool](https://github.com/datreeio/CRDs-catalog?tab=readme-ov-file#crd-extractor). If I used a different method, I have described the method in this PR.
- [X] I am updating existing schemas and have specified the updated schema version.
- [ ] I am adding new schemas and included a link to the GitHub repository that contains the source of these schemas.
