### PR TITLE
Add Knative Serving CRDs (v1.22.0)

### DIFF
--- a/autoscaling.internal.knative.dev/metric_v1alpha1.json
+++ b/autoscaling.internal.knative.dev/metric_v1alpha1.json
@@ -1,0 +1,101 @@
+{
+  "description": "Metric represents a resource to configure the metric collector with.",
+  "type": "object",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Spec holds the desired state of the Metric (from the client).",
+      "type": "object",
+      "required": [
+        "panicWindow",
+        "scrapeTarget",
+        "stableWindow"
+      ],
+      "properties": {
+        "panicWindow": {
+          "description": "PanicWindow is the aggregation window for metrics where quick reactions are needed.",
+          "type": "integer",
+          "format": "int64"
+        },
+        "scrapeTarget": {
+          "description": "ScrapeTarget is the K8s service that publishes the metric endpoint.",
+          "type": "string"
+        },
+        "stableWindow": {
+          "description": "StableWindow is the aggregation window for metrics in a stable state.",
+          "type": "integer",
+          "format": "int64"
+        }
+      },
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "Status communicates the observed state of the Metric (from the controller).",
+      "type": "object",
+      "properties": {
+        "annotations": {
+          "description": "Annotations is additional Status fields for the Resource to save some\nadditional State as well as convey more information to the user. This is\nroughly akin to Annotations on any k8s resource, just the reconciler conveying\nricher information outwards.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "conditions": {
+          "description": "Conditions the latest available observations of a resource's current state.",
+          "type": "array",
+          "items": {
+            "description": "Condition defines a readiness condition for a Knative resource.\nSee: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties",
+            "type": "object",
+            "required": [
+              "status",
+              "type"
+            ],
+            "properties": {
+              "lastTransitionTime": {
+                "description": "LastTransitionTime is the last time the condition transitioned from one status to another.\nWe use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic\ndifferences (all other things held constant).",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity with which to treat failures of this type of condition.\nWhen this is not specified, it defaults to Error.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition.",
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration is the 'Generation' of the Service that\nwas last processed by the controller.",
+          "type": "integer",
+          "format": "int64"
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/autoscaling.internal.knative.dev/podautoscaler_v1alpha1.json
+++ b/autoscaling.internal.knative.dev/podautoscaler_v1alpha1.json
@@ -1,0 +1,141 @@
+{
+  "description": "PodAutoscaler is a Knative abstraction that encapsulates the interface by which Knative\ncomponents instantiate autoscalers.  This definition is an abstraction that may be backed\nby multiple definitions.  For more information, see the Knative Pluggability presentation:\nhttps://docs.google.com/presentation/d/19vW9HFZ6Puxt31biNZF3uLRejDmu82rxJIk1cWmxF7w/edit",
+  "type": "object",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Spec holds the desired state of the PodAutoscaler (from the client).",
+      "type": "object",
+      "required": [
+        "protocolType",
+        "scaleTargetRef"
+      ],
+      "properties": {
+        "containerConcurrency": {
+          "description": "ContainerConcurrency specifies the maximum allowed\nin-flight (concurrent) requests per container of the Revision.\nDefaults to `0` which means unlimited concurrency.",
+          "type": "integer",
+          "format": "int64"
+        },
+        "protocolType": {
+          "description": "The application-layer protocol. Matches `ProtocolType` inferred from the revision spec.",
+          "type": "string"
+        },
+        "reachability": {
+          "description": "Reachability specifies whether or not the `ScaleTargetRef` can be reached (ie. has a route).\nDefaults to `ReachabilityUnknown`",
+          "type": "string"
+        },
+        "scaleTargetRef": {
+          "description": "ScaleTargetRef defines the /scale-able resource that this PodAutoscaler\nis responsible for quickly right-sizing.",
+          "type": "object",
+          "properties": {
+            "apiVersion": {
+              "description": "API version of the referent.",
+              "type": "string"
+            },
+            "kind": {
+              "description": "Kind of the referent.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+              "type": "string"
+            }
+          },
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "Status communicates the observed state of the PodAutoscaler (from the controller).",
+      "type": "object",
+      "required": [
+        "metricsServiceName",
+        "serviceName"
+      ],
+      "properties": {
+        "actualScale": {
+          "description": "ActualScale shows the actual number of replicas for the revision.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "annotations": {
+          "description": "Annotations is additional Status fields for the Resource to save some\nadditional State as well as convey more information to the user. This is\nroughly akin to Annotations on any k8s resource, just the reconciler conveying\nricher information outwards.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "conditions": {
+          "description": "Conditions the latest available observations of a resource's current state.",
+          "type": "array",
+          "items": {
+            "description": "Condition defines a readiness condition for a Knative resource.\nSee: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties",
+            "type": "object",
+            "required": [
+              "status",
+              "type"
+            ],
+            "properties": {
+              "lastTransitionTime": {
+                "description": "LastTransitionTime is the last time the condition transitioned from one status to another.\nWe use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic\ndifferences (all other things held constant).",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity with which to treat failures of this type of condition.\nWhen this is not specified, it defaults to Error.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition.",
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "desiredScale": {
+          "description": "DesiredScale shows the current desired number of replicas for the revision.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "metricsServiceName": {
+          "description": "MetricsServiceName is the K8s Service name that provides revision metrics.\nThe service is managed by the PA object.",
+          "type": "string"
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration is the 'Generation' of the Service that\nwas last processed by the controller.",
+          "type": "integer",
+          "format": "int64"
+        },
+        "serviceName": {
+          "description": "ServiceName is the K8s Service name that serves the revision, scaled by this PA.\nThe service is created and owned by the ServerlessService object owned by this PA.",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/caching.internal.knative.dev/image_v1alpha1.json
+++ b/caching.internal.knative.dev/image_v1alpha1.json
@@ -1,0 +1,110 @@
+{
+  "description": "Image is a Knative abstraction that encapsulates the interface by which Knative\ncomponents express a desire to have a particular image cached.",
+  "type": "object",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Spec holds the desired state of the Image (from the client).",
+      "type": "object",
+      "required": [
+        "image"
+      ],
+      "properties": {
+        "image": {
+          "description": "Image is the name of the container image url to cache across the cluster.",
+          "type": "string"
+        },
+        "imagePullSecrets": {
+          "description": "ImagePullSecrets contains the names of the Kubernetes Secrets containing login\ninformation used by the Pods which will run this container.",
+          "type": "array",
+          "items": {
+            "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
+            "type": "object",
+            "properties": {
+              "name": {
+                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                "type": "string",
+                "default": ""
+              }
+            },
+            "x-kubernetes-map-type": "atomic",
+            "additionalProperties": false
+          }
+        },
+        "serviceAccountName": {
+          "description": "ServiceAccountName is the name of the Kubernetes ServiceAccount as which the Pods\nwill run this container.  This is potentially used to authenticate the image pull\nif the service account has attached pull secrets.  For more information:\nhttps://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#add-imagepullsecrets-to-a-service-account",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "Status communicates the observed state of the Image (from the controller).",
+      "type": "object",
+      "properties": {
+        "annotations": {
+          "description": "Annotations is additional Status fields for the Resource to save some\nadditional State as well as convey more information to the user. This is\nroughly akin to Annotations on any k8s resource, just the reconciler conveying\nricher information outwards.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "conditions": {
+          "description": "Conditions the latest available observations of a resource's current state.",
+          "type": "array",
+          "items": {
+            "description": "Condition defines a readiness condition for a Knative resource.\nSee: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties",
+            "type": "object",
+            "required": [
+              "status",
+              "type"
+            ],
+            "properties": {
+              "lastTransitionTime": {
+                "description": "LastTransitionTime is the last time the condition transitioned from one status to another.\nWe use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic\ndifferences (all other things held constant).",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity with which to treat failures of this type of condition.\nWhen this is not specified, it defaults to Error.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition.",
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration is the 'Generation' of the Service that\nwas last processed by the controller.",
+          "type": "integer",
+          "format": "int64"
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/networking.internal.knative.dev/certificate_v1alpha1.json
+++ b/networking.internal.knative.dev/certificate_v1alpha1.json
@@ -1,0 +1,141 @@
+{
+  "description": "Certificate is responsible for provisioning a SSL certificate for the\ngiven hosts. It is a Knative abstraction for various SSL certificate\nprovisioning solutions (such as cert-manager or self-signed SSL certificate).",
+  "type": "object",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Spec is the desired state of the Certificate.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
+      "type": "object",
+      "required": [
+        "dnsNames",
+        "secretName"
+      ],
+      "properties": {
+        "dnsNames": {
+          "description": "DNSNames is a list of DNS names the Certificate could support.\nThe wildcard format of DNSNames (e.g. *.default.example.com) is supported.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "domain": {
+          "description": "Domain is the top level domain of the values for DNSNames.",
+          "type": "string"
+        },
+        "secretName": {
+          "description": "SecretName is the name of the secret resource to store the SSL certificate in.",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "Status is the current state of the Certificate.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
+      "type": "object",
+      "properties": {
+        "annotations": {
+          "description": "Annotations is additional Status fields for the Resource to save some\nadditional State as well as convey more information to the user. This is\nroughly akin to Annotations on any k8s resource, just the reconciler conveying\nricher information outwards.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "conditions": {
+          "description": "Conditions the latest available observations of a resource's current state.",
+          "type": "array",
+          "items": {
+            "description": "Condition defines a readiness condition for a Knative resource.\nSee: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties",
+            "type": "object",
+            "required": [
+              "status",
+              "type"
+            ],
+            "properties": {
+              "lastTransitionTime": {
+                "description": "LastTransitionTime is the last time the condition transitioned from one status to another.\nWe use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic\ndifferences (all other things held constant).",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity with which to treat failures of this type of condition.\nWhen this is not specified, it defaults to Error.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition.",
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "http01Challenges": {
+          "description": "HTTP01Challenges is a list of HTTP01 challenges that need to be fulfilled\nin order to get the TLS certificate..",
+          "type": "array",
+          "items": {
+            "description": "HTTP01Challenge defines the status of a HTTP01 challenge that a certificate needs\nto fulfill.",
+            "type": "object",
+            "properties": {
+              "serviceName": {
+                "description": "ServiceName is the name of the service to serve HTTP01 challenge requests.",
+                "type": "string"
+              },
+              "serviceNamespace": {
+                "description": "ServiceNamespace is the namespace of the service to serve HTTP01 challenge requests.",
+                "type": "string"
+              },
+              "servicePort": {
+                "description": "ServicePort is the port of the service to serve HTTP01 challenge requests.",
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ],
+                "x-kubernetes-int-or-string": true
+              },
+              "url": {
+                "description": "URL is the URL that the HTTP01 challenge is expected to serve on.",
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "notAfter": {
+          "description": "The expiration time of the TLS certificate stored in the secret named\nby this resource in spec.secretName.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration is the 'Generation' of the Service that\nwas last processed by the controller.",
+          "type": "integer",
+          "format": "int64"
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/networking.internal.knative.dev/clusterdomainclaim_v1alpha1.json
+++ b/networking.internal.knative.dev/clusterdomainclaim_v1alpha1.json
@@ -1,0 +1,31 @@
+{
+  "description": "ClusterDomainClaim is a cluster-wide reservation for a particular domain name.",
+  "type": "object",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Spec is the desired state of the ClusterDomainClaim.\nMore info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
+      "type": "object",
+      "required": [
+        "namespace"
+      ],
+      "properties": {
+        "namespace": {
+          "description": "Namespace is the namespace which is allowed to create a DomainMapping\nusing this ClusterDomainClaim's name.",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/networking.internal.knative.dev/ingress_v1alpha1.json
+++ b/networking.internal.knative.dev/ingress_v1alpha1.json
@@ -1,0 +1,305 @@
+{
+  "description": "Ingress is a collection of rules that allow inbound connections to reach the endpoints defined\nby a backend. An Ingress can be configured to give services externally-reachable URLs, load\nbalance traffic, offer name based virtual hosting, etc.\n\nThis is heavily based on K8s Ingress https://godoc.org/k8s.io/api/networking/v1beta1#Ingress\nwhich some highlighted modifications.",
+  "type": "object",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Spec is the desired state of the Ingress.\nMore info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
+      "type": "object",
+      "properties": {
+        "httpOption": {
+          "description": "HTTPOption is the option of HTTP. It has the following two values:\n`HTTPOptionEnabled`, `HTTPOptionRedirected`",
+          "type": "string"
+        },
+        "rules": {
+          "description": "A list of host rules used to configure the Ingress.",
+          "type": "array",
+          "items": {
+            "description": "IngressRule represents the rules mapping the paths under a specified host to\nthe related backend services. Incoming requests are first evaluated for a host\nmatch, then routed to the backend associated with the matching IngressRuleValue.",
+            "type": "object",
+            "properties": {
+              "hosts": {
+                "description": "Host is the fully qualified domain name of a network host, as defined\nby RFC 3986. Note the following deviations from the \"host\" part of the\nURI as defined in the RFC:\n1. IPs are not allowed. Currently a rule value can only apply to the\n\t  IP in the Spec of the parent .\n2. The `:` delimiter is not respected because ports are not allowed.\n\t  Currently the port of an Ingress is implicitly :80 for http and\n\t  :443 for https.\nBoth these may change in the future.\nIf the host is unspecified, the Ingress routes all traffic based on the\nspecified IngressRuleValue.\nIf multiple matching Hosts were provided, the first rule will take precedent.",
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "http": {
+                "description": "HTTP represents a rule to apply against incoming requests. If the\nrule is satisfied, the request is routed to the specified backend.",
+                "type": "object",
+                "required": [
+                  "paths"
+                ],
+                "properties": {
+                  "paths": {
+                    "description": "A collection of paths that map requests to backends.\n\nIf they are multiple matching paths, the first match takes precedence.",
+                    "type": "array",
+                    "items": {
+                      "description": "HTTPIngressPath associates a path regex with a backend. Incoming URLs matching\nthe path are forwarded to the backend.",
+                      "type": "object",
+                      "required": [
+                        "splits"
+                      ],
+                      "properties": {
+                        "appendHeaders": {
+                          "description": "AppendHeaders allow specifying additional HTTP headers to add\nbefore forwarding a request to the destination service.\n\nNOTE: This differs from K8s Ingress which doesn't allow header appending.",
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "headers": {
+                          "description": "Headers defines header matching rules which is a map from a header name\nto HeaderMatch which specify a matching condition.\nWhen a request matched with all the header matching rules,\nthe request is routed by the corresponding ingress rule.\nIf it is empty, the headers are not used for matching",
+                          "type": "object",
+                          "additionalProperties": {
+                            "description": "HeaderMatch represents a matching value of Headers in HTTPIngressPath.\nCurrently, only the exact matching is supported.",
+                            "type": "object",
+                            "required": [
+                              "exact"
+                            ],
+                            "properties": {
+                              "exact": {
+                                "type": "string"
+                              }
+                            },
+                            "additionalProperties": false
+                          }
+                        },
+                        "path": {
+                          "description": "Path represents a literal prefix to which this rule should apply.\nCurrently it can contain characters disallowed from the conventional\n\"path\" part of a URL as defined by RFC 3986. Paths must begin with\na '/'. If unspecified, the path defaults to a catch all sending\ntraffic to the backend.",
+                          "type": "string"
+                        },
+                        "rewriteHost": {
+                          "description": "RewriteHost rewrites the incoming request's host header.\n\nThis field is currently experimental and not supported by all Ingress\nimplementations.",
+                          "type": "string"
+                        },
+                        "splits": {
+                          "description": "Splits defines the referenced service endpoints to which the traffic\nwill be forwarded to.",
+                          "type": "array",
+                          "items": {
+                            "description": "IngressBackendSplit describes all endpoints for a given service and port.",
+                            "type": "object",
+                            "required": [
+                              "serviceName",
+                              "serviceNamespace",
+                              "servicePort"
+                            ],
+                            "properties": {
+                              "appendHeaders": {
+                                "description": "AppendHeaders allow specifying additional HTTP headers to add\nbefore forwarding a request to the destination service.\n\nNOTE: This differs from K8s Ingress which doesn't allow header appending.",
+                                "type": "object",
+                                "additionalProperties": {
+                                  "type": "string"
+                                }
+                              },
+                              "percent": {
+                                "description": "Specifies the split percentage, a number between 0 and 100.  If\nonly one split is specified, we default to 100.\n\nNOTE: This differs from K8s Ingress to allow percentage split.",
+                                "type": "integer"
+                              },
+                              "serviceName": {
+                                "description": "Specifies the name of the referenced service.",
+                                "type": "string"
+                              },
+                              "serviceNamespace": {
+                                "description": "Specifies the namespace of the referenced service.\n\nNOTE: This differs from K8s Ingress to allow routing to different namespaces.",
+                                "type": "string"
+                              },
+                              "servicePort": {
+                                "description": "Specifies the port of the referenced service.",
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "additionalProperties": false
+                          }
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  }
+                },
+                "additionalProperties": false
+              },
+              "visibility": {
+                "description": "Visibility signifies whether this rule should `ClusterLocal`. If it's not\nspecified then it defaults to `ExternalIP`.",
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "tls": {
+          "description": "TLS configuration. Currently Ingress only supports a single TLS\nport: 443. If multiple members of this list specify different hosts, they\nwill be multiplexed on the same port according to the hostname specified\nthrough the SNI TLS extension, if the ingress controller fulfilling the\ningress supports SNI.",
+          "type": "array",
+          "items": {
+            "description": "IngressTLS describes the transport layer security associated with an Ingress.",
+            "type": "object",
+            "properties": {
+              "hosts": {
+                "description": "Hosts is a list of hosts included in the TLS certificate. The values in\nthis list must match the name/s used in the tlsSecret. Defaults to the\nwildcard host setting for the loadbalancer controller fulfilling this\nIngress, if left unspecified.",
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "secretName": {
+                "description": "SecretName is the name of the secret used to terminate SSL traffic.",
+                "type": "string"
+              },
+              "secretNamespace": {
+                "description": "SecretNamespace is the namespace of the secret used to terminate SSL traffic.\nIf not set the namespace should be assumed to be the same as the Ingress.\nIf set the secret should have the same namespace as the Ingress otherwise\nthe behaviour is undefined and not supported.",
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "Status is the current state of the Ingress.\nMore info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
+      "type": "object",
+      "properties": {
+        "annotations": {
+          "description": "Annotations is additional Status fields for the Resource to save some\nadditional State as well as convey more information to the user. This is\nroughly akin to Annotations on any k8s resource, just the reconciler conveying\nricher information outwards.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "conditions": {
+          "description": "Conditions the latest available observations of a resource's current state.",
+          "type": "array",
+          "items": {
+            "description": "Condition defines a readiness condition for a Knative resource.\nSee: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties",
+            "type": "object",
+            "required": [
+              "status",
+              "type"
+            ],
+            "properties": {
+              "lastTransitionTime": {
+                "description": "LastTransitionTime is the last time the condition transitioned from one status to another.\nWe use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic\ndifferences (all other things held constant).",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity with which to treat failures of this type of condition.\nWhen this is not specified, it defaults to Error.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition.",
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration is the 'Generation' of the Service that\nwas last processed by the controller.",
+          "type": "integer",
+          "format": "int64"
+        },
+        "privateLoadBalancer": {
+          "description": "PrivateLoadBalancer contains the current status of the load-balancer.",
+          "type": "object",
+          "properties": {
+            "ingress": {
+              "description": "Ingress is a list containing ingress points for the load-balancer.\nTraffic intended for the service should be sent to these ingress points.",
+              "type": "array",
+              "items": {
+                "description": "LoadBalancerIngressStatus represents the status of a load-balancer ingress point:\ntraffic intended for the service should be sent to an ingress point.",
+                "type": "object",
+                "properties": {
+                  "domain": {
+                    "description": "Domain is set for load-balancer ingress points that are DNS based\n(typically AWS load-balancers)",
+                    "type": "string"
+                  },
+                  "domainInternal": {
+                    "description": "DomainInternal is set if there is a cluster-local DNS name to access the Ingress.\n\nNOTE: This differs from K8s Ingress, since we also desire to have a cluster-local\n      DNS name to allow routing in case of not having a mesh.",
+                    "type": "string"
+                  },
+                  "ip": {
+                    "description": "IP is set for load-balancer ingress points that are IP based\n(typically GCE or OpenStack load-balancers)",
+                    "type": "string"
+                  },
+                  "meshOnly": {
+                    "description": "MeshOnly is set if the Ingress is only load-balanced through a Service mesh.",
+                    "type": "boolean"
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        "publicLoadBalancer": {
+          "description": "PublicLoadBalancer contains the current status of the load-balancer.",
+          "type": "object",
+          "properties": {
+            "ingress": {
+              "description": "Ingress is a list containing ingress points for the load-balancer.\nTraffic intended for the service should be sent to these ingress points.",
+              "type": "array",
+              "items": {
+                "description": "LoadBalancerIngressStatus represents the status of a load-balancer ingress point:\ntraffic intended for the service should be sent to an ingress point.",
+                "type": "object",
+                "properties": {
+                  "domain": {
+                    "description": "Domain is set for load-balancer ingress points that are DNS based\n(typically AWS load-balancers)",
+                    "type": "string"
+                  },
+                  "domainInternal": {
+                    "description": "DomainInternal is set if there is a cluster-local DNS name to access the Ingress.\n\nNOTE: This differs from K8s Ingress, since we also desire to have a cluster-local\n      DNS name to allow routing in case of not having a mesh.",
+                    "type": "string"
+                  },
+                  "ip": {
+                    "description": "IP is set for load-balancer ingress points that are IP based\n(typically GCE or OpenStack load-balancers)",
+                    "type": "string"
+                  },
+                  "meshOnly": {
+                    "description": "MeshOnly is set if the Ingress is only load-balanced through a Service mesh.",
+                    "type": "boolean"
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/networking.internal.knative.dev/serverlessservice_v1alpha1.json
+++ b/networking.internal.knative.dev/serverlessservice_v1alpha1.json
@@ -1,0 +1,143 @@
+{
+  "description": "ServerlessService is a proxy for the K8s service objects containing the\nendpoints for the revision, whether those are endpoints of the activator or\nrevision pods.\nSee: https://knative.page.link/naxz for details.",
+  "type": "object",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Spec is the desired state of the ServerlessService.\nMore info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
+      "type": "object",
+      "required": [
+        "objectRef",
+        "protocolType"
+      ],
+      "properties": {
+        "mode": {
+          "description": "Mode describes the mode of operation of the ServerlessService.",
+          "type": "string"
+        },
+        "numActivators": {
+          "description": "NumActivators contains number of Activators that this revision should be\nassigned.\nO means \u2014 assign all.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "objectRef": {
+          "description": "ObjectRef defines the resource that this ServerlessService\nis responsible for making \"serverless\".",
+          "type": "object",
+          "properties": {
+            "apiVersion": {
+              "description": "API version of the referent.",
+              "type": "string"
+            },
+            "fieldPath": {
+              "description": "If referring to a piece of an object instead of an entire object, this string\nshould contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].\nFor example, if the object reference is to a container within a pod, this would take on a value like:\n\"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered\nthe event) or if no container name is specified \"spec.containers[2]\" (container with\nindex 2 in this pod). This syntax is chosen only to have some well-defined way of\nreferencing a part of an object.",
+              "type": "string"
+            },
+            "kind": {
+              "description": "Kind of the referent.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "Namespace of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+              "type": "string"
+            },
+            "resourceVersion": {
+              "description": "Specific resourceVersion to which this reference is made, if any.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+              "type": "string"
+            },
+            "uid": {
+              "description": "UID of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+              "type": "string"
+            }
+          },
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
+        "protocolType": {
+          "description": "The application-layer protocol. Matches `RevisionProtocolType` set on the owning pa/revision.\nserving imports networking, so just use string.",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "Status is the current state of the ServerlessService.\nMore info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
+      "type": "object",
+      "properties": {
+        "annotations": {
+          "description": "Annotations is additional Status fields for the Resource to save some\nadditional State as well as convey more information to the user. This is\nroughly akin to Annotations on any k8s resource, just the reconciler conveying\nricher information outwards.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "conditions": {
+          "description": "Conditions the latest available observations of a resource's current state.",
+          "type": "array",
+          "items": {
+            "description": "Condition defines a readiness condition for a Knative resource.\nSee: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties",
+            "type": "object",
+            "required": [
+              "status",
+              "type"
+            ],
+            "properties": {
+              "lastTransitionTime": {
+                "description": "LastTransitionTime is the last time the condition transitioned from one status to another.\nWe use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic\ndifferences (all other things held constant).",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity with which to treat failures of this type of condition.\nWhen this is not specified, it defaults to Error.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition.",
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration is the 'Generation' of the Service that\nwas last processed by the controller.",
+          "type": "integer",
+          "format": "int64"
+        },
+        "privateServiceName": {
+          "description": "PrivateServiceName holds the name of a core K8s Service resource that\nload balances over the user service pods backing this Revision.",
+          "type": "string"
+        },
+        "serviceName": {
+          "description": "ServiceName holds the name of a core K8s Service resource that\nload balances over the pods backing this Revision (activator or revision).",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/serving.knative.dev/configuration_v1.json
+++ b/serving.knative.dev/configuration_v1.json
@@ -1,0 +1,1449 @@
+{
+  "description": "Configuration represents the \"floating HEAD\" of a linear history of Revisions.\nUsers create new Revisions by updating the Configuration's spec.\nThe \"latest created\" revision's name is available under status, as is the\n\"latest ready\" revision's name.\nSee also: https://github.com/knative/serving/blob/main/docs/spec/overview.md#configuration",
+  "type": "object",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "ConfigurationSpec holds the desired state of the Configuration (from the client).",
+      "type": "object",
+      "properties": {
+        "template": {
+          "description": "Template holds the latest specification for the Revision to be stamped out.",
+          "type": "object",
+          "properties": {
+            "metadata": {
+              "type": "object",
+              "properties": {
+                "annotations": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                },
+                "finalizers": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "labels": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                },
+                "name": {
+                  "type": "string"
+                },
+                "namespace": {
+                  "type": "string"
+                }
+              },
+              "x-kubernetes-preserve-unknown-fields": true,
+              "additionalProperties": false
+            },
+            "spec": {
+              "description": "RevisionSpec holds the desired state of the Revision (from the client).",
+              "type": "object",
+              "required": [
+                "containers"
+              ],
+              "properties": {
+                "affinity": {
+                  "description": "This is accessible behind a feature flag - kubernetes.podspec-affinity",
+                  "type": "object",
+                  "x-kubernetes-preserve-unknown-fields": true
+                },
+                "automountServiceAccountToken": {
+                  "description": "AutomountServiceAccountToken indicates whether a service account token should be automatically mounted.",
+                  "type": "boolean"
+                },
+                "containerConcurrency": {
+                  "description": "ContainerConcurrency specifies the maximum allowed in-flight (concurrent)\nrequests per container of the Revision.  Defaults to `0` which means\nconcurrency to the application is not limited, and the system decides the\ntarget concurrency for the autoscaler.",
+                  "type": "integer",
+                  "format": "int64"
+                },
+                "containers": {
+                  "description": "List of containers belonging to the pod.\nContainers cannot currently be added or removed.\nThere must be at least one container in a Pod.\nCannot be updated.",
+                  "type": "array",
+                  "items": {
+                    "description": "A single application container that you want to run within a pod.",
+                    "type": "object",
+                    "properties": {
+                      "args": {
+                        "description": "Arguments to the entrypoint.\nThe container image's CMD is used if this is not provided.\nVariable references $(VAR_NAME) are expanded using the container's environment. If a variable\ncannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will\nproduce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless\nof whether the variable exists or not. Cannot be updated.\nMore info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "x-kubernetes-list-type": "atomic"
+                      },
+                      "command": {
+                        "description": "Entrypoint array. Not executed within a shell.\nThe container image's ENTRYPOINT is used if this is not provided.\nVariable references $(VAR_NAME) are expanded using the container's environment. If a variable\ncannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will\nproduce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless\nof whether the variable exists or not. Cannot be updated.\nMore info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "x-kubernetes-list-type": "atomic"
+                      },
+                      "env": {
+                        "description": "List of environment variables to set in the container.\nCannot be updated.",
+                        "type": "array",
+                        "items": {
+                          "description": "EnvVar represents an environment variable present in a Container.",
+                          "type": "object",
+                          "required": [
+                            "name"
+                          ],
+                          "properties": {
+                            "name": {
+                              "description": "Name of the environment variable.\nMay consist of any printable ASCII characters except '='.",
+                              "type": "string"
+                            },
+                            "value": {
+                              "description": "Variable references $(VAR_NAME) are expanded\nusing the previously defined environment variables in the container and\nany service environment variables. If a variable cannot be resolved,\nthe reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.\n\"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\".\nEscaped references will never be expanded, regardless of whether the variable\nexists or not.\nDefaults to \"\".",
+                              "type": "string"
+                            },
+                            "valueFrom": {
+                              "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
+                              "type": "object",
+                              "properties": {
+                                "configMapKeyRef": {
+                                  "description": "Selects a key of a ConfigMap.",
+                                  "type": "object",
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "properties": {
+                                    "key": {
+                                      "description": "The key to select.",
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                      "type": "string",
+                                      "default": ""
+                                    },
+                                    "optional": {
+                                      "description": "Specify whether the ConfigMap or its key must be defined",
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                },
+                                "fieldRef": {
+                                  "description": "This is accessible behind a feature flag - kubernetes.podspec-fieldref",
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "x-kubernetes-preserve-unknown-fields": true
+                                },
+                                "resourceFieldRef": {
+                                  "description": "This is accessible behind a feature flag - kubernetes.podspec-fieldref",
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "x-kubernetes-preserve-unknown-fields": true
+                                },
+                                "secretKeyRef": {
+                                  "description": "Selects a key of a secret in the pod's namespace",
+                                  "type": "object",
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "properties": {
+                                    "key": {
+                                      "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                      "type": "string",
+                                      "default": ""
+                                    },
+                                    "optional": {
+                                      "description": "Specify whether the Secret or its key must be defined",
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "additionalProperties": false
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "x-kubernetes-list-map-keys": [
+                          "name"
+                        ],
+                        "x-kubernetes-list-type": "map"
+                      },
+                      "envFrom": {
+                        "description": "List of sources to populate environment variables in the container.\nThe keys defined within a source may consist of any printable ASCII characters except '='.\nWhen a key exists in multiple\nsources, the value associated with the last source will take precedence.\nValues defined by an Env with a duplicate key will take precedence.\nCannot be updated.",
+                        "type": "array",
+                        "items": {
+                          "description": "EnvFromSource represents the source of a set of ConfigMaps or Secrets",
+                          "type": "object",
+                          "properties": {
+                            "configMapRef": {
+                              "description": "The ConfigMap to select from",
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                  "type": "string",
+                                  "default": ""
+                                },
+                                "optional": {
+                                  "description": "Specify whether the ConfigMap must be defined",
+                                  "type": "boolean"
+                                }
+                              },
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            },
+                            "prefix": {
+                              "description": "Optional text to prepend to the name of each environment variable.\nMay consist of any printable ASCII characters except '='.",
+                              "type": "string"
+                            },
+                            "secretRef": {
+                              "description": "The Secret to select from",
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                  "type": "string",
+                                  "default": ""
+                                },
+                                "optional": {
+                                  "description": "Specify whether the Secret must be defined",
+                                  "type": "boolean"
+                                }
+                              },
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "x-kubernetes-list-type": "atomic"
+                      },
+                      "image": {
+                        "description": "Container image name.\nMore info: https://kubernetes.io/docs/concepts/containers/images\nThis field is optional to allow higher level config management to default or override\ncontainer images in workload controllers like Deployments and StatefulSets.",
+                        "type": "string"
+                      },
+                      "imagePullPolicy": {
+                        "description": "Image pull policy.\nOne of Always, Never, IfNotPresent.\nDefaults to Always if :latest tag is specified, or IfNotPresent otherwise.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/containers/images#updating-images",
+                        "type": "string"
+                      },
+                      "livenessProbe": {
+                        "description": "Periodic probe of container liveness.\nContainer will be restarted if the probe fails.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                        "type": "object",
+                        "properties": {
+                          "exec": {
+                            "description": "Exec specifies a command to execute in the container.",
+                            "type": "object",
+                            "properties": {
+                              "command": {
+                                "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "x-kubernetes-list-type": "atomic"
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "failureThreshold": {
+                            "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded.\nDefaults to 3. Minimum value is 1.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "grpc": {
+                            "description": "GRPC specifies a GRPC HealthCheckRequest.",
+                            "type": "object",
+                            "properties": {
+                              "port": {
+                                "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                                "type": "integer",
+                                "format": "int32"
+                              },
+                              "service": {
+                                "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                "type": "string",
+                                "default": ""
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "httpGet": {
+                            "description": "HTTPGet specifies an HTTP GET request to perform.",
+                            "type": "object",
+                            "properties": {
+                              "host": {
+                                "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
+                                "type": "string"
+                              },
+                              "httpHeaders": {
+                                "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                "type": "array",
+                                "items": {
+                                  "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                  "type": "object",
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
+                                  "properties": {
+                                    "name": {
+                                      "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "description": "The header field value",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "additionalProperties": false
+                                },
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "path": {
+                                "description": "Path to access on the HTTP server.",
+                                "type": "string"
+                              },
+                              "port": {
+                                "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "scheme": {
+                                "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
+                                "type": "string"
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "initialDelaySeconds": {
+                            "description": "Number of seconds after the container has started before liveness probes are initiated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "periodSeconds": {
+                            "description": "How often (in seconds) to perform the probe.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "successThreshold": {
+                            "description": "Minimum consecutive successes for the probe to be considered successful after having failed.\nDefaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "tcpSocket": {
+                            "description": "TCPSocket specifies a connection to a TCP port.",
+                            "type": "object",
+                            "properties": {
+                              "host": {
+                                "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                "type": "string"
+                              },
+                              "port": {
+                                "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "timeoutSeconds": {
+                            "description": "Number of seconds after which the probe times out.\nDefaults to 1 second. Minimum value is 1.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                            "type": "integer",
+                            "format": "int32"
+                          }
+                        },
+                        "additionalProperties": false
+                      },
+                      "name": {
+                        "description": "Name of the container specified as a DNS_LABEL.\nEach container in a pod must have a unique name (DNS_LABEL).\nCannot be updated.",
+                        "type": "string"
+                      },
+                      "ports": {
+                        "description": "List of ports to expose from the container. Not specifying a port here\nDOES NOT prevent that port from being exposed. Any port which is\nlistening on the default \"0.0.0.0\" address inside a container will be\naccessible from the network.\nModifying this array with strategic merge patch may corrupt the data.\nFor more information See https://github.com/kubernetes/kubernetes/issues/108255.\nCannot be updated.",
+                        "type": "array",
+                        "items": {
+                          "description": "ContainerPort represents a network port in a single container.",
+                          "type": "object",
+                          "properties": {
+                            "containerPort": {
+                              "description": "Number of port to expose on the pod's IP address.\nThis must be a valid port number, 0 < x < 65536.",
+                              "type": "integer",
+                              "format": "int32"
+                            },
+                            "name": {
+                              "description": "If specified, this must be an IANA_SVC_NAME and unique within the pod. Each\nnamed port in a pod must have a unique name. Name for the port that can be\nreferred to by services.",
+                              "type": "string"
+                            },
+                            "protocol": {
+                              "description": "Protocol for port. Must be UDP, TCP, or SCTP.\nDefaults to \"TCP\".",
+                              "type": "string",
+                              "default": "TCP"
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      },
+                      "readinessProbe": {
+                        "description": "Periodic probe of container service readiness.\nContainer will be removed from service endpoints if the probe fails.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                        "type": "object",
+                        "properties": {
+                          "exec": {
+                            "description": "Exec specifies a command to execute in the container.",
+                            "type": "object",
+                            "properties": {
+                              "command": {
+                                "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "x-kubernetes-list-type": "atomic"
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "failureThreshold": {
+                            "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded.\nDefaults to 3. Minimum value is 1.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "grpc": {
+                            "description": "GRPC specifies a GRPC HealthCheckRequest.",
+                            "type": "object",
+                            "properties": {
+                              "port": {
+                                "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                                "type": "integer",
+                                "format": "int32"
+                              },
+                              "service": {
+                                "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                "type": "string",
+                                "default": ""
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "httpGet": {
+                            "description": "HTTPGet specifies an HTTP GET request to perform.",
+                            "type": "object",
+                            "properties": {
+                              "host": {
+                                "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
+                                "type": "string"
+                              },
+                              "httpHeaders": {
+                                "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                "type": "array",
+                                "items": {
+                                  "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                  "type": "object",
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
+                                  "properties": {
+                                    "name": {
+                                      "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "description": "The header field value",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "additionalProperties": false
+                                },
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "path": {
+                                "description": "Path to access on the HTTP server.",
+                                "type": "string"
+                              },
+                              "port": {
+                                "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "scheme": {
+                                "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
+                                "type": "string"
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "initialDelaySeconds": {
+                            "description": "Number of seconds after the container has started before liveness probes are initiated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "periodSeconds": {
+                            "description": "How often (in seconds) to perform the probe.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "successThreshold": {
+                            "description": "Minimum consecutive successes for the probe to be considered successful after having failed.\nDefaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "tcpSocket": {
+                            "description": "TCPSocket specifies a connection to a TCP port.",
+                            "type": "object",
+                            "properties": {
+                              "host": {
+                                "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                "type": "string"
+                              },
+                              "port": {
+                                "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "timeoutSeconds": {
+                            "description": "Number of seconds after which the probe times out.\nDefaults to 1 second. Minimum value is 1.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                            "type": "integer",
+                            "format": "int32"
+                          }
+                        },
+                        "additionalProperties": false
+                      },
+                      "resources": {
+                        "description": "Compute Resources required by this container.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                        "type": "object",
+                        "properties": {
+                          "limits": {
+                            "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                            "type": "object",
+                            "additionalProperties": {
+                              "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            }
+                          },
+                          "requests": {
+                            "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                            "type": "object",
+                            "additionalProperties": {
+                              "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            }
+                          }
+                        },
+                        "additionalProperties": false
+                      },
+                      "securityContext": {
+                        "description": "SecurityContext defines the security options the container should be run with.\nIf set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.\nMore info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/",
+                        "type": "object",
+                        "properties": {
+                          "allowPrivilegeEscalation": {
+                            "description": "AllowPrivilegeEscalation controls whether a process can gain more\nprivileges than its parent process. This bool directly controls if\nthe no_new_privs flag will be set on the container process.\nAllowPrivilegeEscalation is true always when the container is:\n1) run as Privileged\n2) has CAP_SYS_ADMIN\nNote that this field cannot be set when spec.os.name is windows.",
+                            "type": "boolean"
+                          },
+                          "capabilities": {
+                            "description": "The capabilities to add/drop when running containers.\nDefaults to the default set of capabilities granted by the container runtime.\nNote that this field cannot be set when spec.os.name is windows.",
+                            "type": "object",
+                            "properties": {
+                              "add": {
+                                "description": "This is accessible behind a feature flag - kubernetes.containerspec-addcapabilities",
+                                "type": "array",
+                                "items": {
+                                  "description": "Capability represent POSIX capabilities type",
+                                  "type": "string"
+                                },
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "drop": {
+                                "description": "Removed capabilities",
+                                "type": "array",
+                                "items": {
+                                  "description": "Capability represent POSIX capabilities type",
+                                  "type": "string"
+                                },
+                                "x-kubernetes-list-type": "atomic"
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "privileged": {
+                            "description": "Run container in privileged mode. This can only be set to explicitly to 'false'",
+                            "type": "boolean"
+                          },
+                          "readOnlyRootFilesystem": {
+                            "description": "Whether this container has a read-only root filesystem.\nDefault is false.\nNote that this field cannot be set when spec.os.name is windows.",
+                            "type": "boolean"
+                          },
+                          "runAsGroup": {
+                            "description": "The GID to run the entrypoint of the container process.\nUses runtime default if unset.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
+                            "type": "integer",
+                            "format": "int64"
+                          },
+                          "runAsNonRoot": {
+                            "description": "Indicates that the container must run as a non-root user.\nIf true, the Kubelet will validate the image at runtime to ensure that it\ndoes not run as UID 0 (root) and fail to start the container if it does.\nIf unset or false, no such validation will be performed.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
+                            "type": "boolean"
+                          },
+                          "runAsUser": {
+                            "description": "The UID to run the entrypoint of the container process.\nDefaults to user specified in image metadata if unspecified.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
+                            "type": "integer",
+                            "format": "int64"
+                          },
+                          "seccompProfile": {
+                            "description": "The seccomp options to use by this container. If seccomp options are\nprovided at both the pod & container level, the container options\noverride the pod options.\nNote that this field cannot be set when spec.os.name is windows.",
+                            "type": "object",
+                            "required": [
+                              "type"
+                            ],
+                            "properties": {
+                              "localhostProfile": {
+                                "description": "localhostProfile indicates a profile defined in a file on the node should be used.\nThe profile must be preconfigured on the node to work.\nMust be a descending path, relative to the kubelet's configured seccomp profile location.\nMust be set if type is \"Localhost\". Must NOT be set for any other type.",
+                                "type": "string"
+                              },
+                              "type": {
+                                "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
+                                "type": "string"
+                              }
+                            },
+                            "additionalProperties": false
+                          }
+                        },
+                        "additionalProperties": false
+                      },
+                      "startupProbe": {
+                        "description": "StartupProbe indicates that the Pod has successfully initialized.\nIf specified, no other probes are executed until this completes successfully.\nIf this probe fails, the Pod will be restarted, just as if the livenessProbe failed.\nThis can be used to provide different probe parameters at the beginning of a Pod's lifecycle,\nwhen it might take a long time to load data or warm a cache, than during steady-state operation.\nThis cannot be updated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                        "type": "object",
+                        "properties": {
+                          "exec": {
+                            "description": "Exec specifies a command to execute in the container.",
+                            "type": "object",
+                            "properties": {
+                              "command": {
+                                "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "x-kubernetes-list-type": "atomic"
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "failureThreshold": {
+                            "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded.\nDefaults to 3. Minimum value is 1.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "grpc": {
+                            "description": "GRPC specifies a GRPC HealthCheckRequest.",
+                            "type": "object",
+                            "properties": {
+                              "port": {
+                                "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                                "type": "integer",
+                                "format": "int32"
+                              },
+                              "service": {
+                                "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                "type": "string",
+                                "default": ""
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "httpGet": {
+                            "description": "HTTPGet specifies an HTTP GET request to perform.",
+                            "type": "object",
+                            "properties": {
+                              "host": {
+                                "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
+                                "type": "string"
+                              },
+                              "httpHeaders": {
+                                "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                "type": "array",
+                                "items": {
+                                  "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                  "type": "object",
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
+                                  "properties": {
+                                    "name": {
+                                      "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "description": "The header field value",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "additionalProperties": false
+                                },
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "path": {
+                                "description": "Path to access on the HTTP server.",
+                                "type": "string"
+                              },
+                              "port": {
+                                "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "scheme": {
+                                "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
+                                "type": "string"
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "initialDelaySeconds": {
+                            "description": "Number of seconds after the container has started before liveness probes are initiated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "periodSeconds": {
+                            "description": "How often (in seconds) to perform the probe.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "successThreshold": {
+                            "description": "Minimum consecutive successes for the probe to be considered successful after having failed.\nDefaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "tcpSocket": {
+                            "description": "TCPSocket specifies a connection to a TCP port.",
+                            "type": "object",
+                            "properties": {
+                              "host": {
+                                "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                "type": "string"
+                              },
+                              "port": {
+                                "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "timeoutSeconds": {
+                            "description": "Number of seconds after which the probe times out.\nDefaults to 1 second. Minimum value is 1.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                            "type": "integer",
+                            "format": "int32"
+                          }
+                        },
+                        "additionalProperties": false
+                      },
+                      "terminationMessagePath": {
+                        "description": "Optional: Path at which the file to which the container's termination message\nwill be written is mounted into the container's filesystem.\nMessage written is intended to be brief final status, such as an assertion failure message.\nWill be truncated by the node if greater than 4096 bytes. The total message length across\nall containers will be limited to 12kb.\nDefaults to /dev/termination-log.\nCannot be updated.",
+                        "type": "string"
+                      },
+                      "terminationMessagePolicy": {
+                        "description": "Indicate how the termination message should be populated. File will use the contents of\nterminationMessagePath to populate the container status message on both success and failure.\nFallbackToLogsOnError will use the last chunk of container log output if the termination\nmessage file is empty and the container exited with an error.\nThe log output is limited to 2048 bytes or 80 lines, whichever is smaller.\nDefaults to File.\nCannot be updated.",
+                        "type": "string"
+                      },
+                      "volumeMounts": {
+                        "description": "Pod volumes to mount into the container's filesystem.\nCannot be updated.",
+                        "type": "array",
+                        "items": {
+                          "description": "VolumeMount describes a mounting of a Volume within a container.",
+                          "type": "object",
+                          "required": [
+                            "mountPath",
+                            "name"
+                          ],
+                          "properties": {
+                            "mountPath": {
+                              "description": "Path within the container at which the volume should be mounted.  Must\nnot contain ':'.",
+                              "type": "string"
+                            },
+                            "mountPropagation": {
+                              "description": "This is accessible behind a feature flag - kubernetes.podspec-volumes-mount-propagation",
+                              "type": "string"
+                            },
+                            "name": {
+                              "description": "This must match the Name of a Volume.",
+                              "type": "string"
+                            },
+                            "readOnly": {
+                              "description": "Mounted read-only if true, read-write otherwise (false or unspecified).\nDefaults to false.",
+                              "type": "boolean"
+                            },
+                            "subPath": {
+                              "description": "Path within the volume from which the container's volume should be mounted.\nDefaults to \"\" (volume's root).",
+                              "type": "string"
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "x-kubernetes-list-map-keys": [
+                          "mountPath"
+                        ],
+                        "x-kubernetes-list-type": "map"
+                      },
+                      "workingDir": {
+                        "description": "Container's working directory.\nIf not specified, the container runtime's default will be used, which\nmight be configured in the container image.\nCannot be updated.",
+                        "type": "string"
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "dnsConfig": {
+                  "description": "This is accessible behind a feature flag - kubernetes.podspec-dnsconfig",
+                  "type": "object",
+                  "x-kubernetes-preserve-unknown-fields": true
+                },
+                "dnsPolicy": {
+                  "description": "This is accessible behind a feature flag - kubernetes.podspec-dnspolicy",
+                  "type": "string"
+                },
+                "enableServiceLinks": {
+                  "description": "EnableServiceLinks indicates whether information aboutservices should be injected into pod's environment variables, matching the syntax of Docker links. Optional: Knative defaults this to false.",
+                  "type": "boolean"
+                },
+                "hostAliases": {
+                  "description": "This is accessible behind a feature flag - kubernetes.podspec-hostaliases",
+                  "type": "array",
+                  "items": {
+                    "description": "This is accessible behind a feature flag - kubernetes.podspec-hostaliases",
+                    "type": "object",
+                    "x-kubernetes-preserve-unknown-fields": true
+                  }
+                },
+                "hostIPC": {
+                  "description": "This is accessible behind a feature flag - kubernetes.podspec-hostipc",
+                  "type": "boolean"
+                },
+                "hostNetwork": {
+                  "description": "This is accessible behind a feature flag - kubernetes.podspec-hostnetwork",
+                  "type": "boolean"
+                },
+                "hostPID": {
+                  "description": "This is accessible behind a feature flag - kubernetes.podspec-hostpid",
+                  "type": "boolean"
+                },
+                "idleTimeoutSeconds": {
+                  "description": "IdleTimeoutSeconds is the maximum duration in seconds a request will be allowed\nto stay open while not receiving any bytes from the user's application. If\nunspecified, a system default will be provided.",
+                  "type": "integer",
+                  "format": "int64"
+                },
+                "imagePullSecrets": {
+                  "description": "ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec.\nIf specified, these secrets will be passed to individual puller implementations for them to use.\nMore info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod",
+                  "type": "array",
+                  "items": {
+                    "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                        "type": "string",
+                        "default": ""
+                      }
+                    },
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  },
+                  "x-kubernetes-list-map-keys": [
+                    "name"
+                  ],
+                  "x-kubernetes-list-type": "map"
+                },
+                "initContainers": {
+                  "description": "This is accessible behind a feature flag - kubernetes.podspec-init-containers",
+                  "type": "array",
+                  "items": {
+                    "description": "This is accessible behind a feature flag - kubernetes.podspec-init-containers",
+                    "type": "object",
+                    "x-kubernetes-preserve-unknown-fields": true
+                  }
+                },
+                "nodeSelector": {
+                  "description": "This is accessible behind a feature flag - kubernetes.podspec-nodeselector",
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "x-kubernetes-map-type": "atomic"
+                },
+                "priorityClassName": {
+                  "description": "This is accessible behind a feature flag - kubernetes.podspec-priorityclassname",
+                  "type": "string"
+                },
+                "responseStartTimeoutSeconds": {
+                  "description": "ResponseStartTimeoutSeconds is the maximum duration in seconds that the request\nrouting layer will wait for a request delivered to a container to begin\nsending any network traffic.",
+                  "type": "integer",
+                  "format": "int64"
+                },
+                "runtimeClassName": {
+                  "description": "This is accessible behind a feature flag - kubernetes.podspec-runtimeclassname",
+                  "type": "string"
+                },
+                "schedulerName": {
+                  "description": "This is accessible behind a feature flag - kubernetes.podspec-schedulername",
+                  "type": "string"
+                },
+                "securityContext": {
+                  "description": "This is accessible behind a feature flag - kubernetes.podspec-securitycontext",
+                  "type": "object",
+                  "x-kubernetes-preserve-unknown-fields": true
+                },
+                "serviceAccountName": {
+                  "description": "ServiceAccountName is the name of the ServiceAccount to use to run this pod.\nMore info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/",
+                  "type": "string"
+                },
+                "shareProcessNamespace": {
+                  "description": "This is accessible behind a feature flag - kubernetes.podspec-shareprocessnamespace",
+                  "type": "boolean"
+                },
+                "timeoutSeconds": {
+                  "description": "TimeoutSeconds is the maximum duration in seconds that the request instance\nis allowed to respond to a request. If unspecified, a system default will\nbe provided.",
+                  "type": "integer",
+                  "format": "int64"
+                },
+                "tolerations": {
+                  "description": "This is accessible behind a feature flag - kubernetes.podspec-tolerations",
+                  "type": "array",
+                  "items": {
+                    "description": "This is accessible behind a feature flag - kubernetes.podspec-tolerations",
+                    "type": "object",
+                    "x-kubernetes-preserve-unknown-fields": true
+                  }
+                },
+                "topologySpreadConstraints": {
+                  "description": "This is accessible behind a feature flag - kubernetes.podspec-topologyspreadconstraints",
+                  "type": "array",
+                  "items": {
+                    "description": "This is accessible behind a feature flag - kubernetes.podspec-topologyspreadconstraints",
+                    "type": "object",
+                    "x-kubernetes-preserve-unknown-fields": true
+                  }
+                },
+                "volumes": {
+                  "description": "List of volumes that can be mounted by containers belonging to the pod.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes",
+                  "type": "array",
+                  "items": {
+                    "description": "Volume represents a named volume in a pod that may be accessed by any container in the pod.",
+                    "type": "object",
+                    "required": [
+                      "name"
+                    ],
+                    "properties": {
+                      "configMap": {
+                        "description": "configMap represents a configMap that should populate this volume",
+                        "type": "object",
+                        "properties": {
+                          "defaultMode": {
+                            "description": "defaultMode is optional: mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nDefaults to 0644.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "items": {
+                            "description": "items if unspecified, each key-value pair in the Data field of the referenced\nConfigMap will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the ConfigMap,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
+                            "type": "array",
+                            "items": {
+                              "description": "Maps a string key to a path within a volume.",
+                              "type": "object",
+                              "required": [
+                                "key",
+                                "path"
+                              ],
+                              "properties": {
+                                "key": {
+                                  "description": "key is the key to project.",
+                                  "type": "string"
+                                },
+                                "mode": {
+                                  "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "path": {
+                                  "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
+                                  "type": "string"
+                                }
+                              },
+                              "additionalProperties": false
+                            },
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "name": {
+                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                            "type": "string",
+                            "default": ""
+                          },
+                          "optional": {
+                            "description": "optional specify whether the ConfigMap or its keys must be defined",
+                            "type": "boolean"
+                          }
+                        },
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "csi": {
+                        "description": "This is accessible behind a feature flag - kubernetes.podspec-volumes-csi",
+                        "type": "object",
+                        "x-kubernetes-preserve-unknown-fields": true
+                      },
+                      "emptyDir": {
+                        "description": "This is accessible behind a feature flag - kubernetes.podspec-volumes-emptydir",
+                        "type": "object",
+                        "x-kubernetes-preserve-unknown-fields": true
+                      },
+                      "hostPath": {
+                        "description": "This is accessible behind a feature flag - kubernetes.podspec-volumes-hostpath",
+                        "type": "object",
+                        "x-kubernetes-preserve-unknown-fields": true
+                      },
+                      "image": {
+                        "description": "This is accessible behind a feature flag - kubernetes.podspec-volumes-image",
+                        "type": "object",
+                        "x-kubernetes-preserve-unknown-fields": true
+                      },
+                      "name": {
+                        "description": "name of the volume.\nMust be a DNS_LABEL and unique within the pod.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                        "type": "string"
+                      },
+                      "persistentVolumeClaim": {
+                        "description": "This is accessible behind a feature flag - kubernetes.podspec-persistent-volume-claim",
+                        "type": "object",
+                        "x-kubernetes-preserve-unknown-fields": true
+                      },
+                      "projected": {
+                        "description": "projected items for all in one resources secrets, configmaps, and downward API",
+                        "type": "object",
+                        "properties": {
+                          "defaultMode": {
+                            "description": "defaultMode are the mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "sources": {
+                            "description": "sources is the list of volume projections. Each entry in this list\nhandles one source.",
+                            "type": "array",
+                            "items": {
+                              "description": "Projection that may be projected along with other supported volume types.\nExactly one of these fields must be set.",
+                              "type": "object",
+                              "properties": {
+                                "configMap": {
+                                  "description": "configMap information about the configMap data to project",
+                                  "type": "object",
+                                  "properties": {
+                                    "items": {
+                                      "description": "items if unspecified, each key-value pair in the Data field of the referenced\nConfigMap will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the ConfigMap,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
+                                      "type": "array",
+                                      "items": {
+                                        "description": "Maps a string key to a path within a volume.",
+                                        "type": "object",
+                                        "required": [
+                                          "key",
+                                          "path"
+                                        ],
+                                        "properties": {
+                                          "key": {
+                                            "description": "key is the key to project.",
+                                            "type": "string"
+                                          },
+                                          "mode": {
+                                            "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                            "type": "integer",
+                                            "format": "int32"
+                                          },
+                                          "path": {
+                                            "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "additionalProperties": false
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
+                                    },
+                                    "name": {
+                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                      "type": "string",
+                                      "default": ""
+                                    },
+                                    "optional": {
+                                      "description": "optional specify whether the ConfigMap or its keys must be defined",
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                },
+                                "downwardAPI": {
+                                  "description": "downwardAPI information about the downwardAPI data to project",
+                                  "type": "object",
+                                  "properties": {
+                                    "items": {
+                                      "description": "Items is a list of DownwardAPIVolume file",
+                                      "type": "array",
+                                      "items": {
+                                        "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
+                                        "type": "object",
+                                        "required": [
+                                          "path"
+                                        ],
+                                        "properties": {
+                                          "fieldRef": {
+                                            "description": "Required: Selects a field of the pod: only annotations, labels, name, namespace and uid are supported.",
+                                            "type": "object",
+                                            "required": [
+                                              "fieldPath"
+                                            ],
+                                            "properties": {
+                                              "apiVersion": {
+                                                "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                                "type": "string"
+                                              },
+                                              "fieldPath": {
+                                                "description": "Path of the field to select in the specified API version.",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "x-kubernetes-map-type": "atomic",
+                                            "additionalProperties": false
+                                          },
+                                          "mode": {
+                                            "description": "Optional: mode bits used to set permissions on this file, must be an octal value\nbetween 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                            "type": "integer",
+                                            "format": "int32"
+                                          },
+                                          "path": {
+                                            "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'",
+                                            "type": "string"
+                                          },
+                                          "resourceFieldRef": {
+                                            "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.",
+                                            "type": "object",
+                                            "required": [
+                                              "resource"
+                                            ],
+                                            "properties": {
+                                              "containerName": {
+                                                "description": "Container name: required for volumes, optional for env vars",
+                                                "type": "string"
+                                              },
+                                              "divisor": {
+                                                "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                                "anyOf": [
+                                                  {
+                                                    "type": "integer"
+                                                  },
+                                                  {
+                                                    "type": "string"
+                                                  }
+                                                ],
+                                                "x-kubernetes-int-or-string": true
+                                              },
+                                              "resource": {
+                                                "description": "Required: resource to select",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "x-kubernetes-map-type": "atomic",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "additionalProperties": false
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
+                                    }
+                                  },
+                                  "additionalProperties": false
+                                },
+                                "secret": {
+                                  "description": "secret information about the secret data to project",
+                                  "type": "object",
+                                  "properties": {
+                                    "items": {
+                                      "description": "items if unspecified, each key-value pair in the Data field of the referenced\nSecret will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the Secret,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
+                                      "type": "array",
+                                      "items": {
+                                        "description": "Maps a string key to a path within a volume.",
+                                        "type": "object",
+                                        "required": [
+                                          "key",
+                                          "path"
+                                        ],
+                                        "properties": {
+                                          "key": {
+                                            "description": "key is the key to project.",
+                                            "type": "string"
+                                          },
+                                          "mode": {
+                                            "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                            "type": "integer",
+                                            "format": "int32"
+                                          },
+                                          "path": {
+                                            "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "additionalProperties": false
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
+                                    },
+                                    "name": {
+                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                      "type": "string",
+                                      "default": ""
+                                    },
+                                    "optional": {
+                                      "description": "optional field specify whether the Secret or its key must be defined",
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                },
+                                "serviceAccountToken": {
+                                  "description": "serviceAccountToken is information about the serviceAccountToken data to project",
+                                  "type": "object",
+                                  "required": [
+                                    "path"
+                                  ],
+                                  "properties": {
+                                    "audience": {
+                                      "description": "audience is the intended audience of the token. A recipient of a token\nmust identify itself with an identifier specified in the audience of the\ntoken, and otherwise should reject the token. The audience defaults to the\nidentifier of the apiserver.",
+                                      "type": "string"
+                                    },
+                                    "expirationSeconds": {
+                                      "description": "expirationSeconds is the requested duration of validity of the service\naccount token. As the token approaches expiration, the kubelet volume\nplugin will proactively rotate the service account token. The kubelet will\nstart trying to rotate the token if the token is older than 80 percent of\nits time to live or if the token is older than 24 hours.Defaults to 1 hour\nand must be at least 10 minutes.",
+                                      "type": "integer",
+                                      "format": "int64"
+                                    },
+                                    "path": {
+                                      "description": "path is the path relative to the mount point of the file to project the\ntoken into.",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "additionalProperties": false
+                                }
+                              },
+                              "additionalProperties": false
+                            },
+                            "x-kubernetes-list-type": "atomic"
+                          }
+                        },
+                        "additionalProperties": false
+                      },
+                      "secret": {
+                        "description": "secret represents a secret that should populate this volume.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
+                        "type": "object",
+                        "properties": {
+                          "defaultMode": {
+                            "description": "defaultMode is Optional: mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values\nfor mode bits. Defaults to 0644.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "items": {
+                            "description": "items If unspecified, each key-value pair in the Data field of the referenced\nSecret will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the Secret,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
+                            "type": "array",
+                            "items": {
+                              "description": "Maps a string key to a path within a volume.",
+                              "type": "object",
+                              "required": [
+                                "key",
+                                "path"
+                              ],
+                              "properties": {
+                                "key": {
+                                  "description": "key is the key to project.",
+                                  "type": "string"
+                                },
+                                "mode": {
+                                  "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "path": {
+                                  "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
+                                  "type": "string"
+                                }
+                              },
+                              "additionalProperties": false
+                            },
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "optional": {
+                            "description": "optional field specify whether the Secret or its keys must be defined",
+                            "type": "boolean"
+                          },
+                          "secretName": {
+                            "description": "secretName is the name of the secret in the pod's namespace to use.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "x-kubernetes-list-map-keys": [
+                    "name"
+                  ],
+                  "x-kubernetes-list-type": "map"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "ConfigurationStatus communicates the observed state of the Configuration (from the controller).",
+      "type": "object",
+      "properties": {
+        "annotations": {
+          "description": "Annotations is additional Status fields for the Resource to save some\nadditional State as well as convey more information to the user. This is\nroughly akin to Annotations on any k8s resource, just the reconciler conveying\nricher information outwards.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "conditions": {
+          "description": "Conditions the latest available observations of a resource's current state.",
+          "type": "array",
+          "items": {
+            "description": "Condition defines a readiness condition for a Knative resource.\nSee: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties",
+            "type": "object",
+            "required": [
+              "status",
+              "type"
+            ],
+            "properties": {
+              "lastTransitionTime": {
+                "description": "LastTransitionTime is the last time the condition transitioned from one status to another.\nWe use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic\ndifferences (all other things held constant).",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity with which to treat failures of this type of condition.\nWhen this is not specified, it defaults to Error.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition.",
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "latestCreatedRevisionName": {
+          "description": "LatestCreatedRevisionName is the last revision that was created from this\nConfiguration. It might not be ready yet, for that use LatestReadyRevisionName.",
+          "type": "string"
+        },
+        "latestReadyRevisionName": {
+          "description": "LatestReadyRevisionName holds the name of the latest Revision stamped out\nfrom this Configuration that has had its \"Ready\" condition become \"True\".",
+          "type": "string"
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration is the 'Generation' of the Service that\nwas last processed by the controller.",
+          "type": "integer",
+          "format": "int64"
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/serving.knative.dev/domainmapping_v1beta1.json
+++ b/serving.knative.dev/domainmapping_v1beta1.json
@@ -1,0 +1,160 @@
+{
+  "description": "DomainMapping is a mapping from a custom hostname to an Addressable.",
+  "type": "object",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Spec is the desired state of the DomainMapping.\nMore info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
+      "type": "object",
+      "required": [
+        "ref"
+      ],
+      "properties": {
+        "ref": {
+          "description": "Ref specifies the target of the Domain Mapping.\n\nThe object identified by the Ref must be an Addressable with a URL of the\nform `{name}.{namespace}.{domain}` where `{domain}` is the cluster domain,\nand `{name}` and `{namespace}` are the name and namespace of a Kubernetes\nService.\n\nThis contract is satisfied by Knative types such as Knative Services and\nKnative Routes, and by Kubernetes Services.",
+          "type": "object",
+          "required": [
+            "kind",
+            "name"
+          ],
+          "properties": {
+            "address": {
+              "description": "Address points to a specific Address Name.",
+              "type": "string"
+            },
+            "apiVersion": {
+              "description": "API version of the referent.",
+              "type": "string"
+            },
+            "group": {
+              "description": "Group of the API, without the version of the group. This can be used as an alternative to the APIVersion, and then resolved using ResolveGroup.\nNote: This API is EXPERIMENTAL and might break anytime. For more details: https://github.com/knative/eventing/issues/5086",
+              "type": "string"
+            },
+            "kind": {
+              "description": "Kind of the referent.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "Namespace of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/\nThis is optional field, it gets defaulted to the object holding it if left out.",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "tls": {
+          "description": "TLS allows the DomainMapping to terminate TLS traffic with an existing secret.",
+          "type": "object",
+          "required": [
+            "secretName"
+          ],
+          "properties": {
+            "secretName": {
+              "description": "SecretName is the name of the existing secret used to terminate TLS traffic.",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "Status is the current state of the DomainMapping.\nMore info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
+      "type": "object",
+      "properties": {
+        "address": {
+          "description": "Address holds the information needed for a DomainMapping to be the target of an event.",
+          "type": "object",
+          "properties": {
+            "CACerts": {
+              "description": "CACerts is the Certification Authority (CA) certificates in PEM format\naccording to https://www.rfc-editor.org/rfc/rfc7468.",
+              "type": "string"
+            },
+            "audience": {
+              "description": "Audience is the OIDC audience for this address.",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name is the name of the address.",
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "annotations": {
+          "description": "Annotations is additional Status fields for the Resource to save some\nadditional State as well as convey more information to the user. This is\nroughly akin to Annotations on any k8s resource, just the reconciler conveying\nricher information outwards.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "conditions": {
+          "description": "Conditions the latest available observations of a resource's current state.",
+          "type": "array",
+          "items": {
+            "description": "Condition defines a readiness condition for a Knative resource.\nSee: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties",
+            "type": "object",
+            "required": [
+              "status",
+              "type"
+            ],
+            "properties": {
+              "lastTransitionTime": {
+                "description": "LastTransitionTime is the last time the condition transitioned from one status to another.\nWe use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic\ndifferences (all other things held constant).",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity with which to treat failures of this type of condition.\nWhen this is not specified, it defaults to Error.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition.",
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration is the 'Generation' of the Service that\nwas last processed by the controller.",
+          "type": "integer",
+          "format": "int64"
+        },
+        "url": {
+          "description": "URL is the URL of this DomainMapping.",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/serving.knative.dev/revision_v1.json
+++ b/serving.knative.dev/revision_v1.json
@@ -1,0 +1,1444 @@
+{
+  "description": "Revision is an immutable snapshot of code and configuration.  A revision\nreferences a container image. Revisions are created by updates to a\nConfiguration.\n\nSee also: https://github.com/knative/serving/blob/main/docs/spec/overview.md#revision",
+  "type": "object",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "RevisionSpec holds the desired state of the Revision (from the client).",
+      "type": "object",
+      "required": [
+        "containers"
+      ],
+      "properties": {
+        "affinity": {
+          "description": "This is accessible behind a feature flag - kubernetes.podspec-affinity",
+          "type": "object",
+          "x-kubernetes-preserve-unknown-fields": true
+        },
+        "automountServiceAccountToken": {
+          "description": "AutomountServiceAccountToken indicates whether a service account token should be automatically mounted.",
+          "type": "boolean"
+        },
+        "containerConcurrency": {
+          "description": "ContainerConcurrency specifies the maximum allowed in-flight (concurrent)\nrequests per container of the Revision.  Defaults to `0` which means\nconcurrency to the application is not limited, and the system decides the\ntarget concurrency for the autoscaler.",
+          "type": "integer",
+          "format": "int64"
+        },
+        "containers": {
+          "description": "List of containers belonging to the pod.\nContainers cannot currently be added or removed.\nThere must be at least one container in a Pod.\nCannot be updated.",
+          "type": "array",
+          "items": {
+            "description": "A single application container that you want to run within a pod.",
+            "type": "object",
+            "properties": {
+              "args": {
+                "description": "Arguments to the entrypoint.\nThe container image's CMD is used if this is not provided.\nVariable references $(VAR_NAME) are expanded using the container's environment. If a variable\ncannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will\nproduce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless\nof whether the variable exists or not. Cannot be updated.\nMore info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "x-kubernetes-list-type": "atomic"
+              },
+              "command": {
+                "description": "Entrypoint array. Not executed within a shell.\nThe container image's ENTRYPOINT is used if this is not provided.\nVariable references $(VAR_NAME) are expanded using the container's environment. If a variable\ncannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will\nproduce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless\nof whether the variable exists or not. Cannot be updated.\nMore info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "x-kubernetes-list-type": "atomic"
+              },
+              "env": {
+                "description": "List of environment variables to set in the container.\nCannot be updated.",
+                "type": "array",
+                "items": {
+                  "description": "EnvVar represents an environment variable present in a Container.",
+                  "type": "object",
+                  "required": [
+                    "name"
+                  ],
+                  "properties": {
+                    "name": {
+                      "description": "Name of the environment variable.\nMay consist of any printable ASCII characters except '='.",
+                      "type": "string"
+                    },
+                    "value": {
+                      "description": "Variable references $(VAR_NAME) are expanded\nusing the previously defined environment variables in the container and\nany service environment variables. If a variable cannot be resolved,\nthe reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.\n\"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\".\nEscaped references will never be expanded, regardless of whether the variable\nexists or not.\nDefaults to \"\".",
+                      "type": "string"
+                    },
+                    "valueFrom": {
+                      "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
+                      "type": "object",
+                      "properties": {
+                        "configMapKeyRef": {
+                          "description": "Selects a key of a ConfigMap.",
+                          "type": "object",
+                          "required": [
+                            "key"
+                          ],
+                          "properties": {
+                            "key": {
+                              "description": "The key to select.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                              "type": "string",
+                              "default": ""
+                            },
+                            "optional": {
+                              "description": "Specify whether the ConfigMap or its key must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        },
+                        "fieldRef": {
+                          "description": "This is accessible behind a feature flag - kubernetes.podspec-fieldref",
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "x-kubernetes-preserve-unknown-fields": true
+                        },
+                        "resourceFieldRef": {
+                          "description": "This is accessible behind a feature flag - kubernetes.podspec-fieldref",
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "x-kubernetes-preserve-unknown-fields": true
+                        },
+                        "secretKeyRef": {
+                          "description": "Selects a key of a secret in the pod's namespace",
+                          "type": "object",
+                          "required": [
+                            "key"
+                          ],
+                          "properties": {
+                            "key": {
+                              "description": "The key of the secret to select from.  Must be a valid secret key.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                              "type": "string",
+                              "default": ""
+                            },
+                            "optional": {
+                              "description": "Specify whether the Secret or its key must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "x-kubernetes-list-map-keys": [
+                  "name"
+                ],
+                "x-kubernetes-list-type": "map"
+              },
+              "envFrom": {
+                "description": "List of sources to populate environment variables in the container.\nThe keys defined within a source may consist of any printable ASCII characters except '='.\nWhen a key exists in multiple\nsources, the value associated with the last source will take precedence.\nValues defined by an Env with a duplicate key will take precedence.\nCannot be updated.",
+                "type": "array",
+                "items": {
+                  "description": "EnvFromSource represents the source of a set of ConfigMaps or Secrets",
+                  "type": "object",
+                  "properties": {
+                    "configMapRef": {
+                      "description": "The ConfigMap to select from",
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                          "type": "string",
+                          "default": ""
+                        },
+                        "optional": {
+                          "description": "Specify whether the ConfigMap must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    },
+                    "prefix": {
+                      "description": "Optional text to prepend to the name of each environment variable.\nMay consist of any printable ASCII characters except '='.",
+                      "type": "string"
+                    },
+                    "secretRef": {
+                      "description": "The Secret to select from",
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                          "type": "string",
+                          "default": ""
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "x-kubernetes-list-type": "atomic"
+              },
+              "image": {
+                "description": "Container image name.\nMore info: https://kubernetes.io/docs/concepts/containers/images\nThis field is optional to allow higher level config management to default or override\ncontainer images in workload controllers like Deployments and StatefulSets.",
+                "type": "string"
+              },
+              "imagePullPolicy": {
+                "description": "Image pull policy.\nOne of Always, Never, IfNotPresent.\nDefaults to Always if :latest tag is specified, or IfNotPresent otherwise.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/containers/images#updating-images",
+                "type": "string"
+              },
+              "livenessProbe": {
+                "description": "Periodic probe of container liveness.\nContainer will be restarted if the probe fails.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                "type": "object",
+                "properties": {
+                  "exec": {
+                    "description": "Exec specifies a command to execute in the container.",
+                    "type": "object",
+                    "properties": {
+                      "command": {
+                        "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "x-kubernetes-list-type": "atomic"
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "failureThreshold": {
+                    "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded.\nDefaults to 3. Minimum value is 1.",
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "grpc": {
+                    "description": "GRPC specifies a GRPC HealthCheckRequest.",
+                    "type": "object",
+                    "properties": {
+                      "port": {
+                        "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                        "type": "integer",
+                        "format": "int32"
+                      },
+                      "service": {
+                        "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                        "type": "string",
+                        "default": ""
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "httpGet": {
+                    "description": "HTTPGet specifies an HTTP GET request to perform.",
+                    "type": "object",
+                    "properties": {
+                      "host": {
+                        "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
+                        "type": "string"
+                      },
+                      "httpHeaders": {
+                        "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                        "type": "array",
+                        "items": {
+                          "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                          "type": "object",
+                          "required": [
+                            "name",
+                            "value"
+                          ],
+                          "properties": {
+                            "name": {
+                              "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                              "type": "string"
+                            },
+                            "value": {
+                              "description": "The header field value",
+                              "type": "string"
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "x-kubernetes-list-type": "atomic"
+                      },
+                      "path": {
+                        "description": "Path to access on the HTTP server.",
+                        "type": "string"
+                      },
+                      "port": {
+                        "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "scheme": {
+                        "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
+                        "type": "string"
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "initialDelaySeconds": {
+                    "description": "Number of seconds after the container has started before liveness probes are initiated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "periodSeconds": {
+                    "description": "How often (in seconds) to perform the probe.",
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "successThreshold": {
+                    "description": "Minimum consecutive successes for the probe to be considered successful after having failed.\nDefaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "tcpSocket": {
+                    "description": "TCPSocket specifies a connection to a TCP port.",
+                    "type": "object",
+                    "properties": {
+                      "host": {
+                        "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                        "type": "string"
+                      },
+                      "port": {
+                        "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "x-kubernetes-int-or-string": true
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "timeoutSeconds": {
+                    "description": "Number of seconds after which the probe times out.\nDefaults to 1 second. Minimum value is 1.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                    "type": "integer",
+                    "format": "int32"
+                  }
+                },
+                "additionalProperties": false
+              },
+              "name": {
+                "description": "Name of the container specified as a DNS_LABEL.\nEach container in a pod must have a unique name (DNS_LABEL).\nCannot be updated.",
+                "type": "string"
+              },
+              "ports": {
+                "description": "List of ports to expose from the container. Not specifying a port here\nDOES NOT prevent that port from being exposed. Any port which is\nlistening on the default \"0.0.0.0\" address inside a container will be\naccessible from the network.\nModifying this array with strategic merge patch may corrupt the data.\nFor more information See https://github.com/kubernetes/kubernetes/issues/108255.\nCannot be updated.",
+                "type": "array",
+                "items": {
+                  "description": "ContainerPort represents a network port in a single container.",
+                  "type": "object",
+                  "properties": {
+                    "containerPort": {
+                      "description": "Number of port to expose on the pod's IP address.\nThis must be a valid port number, 0 < x < 65536.",
+                      "type": "integer",
+                      "format": "int32"
+                    },
+                    "name": {
+                      "description": "If specified, this must be an IANA_SVC_NAME and unique within the pod. Each\nnamed port in a pod must have a unique name. Name for the port that can be\nreferred to by services.",
+                      "type": "string"
+                    },
+                    "protocol": {
+                      "description": "Protocol for port. Must be UDP, TCP, or SCTP.\nDefaults to \"TCP\".",
+                      "type": "string",
+                      "default": "TCP"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "readinessProbe": {
+                "description": "Periodic probe of container service readiness.\nContainer will be removed from service endpoints if the probe fails.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                "type": "object",
+                "properties": {
+                  "exec": {
+                    "description": "Exec specifies a command to execute in the container.",
+                    "type": "object",
+                    "properties": {
+                      "command": {
+                        "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "x-kubernetes-list-type": "atomic"
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "failureThreshold": {
+                    "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded.\nDefaults to 3. Minimum value is 1.",
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "grpc": {
+                    "description": "GRPC specifies a GRPC HealthCheckRequest.",
+                    "type": "object",
+                    "properties": {
+                      "port": {
+                        "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                        "type": "integer",
+                        "format": "int32"
+                      },
+                      "service": {
+                        "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                        "type": "string",
+                        "default": ""
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "httpGet": {
+                    "description": "HTTPGet specifies an HTTP GET request to perform.",
+                    "type": "object",
+                    "properties": {
+                      "host": {
+                        "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
+                        "type": "string"
+                      },
+                      "httpHeaders": {
+                        "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                        "type": "array",
+                        "items": {
+                          "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                          "type": "object",
+                          "required": [
+                            "name",
+                            "value"
+                          ],
+                          "properties": {
+                            "name": {
+                              "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                              "type": "string"
+                            },
+                            "value": {
+                              "description": "The header field value",
+                              "type": "string"
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "x-kubernetes-list-type": "atomic"
+                      },
+                      "path": {
+                        "description": "Path to access on the HTTP server.",
+                        "type": "string"
+                      },
+                      "port": {
+                        "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "scheme": {
+                        "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
+                        "type": "string"
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "initialDelaySeconds": {
+                    "description": "Number of seconds after the container has started before liveness probes are initiated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "periodSeconds": {
+                    "description": "How often (in seconds) to perform the probe.",
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "successThreshold": {
+                    "description": "Minimum consecutive successes for the probe to be considered successful after having failed.\nDefaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "tcpSocket": {
+                    "description": "TCPSocket specifies a connection to a TCP port.",
+                    "type": "object",
+                    "properties": {
+                      "host": {
+                        "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                        "type": "string"
+                      },
+                      "port": {
+                        "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "x-kubernetes-int-or-string": true
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "timeoutSeconds": {
+                    "description": "Number of seconds after which the probe times out.\nDefaults to 1 second. Minimum value is 1.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                    "type": "integer",
+                    "format": "int32"
+                  }
+                },
+                "additionalProperties": false
+              },
+              "resources": {
+                "description": "Compute Resources required by this container.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                "type": "object",
+                "properties": {
+                  "limits": {
+                    "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                    "type": "object",
+                    "additionalProperties": {
+                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "x-kubernetes-int-or-string": true
+                    }
+                  },
+                  "requests": {
+                    "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                    "type": "object",
+                    "additionalProperties": {
+                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "x-kubernetes-int-or-string": true
+                    }
+                  }
+                },
+                "additionalProperties": false
+              },
+              "securityContext": {
+                "description": "SecurityContext defines the security options the container should be run with.\nIf set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.\nMore info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/",
+                "type": "object",
+                "properties": {
+                  "allowPrivilegeEscalation": {
+                    "description": "AllowPrivilegeEscalation controls whether a process can gain more\nprivileges than its parent process. This bool directly controls if\nthe no_new_privs flag will be set on the container process.\nAllowPrivilegeEscalation is true always when the container is:\n1) run as Privileged\n2) has CAP_SYS_ADMIN\nNote that this field cannot be set when spec.os.name is windows.",
+                    "type": "boolean"
+                  },
+                  "capabilities": {
+                    "description": "The capabilities to add/drop when running containers.\nDefaults to the default set of capabilities granted by the container runtime.\nNote that this field cannot be set when spec.os.name is windows.",
+                    "type": "object",
+                    "properties": {
+                      "add": {
+                        "description": "This is accessible behind a feature flag - kubernetes.containerspec-addcapabilities",
+                        "type": "array",
+                        "items": {
+                          "description": "Capability represent POSIX capabilities type",
+                          "type": "string"
+                        },
+                        "x-kubernetes-list-type": "atomic"
+                      },
+                      "drop": {
+                        "description": "Removed capabilities",
+                        "type": "array",
+                        "items": {
+                          "description": "Capability represent POSIX capabilities type",
+                          "type": "string"
+                        },
+                        "x-kubernetes-list-type": "atomic"
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "privileged": {
+                    "description": "Run container in privileged mode. This can only be set to explicitly to 'false'",
+                    "type": "boolean"
+                  },
+                  "readOnlyRootFilesystem": {
+                    "description": "Whether this container has a read-only root filesystem.\nDefault is false.\nNote that this field cannot be set when spec.os.name is windows.",
+                    "type": "boolean"
+                  },
+                  "runAsGroup": {
+                    "description": "The GID to run the entrypoint of the container process.\nUses runtime default if unset.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
+                    "type": "integer",
+                    "format": "int64"
+                  },
+                  "runAsNonRoot": {
+                    "description": "Indicates that the container must run as a non-root user.\nIf true, the Kubelet will validate the image at runtime to ensure that it\ndoes not run as UID 0 (root) and fail to start the container if it does.\nIf unset or false, no such validation will be performed.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
+                    "type": "boolean"
+                  },
+                  "runAsUser": {
+                    "description": "The UID to run the entrypoint of the container process.\nDefaults to user specified in image metadata if unspecified.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
+                    "type": "integer",
+                    "format": "int64"
+                  },
+                  "seccompProfile": {
+                    "description": "The seccomp options to use by this container. If seccomp options are\nprovided at both the pod & container level, the container options\noverride the pod options.\nNote that this field cannot be set when spec.os.name is windows.",
+                    "type": "object",
+                    "required": [
+                      "type"
+                    ],
+                    "properties": {
+                      "localhostProfile": {
+                        "description": "localhostProfile indicates a profile defined in a file on the node should be used.\nThe profile must be preconfigured on the node to work.\nMust be a descending path, relative to the kubelet's configured seccomp profile location.\nMust be set if type is \"Localhost\". Must NOT be set for any other type.",
+                        "type": "string"
+                      },
+                      "type": {
+                        "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
+                        "type": "string"
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              },
+              "startupProbe": {
+                "description": "StartupProbe indicates that the Pod has successfully initialized.\nIf specified, no other probes are executed until this completes successfully.\nIf this probe fails, the Pod will be restarted, just as if the livenessProbe failed.\nThis can be used to provide different probe parameters at the beginning of a Pod's lifecycle,\nwhen it might take a long time to load data or warm a cache, than during steady-state operation.\nThis cannot be updated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                "type": "object",
+                "properties": {
+                  "exec": {
+                    "description": "Exec specifies a command to execute in the container.",
+                    "type": "object",
+                    "properties": {
+                      "command": {
+                        "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "x-kubernetes-list-type": "atomic"
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "failureThreshold": {
+                    "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded.\nDefaults to 3. Minimum value is 1.",
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "grpc": {
+                    "description": "GRPC specifies a GRPC HealthCheckRequest.",
+                    "type": "object",
+                    "properties": {
+                      "port": {
+                        "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                        "type": "integer",
+                        "format": "int32"
+                      },
+                      "service": {
+                        "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                        "type": "string",
+                        "default": ""
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "httpGet": {
+                    "description": "HTTPGet specifies an HTTP GET request to perform.",
+                    "type": "object",
+                    "properties": {
+                      "host": {
+                        "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
+                        "type": "string"
+                      },
+                      "httpHeaders": {
+                        "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                        "type": "array",
+                        "items": {
+                          "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                          "type": "object",
+                          "required": [
+                            "name",
+                            "value"
+                          ],
+                          "properties": {
+                            "name": {
+                              "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                              "type": "string"
+                            },
+                            "value": {
+                              "description": "The header field value",
+                              "type": "string"
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "x-kubernetes-list-type": "atomic"
+                      },
+                      "path": {
+                        "description": "Path to access on the HTTP server.",
+                        "type": "string"
+                      },
+                      "port": {
+                        "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "scheme": {
+                        "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
+                        "type": "string"
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "initialDelaySeconds": {
+                    "description": "Number of seconds after the container has started before liveness probes are initiated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "periodSeconds": {
+                    "description": "How often (in seconds) to perform the probe.",
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "successThreshold": {
+                    "description": "Minimum consecutive successes for the probe to be considered successful after having failed.\nDefaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "tcpSocket": {
+                    "description": "TCPSocket specifies a connection to a TCP port.",
+                    "type": "object",
+                    "properties": {
+                      "host": {
+                        "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                        "type": "string"
+                      },
+                      "port": {
+                        "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "x-kubernetes-int-or-string": true
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "timeoutSeconds": {
+                    "description": "Number of seconds after which the probe times out.\nDefaults to 1 second. Minimum value is 1.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                    "type": "integer",
+                    "format": "int32"
+                  }
+                },
+                "additionalProperties": false
+              },
+              "terminationMessagePath": {
+                "description": "Optional: Path at which the file to which the container's termination message\nwill be written is mounted into the container's filesystem.\nMessage written is intended to be brief final status, such as an assertion failure message.\nWill be truncated by the node if greater than 4096 bytes. The total message length across\nall containers will be limited to 12kb.\nDefaults to /dev/termination-log.\nCannot be updated.",
+                "type": "string"
+              },
+              "terminationMessagePolicy": {
+                "description": "Indicate how the termination message should be populated. File will use the contents of\nterminationMessagePath to populate the container status message on both success and failure.\nFallbackToLogsOnError will use the last chunk of container log output if the termination\nmessage file is empty and the container exited with an error.\nThe log output is limited to 2048 bytes or 80 lines, whichever is smaller.\nDefaults to File.\nCannot be updated.",
+                "type": "string"
+              },
+              "volumeMounts": {
+                "description": "Pod volumes to mount into the container's filesystem.\nCannot be updated.",
+                "type": "array",
+                "items": {
+                  "description": "VolumeMount describes a mounting of a Volume within a container.",
+                  "type": "object",
+                  "required": [
+                    "mountPath",
+                    "name"
+                  ],
+                  "properties": {
+                    "mountPath": {
+                      "description": "Path within the container at which the volume should be mounted.  Must\nnot contain ':'.",
+                      "type": "string"
+                    },
+                    "mountPropagation": {
+                      "description": "This is accessible behind a feature flag - kubernetes.podspec-volumes-mount-propagation",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "This must match the Name of a Volume.",
+                      "type": "string"
+                    },
+                    "readOnly": {
+                      "description": "Mounted read-only if true, read-write otherwise (false or unspecified).\nDefaults to false.",
+                      "type": "boolean"
+                    },
+                    "subPath": {
+                      "description": "Path within the volume from which the container's volume should be mounted.\nDefaults to \"\" (volume's root).",
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "x-kubernetes-list-map-keys": [
+                  "mountPath"
+                ],
+                "x-kubernetes-list-type": "map"
+              },
+              "workingDir": {
+                "description": "Container's working directory.\nIf not specified, the container runtime's default will be used, which\nmight be configured in the container image.\nCannot be updated.",
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "dnsConfig": {
+          "description": "This is accessible behind a feature flag - kubernetes.podspec-dnsconfig",
+          "type": "object",
+          "x-kubernetes-preserve-unknown-fields": true
+        },
+        "dnsPolicy": {
+          "description": "This is accessible behind a feature flag - kubernetes.podspec-dnspolicy",
+          "type": "string"
+        },
+        "enableServiceLinks": {
+          "description": "EnableServiceLinks indicates whether information aboutservices should be injected into pod's environment variables, matching the syntax of Docker links. Optional: Knative defaults this to false.",
+          "type": "boolean"
+        },
+        "hostAliases": {
+          "description": "This is accessible behind a feature flag - kubernetes.podspec-hostaliases",
+          "type": "array",
+          "items": {
+            "description": "This is accessible behind a feature flag - kubernetes.podspec-hostaliases",
+            "type": "object",
+            "x-kubernetes-preserve-unknown-fields": true
+          }
+        },
+        "hostIPC": {
+          "description": "This is accessible behind a feature flag - kubernetes.podspec-hostipc",
+          "type": "boolean"
+        },
+        "hostNetwork": {
+          "description": "This is accessible behind a feature flag - kubernetes.podspec-hostnetwork",
+          "type": "boolean"
+        },
+        "hostPID": {
+          "description": "This is accessible behind a feature flag - kubernetes.podspec-hostpid",
+          "type": "boolean"
+        },
+        "idleTimeoutSeconds": {
+          "description": "IdleTimeoutSeconds is the maximum duration in seconds a request will be allowed\nto stay open while not receiving any bytes from the user's application. If\nunspecified, a system default will be provided.",
+          "type": "integer",
+          "format": "int64"
+        },
+        "imagePullSecrets": {
+          "description": "ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec.\nIf specified, these secrets will be passed to individual puller implementations for them to use.\nMore info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod",
+          "type": "array",
+          "items": {
+            "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
+            "type": "object",
+            "properties": {
+              "name": {
+                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                "type": "string",
+                "default": ""
+              }
+            },
+            "x-kubernetes-map-type": "atomic",
+            "additionalProperties": false
+          },
+          "x-kubernetes-list-map-keys": [
+            "name"
+          ],
+          "x-kubernetes-list-type": "map"
+        },
+        "initContainers": {
+          "description": "This is accessible behind a feature flag - kubernetes.podspec-init-containers",
+          "type": "array",
+          "items": {
+            "description": "This is accessible behind a feature flag - kubernetes.podspec-init-containers",
+            "type": "object",
+            "x-kubernetes-preserve-unknown-fields": true
+          }
+        },
+        "nodeSelector": {
+          "description": "This is accessible behind a feature flag - kubernetes.podspec-nodeselector",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "x-kubernetes-map-type": "atomic"
+        },
+        "priorityClassName": {
+          "description": "This is accessible behind a feature flag - kubernetes.podspec-priorityclassname",
+          "type": "string"
+        },
+        "responseStartTimeoutSeconds": {
+          "description": "ResponseStartTimeoutSeconds is the maximum duration in seconds that the request\nrouting layer will wait for a request delivered to a container to begin\nsending any network traffic.",
+          "type": "integer",
+          "format": "int64"
+        },
+        "runtimeClassName": {
+          "description": "This is accessible behind a feature flag - kubernetes.podspec-runtimeclassname",
+          "type": "string"
+        },
+        "schedulerName": {
+          "description": "This is accessible behind a feature flag - kubernetes.podspec-schedulername",
+          "type": "string"
+        },
+        "securityContext": {
+          "description": "This is accessible behind a feature flag - kubernetes.podspec-securitycontext",
+          "type": "object",
+          "x-kubernetes-preserve-unknown-fields": true
+        },
+        "serviceAccountName": {
+          "description": "ServiceAccountName is the name of the ServiceAccount to use to run this pod.\nMore info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/",
+          "type": "string"
+        },
+        "shareProcessNamespace": {
+          "description": "This is accessible behind a feature flag - kubernetes.podspec-shareprocessnamespace",
+          "type": "boolean"
+        },
+        "timeoutSeconds": {
+          "description": "TimeoutSeconds is the maximum duration in seconds that the request instance\nis allowed to respond to a request. If unspecified, a system default will\nbe provided.",
+          "type": "integer",
+          "format": "int64"
+        },
+        "tolerations": {
+          "description": "This is accessible behind a feature flag - kubernetes.podspec-tolerations",
+          "type": "array",
+          "items": {
+            "description": "This is accessible behind a feature flag - kubernetes.podspec-tolerations",
+            "type": "object",
+            "x-kubernetes-preserve-unknown-fields": true
+          }
+        },
+        "topologySpreadConstraints": {
+          "description": "This is accessible behind a feature flag - kubernetes.podspec-topologyspreadconstraints",
+          "type": "array",
+          "items": {
+            "description": "This is accessible behind a feature flag - kubernetes.podspec-topologyspreadconstraints",
+            "type": "object",
+            "x-kubernetes-preserve-unknown-fields": true
+          }
+        },
+        "volumes": {
+          "description": "List of volumes that can be mounted by containers belonging to the pod.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes",
+          "type": "array",
+          "items": {
+            "description": "Volume represents a named volume in a pod that may be accessed by any container in the pod.",
+            "type": "object",
+            "required": [
+              "name"
+            ],
+            "properties": {
+              "configMap": {
+                "description": "configMap represents a configMap that should populate this volume",
+                "type": "object",
+                "properties": {
+                  "defaultMode": {
+                    "description": "defaultMode is optional: mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nDefaults to 0644.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "items": {
+                    "description": "items if unspecified, each key-value pair in the Data field of the referenced\nConfigMap will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the ConfigMap,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
+                    "type": "array",
+                    "items": {
+                      "description": "Maps a string key to a path within a volume.",
+                      "type": "object",
+                      "required": [
+                        "key",
+                        "path"
+                      ],
+                      "properties": {
+                        "key": {
+                          "description": "key is the key to project.",
+                          "type": "string"
+                        },
+                        "mode": {
+                          "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                          "type": "integer",
+                          "format": "int32"
+                        },
+                        "path": {
+                          "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
+                          "type": "string"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "x-kubernetes-list-type": "atomic"
+                  },
+                  "name": {
+                    "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                    "type": "string",
+                    "default": ""
+                  },
+                  "optional": {
+                    "description": "optional specify whether the ConfigMap or its keys must be defined",
+                    "type": "boolean"
+                  }
+                },
+                "x-kubernetes-map-type": "atomic",
+                "additionalProperties": false
+              },
+              "csi": {
+                "description": "This is accessible behind a feature flag - kubernetes.podspec-volumes-csi",
+                "type": "object",
+                "x-kubernetes-preserve-unknown-fields": true
+              },
+              "emptyDir": {
+                "description": "This is accessible behind a feature flag - kubernetes.podspec-volumes-emptydir",
+                "type": "object",
+                "x-kubernetes-preserve-unknown-fields": true
+              },
+              "hostPath": {
+                "description": "This is accessible behind a feature flag - kubernetes.podspec-volumes-hostpath",
+                "type": "object",
+                "x-kubernetes-preserve-unknown-fields": true
+              },
+              "image": {
+                "description": "This is accessible behind a feature flag - kubernetes.podspec-volumes-image",
+                "type": "object",
+                "x-kubernetes-preserve-unknown-fields": true
+              },
+              "name": {
+                "description": "name of the volume.\nMust be a DNS_LABEL and unique within the pod.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                "type": "string"
+              },
+              "persistentVolumeClaim": {
+                "description": "This is accessible behind a feature flag - kubernetes.podspec-persistent-volume-claim",
+                "type": "object",
+                "x-kubernetes-preserve-unknown-fields": true
+              },
+              "projected": {
+                "description": "projected items for all in one resources secrets, configmaps, and downward API",
+                "type": "object",
+                "properties": {
+                  "defaultMode": {
+                    "description": "defaultMode are the mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "sources": {
+                    "description": "sources is the list of volume projections. Each entry in this list\nhandles one source.",
+                    "type": "array",
+                    "items": {
+                      "description": "Projection that may be projected along with other supported volume types.\nExactly one of these fields must be set.",
+                      "type": "object",
+                      "properties": {
+                        "configMap": {
+                          "description": "configMap information about the configMap data to project",
+                          "type": "object",
+                          "properties": {
+                            "items": {
+                              "description": "items if unspecified, each key-value pair in the Data field of the referenced\nConfigMap will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the ConfigMap,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
+                              "type": "array",
+                              "items": {
+                                "description": "Maps a string key to a path within a volume.",
+                                "type": "object",
+                                "required": [
+                                  "key",
+                                  "path"
+                                ],
+                                "properties": {
+                                  "key": {
+                                    "description": "key is the key to project.",
+                                    "type": "string"
+                                  },
+                                  "mode": {
+                                    "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                    "type": "integer",
+                                    "format": "int32"
+                                  },
+                                  "path": {
+                                    "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
+                                    "type": "string"
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "x-kubernetes-list-type": "atomic"
+                            },
+                            "name": {
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                              "type": "string",
+                              "default": ""
+                            },
+                            "optional": {
+                              "description": "optional specify whether the ConfigMap or its keys must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        },
+                        "downwardAPI": {
+                          "description": "downwardAPI information about the downwardAPI data to project",
+                          "type": "object",
+                          "properties": {
+                            "items": {
+                              "description": "Items is a list of DownwardAPIVolume file",
+                              "type": "array",
+                              "items": {
+                                "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
+                                "type": "object",
+                                "required": [
+                                  "path"
+                                ],
+                                "properties": {
+                                  "fieldRef": {
+                                    "description": "Required: Selects a field of the pod: only annotations, labels, name, namespace and uid are supported.",
+                                    "type": "object",
+                                    "required": [
+                                      "fieldPath"
+                                    ],
+                                    "properties": {
+                                      "apiVersion": {
+                                        "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                        "type": "string"
+                                      },
+                                      "fieldPath": {
+                                        "description": "Path of the field to select in the specified API version.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  },
+                                  "mode": {
+                                    "description": "Optional: mode bits used to set permissions on this file, must be an octal value\nbetween 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                    "type": "integer",
+                                    "format": "int32"
+                                  },
+                                  "path": {
+                                    "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'",
+                                    "type": "string"
+                                  },
+                                  "resourceFieldRef": {
+                                    "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.",
+                                    "type": "object",
+                                    "required": [
+                                      "resource"
+                                    ],
+                                    "properties": {
+                                      "containerName": {
+                                        "description": "Container name: required for volumes, optional for env vars",
+                                        "type": "string"
+                                      },
+                                      "divisor": {
+                                        "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "resource": {
+                                        "description": "Required: resource to select",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "x-kubernetes-list-type": "atomic"
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "secret": {
+                          "description": "secret information about the secret data to project",
+                          "type": "object",
+                          "properties": {
+                            "items": {
+                              "description": "items if unspecified, each key-value pair in the Data field of the referenced\nSecret will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the Secret,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
+                              "type": "array",
+                              "items": {
+                                "description": "Maps a string key to a path within a volume.",
+                                "type": "object",
+                                "required": [
+                                  "key",
+                                  "path"
+                                ],
+                                "properties": {
+                                  "key": {
+                                    "description": "key is the key to project.",
+                                    "type": "string"
+                                  },
+                                  "mode": {
+                                    "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                    "type": "integer",
+                                    "format": "int32"
+                                  },
+                                  "path": {
+                                    "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
+                                    "type": "string"
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "x-kubernetes-list-type": "atomic"
+                            },
+                            "name": {
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                              "type": "string",
+                              "default": ""
+                            },
+                            "optional": {
+                              "description": "optional field specify whether the Secret or its key must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        },
+                        "serviceAccountToken": {
+                          "description": "serviceAccountToken is information about the serviceAccountToken data to project",
+                          "type": "object",
+                          "required": [
+                            "path"
+                          ],
+                          "properties": {
+                            "audience": {
+                              "description": "audience is the intended audience of the token. A recipient of a token\nmust identify itself with an identifier specified in the audience of the\ntoken, and otherwise should reject the token. The audience defaults to the\nidentifier of the apiserver.",
+                              "type": "string"
+                            },
+                            "expirationSeconds": {
+                              "description": "expirationSeconds is the requested duration of validity of the service\naccount token. As the token approaches expiration, the kubelet volume\nplugin will proactively rotate the service account token. The kubelet will\nstart trying to rotate the token if the token is older than 80 percent of\nits time to live or if the token is older than 24 hours.Defaults to 1 hour\nand must be at least 10 minutes.",
+                              "type": "integer",
+                              "format": "int64"
+                            },
+                            "path": {
+                              "description": "path is the path relative to the mount point of the file to project the\ntoken into.",
+                              "type": "string"
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "x-kubernetes-list-type": "atomic"
+                  }
+                },
+                "additionalProperties": false
+              },
+              "secret": {
+                "description": "secret represents a secret that should populate this volume.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
+                "type": "object",
+                "properties": {
+                  "defaultMode": {
+                    "description": "defaultMode is Optional: mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values\nfor mode bits. Defaults to 0644.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "items": {
+                    "description": "items If unspecified, each key-value pair in the Data field of the referenced\nSecret will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the Secret,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
+                    "type": "array",
+                    "items": {
+                      "description": "Maps a string key to a path within a volume.",
+                      "type": "object",
+                      "required": [
+                        "key",
+                        "path"
+                      ],
+                      "properties": {
+                        "key": {
+                          "description": "key is the key to project.",
+                          "type": "string"
+                        },
+                        "mode": {
+                          "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                          "type": "integer",
+                          "format": "int32"
+                        },
+                        "path": {
+                          "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
+                          "type": "string"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "x-kubernetes-list-type": "atomic"
+                  },
+                  "optional": {
+                    "description": "optional field specify whether the Secret or its keys must be defined",
+                    "type": "boolean"
+                  },
+                  "secretName": {
+                    "description": "secretName is the name of the secret in the pod's namespace to use.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          "x-kubernetes-list-map-keys": [
+            "name"
+          ],
+          "x-kubernetes-list-type": "map"
+        }
+      },
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "RevisionStatus communicates the observed state of the Revision (from the controller).",
+      "type": "object",
+      "properties": {
+        "actualReplicas": {
+          "description": "ActualReplicas reflects the amount of ready pods running this revision.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "annotations": {
+          "description": "Annotations is additional Status fields for the Resource to save some\nadditional State as well as convey more information to the user. This is\nroughly akin to Annotations on any k8s resource, just the reconciler conveying\nricher information outwards.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "conditions": {
+          "description": "Conditions the latest available observations of a resource's current state.",
+          "type": "array",
+          "items": {
+            "description": "Condition defines a readiness condition for a Knative resource.\nSee: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties",
+            "type": "object",
+            "required": [
+              "status",
+              "type"
+            ],
+            "properties": {
+              "lastTransitionTime": {
+                "description": "LastTransitionTime is the last time the condition transitioned from one status to another.\nWe use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic\ndifferences (all other things held constant).",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity with which to treat failures of this type of condition.\nWhen this is not specified, it defaults to Error.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition.",
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "containerStatuses": {
+          "description": "ContainerStatuses is a slice of images present in .Spec.Container[*].Image\nto their respective digests and their container name.\nThe digests are resolved during the creation of Revision.\nContainerStatuses holds the container name and image digests\nfor both serving and non serving containers.\nref: https://bit.ly/image-digests",
+          "type": "array",
+          "items": {
+            "description": "ContainerStatus holds the information of container name and image digest value",
+            "type": "object",
+            "properties": {
+              "imageDigest": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "desiredReplicas": {
+          "description": "DesiredReplicas reflects the desired amount of pods running this revision.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "initContainerStatuses": {
+          "description": "InitContainerStatuses is a slice of images present in .Spec.InitContainer[*].Image\nto their respective digests and their container name.\nThe digests are resolved during the creation of Revision.\nContainerStatuses holds the container name and image digests\nfor both serving and non serving containers.\nref: https://bit.ly/image-digests",
+          "type": "array",
+          "items": {
+            "description": "ContainerStatus holds the information of container name and image digest value",
+            "type": "object",
+            "properties": {
+              "imageDigest": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "logUrl": {
+          "description": "LogURL specifies the generated logging url for this particular revision\nbased on the revision url template specified in the controller's config.",
+          "type": "string"
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration is the 'Generation' of the Service that\nwas last processed by the controller.",
+          "type": "integer",
+          "format": "int64"
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/serving.knative.dev/route_v1.json
+++ b/serving.knative.dev/route_v1.json
@@ -1,0 +1,180 @@
+{
+  "description": "Route is responsible for configuring ingress over a collection of Revisions.\nSome of the Revisions a Route distributes traffic over may be specified by\nreferencing the Configuration responsible for creating them; in these cases\nthe Route is additionally responsible for monitoring the Configuration for\n\"latest ready revision\" changes, and smoothly rolling out latest revisions.\nSee also: https://github.com/knative/serving/blob/main/docs/spec/overview.md#route",
+  "type": "object",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Spec holds the desired state of the Route (from the client).",
+      "type": "object",
+      "properties": {
+        "traffic": {
+          "description": "Traffic specifies how to distribute traffic over a collection of\nrevisions and configurations.",
+          "type": "array",
+          "items": {
+            "description": "TrafficTarget holds a single entry of the routing table for a Route.",
+            "type": "object",
+            "properties": {
+              "configurationName": {
+                "description": "ConfigurationName of a configuration to whose latest revision we will send\nthis portion of traffic. When the \"status.latestReadyRevisionName\" of the\nreferenced configuration changes, we will automatically migrate traffic\nfrom the prior \"latest ready\" revision to the new one.  This field is never\nset in Route's status, only its spec.  This is mutually exclusive with\nRevisionName.",
+                "type": "string"
+              },
+              "latestRevision": {
+                "description": "LatestRevision may be optionally provided to indicate that the latest\nready Revision of the Configuration should be used for this traffic\ntarget.  When provided LatestRevision must be true if RevisionName is\nempty; it must be false when RevisionName is non-empty.",
+                "type": "boolean"
+              },
+              "percent": {
+                "description": "Percent indicates that percentage based routing should be used and\nthe value indicates the percent of traffic that is be routed to this\nRevision or Configuration. `0` (zero) mean no traffic, `100` means all\ntraffic.\nWhen percentage based routing is being used the follow rules apply:\n- the sum of all percent values must equal 100\n- when not specified, the implied value for `percent` is zero for\n  that particular Revision or Configuration",
+                "type": "integer",
+                "format": "int64"
+              },
+              "revisionName": {
+                "description": "RevisionName of a specific revision to which to send this portion of\ntraffic.  This is mutually exclusive with ConfigurationName.",
+                "type": "string"
+              },
+              "tag": {
+                "description": "Tag is optionally used to expose a dedicated url for referencing\nthis target exclusively.",
+                "type": "string"
+              },
+              "url": {
+                "description": "URL displays the URL for accessing named traffic targets. URL is displayed in\nstatus, and is disallowed on spec. URL must contain a scheme (e.g. http://) and\na hostname, but may not contain anything else (e.g. basic auth, url path, etc.)",
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "Status communicates the observed state of the Route (from the controller).",
+      "type": "object",
+      "properties": {
+        "address": {
+          "description": "Address holds the information needed for a Route to be the target of an event.",
+          "type": "object",
+          "properties": {
+            "CACerts": {
+              "description": "CACerts is the Certification Authority (CA) certificates in PEM format\naccording to https://www.rfc-editor.org/rfc/rfc7468.",
+              "type": "string"
+            },
+            "audience": {
+              "description": "Audience is the OIDC audience for this address.",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name is the name of the address.",
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "annotations": {
+          "description": "Annotations is additional Status fields for the Resource to save some\nadditional State as well as convey more information to the user. This is\nroughly akin to Annotations on any k8s resource, just the reconciler conveying\nricher information outwards.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "conditions": {
+          "description": "Conditions the latest available observations of a resource's current state.",
+          "type": "array",
+          "items": {
+            "description": "Condition defines a readiness condition for a Knative resource.\nSee: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties",
+            "type": "object",
+            "required": [
+              "status",
+              "type"
+            ],
+            "properties": {
+              "lastTransitionTime": {
+                "description": "LastTransitionTime is the last time the condition transitioned from one status to another.\nWe use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic\ndifferences (all other things held constant).",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity with which to treat failures of this type of condition.\nWhen this is not specified, it defaults to Error.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition.",
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration is the 'Generation' of the Service that\nwas last processed by the controller.",
+          "type": "integer",
+          "format": "int64"
+        },
+        "traffic": {
+          "description": "Traffic holds the configured traffic distribution.\nThese entries will always contain RevisionName references.\nWhen ConfigurationName appears in the spec, this will hold the\nLatestReadyRevisionName that we last observed.",
+          "type": "array",
+          "items": {
+            "description": "TrafficTarget holds a single entry of the routing table for a Route.",
+            "type": "object",
+            "properties": {
+              "configurationName": {
+                "description": "ConfigurationName of a configuration to whose latest revision we will send\nthis portion of traffic. When the \"status.latestReadyRevisionName\" of the\nreferenced configuration changes, we will automatically migrate traffic\nfrom the prior \"latest ready\" revision to the new one.  This field is never\nset in Route's status, only its spec.  This is mutually exclusive with\nRevisionName.",
+                "type": "string"
+              },
+              "latestRevision": {
+                "description": "LatestRevision may be optionally provided to indicate that the latest\nready Revision of the Configuration should be used for this traffic\ntarget.  When provided LatestRevision must be true if RevisionName is\nempty; it must be false when RevisionName is non-empty.",
+                "type": "boolean"
+              },
+              "percent": {
+                "description": "Percent indicates that percentage based routing should be used and\nthe value indicates the percent of traffic that is be routed to this\nRevision or Configuration. `0` (zero) mean no traffic, `100` means all\ntraffic.\nWhen percentage based routing is being used the follow rules apply:\n- the sum of all percent values must equal 100\n- when not specified, the implied value for `percent` is zero for\n  that particular Revision or Configuration",
+                "type": "integer",
+                "format": "int64"
+              },
+              "revisionName": {
+                "description": "RevisionName of a specific revision to which to send this portion of\ntraffic.  This is mutually exclusive with ConfigurationName.",
+                "type": "string"
+              },
+              "tag": {
+                "description": "Tag is optionally used to expose a dedicated url for referencing\nthis target exclusively.",
+                "type": "string"
+              },
+              "url": {
+                "description": "URL displays the URL for accessing named traffic targets. URL is displayed in\nstatus, and is disallowed on spec. URL must contain a scheme (e.g. http://) and\na hostname, but may not contain anything else (e.g. basic auth, url path, etc.)",
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "url": {
+          "description": "URL holds the url that will distribute traffic over the provided traffic targets.\nIt generally has the form http[s]://{route-name}.{route-namespace}.{cluster-level-suffix}",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/serving.knative.dev/service_v1.json
+++ b/serving.knative.dev/service_v1.json
@@ -1,0 +1,1547 @@
+{
+  "description": "Service acts as a top-level container that manages a Route and Configuration\nwhich implement a network service. Service exists to provide a singular\nabstraction which can be access controlled, reasoned about, and which\nencapsulates software lifecycle decisions such as rollout policy and\nteam resource ownership. Service acts only as an orchestrator of the\nunderlying Routes and Configurations (much as a kubernetes Deployment\norchestrates ReplicaSets), and its usage is optional but recommended.\n\nThe Service's controller will track the statuses of its owned Configuration\nand Route, reflecting their statuses and conditions as its own.\n\nSee also: https://github.com/knative/serving/blob/main/docs/spec/overview.md#service",
+  "type": "object",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "ServiceSpec represents the configuration for the Service object.\nA Service's specification is the union of the specifications for a Route\nand Configuration.  The Service restricts what can be expressed in these\nfields, e.g. the Route must reference the provided Configuration;\nhowever, these limitations also enable friendlier defaulting,\ne.g. Route never needs a Configuration name, and may be defaulted to\nthe appropriate \"run latest\" spec.",
+      "type": "object",
+      "properties": {
+        "template": {
+          "description": "Template holds the latest specification for the Revision to be stamped out.",
+          "type": "object",
+          "properties": {
+            "metadata": {
+              "type": "object",
+              "properties": {
+                "annotations": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                },
+                "finalizers": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "labels": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                },
+                "name": {
+                  "type": "string"
+                },
+                "namespace": {
+                  "type": "string"
+                }
+              },
+              "x-kubernetes-preserve-unknown-fields": true,
+              "additionalProperties": false
+            },
+            "spec": {
+              "description": "RevisionSpec holds the desired state of the Revision (from the client).",
+              "type": "object",
+              "required": [
+                "containers"
+              ],
+              "properties": {
+                "affinity": {
+                  "description": "This is accessible behind a feature flag - kubernetes.podspec-affinity",
+                  "type": "object",
+                  "x-kubernetes-preserve-unknown-fields": true
+                },
+                "automountServiceAccountToken": {
+                  "description": "AutomountServiceAccountToken indicates whether a service account token should be automatically mounted.",
+                  "type": "boolean"
+                },
+                "containerConcurrency": {
+                  "description": "ContainerConcurrency specifies the maximum allowed in-flight (concurrent)\nrequests per container of the Revision.  Defaults to `0` which means\nconcurrency to the application is not limited, and the system decides the\ntarget concurrency for the autoscaler.",
+                  "type": "integer",
+                  "format": "int64"
+                },
+                "containers": {
+                  "description": "List of containers belonging to the pod.\nContainers cannot currently be added or removed.\nThere must be at least one container in a Pod.\nCannot be updated.",
+                  "type": "array",
+                  "items": {
+                    "description": "A single application container that you want to run within a pod.",
+                    "type": "object",
+                    "properties": {
+                      "args": {
+                        "description": "Arguments to the entrypoint.\nThe container image's CMD is used if this is not provided.\nVariable references $(VAR_NAME) are expanded using the container's environment. If a variable\ncannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will\nproduce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless\nof whether the variable exists or not. Cannot be updated.\nMore info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "x-kubernetes-list-type": "atomic"
+                      },
+                      "command": {
+                        "description": "Entrypoint array. Not executed within a shell.\nThe container image's ENTRYPOINT is used if this is not provided.\nVariable references $(VAR_NAME) are expanded using the container's environment. If a variable\ncannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will\nproduce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless\nof whether the variable exists or not. Cannot be updated.\nMore info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "x-kubernetes-list-type": "atomic"
+                      },
+                      "env": {
+                        "description": "List of environment variables to set in the container.\nCannot be updated.",
+                        "type": "array",
+                        "items": {
+                          "description": "EnvVar represents an environment variable present in a Container.",
+                          "type": "object",
+                          "required": [
+                            "name"
+                          ],
+                          "properties": {
+                            "name": {
+                              "description": "Name of the environment variable.\nMay consist of any printable ASCII characters except '='.",
+                              "type": "string"
+                            },
+                            "value": {
+                              "description": "Variable references $(VAR_NAME) are expanded\nusing the previously defined environment variables in the container and\nany service environment variables. If a variable cannot be resolved,\nthe reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.\n\"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\".\nEscaped references will never be expanded, regardless of whether the variable\nexists or not.\nDefaults to \"\".",
+                              "type": "string"
+                            },
+                            "valueFrom": {
+                              "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
+                              "type": "object",
+                              "properties": {
+                                "configMapKeyRef": {
+                                  "description": "Selects a key of a ConfigMap.",
+                                  "type": "object",
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "properties": {
+                                    "key": {
+                                      "description": "The key to select.",
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                      "type": "string",
+                                      "default": ""
+                                    },
+                                    "optional": {
+                                      "description": "Specify whether the ConfigMap or its key must be defined",
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                },
+                                "fieldRef": {
+                                  "description": "This is accessible behind a feature flag - kubernetes.podspec-fieldref",
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "x-kubernetes-preserve-unknown-fields": true
+                                },
+                                "resourceFieldRef": {
+                                  "description": "This is accessible behind a feature flag - kubernetes.podspec-fieldref",
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "x-kubernetes-preserve-unknown-fields": true
+                                },
+                                "secretKeyRef": {
+                                  "description": "Selects a key of a secret in the pod's namespace",
+                                  "type": "object",
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "properties": {
+                                    "key": {
+                                      "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                      "type": "string",
+                                      "default": ""
+                                    },
+                                    "optional": {
+                                      "description": "Specify whether the Secret or its key must be defined",
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "additionalProperties": false
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "x-kubernetes-list-map-keys": [
+                          "name"
+                        ],
+                        "x-kubernetes-list-type": "map"
+                      },
+                      "envFrom": {
+                        "description": "List of sources to populate environment variables in the container.\nThe keys defined within a source may consist of any printable ASCII characters except '='.\nWhen a key exists in multiple\nsources, the value associated with the last source will take precedence.\nValues defined by an Env with a duplicate key will take precedence.\nCannot be updated.",
+                        "type": "array",
+                        "items": {
+                          "description": "EnvFromSource represents the source of a set of ConfigMaps or Secrets",
+                          "type": "object",
+                          "properties": {
+                            "configMapRef": {
+                              "description": "The ConfigMap to select from",
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                  "type": "string",
+                                  "default": ""
+                                },
+                                "optional": {
+                                  "description": "Specify whether the ConfigMap must be defined",
+                                  "type": "boolean"
+                                }
+                              },
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            },
+                            "prefix": {
+                              "description": "Optional text to prepend to the name of each environment variable.\nMay consist of any printable ASCII characters except '='.",
+                              "type": "string"
+                            },
+                            "secretRef": {
+                              "description": "The Secret to select from",
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                  "type": "string",
+                                  "default": ""
+                                },
+                                "optional": {
+                                  "description": "Specify whether the Secret must be defined",
+                                  "type": "boolean"
+                                }
+                              },
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "x-kubernetes-list-type": "atomic"
+                      },
+                      "image": {
+                        "description": "Container image name.\nMore info: https://kubernetes.io/docs/concepts/containers/images\nThis field is optional to allow higher level config management to default or override\ncontainer images in workload controllers like Deployments and StatefulSets.",
+                        "type": "string"
+                      },
+                      "imagePullPolicy": {
+                        "description": "Image pull policy.\nOne of Always, Never, IfNotPresent.\nDefaults to Always if :latest tag is specified, or IfNotPresent otherwise.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/containers/images#updating-images",
+                        "type": "string"
+                      },
+                      "livenessProbe": {
+                        "description": "Periodic probe of container liveness.\nContainer will be restarted if the probe fails.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                        "type": "object",
+                        "properties": {
+                          "exec": {
+                            "description": "Exec specifies a command to execute in the container.",
+                            "type": "object",
+                            "properties": {
+                              "command": {
+                                "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "x-kubernetes-list-type": "atomic"
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "failureThreshold": {
+                            "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded.\nDefaults to 3. Minimum value is 1.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "grpc": {
+                            "description": "GRPC specifies a GRPC HealthCheckRequest.",
+                            "type": "object",
+                            "properties": {
+                              "port": {
+                                "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                                "type": "integer",
+                                "format": "int32"
+                              },
+                              "service": {
+                                "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                "type": "string",
+                                "default": ""
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "httpGet": {
+                            "description": "HTTPGet specifies an HTTP GET request to perform.",
+                            "type": "object",
+                            "properties": {
+                              "host": {
+                                "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
+                                "type": "string"
+                              },
+                              "httpHeaders": {
+                                "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                "type": "array",
+                                "items": {
+                                  "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                  "type": "object",
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
+                                  "properties": {
+                                    "name": {
+                                      "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "description": "The header field value",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "additionalProperties": false
+                                },
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "path": {
+                                "description": "Path to access on the HTTP server.",
+                                "type": "string"
+                              },
+                              "port": {
+                                "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "scheme": {
+                                "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
+                                "type": "string"
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "initialDelaySeconds": {
+                            "description": "Number of seconds after the container has started before liveness probes are initiated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "periodSeconds": {
+                            "description": "How often (in seconds) to perform the probe.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "successThreshold": {
+                            "description": "Minimum consecutive successes for the probe to be considered successful after having failed.\nDefaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "tcpSocket": {
+                            "description": "TCPSocket specifies a connection to a TCP port.",
+                            "type": "object",
+                            "properties": {
+                              "host": {
+                                "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                "type": "string"
+                              },
+                              "port": {
+                                "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "timeoutSeconds": {
+                            "description": "Number of seconds after which the probe times out.\nDefaults to 1 second. Minimum value is 1.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                            "type": "integer",
+                            "format": "int32"
+                          }
+                        },
+                        "additionalProperties": false
+                      },
+                      "name": {
+                        "description": "Name of the container specified as a DNS_LABEL.\nEach container in a pod must have a unique name (DNS_LABEL).\nCannot be updated.",
+                        "type": "string"
+                      },
+                      "ports": {
+                        "description": "List of ports to expose from the container. Not specifying a port here\nDOES NOT prevent that port from being exposed. Any port which is\nlistening on the default \"0.0.0.0\" address inside a container will be\naccessible from the network.\nModifying this array with strategic merge patch may corrupt the data.\nFor more information See https://github.com/kubernetes/kubernetes/issues/108255.\nCannot be updated.",
+                        "type": "array",
+                        "items": {
+                          "description": "ContainerPort represents a network port in a single container.",
+                          "type": "object",
+                          "properties": {
+                            "containerPort": {
+                              "description": "Number of port to expose on the pod's IP address.\nThis must be a valid port number, 0 < x < 65536.",
+                              "type": "integer",
+                              "format": "int32"
+                            },
+                            "name": {
+                              "description": "If specified, this must be an IANA_SVC_NAME and unique within the pod. Each\nnamed port in a pod must have a unique name. Name for the port that can be\nreferred to by services.",
+                              "type": "string"
+                            },
+                            "protocol": {
+                              "description": "Protocol for port. Must be UDP, TCP, or SCTP.\nDefaults to \"TCP\".",
+                              "type": "string",
+                              "default": "TCP"
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      },
+                      "readinessProbe": {
+                        "description": "Periodic probe of container service readiness.\nContainer will be removed from service endpoints if the probe fails.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                        "type": "object",
+                        "properties": {
+                          "exec": {
+                            "description": "Exec specifies a command to execute in the container.",
+                            "type": "object",
+                            "properties": {
+                              "command": {
+                                "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "x-kubernetes-list-type": "atomic"
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "failureThreshold": {
+                            "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded.\nDefaults to 3. Minimum value is 1.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "grpc": {
+                            "description": "GRPC specifies a GRPC HealthCheckRequest.",
+                            "type": "object",
+                            "properties": {
+                              "port": {
+                                "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                                "type": "integer",
+                                "format": "int32"
+                              },
+                              "service": {
+                                "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                "type": "string",
+                                "default": ""
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "httpGet": {
+                            "description": "HTTPGet specifies an HTTP GET request to perform.",
+                            "type": "object",
+                            "properties": {
+                              "host": {
+                                "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
+                                "type": "string"
+                              },
+                              "httpHeaders": {
+                                "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                "type": "array",
+                                "items": {
+                                  "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                  "type": "object",
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
+                                  "properties": {
+                                    "name": {
+                                      "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "description": "The header field value",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "additionalProperties": false
+                                },
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "path": {
+                                "description": "Path to access on the HTTP server.",
+                                "type": "string"
+                              },
+                              "port": {
+                                "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "scheme": {
+                                "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
+                                "type": "string"
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "initialDelaySeconds": {
+                            "description": "Number of seconds after the container has started before liveness probes are initiated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "periodSeconds": {
+                            "description": "How often (in seconds) to perform the probe.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "successThreshold": {
+                            "description": "Minimum consecutive successes for the probe to be considered successful after having failed.\nDefaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "tcpSocket": {
+                            "description": "TCPSocket specifies a connection to a TCP port.",
+                            "type": "object",
+                            "properties": {
+                              "host": {
+                                "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                "type": "string"
+                              },
+                              "port": {
+                                "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "timeoutSeconds": {
+                            "description": "Number of seconds after which the probe times out.\nDefaults to 1 second. Minimum value is 1.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                            "type": "integer",
+                            "format": "int32"
+                          }
+                        },
+                        "additionalProperties": false
+                      },
+                      "resources": {
+                        "description": "Compute Resources required by this container.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                        "type": "object",
+                        "properties": {
+                          "limits": {
+                            "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                            "type": "object",
+                            "additionalProperties": {
+                              "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            }
+                          },
+                          "requests": {
+                            "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                            "type": "object",
+                            "additionalProperties": {
+                              "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            }
+                          }
+                        },
+                        "additionalProperties": false
+                      },
+                      "securityContext": {
+                        "description": "SecurityContext defines the security options the container should be run with.\nIf set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.\nMore info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/",
+                        "type": "object",
+                        "properties": {
+                          "allowPrivilegeEscalation": {
+                            "description": "AllowPrivilegeEscalation controls whether a process can gain more\nprivileges than its parent process. This bool directly controls if\nthe no_new_privs flag will be set on the container process.\nAllowPrivilegeEscalation is true always when the container is:\n1) run as Privileged\n2) has CAP_SYS_ADMIN\nNote that this field cannot be set when spec.os.name is windows.",
+                            "type": "boolean"
+                          },
+                          "capabilities": {
+                            "description": "The capabilities to add/drop when running containers.\nDefaults to the default set of capabilities granted by the container runtime.\nNote that this field cannot be set when spec.os.name is windows.",
+                            "type": "object",
+                            "properties": {
+                              "add": {
+                                "description": "This is accessible behind a feature flag - kubernetes.containerspec-addcapabilities",
+                                "type": "array",
+                                "items": {
+                                  "description": "Capability represent POSIX capabilities type",
+                                  "type": "string"
+                                },
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "drop": {
+                                "description": "Removed capabilities",
+                                "type": "array",
+                                "items": {
+                                  "description": "Capability represent POSIX capabilities type",
+                                  "type": "string"
+                                },
+                                "x-kubernetes-list-type": "atomic"
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "privileged": {
+                            "description": "Run container in privileged mode. This can only be set to explicitly to 'false'",
+                            "type": "boolean"
+                          },
+                          "readOnlyRootFilesystem": {
+                            "description": "Whether this container has a read-only root filesystem.\nDefault is false.\nNote that this field cannot be set when spec.os.name is windows.",
+                            "type": "boolean"
+                          },
+                          "runAsGroup": {
+                            "description": "The GID to run the entrypoint of the container process.\nUses runtime default if unset.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
+                            "type": "integer",
+                            "format": "int64"
+                          },
+                          "runAsNonRoot": {
+                            "description": "Indicates that the container must run as a non-root user.\nIf true, the Kubelet will validate the image at runtime to ensure that it\ndoes not run as UID 0 (root) and fail to start the container if it does.\nIf unset or false, no such validation will be performed.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.",
+                            "type": "boolean"
+                          },
+                          "runAsUser": {
+                            "description": "The UID to run the entrypoint of the container process.\nDefaults to user specified in image metadata if unspecified.\nMay also be set in PodSecurityContext.  If set in both SecurityContext and\nPodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is windows.",
+                            "type": "integer",
+                            "format": "int64"
+                          },
+                          "seccompProfile": {
+                            "description": "The seccomp options to use by this container. If seccomp options are\nprovided at both the pod & container level, the container options\noverride the pod options.\nNote that this field cannot be set when spec.os.name is windows.",
+                            "type": "object",
+                            "required": [
+                              "type"
+                            ],
+                            "properties": {
+                              "localhostProfile": {
+                                "description": "localhostProfile indicates a profile defined in a file on the node should be used.\nThe profile must be preconfigured on the node to work.\nMust be a descending path, relative to the kubelet's configured seccomp profile location.\nMust be set if type is \"Localhost\". Must NOT be set for any other type.",
+                                "type": "string"
+                              },
+                              "type": {
+                                "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
+                                "type": "string"
+                              }
+                            },
+                            "additionalProperties": false
+                          }
+                        },
+                        "additionalProperties": false
+                      },
+                      "startupProbe": {
+                        "description": "StartupProbe indicates that the Pod has successfully initialized.\nIf specified, no other probes are executed until this completes successfully.\nIf this probe fails, the Pod will be restarted, just as if the livenessProbe failed.\nThis can be used to provide different probe parameters at the beginning of a Pod's lifecycle,\nwhen it might take a long time to load data or warm a cache, than during steady-state operation.\nThis cannot be updated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                        "type": "object",
+                        "properties": {
+                          "exec": {
+                            "description": "Exec specifies a command to execute in the container.",
+                            "type": "object",
+                            "properties": {
+                              "command": {
+                                "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "x-kubernetes-list-type": "atomic"
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "failureThreshold": {
+                            "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded.\nDefaults to 3. Minimum value is 1.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "grpc": {
+                            "description": "GRPC specifies a GRPC HealthCheckRequest.",
+                            "type": "object",
+                            "properties": {
+                              "port": {
+                                "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                                "type": "integer",
+                                "format": "int32"
+                              },
+                              "service": {
+                                "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                "type": "string",
+                                "default": ""
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "httpGet": {
+                            "description": "HTTPGet specifies an HTTP GET request to perform.",
+                            "type": "object",
+                            "properties": {
+                              "host": {
+                                "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
+                                "type": "string"
+                              },
+                              "httpHeaders": {
+                                "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                "type": "array",
+                                "items": {
+                                  "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                  "type": "object",
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
+                                  "properties": {
+                                    "name": {
+                                      "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "description": "The header field value",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "additionalProperties": false
+                                },
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "path": {
+                                "description": "Path to access on the HTTP server.",
+                                "type": "string"
+                              },
+                              "port": {
+                                "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "scheme": {
+                                "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
+                                "type": "string"
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "initialDelaySeconds": {
+                            "description": "Number of seconds after the container has started before liveness probes are initiated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "periodSeconds": {
+                            "description": "How often (in seconds) to perform the probe.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "successThreshold": {
+                            "description": "Minimum consecutive successes for the probe to be considered successful after having failed.\nDefaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "tcpSocket": {
+                            "description": "TCPSocket specifies a connection to a TCP port.",
+                            "type": "object",
+                            "properties": {
+                              "host": {
+                                "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                "type": "string"
+                              },
+                              "port": {
+                                "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "timeoutSeconds": {
+                            "description": "Number of seconds after which the probe times out.\nDefaults to 1 second. Minimum value is 1.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                            "type": "integer",
+                            "format": "int32"
+                          }
+                        },
+                        "additionalProperties": false
+                      },
+                      "terminationMessagePath": {
+                        "description": "Optional: Path at which the file to which the container's termination message\nwill be written is mounted into the container's filesystem.\nMessage written is intended to be brief final status, such as an assertion failure message.\nWill be truncated by the node if greater than 4096 bytes. The total message length across\nall containers will be limited to 12kb.\nDefaults to /dev/termination-log.\nCannot be updated.",
+                        "type": "string"
+                      },
+                      "terminationMessagePolicy": {
+                        "description": "Indicate how the termination message should be populated. File will use the contents of\nterminationMessagePath to populate the container status message on both success and failure.\nFallbackToLogsOnError will use the last chunk of container log output if the termination\nmessage file is empty and the container exited with an error.\nThe log output is limited to 2048 bytes or 80 lines, whichever is smaller.\nDefaults to File.\nCannot be updated.",
+                        "type": "string"
+                      },
+                      "volumeMounts": {
+                        "description": "Pod volumes to mount into the container's filesystem.\nCannot be updated.",
+                        "type": "array",
+                        "items": {
+                          "description": "VolumeMount describes a mounting of a Volume within a container.",
+                          "type": "object",
+                          "required": [
+                            "mountPath",
+                            "name"
+                          ],
+                          "properties": {
+                            "mountPath": {
+                              "description": "Path within the container at which the volume should be mounted.  Must\nnot contain ':'.",
+                              "type": "string"
+                            },
+                            "mountPropagation": {
+                              "description": "This is accessible behind a feature flag - kubernetes.podspec-volumes-mount-propagation",
+                              "type": "string"
+                            },
+                            "name": {
+                              "description": "This must match the Name of a Volume.",
+                              "type": "string"
+                            },
+                            "readOnly": {
+                              "description": "Mounted read-only if true, read-write otherwise (false or unspecified).\nDefaults to false.",
+                              "type": "boolean"
+                            },
+                            "subPath": {
+                              "description": "Path within the volume from which the container's volume should be mounted.\nDefaults to \"\" (volume's root).",
+                              "type": "string"
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "x-kubernetes-list-map-keys": [
+                          "mountPath"
+                        ],
+                        "x-kubernetes-list-type": "map"
+                      },
+                      "workingDir": {
+                        "description": "Container's working directory.\nIf not specified, the container runtime's default will be used, which\nmight be configured in the container image.\nCannot be updated.",
+                        "type": "string"
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "dnsConfig": {
+                  "description": "This is accessible behind a feature flag - kubernetes.podspec-dnsconfig",
+                  "type": "object",
+                  "x-kubernetes-preserve-unknown-fields": true
+                },
+                "dnsPolicy": {
+                  "description": "This is accessible behind a feature flag - kubernetes.podspec-dnspolicy",
+                  "type": "string"
+                },
+                "enableServiceLinks": {
+                  "description": "EnableServiceLinks indicates whether information aboutservices should be injected into pod's environment variables, matching the syntax of Docker links. Optional: Knative defaults this to false.",
+                  "type": "boolean"
+                },
+                "hostAliases": {
+                  "description": "This is accessible behind a feature flag - kubernetes.podspec-hostaliases",
+                  "type": "array",
+                  "items": {
+                    "description": "This is accessible behind a feature flag - kubernetes.podspec-hostaliases",
+                    "type": "object",
+                    "x-kubernetes-preserve-unknown-fields": true
+                  }
+                },
+                "hostIPC": {
+                  "description": "This is accessible behind a feature flag - kubernetes.podspec-hostipc",
+                  "type": "boolean"
+                },
+                "hostNetwork": {
+                  "description": "This is accessible behind a feature flag - kubernetes.podspec-hostnetwork",
+                  "type": "boolean"
+                },
+                "hostPID": {
+                  "description": "This is accessible behind a feature flag - kubernetes.podspec-hostpid",
+                  "type": "boolean"
+                },
+                "idleTimeoutSeconds": {
+                  "description": "IdleTimeoutSeconds is the maximum duration in seconds a request will be allowed\nto stay open while not receiving any bytes from the user's application. If\nunspecified, a system default will be provided.",
+                  "type": "integer",
+                  "format": "int64"
+                },
+                "imagePullSecrets": {
+                  "description": "ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec.\nIf specified, these secrets will be passed to individual puller implementations for them to use.\nMore info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod",
+                  "type": "array",
+                  "items": {
+                    "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                        "type": "string",
+                        "default": ""
+                      }
+                    },
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  },
+                  "x-kubernetes-list-map-keys": [
+                    "name"
+                  ],
+                  "x-kubernetes-list-type": "map"
+                },
+                "initContainers": {
+                  "description": "This is accessible behind a feature flag - kubernetes.podspec-init-containers",
+                  "type": "array",
+                  "items": {
+                    "description": "This is accessible behind a feature flag - kubernetes.podspec-init-containers",
+                    "type": "object",
+                    "x-kubernetes-preserve-unknown-fields": true
+                  }
+                },
+                "nodeSelector": {
+                  "description": "This is accessible behind a feature flag - kubernetes.podspec-nodeselector",
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "x-kubernetes-map-type": "atomic"
+                },
+                "priorityClassName": {
+                  "description": "This is accessible behind a feature flag - kubernetes.podspec-priorityclassname",
+                  "type": "string"
+                },
+                "responseStartTimeoutSeconds": {
+                  "description": "ResponseStartTimeoutSeconds is the maximum duration in seconds that the request\nrouting layer will wait for a request delivered to a container to begin\nsending any network traffic.",
+                  "type": "integer",
+                  "format": "int64"
+                },
+                "runtimeClassName": {
+                  "description": "This is accessible behind a feature flag - kubernetes.podspec-runtimeclassname",
+                  "type": "string"
+                },
+                "schedulerName": {
+                  "description": "This is accessible behind a feature flag - kubernetes.podspec-schedulername",
+                  "type": "string"
+                },
+                "securityContext": {
+                  "description": "This is accessible behind a feature flag - kubernetes.podspec-securitycontext",
+                  "type": "object",
+                  "x-kubernetes-preserve-unknown-fields": true
+                },
+                "serviceAccountName": {
+                  "description": "ServiceAccountName is the name of the ServiceAccount to use to run this pod.\nMore info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/",
+                  "type": "string"
+                },
+                "shareProcessNamespace": {
+                  "description": "This is accessible behind a feature flag - kubernetes.podspec-shareprocessnamespace",
+                  "type": "boolean"
+                },
+                "timeoutSeconds": {
+                  "description": "TimeoutSeconds is the maximum duration in seconds that the request instance\nis allowed to respond to a request. If unspecified, a system default will\nbe provided.",
+                  "type": "integer",
+                  "format": "int64"
+                },
+                "tolerations": {
+                  "description": "This is accessible behind a feature flag - kubernetes.podspec-tolerations",
+                  "type": "array",
+                  "items": {
+                    "description": "This is accessible behind a feature flag - kubernetes.podspec-tolerations",
+                    "type": "object",
+                    "x-kubernetes-preserve-unknown-fields": true
+                  }
+                },
+                "topologySpreadConstraints": {
+                  "description": "This is accessible behind a feature flag - kubernetes.podspec-topologyspreadconstraints",
+                  "type": "array",
+                  "items": {
+                    "description": "This is accessible behind a feature flag - kubernetes.podspec-topologyspreadconstraints",
+                    "type": "object",
+                    "x-kubernetes-preserve-unknown-fields": true
+                  }
+                },
+                "volumes": {
+                  "description": "List of volumes that can be mounted by containers belonging to the pod.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes",
+                  "type": "array",
+                  "items": {
+                    "description": "Volume represents a named volume in a pod that may be accessed by any container in the pod.",
+                    "type": "object",
+                    "required": [
+                      "name"
+                    ],
+                    "properties": {
+                      "configMap": {
+                        "description": "configMap represents a configMap that should populate this volume",
+                        "type": "object",
+                        "properties": {
+                          "defaultMode": {
+                            "description": "defaultMode is optional: mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nDefaults to 0644.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "items": {
+                            "description": "items if unspecified, each key-value pair in the Data field of the referenced\nConfigMap will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the ConfigMap,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
+                            "type": "array",
+                            "items": {
+                              "description": "Maps a string key to a path within a volume.",
+                              "type": "object",
+                              "required": [
+                                "key",
+                                "path"
+                              ],
+                              "properties": {
+                                "key": {
+                                  "description": "key is the key to project.",
+                                  "type": "string"
+                                },
+                                "mode": {
+                                  "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "path": {
+                                  "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
+                                  "type": "string"
+                                }
+                              },
+                              "additionalProperties": false
+                            },
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "name": {
+                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                            "type": "string",
+                            "default": ""
+                          },
+                          "optional": {
+                            "description": "optional specify whether the ConfigMap or its keys must be defined",
+                            "type": "boolean"
+                          }
+                        },
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "csi": {
+                        "description": "This is accessible behind a feature flag - kubernetes.podspec-volumes-csi",
+                        "type": "object",
+                        "x-kubernetes-preserve-unknown-fields": true
+                      },
+                      "emptyDir": {
+                        "description": "This is accessible behind a feature flag - kubernetes.podspec-volumes-emptydir",
+                        "type": "object",
+                        "x-kubernetes-preserve-unknown-fields": true
+                      },
+                      "hostPath": {
+                        "description": "This is accessible behind a feature flag - kubernetes.podspec-volumes-hostpath",
+                        "type": "object",
+                        "x-kubernetes-preserve-unknown-fields": true
+                      },
+                      "image": {
+                        "description": "This is accessible behind a feature flag - kubernetes.podspec-volumes-image",
+                        "type": "object",
+                        "x-kubernetes-preserve-unknown-fields": true
+                      },
+                      "name": {
+                        "description": "name of the volume.\nMust be a DNS_LABEL and unique within the pod.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                        "type": "string"
+                      },
+                      "persistentVolumeClaim": {
+                        "description": "This is accessible behind a feature flag - kubernetes.podspec-persistent-volume-claim",
+                        "type": "object",
+                        "x-kubernetes-preserve-unknown-fields": true
+                      },
+                      "projected": {
+                        "description": "projected items for all in one resources secrets, configmaps, and downward API",
+                        "type": "object",
+                        "properties": {
+                          "defaultMode": {
+                            "description": "defaultMode are the mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "sources": {
+                            "description": "sources is the list of volume projections. Each entry in this list\nhandles one source.",
+                            "type": "array",
+                            "items": {
+                              "description": "Projection that may be projected along with other supported volume types.\nExactly one of these fields must be set.",
+                              "type": "object",
+                              "properties": {
+                                "configMap": {
+                                  "description": "configMap information about the configMap data to project",
+                                  "type": "object",
+                                  "properties": {
+                                    "items": {
+                                      "description": "items if unspecified, each key-value pair in the Data field of the referenced\nConfigMap will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the ConfigMap,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
+                                      "type": "array",
+                                      "items": {
+                                        "description": "Maps a string key to a path within a volume.",
+                                        "type": "object",
+                                        "required": [
+                                          "key",
+                                          "path"
+                                        ],
+                                        "properties": {
+                                          "key": {
+                                            "description": "key is the key to project.",
+                                            "type": "string"
+                                          },
+                                          "mode": {
+                                            "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                            "type": "integer",
+                                            "format": "int32"
+                                          },
+                                          "path": {
+                                            "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "additionalProperties": false
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
+                                    },
+                                    "name": {
+                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                      "type": "string",
+                                      "default": ""
+                                    },
+                                    "optional": {
+                                      "description": "optional specify whether the ConfigMap or its keys must be defined",
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                },
+                                "downwardAPI": {
+                                  "description": "downwardAPI information about the downwardAPI data to project",
+                                  "type": "object",
+                                  "properties": {
+                                    "items": {
+                                      "description": "Items is a list of DownwardAPIVolume file",
+                                      "type": "array",
+                                      "items": {
+                                        "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
+                                        "type": "object",
+                                        "required": [
+                                          "path"
+                                        ],
+                                        "properties": {
+                                          "fieldRef": {
+                                            "description": "Required: Selects a field of the pod: only annotations, labels, name, namespace and uid are supported.",
+                                            "type": "object",
+                                            "required": [
+                                              "fieldPath"
+                                            ],
+                                            "properties": {
+                                              "apiVersion": {
+                                                "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                                "type": "string"
+                                              },
+                                              "fieldPath": {
+                                                "description": "Path of the field to select in the specified API version.",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "x-kubernetes-map-type": "atomic",
+                                            "additionalProperties": false
+                                          },
+                                          "mode": {
+                                            "description": "Optional: mode bits used to set permissions on this file, must be an octal value\nbetween 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                            "type": "integer",
+                                            "format": "int32"
+                                          },
+                                          "path": {
+                                            "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'",
+                                            "type": "string"
+                                          },
+                                          "resourceFieldRef": {
+                                            "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.",
+                                            "type": "object",
+                                            "required": [
+                                              "resource"
+                                            ],
+                                            "properties": {
+                                              "containerName": {
+                                                "description": "Container name: required for volumes, optional for env vars",
+                                                "type": "string"
+                                              },
+                                              "divisor": {
+                                                "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                                "anyOf": [
+                                                  {
+                                                    "type": "integer"
+                                                  },
+                                                  {
+                                                    "type": "string"
+                                                  }
+                                                ],
+                                                "x-kubernetes-int-or-string": true
+                                              },
+                                              "resource": {
+                                                "description": "Required: resource to select",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "x-kubernetes-map-type": "atomic",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "additionalProperties": false
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
+                                    }
+                                  },
+                                  "additionalProperties": false
+                                },
+                                "secret": {
+                                  "description": "secret information about the secret data to project",
+                                  "type": "object",
+                                  "properties": {
+                                    "items": {
+                                      "description": "items if unspecified, each key-value pair in the Data field of the referenced\nSecret will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the Secret,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
+                                      "type": "array",
+                                      "items": {
+                                        "description": "Maps a string key to a path within a volume.",
+                                        "type": "object",
+                                        "required": [
+                                          "key",
+                                          "path"
+                                        ],
+                                        "properties": {
+                                          "key": {
+                                            "description": "key is the key to project.",
+                                            "type": "string"
+                                          },
+                                          "mode": {
+                                            "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                            "type": "integer",
+                                            "format": "int32"
+                                          },
+                                          "path": {
+                                            "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "additionalProperties": false
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
+                                    },
+                                    "name": {
+                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                      "type": "string",
+                                      "default": ""
+                                    },
+                                    "optional": {
+                                      "description": "optional field specify whether the Secret or its key must be defined",
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                },
+                                "serviceAccountToken": {
+                                  "description": "serviceAccountToken is information about the serviceAccountToken data to project",
+                                  "type": "object",
+                                  "required": [
+                                    "path"
+                                  ],
+                                  "properties": {
+                                    "audience": {
+                                      "description": "audience is the intended audience of the token. A recipient of a token\nmust identify itself with an identifier specified in the audience of the\ntoken, and otherwise should reject the token. The audience defaults to the\nidentifier of the apiserver.",
+                                      "type": "string"
+                                    },
+                                    "expirationSeconds": {
+                                      "description": "expirationSeconds is the requested duration of validity of the service\naccount token. As the token approaches expiration, the kubelet volume\nplugin will proactively rotate the service account token. The kubelet will\nstart trying to rotate the token if the token is older than 80 percent of\nits time to live or if the token is older than 24 hours.Defaults to 1 hour\nand must be at least 10 minutes.",
+                                      "type": "integer",
+                                      "format": "int64"
+                                    },
+                                    "path": {
+                                      "description": "path is the path relative to the mount point of the file to project the\ntoken into.",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "additionalProperties": false
+                                }
+                              },
+                              "additionalProperties": false
+                            },
+                            "x-kubernetes-list-type": "atomic"
+                          }
+                        },
+                        "additionalProperties": false
+                      },
+                      "secret": {
+                        "description": "secret represents a secret that should populate this volume.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
+                        "type": "object",
+                        "properties": {
+                          "defaultMode": {
+                            "description": "defaultMode is Optional: mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values\nfor mode bits. Defaults to 0644.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "items": {
+                            "description": "items If unspecified, each key-value pair in the Data field of the referenced\nSecret will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the Secret,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
+                            "type": "array",
+                            "items": {
+                              "description": "Maps a string key to a path within a volume.",
+                              "type": "object",
+                              "required": [
+                                "key",
+                                "path"
+                              ],
+                              "properties": {
+                                "key": {
+                                  "description": "key is the key to project.",
+                                  "type": "string"
+                                },
+                                "mode": {
+                                  "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "path": {
+                                  "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
+                                  "type": "string"
+                                }
+                              },
+                              "additionalProperties": false
+                            },
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "optional": {
+                            "description": "optional field specify whether the Secret or its keys must be defined",
+                            "type": "boolean"
+                          },
+                          "secretName": {
+                            "description": "secretName is the name of the secret in the pod's namespace to use.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "x-kubernetes-list-map-keys": [
+                    "name"
+                  ],
+                  "x-kubernetes-list-type": "map"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        "traffic": {
+          "description": "Traffic specifies how to distribute traffic over a collection of\nrevisions and configurations.",
+          "type": "array",
+          "items": {
+            "description": "TrafficTarget holds a single entry of the routing table for a Route.",
+            "type": "object",
+            "properties": {
+              "configurationName": {
+                "description": "ConfigurationName of a configuration to whose latest revision we will send\nthis portion of traffic. When the \"status.latestReadyRevisionName\" of the\nreferenced configuration changes, we will automatically migrate traffic\nfrom the prior \"latest ready\" revision to the new one.  This field is never\nset in Route's status, only its spec.  This is mutually exclusive with\nRevisionName.",
+                "type": "string"
+              },
+              "latestRevision": {
+                "description": "LatestRevision may be optionally provided to indicate that the latest\nready Revision of the Configuration should be used for this traffic\ntarget.  When provided LatestRevision must be true if RevisionName is\nempty; it must be false when RevisionName is non-empty.",
+                "type": "boolean"
+              },
+              "percent": {
+                "description": "Percent indicates that percentage based routing should be used and\nthe value indicates the percent of traffic that is be routed to this\nRevision or Configuration. `0` (zero) mean no traffic, `100` means all\ntraffic.\nWhen percentage based routing is being used the follow rules apply:\n- the sum of all percent values must equal 100\n- when not specified, the implied value for `percent` is zero for\n  that particular Revision or Configuration",
+                "type": "integer",
+                "format": "int64"
+              },
+              "revisionName": {
+                "description": "RevisionName of a specific revision to which to send this portion of\ntraffic.  This is mutually exclusive with ConfigurationName.",
+                "type": "string"
+              },
+              "tag": {
+                "description": "Tag is optionally used to expose a dedicated url for referencing\nthis target exclusively.",
+                "type": "string"
+              },
+              "url": {
+                "description": "URL displays the URL for accessing named traffic targets. URL is displayed in\nstatus, and is disallowed on spec. URL must contain a scheme (e.g. http://) and\na hostname, but may not contain anything else (e.g. basic auth, url path, etc.)",
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "ServiceStatus represents the Status stanza of the Service resource.",
+      "type": "object",
+      "properties": {
+        "address": {
+          "description": "Address holds the information needed for a Route to be the target of an event.",
+          "type": "object",
+          "properties": {
+            "CACerts": {
+              "description": "CACerts is the Certification Authority (CA) certificates in PEM format\naccording to https://www.rfc-editor.org/rfc/rfc7468.",
+              "type": "string"
+            },
+            "audience": {
+              "description": "Audience is the OIDC audience for this address.",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name is the name of the address.",
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "annotations": {
+          "description": "Annotations is additional Status fields for the Resource to save some\nadditional State as well as convey more information to the user. This is\nroughly akin to Annotations on any k8s resource, just the reconciler conveying\nricher information outwards.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "conditions": {
+          "description": "Conditions the latest available observations of a resource's current state.",
+          "type": "array",
+          "items": {
+            "description": "Condition defines a readiness condition for a Knative resource.\nSee: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties",
+            "type": "object",
+            "required": [
+              "status",
+              "type"
+            ],
+            "properties": {
+              "lastTransitionTime": {
+                "description": "LastTransitionTime is the last time the condition transitioned from one status to another.\nWe use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic\ndifferences (all other things held constant).",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity with which to treat failures of this type of condition.\nWhen this is not specified, it defaults to Error.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition.",
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "latestCreatedRevisionName": {
+          "description": "LatestCreatedRevisionName is the last revision that was created from this\nConfiguration. It might not be ready yet, for that use LatestReadyRevisionName.",
+          "type": "string"
+        },
+        "latestReadyRevisionName": {
+          "description": "LatestReadyRevisionName holds the name of the latest Revision stamped out\nfrom this Configuration that has had its \"Ready\" condition become \"True\".",
+          "type": "string"
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration is the 'Generation' of the Service that\nwas last processed by the controller.",
+          "type": "integer",
+          "format": "int64"
+        },
+        "traffic": {
+          "description": "Traffic holds the configured traffic distribution.\nThese entries will always contain RevisionName references.\nWhen ConfigurationName appears in the spec, this will hold the\nLatestReadyRevisionName that we last observed.",
+          "type": "array",
+          "items": {
+            "description": "TrafficTarget holds a single entry of the routing table for a Route.",
+            "type": "object",
+            "properties": {
+              "configurationName": {
+                "description": "ConfigurationName of a configuration to whose latest revision we will send\nthis portion of traffic. When the \"status.latestReadyRevisionName\" of the\nreferenced configuration changes, we will automatically migrate traffic\nfrom the prior \"latest ready\" revision to the new one.  This field is never\nset in Route's status, only its spec.  This is mutually exclusive with\nRevisionName.",
+                "type": "string"
+              },
+              "latestRevision": {
+                "description": "LatestRevision may be optionally provided to indicate that the latest\nready Revision of the Configuration should be used for this traffic\ntarget.  When provided LatestRevision must be true if RevisionName is\nempty; it must be false when RevisionName is non-empty.",
+                "type": "boolean"
+              },
+              "percent": {
+                "description": "Percent indicates that percentage based routing should be used and\nthe value indicates the percent of traffic that is be routed to this\nRevision or Configuration. `0` (zero) mean no traffic, `100` means all\ntraffic.\nWhen percentage based routing is being used the follow rules apply:\n- the sum of all percent values must equal 100\n- when not specified, the implied value for `percent` is zero for\n  that particular Revision or Configuration",
+                "type": "integer",
+                "format": "int64"
+              },
+              "revisionName": {
+                "description": "RevisionName of a specific revision to which to send this portion of\ntraffic.  This is mutually exclusive with ConfigurationName.",
+                "type": "string"
+              },
+              "tag": {
+                "description": "Tag is optionally used to expose a dedicated url for referencing\nthis target exclusively.",
+                "type": "string"
+              },
+              "url": {
+                "description": "URL displays the URL for accessing named traffic targets. URL is displayed in\nstatus, and is disallowed on spec. URL must contain a scheme (e.g. http://) and\na hostname, but may not contain anything else (e.g. basic auth, url path, etc.)",
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "url": {
+          "description": "URL holds the url that will distribute traffic over the provided traffic targets.\nIt generally has the form http[s]://{route-name}.{route-namespace}.{cluster-level-suffix}",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}


### PR DESCRIPTION
## PR Checklist

- [x] I generated these CRs using the [CRD Extractor tool](https://github.com/datreeio/CRDs-catalog?tab=readme-ov-file#crd-extractor). If I used a different method, I have described the method in this PR.
- [x] I am updating existing schemas and have specified the updated schema version.
- [ ] I am adding new schemas and included a link to the GitHub repository that contains the source of these schemas.

Generated with:

```bash
export FILENAME_FORMAT="{fullgroup}__{kind}_{version}"
curl -s https://raw.githubusercontent.com/yannh/kubeconform/master/scripts/openapi2jsonschema.py | \
  python3 /dev/stdin https://github.com/knative/serving/releases/download/knative-v1.22.0/serving-crds.yaml | \
  grep 'JSON schema written to' | \
  awk '{ print $(NF) }' | \
  xargs -I {} sh -c 'f=$0; mkdir -p $(dirname $(echo $f | sed "s|__|/|")) && mv $f $(echo $f | sed "s|__|/|")' '{}'
```