### PR TITLE
Add MongoDB Atlas Kubernetes Operator CRDs (v2.14.1)

### DIFF
--- a/atlas.generated.mongodb.com/cluster_v1.json
+++ b/atlas.generated.mongodb.com/cluster_v1.json
@@ -1,0 +1,1086 @@
+{
+  "description": "A cluster, managed by the MongoDB Kubernetes Atlas Operator.",
+  "properties": {
+    "spec": {
+      "description": "Specification of the cluster supporting the following versions:\n\n- v20250312\n\nAt most one versioned spec can be specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
+      "properties": {
+        "connectionSecretRef": {
+          "description": "SENSITIVE FIELD\n\nReference to a secret containing the credentials to setup the connection to Atlas.",
+          "properties": {
+            "name": {
+              "description": "Name of the secret containing the Atlas credentials.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "v20250312": {
+          "description": "The spec of the cluster resource for version v20250312.",
+          "properties": {
+            "entry": {
+              "description": "The entry fields of the cluster resource spec. These fields can be set for creating and updating clusters.",
+              "properties": {
+                "acceptDataRisksAndForceReplicaSetReconfig": {
+                  "description": "If reconfiguration is necessary to regain a primary due to a regional outage, submit this field alongside your topology reconfiguration to request a new regional outage resistant topology. Forced reconfigurations during an outage of the majority of electable nodes carry a risk of data loss if replicated writes (even majority committed writes) have not been replicated to the new primary node. MongoDB Atlas docs contain more information. To proceed with an operation which carries that risk, set `acceptDataRisksAndForceReplicaSetReconfig` to the current date. This parameter expresses its value in the ISO 8601 timestamp format in UTC.",
+                  "type": "string"
+                },
+                "advancedConfiguration": {
+                  "description": "Group of settings that configures a subset of the advanced configuration details.",
+                  "properties": {
+                    "customOpensslCipherConfigTls12": {
+                      "description": "The custom OpenSSL cipher suite list for TLS 1.2. This field is only valid when `tlsCipherConfigMode` is set to `CUSTOM`.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "customOpensslCipherConfigTls13": {
+                      "description": "The custom OpenSSL cipher suite list for TLS 1.3. This field is only valid when `tlsCipherConfigMode` is set to `CUSTOM`.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "minimumEnabledTlsProtocol": {
+                      "description": "Minimum Transport Layer Security (TLS) version that the cluster accepts for incoming connections. Clusters using TLS 1.0 or 1.1 should consider setting TLS 1.2 as the minimum TLS protocol version.",
+                      "type": "string"
+                    },
+                    "tlsCipherConfigMode": {
+                      "description": "The TLS cipher suite configuration mode. The default mode uses the default cipher suites. The custom mode allows you to specify custom cipher suites for both TLS 1.2 and TLS 1.3.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "backupEnabled": {
+                  "description": "Flag that indicates whether the cluster can perform backups. If set to `true`, the cluster can perform backups. You must set this value to `true` for NVMe clusters. Backup uses Cloud Backups for dedicated clusters and [Shared Cluster Backups](https://docs.atlas.mongodb.com/backup/shared-tier/overview/) for tenant clusters. If set to `false`, the cluster doesn't use backups.",
+                  "type": "boolean"
+                },
+                "biConnector": {
+                  "description": "Settings needed to configure the MongoDB Connector for Business Intelligence for this cluster.",
+                  "properties": {
+                    "enabled": {
+                      "description": "Flag that indicates whether MongoDB Connector for Business Intelligence is enabled on the specified cluster.",
+                      "type": "boolean"
+                    },
+                    "readPreference": {
+                      "description": "Data source node designated for the MongoDB Connector for Business Intelligence on MongoDB Cloud. The MongoDB Connector for Business Intelligence on MongoDB Cloud reads data from the primary, secondary, or analytics node based on your read preferences. Defaults to `ANALYTICS` node, or `SECONDARY` if there are no `ANALYTICS` nodes.",
+                      "type": "string"
+                    }
+                  },
+                  "title": "MongoDB Connector for Business Intelligence Settings",
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "clusterType": {
+                  "description": "Configuration of nodes that comprise the cluster.",
+                  "type": "string"
+                },
+                "configServerManagementMode": {
+                  "description": "Config Server Management Mode for creating or updating a sharded cluster. When configured as `ATLAS_MANAGED`, Atlas may automatically switch the cluster's config server type for optimal performance and savings. When configured as `FIXED_TO_DEDICATED`, the cluster will always use a dedicated config server.",
+                  "type": "string"
+                },
+                "configServerType": {
+                  "description": "Describes a sharded cluster's config server type.",
+                  "type": "string"
+                },
+                "diskWarmingMode": {
+                  "description": "Disk warming mode selection.",
+                  "type": "string"
+                },
+                "encryptionAtRestProvider": {
+                  "description": "Cloud service provider that manages your customer keys to provide an additional layer of encryption at rest for the cluster. To enable customer key management for encryption at rest, the cluster `replicationSpecs[n].regionConfigs[m].{type}Specs.instanceSize` setting must be `M10` or higher and `\"backupEnabled\" : false` or omitted entirely.",
+                  "type": "string"
+                },
+                "globalClusterSelfManagedSharding": {
+                  "description": "Set this field to configure the Sharding Management Mode when creating a new Global Cluster.\n\nWhen set to false, the management mode is set to Atlas-Managed Sharding. This mode fully manages the sharding of your Global Cluster and is built to provide a seamless deployment experience.\n\nWhen set to true, the management mode is set to Self-Managed Sharding. This mode leaves the management of shards in your hands and is built to provide an advanced and flexible deployment experience.\n\nThis setting cannot be changed once the cluster is deployed.",
+                  "type": "boolean"
+                },
+                "labels": {
+                  "description": "Collection of key-value pairs between 1 to 255 characters in length that tag and categorize the cluster. The MongoDB Cloud console doesn't display your labels.\n\nCluster labels are deprecated and will be removed in a future release. We strongly recommend that you use Resource Tags instead.",
+                  "items": {
+                    "description": "Human-readable labels applied to this MongoDB Cloud component.",
+                    "properties": {
+                      "key": {
+                        "description": "Key applied to tag and categorize this component.",
+                        "type": "string"
+                      },
+                      "value": {
+                        "description": "Value set to the Key applied to tag and categorize this component.",
+                        "type": "string"
+                      }
+                    },
+                    "title": "Component Label",
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "mongoDBEmployeeAccessGrant": {
+                  "description": "MongoDB employee granted access level and expiration for a cluster.",
+                  "properties": {
+                    "expirationTime": {
+                      "description": "Expiration date for the employee access grant. This parameter expresses its value in the ISO 8601 timestamp format in UTC.",
+                      "type": "string"
+                    },
+                    "grantType": {
+                      "description": "Level of access to grant to MongoDB Employees.",
+                      "type": "string"
+                    },
+                    "links": {
+                      "description": "List of one or more Uniform Resource Locators (URLs) that point to API sub-resources, related API resources, or both. RFC 5988 outlines these relationships.",
+                      "items": {
+                        "properties": {
+                          "href": {
+                            "description": "Uniform Resource Locator (URL) that points another API resource to which this response has some relationship. This URL often begins with `https://cloud.mongodb.com/api/atlas`.",
+                            "example": "https://cloud.mongodb.com/api/atlas",
+                            "type": "string"
+                          },
+                          "rel": {
+                            "description": "Uniform Resource Locator (URL) that defines the semantic relationship between this resource and another API resource. This URL often begins with `https://cloud.mongodb.com/api/atlas`.",
+                            "example": "self",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "expirationTime",
+                    "grantType"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "mongoDBMajorVersion": {
+                  "description": "MongoDB major version of the cluster. Set to the binary major version. \n\nOn creation: Choose from the available versions of MongoDB, or leave unspecified for the current recommended default in the MongoDB Cloud platform. The recommended version is a recent Long Term Support version. The default is not guaranteed to be the most recently released version throughout the entire release cycle. For versions available in a specific project, see the linked documentation or use the API endpoint for [project LTS versions endpoint](#tag/Projects/operation/getProjectLtsVersions).\n\n On update: Increase version only by 1 major version at a time. If the cluster is pinned to a MongoDB feature compatibility version exactly one major version below the current MongoDB version, the MongoDB version can be downgraded to the previous major version.",
+                  "type": "string"
+                },
+                "name": {
+                  "description": "Human-readable label that identifies the cluster.",
+                  "type": "string"
+                },
+                "paused": {
+                  "description": "Flag that indicates whether the cluster is paused.",
+                  "type": "boolean"
+                },
+                "pitEnabled": {
+                  "description": "Flag that indicates whether the cluster uses continuous cloud backups.",
+                  "type": "boolean"
+                },
+                "redactClientLogData": {
+                  "description": "Enable or disable log redaction.\n\nThis setting configures the ``mongod`` or ``mongos`` to redact any document field contents from a message accompanying a given log event before logging. This prevents the program from writing potentially sensitive data stored on the database to the diagnostic log. Metadata such as error or operation codes, line numbers, and source file names are still visible in the logs.\n\nUse ``redactClientLogData`` in conjunction with Encryption at Rest and TLS/SSL (Transport Encryption) to assist compliance with regulatory requirements.\n\n*Note*: changing this setting on a cluster will trigger a rolling restart as soon as the cluster is updated.",
+                  "type": "boolean"
+                },
+                "replicaSetScalingStrategy": {
+                  "description": "Set this field to configure the replica set scaling mode for your cluster.\n\nBy default, Atlas scales under `WORKLOAD_TYPE`. This mode allows Atlas to scale your analytics nodes in parallel to your operational nodes.\n\nWhen configured as `SEQUENTIAL`, Atlas scales all nodes sequentially. This mode is intended for steady-state workloads and applications performing latency-sensitive secondary reads.\n\nWhen configured as `NODE_TYPE`, Atlas scales your electable nodes in parallel with your read-only and analytics nodes. This mode is intended for large, dynamic workloads requiring frequent and timely cluster tier scaling. This is the fastest scaling strategy, but it might impact latency of workloads when performing extensive secondary reads.",
+                  "type": "string"
+                },
+                "replicationSpecs": {
+                  "description": "List of settings that configure your cluster regions. This array has one object per shard representing node configurations in each shard. For replica sets there is only one object representing node configurations.",
+                  "items": {
+                    "description": "Details that explain how MongoDB Cloud replicates data on the specified MongoDB database.",
+                    "properties": {
+                      "regionConfigs": {
+                        "description": "Hardware specifications for nodes set for a given region. Each `regionConfigs` object must be unique by region and cloud provider within the `replicationSpec`. Each `regionConfigs` object describes the region's priority in elections and the number and type of MongoDB nodes that MongoDB Cloud deploys to the region. Each `regionConfigs` object must have either an `analyticsSpecs` object, `electableSpecs` object, or `readOnlySpecs` object. Tenant clusters only require `electableSpecs`. Dedicated clusters can specify any of these specifications, but must have at least one `electableSpecs` object within a `replicationSpec`.\n\n**Example:**\n\nIf you set `replicationSpecs[n].regionConfigs[m].analyticsSpecs.instanceSize` : `M30`, set `replicationSpecs[n].regionConfigs[m].electableSpecs.instanceSize` : `M30` if you have electable nodes and `replicationSpecs[n].regionConfigs[m].readOnlySpecs.instanceSize` : `M30` if you have read-only nodes.",
+                        "items": {
+                          "description": "Cloud service provider on which MongoDB Cloud provisions the hosts.",
+                          "properties": {
+                            "analyticsAutoScaling": {
+                              "description": "Options that determine how this cluster handles resource scaling.",
+                              "properties": {
+                                "compute": {
+                                  "description": "Options that determine how this cluster handles CPU scaling.",
+                                  "properties": {
+                                    "enabled": {
+                                      "description": "Flag that indicates whether instance size reactive auto-scaling is enabled.\n\n- Set to `true` to enable instance size reactive auto-scaling. If enabled, you must specify a value for `replicationSpecs[n].regionConfigs[m].autoScaling.compute.maxInstanceSize`.\n- Set to `false` to disable instance size reactive auto-scaling.",
+                                      "type": "boolean"
+                                    },
+                                    "maxInstanceSize": {
+                                      "description": "Instance size boundary to which your cluster can automatically scale.",
+                                      "type": "string"
+                                    },
+                                    "minInstanceSize": {
+                                      "description": "Instance size boundary to which your cluster can automatically scale.",
+                                      "type": "string"
+                                    },
+                                    "scaleDownEnabled": {
+                                      "description": "Flag that indicates whether the instance size may scale down via reactive auto-scaling. MongoDB Cloud requires this parameter if `replicationSpecs[n].regionConfigs[m].autoScaling.compute.enabled` is `true`. If you enable this option, specify a value for `replicationSpecs[n].regionConfigs[m].autoScaling.compute.minInstanceSize`.",
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "title": "Automatic Compute Scaling Settings",
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "diskGB": {
+                                  "description": "Setting that enables disk auto-scaling.",
+                                  "properties": {
+                                    "enabled": {
+                                      "description": "Flag that indicates whether this cluster enables disk auto-scaling. The maximum memory allowed for the selected cluster tier and the oplog size can limit storage auto-scaling.",
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "title": "Automatic Scaling Settings",
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "analyticsSpecs": {
+                              "description": "The current hardware specifications for read only nodes in the region.",
+                              "properties": {
+                                "diskIOPS": {
+                                  "description": "Target throughput desired for storage attached to your Azure-provisioned cluster. Change this parameter if you:\n\n- set `replicationSpecs[n].regionConfigs[m].providerName` : `Azure`.\n- set `replicationSpecs[n].regionConfigs[m].electableSpecs.instanceSize` : `M40` or greater not including `Mxx_NVME` tiers.\n\nThe maximum input/output operations per second (IOPS) depend on the selected `.instanceSize` and `.diskSizeGB`.\nThis parameter defaults to the cluster tier's standard IOPS value.\nChanging this value impacts cluster cost.",
+                                  "type": "integer"
+                                },
+                                "diskSizeGB": {
+                                  "description": "Storage capacity of instance data volumes expressed in gigabytes. Increase this number to add capacity.\n\n This value must be equal for all shards and node types.\n\n This value is not configurable on M0/M2/M5 clusters.\n\n MongoDB Cloud requires this parameter if you set `replicationSpecs`.\n\n If you specify a disk size below the minimum (10 GB), this parameter defaults to the minimum disk size value. \n\n Storage charge calculations depend on whether you choose the default value or a custom value.\n\n The maximum value for disk storage cannot exceed 50 times the maximum RAM for the selected cluster. If you require more storage space, consider upgrading your cluster to a higher tier.",
+                                  "type": "number"
+                                },
+                                "ebsVolumeType": {
+                                  "description": "Type of storage you want to attach to your AWS-provisioned cluster.\n\n- `STANDARD` volume types can't exceed the default input/output operations per second (IOPS) rate for the selected volume size. \n\n- `PROVISIONED` volume types must fall within the allowable IOPS range for the selected volume size. You must set this value to (`PROVISIONED`) for NVMe clusters.",
+                                  "type": "string"
+                                },
+                                "instanceSize": {
+                                  "description": "Hardware specification for the instance sizes in this region in this shard. Each instance size has a default storage and memory capacity. Electable nodes and read-only nodes (known as \"base nodes\") within a single shard must use the same instance size. Analytics nodes can scale independently from base nodes within a shard. Both base nodes and analytics nodes can scale independently from their equivalents in other shards.",
+                                  "title": "GCP Instance Sizes",
+                                  "type": "string"
+                                },
+                                "nodeCount": {
+                                  "description": "Number of nodes of the given type for MongoDB Cloud to deploy to the region.",
+                                  "type": "integer"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "autoScaling": {
+                              "description": "Options that determine how this cluster handles resource scaling.",
+                              "properties": {
+                                "compute": {
+                                  "description": "Options that determine how this cluster handles CPU scaling.",
+                                  "properties": {
+                                    "enabled": {
+                                      "description": "Flag that indicates whether instance size reactive auto-scaling is enabled.\n\n- Set to `true` to enable instance size reactive auto-scaling. If enabled, you must specify a value for `replicationSpecs[n].regionConfigs[m].autoScaling.compute.maxInstanceSize`.\n- Set to `false` to disable instance size reactive auto-scaling.",
+                                      "type": "boolean"
+                                    },
+                                    "maxInstanceSize": {
+                                      "description": "Instance size boundary to which your cluster can automatically scale.",
+                                      "type": "string"
+                                    },
+                                    "minInstanceSize": {
+                                      "description": "Instance size boundary to which your cluster can automatically scale.",
+                                      "type": "string"
+                                    },
+                                    "scaleDownEnabled": {
+                                      "description": "Flag that indicates whether the instance size may scale down via reactive auto-scaling. MongoDB Cloud requires this parameter if `replicationSpecs[n].regionConfigs[m].autoScaling.compute.enabled` is `true`. If you enable this option, specify a value for `replicationSpecs[n].regionConfigs[m].autoScaling.compute.minInstanceSize`.",
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "title": "Automatic Compute Scaling Settings",
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "diskGB": {
+                                  "description": "Setting that enables disk auto-scaling.",
+                                  "properties": {
+                                    "enabled": {
+                                      "description": "Flag that indicates whether this cluster enables disk auto-scaling. The maximum memory allowed for the selected cluster tier and the oplog size can limit storage auto-scaling.",
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "title": "Automatic Scaling Settings",
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "backingProviderName": {
+                              "description": "Cloud service provider on which MongoDB Cloud provisioned the multi-tenant cluster. The resource returns this parameter when `providerName` is `TENANT` and `electableSpecs.instanceSize` is `M0`, `M2` or `M5`. \n\nPlease note that  using an `instanceSize` of `M2` or `M5` will create a Flex cluster instead. Support for the `instanceSize` of `M2` or `M5` will be discontinued in January 2026. We recommend using the Create Flex Cluster API for such configurations moving forward.",
+                              "type": "string"
+                            },
+                            "electableSpecs": {
+                              "description": "Hardware specifications for all electable nodes deployed in the region. Electable nodes can become the primary and can enable local reads. If you don't specify this option, MongoDB Cloud deploys no electable nodes to the region.",
+                              "properties": {
+                                "diskIOPS": {
+                                  "description": "Target throughput desired for storage attached to your Azure-provisioned cluster. Change this parameter if you:\n\n- set `replicationSpecs[n].regionConfigs[m].providerName` : `Azure`.\n- set `replicationSpecs[n].regionConfigs[m].electableSpecs.instanceSize` : `M40` or greater not including `Mxx_NVME` tiers.\n\nThe maximum input/output operations per second (IOPS) depend on the selected `.instanceSize` and `.diskSizeGB`.\nThis parameter defaults to the cluster tier's standard IOPS value.\nChanging this value impacts cluster cost.",
+                                  "type": "integer"
+                                },
+                                "diskSizeGB": {
+                                  "description": "Storage capacity of instance data volumes expressed in gigabytes. Increase this number to add capacity.\n\n This value must be equal for all shards and node types.\n\n This value is not configurable on M0/M2/M5 clusters.\n\n MongoDB Cloud requires this parameter if you set `replicationSpecs`.\n\n If you specify a disk size below the minimum (10 GB), this parameter defaults to the minimum disk size value. \n\n Storage charge calculations depend on whether you choose the default value or a custom value.\n\n The maximum value for disk storage cannot exceed 50 times the maximum RAM for the selected cluster. If you require more storage space, consider upgrading your cluster to a higher tier.",
+                                  "type": "number"
+                                },
+                                "ebsVolumeType": {
+                                  "description": "Type of storage you want to attach to your AWS-provisioned cluster.\n\n- `STANDARD` volume types can't exceed the default input/output operations per second (IOPS) rate for the selected volume size. \n\n- `PROVISIONED` volume types must fall within the allowable IOPS range for the selected volume size. You must set this value to (`PROVISIONED`) for NVMe clusters.",
+                                  "type": "string"
+                                },
+                                "effectiveInstanceSize": {
+                                  "description": "The true tenant instance size. This is present to support backwards compatibility for deprecated provider types and/or instance sizes.",
+                                  "type": "string"
+                                },
+                                "instanceSize": {
+                                  "description": "Hardware specification for the instances in this M0/M2/M5 tier cluster.",
+                                  "title": "Tenant Instance Sizes",
+                                  "type": "string"
+                                },
+                                "nodeCount": {
+                                  "description": "Number of nodes of the given type for MongoDB Cloud to deploy to the region.",
+                                  "type": "integer"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "priority": {
+                              "description": "Precedence is given to this region when a primary election occurs. If your `regionConfigs` has only `readOnlySpecs`, `analyticsSpecs`, or both, set this value to `0`. If you have multiple `regionConfigs` objects (your cluster is multi-region or multi-cloud), they must have priorities in descending order. The highest priority is `7`.\n\n**Example:** If you have three regions, their priorities would be `7`, `6`, and `5` respectively. If you added two more regions for supporting electable nodes, the priorities of those regions would be `4` and `3` respectively.",
+                              "type": "integer"
+                            },
+                            "providerName": {
+                              "description": "Cloud service provider on which MongoDB Cloud provisions the hosts. Set dedicated clusters to `AWS`, `GCP`, `AZURE` or `TENANT`.",
+                              "type": "string"
+                            },
+                            "readOnlySpecs": {
+                              "description": "The current hardware specifications for read only nodes in the region.",
+                              "properties": {
+                                "diskIOPS": {
+                                  "description": "Target throughput desired for storage attached to your Azure-provisioned cluster. Change this parameter if you:\n\n- set `replicationSpecs[n].regionConfigs[m].providerName` : `Azure`.\n- set `replicationSpecs[n].regionConfigs[m].electableSpecs.instanceSize` : `M40` or greater not including `Mxx_NVME` tiers.\n\nThe maximum input/output operations per second (IOPS) depend on the selected `.instanceSize` and `.diskSizeGB`.\nThis parameter defaults to the cluster tier's standard IOPS value.\nChanging this value impacts cluster cost.",
+                                  "type": "integer"
+                                },
+                                "diskSizeGB": {
+                                  "description": "Storage capacity of instance data volumes expressed in gigabytes. Increase this number to add capacity.\n\n This value must be equal for all shards and node types.\n\n This value is not configurable on M0/M2/M5 clusters.\n\n MongoDB Cloud requires this parameter if you set `replicationSpecs`.\n\n If you specify a disk size below the minimum (10 GB), this parameter defaults to the minimum disk size value. \n\n Storage charge calculations depend on whether you choose the default value or a custom value.\n\n The maximum value for disk storage cannot exceed 50 times the maximum RAM for the selected cluster. If you require more storage space, consider upgrading your cluster to a higher tier.",
+                                  "type": "number"
+                                },
+                                "ebsVolumeType": {
+                                  "description": "Type of storage you want to attach to your AWS-provisioned cluster.\n\n- `STANDARD` volume types can't exceed the default input/output operations per second (IOPS) rate for the selected volume size. \n\n- `PROVISIONED` volume types must fall within the allowable IOPS range for the selected volume size. You must set this value to (`PROVISIONED`) for NVMe clusters.",
+                                  "type": "string"
+                                },
+                                "instanceSize": {
+                                  "description": "Hardware specification for the instance sizes in this region in this shard. Each instance size has a default storage and memory capacity. Electable nodes and read-only nodes (known as \"base nodes\") within a single shard must use the same instance size. Analytics nodes can scale independently from base nodes within a shard. Both base nodes and analytics nodes can scale independently from their equivalents in other shards.",
+                                  "title": "GCP Instance Sizes",
+                                  "type": "string"
+                                },
+                                "nodeCount": {
+                                  "description": "Number of nodes of the given type for MongoDB Cloud to deploy to the region.",
+                                  "type": "integer"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "regionName": {
+                              "description": "Physical location of your MongoDB cluster nodes. The region you choose can affect network latency for clients accessing your databases. The region name is only returned in the response for single-region clusters. When MongoDB Cloud deploys a dedicated cluster, it checks if a VPC or VPC connection exists for that provider and region. If not, MongoDB Cloud creates them as part of the deployment. It assigns the VPC a Classless Inter-Domain Routing (CIDR) block. To limit a new VPC peering connection to one Classless Inter-Domain Routing (CIDR) block and region, create the connection first. Deploy the cluster after the connection starts. GCP Clusters and Multi-region clusters require one VPC peering connection for each region. MongoDB nodes can use only the peering connection that resides in the same region as the nodes to communicate with the peered VPC.",
+                              "type": "string"
+                            }
+                          },
+                          "title": "Cloud Service Provider Settings",
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "zoneId": {
+                        "description": "Unique 24-hexadecimal digit string that identifies the zone in a Global Cluster. This value can be used to configure Global Cluster backup policies.",
+                        "example": "32b6e34b3d91647abb20e7b8",
+                        "type": "string"
+                      },
+                      "zoneName": {
+                        "description": "Human-readable label that describes the zone this shard belongs to in a Global Cluster. Provide this value only if `clusterType` : `GEOSHARDED` but not `selfManagedSharding` : `true`.",
+                        "type": "string"
+                      }
+                    },
+                    "title": "Replication Specifications",
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "retainBackups": {
+                  "description": "Flag that indicates whether the cluster retains backups.",
+                  "type": "boolean"
+                },
+                "rootCertType": {
+                  "description": "Root Certificate Authority that MongoDB Atlas cluster uses. MongoDB Cloud supports Internet Security Research Group.",
+                  "type": "string"
+                },
+                "tags": {
+                  "description": "List that contains key-value pairs between 1 to 255 characters in length for tagging and categorizing the cluster.",
+                  "items": {
+                    "description": "Key-value pair that tags and categorizes a MongoDB Cloud organization, project, or cluster. For example, `environment : production`.",
+                    "properties": {
+                      "key": {
+                        "description": "Constant that defines the set of the tag. For example, `environment` in the `environment : production` tag.",
+                        "type": "string"
+                      },
+                      "value": {
+                        "description": "Variable that belongs to the set of the tag. For example, `production` in the `environment : production` tag.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "key",
+                      "value"
+                    ],
+                    "title": "Resource Tag",
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "terminationProtectionEnabled": {
+                  "description": "Flag that indicates whether termination protection is enabled on the cluster. If set to `true`, MongoDB Cloud won't delete the cluster. If set to `false`, MongoDB Cloud will delete the cluster.",
+                  "type": "boolean"
+                },
+                "useAwsTimeBasedSnapshotCopyForFastInitialSync": {
+                  "description": "Flag that indicates whether AWS time-based snapshot copies will be used instead of slower standard snapshot copies during fast Atlas cross-region initial syncs. This flag is only relevant for clusters containing AWS nodes.",
+                  "type": "boolean"
+                },
+                "versionReleaseSystem": {
+                  "description": "Method by which the cluster maintains the MongoDB versions. If value is `CONTINUOUS`, you must not specify `mongoDBMajorVersion`.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "groupId": {
+              "description": "Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.\n\n**NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.",
+              "example": "32b6e34b3d91647abb20e7b8",
+              "type": "string",
+              "x-kubernetes-validations": [
+                {
+                  "message": "groupId cannot be modified after creation",
+                  "rule": "self == oldSelf"
+                }
+              ]
+            },
+            "groupRef": {
+              "description": "A reference to a \"Group\" resource.\nThe value of \"$.status.v20250312.id\" will be used to set \"groupId\".\nMutually exclusive with the \"groupId\" property.",
+              "properties": {
+                "name": {
+                  "description": "Name of the \"Group\" resource.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "x-kubernetes-validations": [
+            {
+              "message": "groupId and groupRef are mutually exclusive; only one of them can be set",
+              "rule": "(has(self.groupId) && !has(self.groupRef)) || (!has(self.groupId) && has(self.groupRef))"
+            }
+          ],
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "x-kubernetes-validations": [
+        {
+          "message": "spec.connectionSecretRef must be set if spec.v20250312.groupId is set.",
+          "rule": "(has(self.v20250312.groupId) && has(self.connectionSecretRef)) || (!has(self.v20250312.groupId))"
+        }
+      ],
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "Most recently observed read-only status of the cluster for the specified resource version. This data may not be up to date and is populated by the system. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
+      "properties": {
+        "conditions": {
+          "description": "Represents the latest available observations of a resource's current state.",
+          "items": {
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition.",
+                "type": "string"
+              },
+              "observedGeneration": {
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.",
+                "type": "integer"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "type",
+              "status"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "type"
+          ],
+          "x-kubernetes-list-type": "map"
+        },
+        "v20250312": {
+          "description": "The last observed Atlas state of the cluster resource for version v20250312.",
+          "properties": {
+            "advancedConfiguration": {
+              "description": "Group of settings that configures a subset of the advanced configuration details.",
+              "properties": {
+                "customOpensslCipherConfigTls12": {
+                  "description": "The custom OpenSSL cipher suite list for TLS 1.2. This field is only valid when `tlsCipherConfigMode` is set to `CUSTOM`.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "customOpensslCipherConfigTls13": {
+                  "description": "The custom OpenSSL cipher suite list for TLS 1.3. This field is only valid when `tlsCipherConfigMode` is set to `CUSTOM`.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "minimumEnabledTlsProtocol": {
+                  "description": "Minimum Transport Layer Security (TLS) version that the cluster accepts for incoming connections. Clusters using TLS 1.0 or 1.1 should consider setting TLS 1.2 as the minimum TLS protocol version.",
+                  "type": "string"
+                },
+                "tlsCipherConfigMode": {
+                  "description": "The TLS cipher suite configuration mode. The default mode uses the default cipher suites. The custom mode allows you to specify custom cipher suites for both TLS 1.2 and TLS 1.3.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "configServerManagementMode": {
+              "description": "Config Server Management Mode for creating or updating a sharded cluster. When configured as `ATLAS_MANAGED`, Atlas may automatically switch the cluster's config server type for optimal performance and savings. When configured as `FIXED_TO_DEDICATED`, the cluster will always use a dedicated config server.",
+              "type": "string"
+            },
+            "configServerType": {
+              "description": "Describes a sharded cluster's config server type.",
+              "type": "string"
+            },
+            "connectionStrings": {
+              "description": "Collection of Uniform Resource Locators that point to the MongoDB database.",
+              "properties": {
+                "awsPrivateLink": {
+                  "additionalProperties": {
+                    "description": "Private endpoint-aware connection strings that use AWS-hosted clusters with Amazon Web Services (AWS) PrivateLink. Each key identifies an Amazon Web Services (AWS) interface endpoint. Each value identifies the related `mongodb://` connection string that you use to connect to MongoDB Cloud through the interface endpoint that the key names.",
+                    "type": "string"
+                  },
+                  "description": "Private endpoint-aware connection strings that use AWS-hosted clusters with Amazon Web Services (AWS) PrivateLink. Each key identifies an Amazon Web Services (AWS) interface endpoint. Each value identifies the related `mongodb://` connection string that you use to connect to MongoDB Cloud through the interface endpoint that the key names.",
+                  "type": "object"
+                },
+                "awsPrivateLinkSrv": {
+                  "additionalProperties": {
+                    "description": "Private endpoint-aware connection strings that use AWS-hosted clusters with Amazon Web Services (AWS) PrivateLink. Each key identifies an Amazon Web Services (AWS) interface endpoint. Each value identifies the related `mongodb://` connection string that you use to connect to Atlas through the interface endpoint that the key names. If the cluster uses an optimized connection string, `awsPrivateLinkSrv` contains the optimized connection string. If the cluster has the non-optimized (legacy) connection string, `awsPrivateLinkSrv` contains the non-optimized connection string even if an optimized connection string is also present.",
+                    "type": "string"
+                  },
+                  "description": "Private endpoint-aware connection strings that use AWS-hosted clusters with Amazon Web Services (AWS) PrivateLink. Each key identifies an Amazon Web Services (AWS) interface endpoint. Each value identifies the related `mongodb://` connection string that you use to connect to Atlas through the interface endpoint that the key names. If the cluster uses an optimized connection string, `awsPrivateLinkSrv` contains the optimized connection string. If the cluster has the non-optimized (legacy) connection string, `awsPrivateLinkSrv` contains the non-optimized connection string even if an optimized connection string is also present.",
+                  "type": "object"
+                },
+                "private": {
+                  "description": "Network peering connection strings for each interface Virtual Private Cloud (VPC) endpoint that you configured to connect to this cluster. This connection string uses the `mongodb+srv://` protocol. The resource returns this parameter once someone creates a network peering connection to this cluster. This protocol tells the application to look up the host seed list in the Domain Name System (DNS). This list synchronizes with the nodes in a cluster. If the connection string uses this Uniform Resource Identifier (URI) format, you don't need to append the seed list or change the URI if the nodes change. Use this URI format if your driver supports it. If it doesn't, use `connectionStrings.private`. For Amazon Web Services (AWS) clusters, this resource returns this parameter only if you enable custom DNS.",
+                  "type": "string"
+                },
+                "privateEndpoint": {
+                  "description": "List of private endpoint-aware connection strings that you can use to connect to this cluster through a private endpoint. This parameter returns only if you deployed a private endpoint to all regions to which you deployed this clusters' nodes.",
+                  "items": {
+                    "description": "Private endpoint-aware connection string that you can use to connect to this cluster through a private endpoint.",
+                    "properties": {
+                      "connectionString": {
+                        "description": "Private endpoint-aware connection string that uses the `mongodb://` protocol to connect to MongoDB Cloud through a private endpoint.",
+                        "type": "string"
+                      },
+                      "endpoints": {
+                        "description": "List that contains the private endpoints through which you connect to MongoDB Cloud when you use `connectionStrings.privateEndpoint[n].connectionString` or `connectionStrings.privateEndpoint[n].srvConnectionString`.",
+                        "items": {
+                          "description": "Details of a private endpoint deployed for this cluster.",
+                          "properties": {
+                            "endpointId": {
+                              "description": "Unique string that the cloud provider uses to identify the private endpoint.",
+                              "type": "string"
+                            },
+                            "providerName": {
+                              "description": "Cloud provider in which MongoDB Cloud deploys the private endpoint.",
+                              "type": "string"
+                            },
+                            "region": {
+                              "description": "Region where the private endpoint is deployed.",
+                              "type": "string"
+                            }
+                          },
+                          "title": "Cluster Private Endpoint Connection Strings Endpoint",
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "srvConnectionString": {
+                        "description": "Private endpoint-aware connection string that uses the `mongodb+srv://` protocol to connect to MongoDB Cloud through a private endpoint. The `mongodb+srv` protocol tells the driver to look up the seed list of hosts in the Domain Name System (DNS). This list synchronizes with the nodes in a cluster. If the connection string uses this Uniform Resource Identifier (URI) format, you don't need to append the seed list or change the Uniform Resource Identifier (URI) if the nodes change. Use this Uniform Resource Identifier (URI) format if your application supports it. If it doesn't, use `connectionStrings.privateEndpoint[n].connectionString`.",
+                        "type": "string"
+                      },
+                      "srvShardOptimizedConnectionString": {
+                        "description": "Private endpoint-aware connection string optimized for sharded clusters that uses the `mongodb+srv://` protocol to connect to MongoDB Cloud through a private endpoint. If the connection string uses this Uniform Resource Identifier (URI) format, you don't need to change the Uniform Resource Identifier (URI) if the nodes change. Use this Uniform Resource Identifier (URI) format if your application and Atlas cluster supports it. If it doesn't, use and consult the documentation for `connectionStrings.privateEndpoint[n].srvConnectionString`.",
+                        "type": "string"
+                      },
+                      "type": {
+                        "description": "MongoDB process type to which your application connects. Use `MONGOD` for replica sets and `MONGOS` for sharded clusters.",
+                        "type": "string"
+                      }
+                    },
+                    "title": "Cluster Private Endpoint Connection String",
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "privateSrv": {
+                  "description": "Network peering connection strings for each interface Virtual Private Cloud (VPC) endpoint that you configured to connect to this cluster. This connection string uses the `mongodb+srv://` protocol. The resource returns this parameter when someone creates a network peering connection to this cluster. This protocol tells the application to look up the host seed list in the Domain Name System (DNS). This list synchronizes with the nodes in a cluster. If the connection string uses this Uniform Resource Identifier (URI) format, you don't need to append the seed list or change the Uniform Resource Identifier (URI) if the nodes change. Use this Uniform Resource Identifier (URI) format if your driver supports it. If it doesn't, use `connectionStrings.private`. For Amazon Web Services (AWS) clusters, this parameter returns only if you [enable custom DNS](https://docs.atlas.mongodb.com/reference/api/aws-custom-dns-update/).",
+                  "type": "string"
+                },
+                "standard": {
+                  "description": "Public connection string that you can use to connect to this cluster. This connection string uses the `mongodb://` protocol.",
+                  "type": "string"
+                },
+                "standardSrv": {
+                  "description": "Public connection string that you can use to connect to this cluster. This connection string uses the `mongodb+srv://` protocol.",
+                  "type": "string"
+                }
+              },
+              "title": "Cluster Connection Strings",
+              "type": "object",
+              "additionalProperties": false
+            },
+            "createDate": {
+              "description": "Date and time when MongoDB Cloud created this cluster. This parameter expresses its value in ISO 8601 format in UTC.",
+              "type": "string"
+            },
+            "effectiveReplicationSpecs": {
+              "description": "List of settings that represent the actual cluster state. This is read-only and always returned in the response. It reflects the current cluster configuration, which may differ from `replicationSpecs` due to system-managed changes.",
+              "items": {
+                "description": "Details that explain how MongoDB Cloud replicates data on the specified MongoDB database.",
+                "properties": {
+                  "id": {
+                    "description": "Unique 24-hexadecimal digit string that identifies the replication object for a shard in a Cluster. If you include existing shard replication configurations in the request, you must specify this parameter. If you add a new shard to an existing Cluster, you may specify this parameter. The request deletes any existing shards  in the Cluster that you exclude from the request. This corresponds to Shard ID displayed in the UI.",
+                    "example": "32b6e34b3d91647abb20e7b8",
+                    "type": "string"
+                  },
+                  "regionConfigs": {
+                    "description": "Hardware specifications for nodes set for a given region. Each `regionConfigs` object must be unique by region and cloud provider within the `replicationSpec`. Each `regionConfigs` object describes the region's priority in elections and the number and type of MongoDB nodes that MongoDB Cloud deploys to the region. Each `regionConfigs` object must have either an `analyticsSpecs` object, `electableSpecs` object, or `readOnlySpecs` object. Tenant clusters only require `electableSpecs`. Dedicated clusters can specify any of these specifications, but must have at least one `electableSpecs` object within a `replicationSpec`.\n\n**Example:**\n\nIf you set `replicationSpecs[n].regionConfigs[m].analyticsSpecs.instanceSize` : `M30`, set `replicationSpecs[n].regionConfigs[m].electableSpecs.instanceSize` : `M30` if you have electable nodes and `replicationSpecs[n].regionConfigs[m].readOnlySpecs.instanceSize` : `M30` if you have read-only nodes.",
+                    "items": {
+                      "description": "Cloud service provider on which MongoDB Cloud provisions the hosts.",
+                      "properties": {
+                        "analyticsAutoScaling": {
+                          "description": "Options that determine how this cluster handles resource scaling.",
+                          "properties": {
+                            "compute": {
+                              "description": "Options that determine how this cluster handles CPU scaling.",
+                              "properties": {
+                                "enabled": {
+                                  "description": "Flag that indicates whether instance size reactive auto-scaling is enabled.\n\n- Set to `true` to enable instance size reactive auto-scaling. If enabled, you must specify a value for `replicationSpecs[n].regionConfigs[m].autoScaling.compute.maxInstanceSize`.\n- Set to `false` to disable instance size reactive auto-scaling.",
+                                  "type": "boolean"
+                                },
+                                "maxInstanceSize": {
+                                  "description": "Instance size boundary to which your cluster can automatically scale.",
+                                  "type": "string"
+                                },
+                                "minInstanceSize": {
+                                  "description": "Instance size boundary to which your cluster can automatically scale.",
+                                  "type": "string"
+                                },
+                                "scaleDownEnabled": {
+                                  "description": "Flag that indicates whether the instance size may scale down via reactive auto-scaling. MongoDB Cloud requires this parameter if `replicationSpecs[n].regionConfigs[m].autoScaling.compute.enabled` is `true`. If you enable this option, specify a value for `replicationSpecs[n].regionConfigs[m].autoScaling.compute.minInstanceSize`.",
+                                  "type": "boolean"
+                                }
+                              },
+                              "title": "Automatic Compute Scaling Settings",
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "diskGB": {
+                              "description": "Setting that enables disk auto-scaling.",
+                              "properties": {
+                                "enabled": {
+                                  "description": "Flag that indicates whether this cluster enables disk auto-scaling. The maximum memory allowed for the selected cluster tier and the oplog size can limit storage auto-scaling.",
+                                  "type": "boolean"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "title": "Automatic Scaling Settings",
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "analyticsSpecs": {
+                          "description": "The current hardware specifications for read only nodes in the region.",
+                          "properties": {
+                            "diskIOPS": {
+                              "description": "Target throughput desired for storage attached to your Azure-provisioned cluster. Change this parameter if you:\n\n- set `replicationSpecs[n].regionConfigs[m].providerName` : `Azure`.\n- set `replicationSpecs[n].regionConfigs[m].electableSpecs.instanceSize` : `M40` or greater not including `Mxx_NVME` tiers.\n\nThe maximum input/output operations per second (IOPS) depend on the selected `.instanceSize` and `.diskSizeGB`.\nThis parameter defaults to the cluster tier's standard IOPS value.\nChanging this value impacts cluster cost.",
+                              "type": "integer"
+                            },
+                            "diskSizeGB": {
+                              "description": "Storage capacity of instance data volumes expressed in gigabytes. Increase this number to add capacity.\n\n This value must be equal for all shards and node types.\n\n This value is not configurable on M0/M2/M5 clusters.\n\n MongoDB Cloud requires this parameter if you set `replicationSpecs`.\n\n If you specify a disk size below the minimum (10 GB), this parameter defaults to the minimum disk size value. \n\n Storage charge calculations depend on whether you choose the default value or a custom value.\n\n The maximum value for disk storage cannot exceed 50 times the maximum RAM for the selected cluster. If you require more storage space, consider upgrading your cluster to a higher tier.",
+                              "type": "number"
+                            },
+                            "ebsVolumeType": {
+                              "description": "Type of storage you want to attach to your AWS-provisioned cluster.\n\n- `STANDARD` volume types can't exceed the default input/output operations per second (IOPS) rate for the selected volume size. \n\n- `PROVISIONED` volume types must fall within the allowable IOPS range for the selected volume size. You must set this value to (`PROVISIONED`) for NVMe clusters.",
+                              "type": "string"
+                            },
+                            "instanceSize": {
+                              "description": "Hardware specification for the instance sizes in this region in this shard. Each instance size has a default storage and memory capacity. Electable nodes and read-only nodes (known as \"base nodes\") within a single shard must use the same instance size. Analytics nodes can scale independently from base nodes within a shard. Both base nodes and analytics nodes can scale independently from their equivalents in other shards.",
+                              "title": "GCP Instance Sizes",
+                              "type": "string"
+                            },
+                            "nodeCount": {
+                              "description": "Number of nodes of the given type for MongoDB Cloud to deploy to the region.",
+                              "type": "integer"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "autoScaling": {
+                          "description": "Options that determine how this cluster handles resource scaling.",
+                          "properties": {
+                            "compute": {
+                              "description": "Options that determine how this cluster handles CPU scaling.",
+                              "properties": {
+                                "enabled": {
+                                  "description": "Flag that indicates whether instance size reactive auto-scaling is enabled.\n\n- Set to `true` to enable instance size reactive auto-scaling. If enabled, you must specify a value for `replicationSpecs[n].regionConfigs[m].autoScaling.compute.maxInstanceSize`.\n- Set to `false` to disable instance size reactive auto-scaling.",
+                                  "type": "boolean"
+                                },
+                                "maxInstanceSize": {
+                                  "description": "Instance size boundary to which your cluster can automatically scale.",
+                                  "type": "string"
+                                },
+                                "minInstanceSize": {
+                                  "description": "Instance size boundary to which your cluster can automatically scale.",
+                                  "type": "string"
+                                },
+                                "scaleDownEnabled": {
+                                  "description": "Flag that indicates whether the instance size may scale down via reactive auto-scaling. MongoDB Cloud requires this parameter if `replicationSpecs[n].regionConfigs[m].autoScaling.compute.enabled` is `true`. If you enable this option, specify a value for `replicationSpecs[n].regionConfigs[m].autoScaling.compute.minInstanceSize`.",
+                                  "type": "boolean"
+                                }
+                              },
+                              "title": "Automatic Compute Scaling Settings",
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "diskGB": {
+                              "description": "Setting that enables disk auto-scaling.",
+                              "properties": {
+                                "enabled": {
+                                  "description": "Flag that indicates whether this cluster enables disk auto-scaling. The maximum memory allowed for the selected cluster tier and the oplog size can limit storage auto-scaling.",
+                                  "type": "boolean"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "title": "Automatic Scaling Settings",
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "backingProviderName": {
+                          "description": "Cloud service provider on which MongoDB Cloud provisioned the multi-tenant cluster. The resource returns this parameter when `providerName` is `TENANT` and `electableSpecs.instanceSize` is `M0`, `M2` or `M5`. \n\nPlease note that  using an `instanceSize` of `M2` or `M5` will create a Flex cluster instead. Support for the `instanceSize` of `M2` or `M5` will be discontinued in January 2026. We recommend using the Create Flex Cluster API for such configurations moving forward.",
+                          "type": "string"
+                        },
+                        "effectiveAnalyticsSpecs": {
+                          "description": "The current hardware specifications for read only nodes in the region.",
+                          "properties": {
+                            "diskIOPS": {
+                              "description": "Target throughput desired for storage attached to your Azure-provisioned cluster. Change this parameter if you:\n\n- set `replicationSpecs[n].regionConfigs[m].providerName` : `Azure`.\n- set `replicationSpecs[n].regionConfigs[m].electableSpecs.instanceSize` : `M40` or greater not including `Mxx_NVME` tiers.\n\nThe maximum input/output operations per second (IOPS) depend on the selected `.instanceSize` and `.diskSizeGB`.\nThis parameter defaults to the cluster tier's standard IOPS value.\nChanging this value impacts cluster cost.",
+                              "type": "integer"
+                            },
+                            "diskSizeGB": {
+                              "description": "Storage capacity of instance data volumes expressed in gigabytes. Increase this number to add capacity.\n\n This value must be equal for all shards and node types.\n\n This value is not configurable on M0/M2/M5 clusters.\n\n MongoDB Cloud requires this parameter if you set `replicationSpecs`.\n\n If you specify a disk size below the minimum (10 GB), this parameter defaults to the minimum disk size value. \n\n Storage charge calculations depend on whether you choose the default value or a custom value.\n\n The maximum value for disk storage cannot exceed 50 times the maximum RAM for the selected cluster. If you require more storage space, consider upgrading your cluster to a higher tier.",
+                              "type": "number"
+                            },
+                            "ebsVolumeType": {
+                              "description": "Type of storage you want to attach to your AWS-provisioned cluster.\n\n- `STANDARD` volume types can't exceed the default input/output operations per second (IOPS) rate for the selected volume size. \n\n- `PROVISIONED` volume types must fall within the allowable IOPS range for the selected volume size. You must set this value to (`PROVISIONED`) for NVMe clusters.",
+                              "type": "string"
+                            },
+                            "instanceSize": {
+                              "description": "Hardware specification for the instance sizes in this region in this shard. Each instance size has a default storage and memory capacity. Electable nodes and read-only nodes (known as \"base nodes\") within a single shard must use the same instance size. Analytics nodes can scale independently from base nodes within a shard. Both base nodes and analytics nodes can scale independently from their equivalents in other shards.",
+                              "title": "GCP Instance Sizes",
+                              "type": "string"
+                            },
+                            "nodeCount": {
+                              "description": "Number of nodes of the given type for MongoDB Cloud to deploy to the region.",
+                              "type": "integer"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "effectiveElectableSpecs": {
+                          "description": "The current hardware specifications for read only nodes in the region.",
+                          "properties": {
+                            "diskIOPS": {
+                              "description": "Target throughput desired for storage attached to your Azure-provisioned cluster. Change this parameter if you:\n\n- set `replicationSpecs[n].regionConfigs[m].providerName` : `Azure`.\n- set `replicationSpecs[n].regionConfigs[m].electableSpecs.instanceSize` : `M40` or greater not including `Mxx_NVME` tiers.\n\nThe maximum input/output operations per second (IOPS) depend on the selected `.instanceSize` and `.diskSizeGB`.\nThis parameter defaults to the cluster tier's standard IOPS value.\nChanging this value impacts cluster cost.",
+                              "type": "integer"
+                            },
+                            "diskSizeGB": {
+                              "description": "Storage capacity of instance data volumes expressed in gigabytes. Increase this number to add capacity.\n\n This value must be equal for all shards and node types.\n\n This value is not configurable on M0/M2/M5 clusters.\n\n MongoDB Cloud requires this parameter if you set `replicationSpecs`.\n\n If you specify a disk size below the minimum (10 GB), this parameter defaults to the minimum disk size value. \n\n Storage charge calculations depend on whether you choose the default value or a custom value.\n\n The maximum value for disk storage cannot exceed 50 times the maximum RAM for the selected cluster. If you require more storage space, consider upgrading your cluster to a higher tier.",
+                              "type": "number"
+                            },
+                            "ebsVolumeType": {
+                              "description": "Type of storage you want to attach to your AWS-provisioned cluster.\n\n- `STANDARD` volume types can't exceed the default input/output operations per second (IOPS) rate for the selected volume size. \n\n- `PROVISIONED` volume types must fall within the allowable IOPS range for the selected volume size. You must set this value to (`PROVISIONED`) for NVMe clusters.",
+                              "type": "string"
+                            },
+                            "instanceSize": {
+                              "description": "Hardware specification for the instance sizes in this region in this shard. Each instance size has a default storage and memory capacity. Electable nodes and read-only nodes (known as \"base nodes\") within a single shard must use the same instance size. Analytics nodes can scale independently from base nodes within a shard. Both base nodes and analytics nodes can scale independently from their equivalents in other shards.",
+                              "title": "GCP Instance Sizes",
+                              "type": "string"
+                            },
+                            "nodeCount": {
+                              "description": "Number of nodes of the given type for MongoDB Cloud to deploy to the region.",
+                              "type": "integer"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "effectiveReadOnlySpecs": {
+                          "description": "The current hardware specifications for read only nodes in the region.",
+                          "properties": {
+                            "diskIOPS": {
+                              "description": "Target throughput desired for storage attached to your Azure-provisioned cluster. Change this parameter if you:\n\n- set `replicationSpecs[n].regionConfigs[m].providerName` : `Azure`.\n- set `replicationSpecs[n].regionConfigs[m].electableSpecs.instanceSize` : `M40` or greater not including `Mxx_NVME` tiers.\n\nThe maximum input/output operations per second (IOPS) depend on the selected `.instanceSize` and `.diskSizeGB`.\nThis parameter defaults to the cluster tier's standard IOPS value.\nChanging this value impacts cluster cost.",
+                              "type": "integer"
+                            },
+                            "diskSizeGB": {
+                              "description": "Storage capacity of instance data volumes expressed in gigabytes. Increase this number to add capacity.\n\n This value must be equal for all shards and node types.\n\n This value is not configurable on M0/M2/M5 clusters.\n\n MongoDB Cloud requires this parameter if you set `replicationSpecs`.\n\n If you specify a disk size below the minimum (10 GB), this parameter defaults to the minimum disk size value. \n\n Storage charge calculations depend on whether you choose the default value or a custom value.\n\n The maximum value for disk storage cannot exceed 50 times the maximum RAM for the selected cluster. If you require more storage space, consider upgrading your cluster to a higher tier.",
+                              "type": "number"
+                            },
+                            "ebsVolumeType": {
+                              "description": "Type of storage you want to attach to your AWS-provisioned cluster.\n\n- `STANDARD` volume types can't exceed the default input/output operations per second (IOPS) rate for the selected volume size. \n\n- `PROVISIONED` volume types must fall within the allowable IOPS range for the selected volume size. You must set this value to (`PROVISIONED`) for NVMe clusters.",
+                              "type": "string"
+                            },
+                            "instanceSize": {
+                              "description": "Hardware specification for the instance sizes in this region in this shard. Each instance size has a default storage and memory capacity. Electable nodes and read-only nodes (known as \"base nodes\") within a single shard must use the same instance size. Analytics nodes can scale independently from base nodes within a shard. Both base nodes and analytics nodes can scale independently from their equivalents in other shards.",
+                              "title": "GCP Instance Sizes",
+                              "type": "string"
+                            },
+                            "nodeCount": {
+                              "description": "Number of nodes of the given type for MongoDB Cloud to deploy to the region.",
+                              "type": "integer"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "electableSpecs": {
+                          "description": "Hardware specifications for all electable nodes deployed in the region. Electable nodes can become the primary and can enable local reads. If you don't specify this option, MongoDB Cloud deploys no electable nodes to the region.",
+                          "properties": {
+                            "diskIOPS": {
+                              "description": "Target throughput desired for storage attached to your Azure-provisioned cluster. Change this parameter if you:\n\n- set `replicationSpecs[n].regionConfigs[m].providerName` : `Azure`.\n- set `replicationSpecs[n].regionConfigs[m].electableSpecs.instanceSize` : `M40` or greater not including `Mxx_NVME` tiers.\n\nThe maximum input/output operations per second (IOPS) depend on the selected `.instanceSize` and `.diskSizeGB`.\nThis parameter defaults to the cluster tier's standard IOPS value.\nChanging this value impacts cluster cost.",
+                              "type": "integer"
+                            },
+                            "diskSizeGB": {
+                              "description": "Storage capacity of instance data volumes expressed in gigabytes. Increase this number to add capacity.\n\n This value must be equal for all shards and node types.\n\n This value is not configurable on M0/M2/M5 clusters.\n\n MongoDB Cloud requires this parameter if you set `replicationSpecs`.\n\n If you specify a disk size below the minimum (10 GB), this parameter defaults to the minimum disk size value. \n\n Storage charge calculations depend on whether you choose the default value or a custom value.\n\n The maximum value for disk storage cannot exceed 50 times the maximum RAM for the selected cluster. If you require more storage space, consider upgrading your cluster to a higher tier.",
+                              "type": "number"
+                            },
+                            "ebsVolumeType": {
+                              "description": "Type of storage you want to attach to your AWS-provisioned cluster.\n\n- `STANDARD` volume types can't exceed the default input/output operations per second (IOPS) rate for the selected volume size. \n\n- `PROVISIONED` volume types must fall within the allowable IOPS range for the selected volume size. You must set this value to (`PROVISIONED`) for NVMe clusters.",
+                              "type": "string"
+                            },
+                            "effectiveInstanceSize": {
+                              "description": "The true tenant instance size. This is present to support backwards compatibility for deprecated provider types and/or instance sizes.",
+                              "type": "string"
+                            },
+                            "instanceSize": {
+                              "description": "Hardware specification for the instances in this M0/M2/M5 tier cluster.",
+                              "title": "Tenant Instance Sizes",
+                              "type": "string"
+                            },
+                            "nodeCount": {
+                              "description": "Number of nodes of the given type for MongoDB Cloud to deploy to the region.",
+                              "type": "integer"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "priority": {
+                          "description": "Precedence is given to this region when a primary election occurs. If your `regionConfigs` has only `readOnlySpecs`, `analyticsSpecs`, or both, set this value to `0`. If you have multiple `regionConfigs` objects (your cluster is multi-region or multi-cloud), they must have priorities in descending order. The highest priority is `7`.\n\n**Example:** If you have three regions, their priorities would be `7`, `6`, and `5` respectively. If you added two more regions for supporting electable nodes, the priorities of those regions would be `4` and `3` respectively.",
+                          "type": "integer"
+                        },
+                        "providerName": {
+                          "description": "Cloud service provider on which MongoDB Cloud provisions the hosts. Set dedicated clusters to `AWS`, `GCP`, `AZURE` or `TENANT`.",
+                          "type": "string"
+                        },
+                        "readOnlySpecs": {
+                          "description": "The current hardware specifications for read only nodes in the region.",
+                          "properties": {
+                            "diskIOPS": {
+                              "description": "Target throughput desired for storage attached to your Azure-provisioned cluster. Change this parameter if you:\n\n- set `replicationSpecs[n].regionConfigs[m].providerName` : `Azure`.\n- set `replicationSpecs[n].regionConfigs[m].electableSpecs.instanceSize` : `M40` or greater not including `Mxx_NVME` tiers.\n\nThe maximum input/output operations per second (IOPS) depend on the selected `.instanceSize` and `.diskSizeGB`.\nThis parameter defaults to the cluster tier's standard IOPS value.\nChanging this value impacts cluster cost.",
+                              "type": "integer"
+                            },
+                            "diskSizeGB": {
+                              "description": "Storage capacity of instance data volumes expressed in gigabytes. Increase this number to add capacity.\n\n This value must be equal for all shards and node types.\n\n This value is not configurable on M0/M2/M5 clusters.\n\n MongoDB Cloud requires this parameter if you set `replicationSpecs`.\n\n If you specify a disk size below the minimum (10 GB), this parameter defaults to the minimum disk size value. \n\n Storage charge calculations depend on whether you choose the default value or a custom value.\n\n The maximum value for disk storage cannot exceed 50 times the maximum RAM for the selected cluster. If you require more storage space, consider upgrading your cluster to a higher tier.",
+                              "type": "number"
+                            },
+                            "ebsVolumeType": {
+                              "description": "Type of storage you want to attach to your AWS-provisioned cluster.\n\n- `STANDARD` volume types can't exceed the default input/output operations per second (IOPS) rate for the selected volume size. \n\n- `PROVISIONED` volume types must fall within the allowable IOPS range for the selected volume size. You must set this value to (`PROVISIONED`) for NVMe clusters.",
+                              "type": "string"
+                            },
+                            "instanceSize": {
+                              "description": "Hardware specification for the instance sizes in this region in this shard. Each instance size has a default storage and memory capacity. Electable nodes and read-only nodes (known as \"base nodes\") within a single shard must use the same instance size. Analytics nodes can scale independently from base nodes within a shard. Both base nodes and analytics nodes can scale independently from their equivalents in other shards.",
+                              "title": "GCP Instance Sizes",
+                              "type": "string"
+                            },
+                            "nodeCount": {
+                              "description": "Number of nodes of the given type for MongoDB Cloud to deploy to the region.",
+                              "type": "integer"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "regionName": {
+                          "description": "Physical location of your MongoDB cluster nodes. The region you choose can affect network latency for clients accessing your databases. The region name is only returned in the response for single-region clusters. When MongoDB Cloud deploys a dedicated cluster, it checks if a VPC or VPC connection exists for that provider and region. If not, MongoDB Cloud creates them as part of the deployment. It assigns the VPC a Classless Inter-Domain Routing (CIDR) block. To limit a new VPC peering connection to one Classless Inter-Domain Routing (CIDR) block and region, create the connection first. Deploy the cluster after the connection starts. GCP Clusters and Multi-region clusters require one VPC peering connection for each region. MongoDB nodes can use only the peering connection that resides in the same region as the nodes to communicate with the peered VPC.",
+                          "type": "string"
+                        }
+                      },
+                      "title": "Cloud Service Provider Settings",
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
+                  "zoneId": {
+                    "description": "Unique 24-hexadecimal digit string that identifies the zone in a Global Cluster. This value can be used to configure Global Cluster backup policies.",
+                    "example": "32b6e34b3d91647abb20e7b8",
+                    "type": "string"
+                  },
+                  "zoneName": {
+                    "description": "Human-readable label that describes the zone this shard belongs to in a Global Cluster. Provide this value only if `clusterType` : `GEOSHARDED` but not `selfManagedSharding` : `true`.",
+                    "type": "string"
+                  }
+                },
+                "title": "Replication Specifications",
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "featureCompatibilityVersion": {
+              "description": "Feature compatibility version of the cluster. This will always appear regardless of whether FCV is pinned.",
+              "type": "string"
+            },
+            "featureCompatibilityVersionExpirationDate": {
+              "description": "Feature compatibility version expiration date. Will only appear if FCV is pinned. This parameter expresses its value in the ISO 8601 timestamp format in UTC.",
+              "type": "string"
+            },
+            "globalClusterSelfManagedSharding": {
+              "description": "Set this field to configure the Sharding Management Mode when creating a new Global Cluster.\n\nWhen set to false, the management mode is set to Atlas-Managed Sharding. This mode fully manages the sharding of your Global Cluster and is built to provide a seamless deployment experience.\n\nWhen set to true, the management mode is set to Self-Managed Sharding. This mode leaves the management of shards in your hands and is built to provide an advanced and flexible deployment experience.\n\nThis setting cannot be changed once the cluster is deployed.",
+              "type": "boolean"
+            },
+            "groupId": {
+              "description": "Unique 24-hexadecimal character string that identifies the project.",
+              "example": "32b6e34b3d91647abb20e7b8",
+              "type": "string"
+            },
+            "id": {
+              "description": "Unique 24-hexadecimal digit string that identifies the cluster.",
+              "example": "32b6e34b3d91647abb20e7b8",
+              "type": "string"
+            },
+            "internalClusterRole": {
+              "description": "Internal classification of the cluster's role. Possible values: `NONE` (regular user cluster), `SYSTEM_CLUSTER` (system cluster for backup), `INTERNAL_SHADOW_CLUSTER` (internal use shadow cluster for testing).",
+              "type": "string"
+            },
+            "mongoDBEmployeeAccessGrant": {
+              "description": "MongoDB employee granted access level and expiration for a cluster.",
+              "properties": {
+                "expirationTime": {
+                  "description": "Expiration date for the employee access grant. This parameter expresses its value in the ISO 8601 timestamp format in UTC.",
+                  "type": "string"
+                },
+                "grantType": {
+                  "description": "Level of access to grant to MongoDB Employees.",
+                  "type": "string"
+                },
+                "links": {
+                  "description": "List of one or more Uniform Resource Locators (URLs) that point to API sub-resources, related API resources, or both. RFC 5988 outlines these relationships.",
+                  "items": {
+                    "properties": {
+                      "href": {
+                        "description": "Uniform Resource Locator (URL) that points another API resource to which this response has some relationship. This URL often begins with `https://cloud.mongodb.com/api/atlas`.",
+                        "example": "https://cloud.mongodb.com/api/atlas",
+                        "type": "string"
+                      },
+                      "rel": {
+                        "description": "Uniform Resource Locator (URL) that defines the semantic relationship between this resource and another API resource. This URL often begins with `https://cloud.mongodb.com/api/atlas`.",
+                        "example": "self",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "expirationTime",
+                "grantType"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "mongoDBVersion": {
+              "description": "Version of MongoDB that the cluster runs.",
+              "type": "string"
+            },
+            "redactClientLogData": {
+              "description": "Enable or disable log redaction.\n\nThis setting configures the ``mongod`` or ``mongos`` to redact any document field contents from a message accompanying a given log event before logging. This prevents the program from writing potentially sensitive data stored on the database to the diagnostic log. Metadata such as error or operation codes, line numbers, and source file names are still visible in the logs.\n\nUse ``redactClientLogData`` in conjunction with Encryption at Rest and TLS/SSL (Transport Encryption) to assist compliance with regulatory requirements.\n\n*Note*: changing this setting on a cluster will trigger a rolling restart as soon as the cluster is updated.",
+              "type": "boolean"
+            },
+            "replicaSetScalingStrategy": {
+              "description": "Set this field to configure the replica set scaling mode for your cluster.\n\nBy default, Atlas scales under `WORKLOAD_TYPE`. This mode allows Atlas to scale your analytics nodes in parallel to your operational nodes.\n\nWhen configured as `SEQUENTIAL`, Atlas scales all nodes sequentially. This mode is intended for steady-state workloads and applications performing latency-sensitive secondary reads.\n\nWhen configured as `NODE_TYPE`, Atlas scales your electable nodes in parallel with your read-only and analytics nodes. This mode is intended for large, dynamic workloads requiring frequent and timely cluster tier scaling. This is the fastest scaling strategy, but it might impact latency of workloads when performing extensive secondary reads.",
+              "type": "string"
+            },
+            "retainBackups": {
+              "description": "Flag that indicates whether the cluster retains backups.",
+              "type": "boolean"
+            },
+            "stateName": {
+              "description": "Human-readable label that indicates any current activity being taken on this cluster by the Atlas control plane. With the exception of CREATING and DELETING states, clusters should always be available and have a Primary node even when in states indicating ongoing activity.\n\n - `IDLE`: Atlas is making no changes to this cluster and all changes requested via the UI or API can be assumed to have been applied.\n - `CREATING`: A cluster being provisioned for the very first time returns state CREATING until it is ready for connections. Ensure IP Access List and DB Users are configured before attempting to connect.\n - `UPDATING`: A change requested via the UI, API, AutoScaling, or other scheduled activity is taking place.\n - `DELETING`: The cluster is in the process of deletion and will soon be deleted.\n - `REPAIRING`: One or more nodes in the cluster are being returned to service by the Atlas control plane. Other nodes should continue to provide service as normal.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/atlas.generated.mongodb.com/databaseuser_v1.json
+++ b/atlas.generated.mongodb.com/databaseuser_v1.json
@@ -1,0 +1,274 @@
+{
+  "description": "A databaseuser, managed by the MongoDB Kubernetes Atlas Operator.",
+  "properties": {
+    "spec": {
+      "description": "Specification of the databaseuser supporting the following versions:\n\n- v20250312\n\nAt most one versioned spec can be specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
+      "properties": {
+        "connectionSecretRef": {
+          "description": "SENSITIVE FIELD\n\nReference to a secret containing the credentials to setup the connection to Atlas.",
+          "properties": {
+            "name": {
+              "description": "Name of the secret containing the Atlas credentials.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "v20250312": {
+          "description": "The spec of the databaseuser resource for version v20250312.",
+          "properties": {
+            "entry": {
+              "description": "The entry fields of the databaseuser resource spec. These fields can be set for creating and updating databaseusers.",
+              "properties": {
+                "awsIAMType": {
+                  "description": "Human-readable label that indicates whether the new database user authenticates with the Amazon Web Services (AWS) Identity and Access Management (IAM) credentials associated with the user or the user's role.",
+                  "type": "string"
+                },
+                "databaseName": {
+                  "description": "The database against which the database user authenticates. Database users must provide both a username and authentication database to log into MongoDB. If the user authenticates with AWS IAM, x.509, LDAP, or OIDC Workload this value should be `$external`. If the user authenticates with SCRAM-SHA or OIDC Workforce, this value should be `admin`.",
+                  "type": "string"
+                },
+                "deleteAfterDate": {
+                  "description": "Date and time when MongoDB Cloud deletes the user. This parameter expresses its value in the ISO 8601 timestamp format in UTC and can include the time zone designation. You must specify a future date that falls within one week of making the Application Programming Interface (API) request.",
+                  "type": "string"
+                },
+                "description": {
+                  "description": "Description of this database user.",
+                  "type": "string"
+                },
+                "labels": {
+                  "description": "List that contains the key-value pairs for tagging and categorizing the MongoDB database user. The labels that you define do not appear in the console.",
+                  "items": {
+                    "description": "Human-readable labels applied to this MongoDB Cloud component.",
+                    "properties": {
+                      "key": {
+                        "description": "Key applied to tag and categorize this component.",
+                        "type": "string"
+                      },
+                      "value": {
+                        "description": "Value set to the Key applied to tag and categorize this component.",
+                        "type": "string"
+                      }
+                    },
+                    "title": "Component Label",
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "ldapAuthType": {
+                  "description": "Part of the Lightweight Directory Access Protocol (LDAP) record that the database uses to authenticate this database user on the LDAP host.",
+                  "type": "string"
+                },
+                "oidcAuthType": {
+                  "description": "Human-readable label that indicates whether the new database user or group authenticates with OIDC federated authentication. To create a federated authentication user, specify the value of USER in this field. To create a federated authentication group, specify the value of `IDP_GROUP` in this field.",
+                  "type": "string"
+                },
+                "passwordSecretRef": {
+                  "description": "SENSITIVE FIELD\n\nReference to a secret containing data for the \"password\" field:\n\nAlphanumeric string that authenticates this database user against the database specified in `databaseName`. To authenticate with SCRAM-SHA, you must specify this parameter. This parameter doesn't appear in this response.",
+                  "properties": {
+                    "key": {
+                      "default": "password",
+                      "description": "Key of the secret data containing the sensitive field value, defaults to \"password\".",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name of the secret containing the sensitive field value.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "roles": {
+                  "description": "List that provides the pairings of one role with one applicable database.",
+                  "items": {
+                    "description": "Range of resources available to this database user.",
+                    "properties": {
+                      "collectionName": {
+                        "description": "Collection on which this role applies.",
+                        "type": "string"
+                      },
+                      "databaseName": {
+                        "description": "Database to which the user is granted access privileges.",
+                        "type": "string"
+                      },
+                      "roleName": {
+                        "description": "Human-readable label that identifies a group of privileges assigned to a database user. This value can either be a built-in role or a custom role.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "databaseName",
+                      "roleName"
+                    ],
+                    "title": "Database User Role",
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "scopes": {
+                  "description": "List that contains clusters, MongoDB Atlas Data Lakes, and MongoDB Atlas Streams Workspaces that this database user can access. If omitted, MongoDB Cloud grants the database user access to all the clusters, MongoDB Atlas Data Lakes, and MongoDB Atlas Streams Workspaces in the project.",
+                  "items": {
+                    "description": "Range of resources available to this database user.",
+                    "properties": {
+                      "name": {
+                        "description": "Human-readable label that identifies the cluster or MongoDB Atlas Data Lake that this database user can access.",
+                        "type": "string"
+                      },
+                      "type": {
+                        "description": "Category of resource that this database user can access.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "name",
+                      "type"
+                    ],
+                    "title": "Database User Scope",
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "username": {
+                  "description": "Human-readable label that represents the user that authenticates to MongoDB. The format of this label depends on the method of authentication:\n\n| Authentication Method | Parameter Needed | Parameter Value | username Format |\n|---|---|---|---|\n| AWS IAM | `awsIAMType` | `ROLE` | <abbr title=\"Amazon Resource Name\">ARN</abbr> |\n| AWS IAM | `awsIAMType` | `USER` | <abbr title=\"Amazon Resource Name\">ARN</abbr> |\n| x.509 | `x509Type` | `CUSTOMER` | [RFC 2253](https://tools.ietf.org/html/2253) Distinguished Name |\n| x.509 | `x509Type` | `MANAGED` | [RFC 2253](https://tools.ietf.org/html/2253) Distinguished Name |\n| LDAP | `ldapAuthType` | `USER` | [RFC 2253](https://tools.ietf.org/html/2253) Distinguished Name |\n| LDAP | `ldapAuthType` | `GROUP` | [RFC 2253](https://tools.ietf.org/html/2253) Distinguished Name |\n| OIDC Workforce | `oidcAuthType` | `IDP_GROUP` | Atlas OIDC IdP ID (found in federation settings), followed by a '/', followed by the IdP group name |\n| OIDC Workload | `oidcAuthType` | `USER` | Atlas OIDC IdP ID (found in federation settings), followed by a '/', followed by the IdP user name |\n| SCRAM-SHA | `awsIAMType`, `x509Type`, `ldapAuthType`, `oidcAuthType` | `NONE` | Alphanumeric string |\n",
+                  "type": "string"
+                },
+                "x509Type": {
+                  "description": "X.509 method that MongoDB Cloud uses to authenticate the database user.\n\n- For application-managed X.509, specify `MANAGED`.\n- For self-managed X.509, specify `CUSTOMER`.\n\nUsers created with the `CUSTOMER` method require a Common Name (CN) in the **username** parameter. You must create externally authenticated users on the `$external` database.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "databaseName",
+                "roles",
+                "username"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "groupId": {
+              "description": "Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.\n\n**NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.",
+              "example": "32b6e34b3d91647abb20e7b8",
+              "type": "string",
+              "x-kubernetes-validations": [
+                {
+                  "message": "groupId cannot be modified after creation",
+                  "rule": "self == oldSelf"
+                }
+              ]
+            },
+            "groupRef": {
+              "description": "A reference to a \"Group\" resource.\nThe value of \"$.status.v20250312.id\" will be used to set \"groupId\".\nMutually exclusive with the \"groupId\" property.",
+              "properties": {
+                "name": {
+                  "description": "Name of the \"Group\" resource.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "x-kubernetes-validations": [
+            {
+              "message": "groupId and groupRef are mutually exclusive; only one of them can be set",
+              "rule": "(has(self.groupId) && !has(self.groupRef)) || (!has(self.groupId) && has(self.groupRef))"
+            }
+          ],
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "x-kubernetes-validations": [
+        {
+          "message": "spec.connectionSecretRef must be set if spec.v20250312.groupId is set.",
+          "rule": "(has(self.v20250312.groupId) && has(self.connectionSecretRef)) || (!has(self.v20250312.groupId))"
+        }
+      ],
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "Most recently observed read-only status of the databaseuser for the specified resource version. This data may not be up to date and is populated by the system. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
+      "properties": {
+        "conditions": {
+          "description": "Represents the latest available observations of a resource's current state.",
+          "items": {
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition.",
+                "type": "string"
+              },
+              "observedGeneration": {
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.",
+                "type": "integer"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "type",
+              "status"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "type"
+          ],
+          "x-kubernetes-list-type": "map"
+        },
+        "v20250312": {
+          "description": "The last observed Atlas state of the databaseuser resource for version v20250312.",
+          "properties": {
+            "databaseName": {
+              "description": "The database against which the database user authenticates. Database users must provide both a username and authentication database to log into MongoDB. If the user authenticates with AWS IAM, x.509, LDAP, or OIDC Workload this value should be `$external`. If the user authenticates with SCRAM-SHA or OIDC Workforce, this value should be `admin`.",
+              "type": "string"
+            },
+            "groupId": {
+              "description": "Unique 24-hexadecimal digit string that identifies the project.",
+              "type": "string"
+            },
+            "username": {
+              "description": "Human-readable label that represents the user that authenticates to MongoDB. The format of this label depends on the method of authentication:\n\n| Authentication Method | Parameter Needed | Parameter Value | username Format |\n|---|---|---|---|\n| AWS IAM | `awsIAMType` | `ROLE` | <abbr title=\"Amazon Resource Name\">ARN</abbr> |\n| AWS IAM | `awsIAMType` | `USER` | <abbr title=\"Amazon Resource Name\">ARN</abbr> |\n| x.509 | `x509Type` | `CUSTOMER` | [RFC 2253](https://tools.ietf.org/html/2253) Distinguished Name |\n| x.509 | `x509Type` | `MANAGED` | [RFC 2253](https://tools.ietf.org/html/2253) Distinguished Name |\n| LDAP | `ldapAuthType` | `USER` | [RFC 2253](https://tools.ietf.org/html/2253) Distinguished Name |\n| LDAP | `ldapAuthType` | `GROUP` | [RFC 2253](https://tools.ietf.org/html/2253) Distinguished Name |\n| OIDC Workforce | `oidcAuthType` | `IDP_GROUP` | Atlas OIDC IdP ID (found in federation settings), followed by a '/', followed by the IdP group name |\n| OIDC Workload | `oidcAuthType` | `USER` | Atlas OIDC IdP ID (found in federation settings), followed by a '/', followed by the IdP user name |\n| SCRAM-SHA | `awsIAMType`, `x509Type`, `ldapAuthType`, `oidcAuthType` | `NONE` | Alphanumeric string |\n",
+              "type": "string"
+            }
+          },
+          "required": [
+            "databaseName",
+            "groupId",
+            "username"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/atlas.generated.mongodb.com/flexcluster_v1.json
+++ b/atlas.generated.mongodb.com/flexcluster_v1.json
@@ -1,0 +1,276 @@
+{
+  "description": "A flexcluster, managed by the MongoDB Kubernetes Atlas Operator.",
+  "properties": {
+    "spec": {
+      "description": "Specification of the flexcluster supporting the following versions:\n\n- v20250312\n\nAt most one versioned spec can be specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
+      "properties": {
+        "connectionSecretRef": {
+          "description": "SENSITIVE FIELD\n\nReference to a secret containing the credentials to setup the connection to Atlas.",
+          "properties": {
+            "name": {
+              "description": "Name of the secret containing the Atlas credentials.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "v20250312": {
+          "description": "The spec of the flexcluster resource for version v20250312.",
+          "properties": {
+            "entry": {
+              "description": "The entry fields of the flexcluster resource spec. These fields can be set for creating and updating flexclusters.",
+              "properties": {
+                "name": {
+                  "description": "Human-readable label that identifies the instance.",
+                  "type": "string"
+                },
+                "providerSettings": {
+                  "description": "Group of cloud provider settings that configure the provisioned MongoDB flex cluster.",
+                  "properties": {
+                    "backingProviderName": {
+                      "description": "Cloud service provider on which MongoDB Cloud provisioned the flex cluster.",
+                      "type": "string"
+                    },
+                    "regionName": {
+                      "description": "Human-readable label that identifies the geographic location of your MongoDB flex cluster. The region you choose can affect network latency for clients accessing your databases. For a complete list of region names, see [AWS](https://docs.atlas.mongodb.com/reference/amazon-aws/#std-label-amazon-aws), [GCP](https://docs.atlas.mongodb.com/reference/google-gcp/), and [Azure](https://docs.atlas.mongodb.com/reference/microsoft-azure/).",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "backingProviderName",
+                    "regionName"
+                  ],
+                  "title": "Cloud Service Provider Settings for a Flex Cluster",
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "tags": {
+                  "description": "List that contains key-value pairs between 1 to 255 characters in length for tagging and categorizing the instance.",
+                  "items": {
+                    "description": "Key-value pair that tags and categorizes a MongoDB Cloud organization, project, or cluster. For example, `environment : production`.",
+                    "properties": {
+                      "key": {
+                        "description": "Constant that defines the set of the tag. For example, `environment` in the `environment : production` tag.",
+                        "type": "string"
+                      },
+                      "value": {
+                        "description": "Variable that belongs to the set of the tag. For example, `production` in the `environment : production` tag.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "key",
+                      "value"
+                    ],
+                    "title": "Resource Tag",
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "terminationProtectionEnabled": {
+                  "description": "Flag that indicates whether termination protection is enabled on the cluster. If set to `true`, MongoDB Cloud won't delete the cluster. If set to `false`, MongoDB Cloud will delete the cluster.",
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "name",
+                "providerSettings"
+              ],
+              "title": "Flex Cluster Description Create",
+              "type": "object",
+              "additionalProperties": false
+            },
+            "groupId": {
+              "description": "Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.\n\n**NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.",
+              "example": "32b6e34b3d91647abb20e7b8",
+              "type": "string",
+              "x-kubernetes-validations": [
+                {
+                  "message": "groupId cannot be modified after creation",
+                  "rule": "self == oldSelf"
+                }
+              ]
+            },
+            "groupRef": {
+              "description": "A reference to a \"Group\" resource.\nThe value of \"$.status.v20250312.id\" will be used to set \"groupId\".\nMutually exclusive with the \"groupId\" property.",
+              "properties": {
+                "name": {
+                  "description": "Name of the \"Group\" resource.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "x-kubernetes-validations": [
+            {
+              "message": "groupId and groupRef are mutually exclusive; only one of them can be set",
+              "rule": "(has(self.groupId) && !has(self.groupRef)) || (!has(self.groupId) && has(self.groupRef))"
+            }
+          ],
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "x-kubernetes-validations": [
+        {
+          "message": "spec.connectionSecretRef must be set if spec.v20250312.groupId is set.",
+          "rule": "(has(self.v20250312.groupId) && has(self.connectionSecretRef)) || (!has(self.v20250312.groupId))"
+        }
+      ],
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "Most recently observed read-only status of the flexcluster for the specified resource version. This data may not be up to date and is populated by the system. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
+      "properties": {
+        "conditions": {
+          "description": "Represents the latest available observations of a resource's current state.",
+          "items": {
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition.",
+                "type": "string"
+              },
+              "observedGeneration": {
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.",
+                "type": "integer"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "type",
+              "status"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "type"
+          ],
+          "x-kubernetes-list-type": "map"
+        },
+        "v20250312": {
+          "description": "The last observed Atlas state of the flexcluster resource for version v20250312.",
+          "properties": {
+            "backupSettings": {
+              "description": "Flex backup configuration.",
+              "properties": {
+                "enabled": {
+                  "description": "Flag that indicates whether backups are performed for this flex cluster. Backup uses flex cluster backups.",
+                  "type": "boolean"
+                }
+              },
+              "title": "Flex Backup Configuration",
+              "type": "object",
+              "additionalProperties": false
+            },
+            "clusterType": {
+              "description": "Flex cluster topology.",
+              "type": "string"
+            },
+            "connectionStrings": {
+              "description": "Collection of Uniform Resource Locators that point to the MongoDB database.",
+              "properties": {
+                "standard": {
+                  "description": "Public connection string that you can use to connect to this cluster. This connection string uses the `mongodb://` protocol.",
+                  "type": "string"
+                },
+                "standardSrv": {
+                  "description": "Public connection string that you can use to connect to this flex cluster. This connection string uses the `mongodb+srv://` protocol.",
+                  "type": "string"
+                }
+              },
+              "title": "Flex Cluster Connection Strings",
+              "type": "object",
+              "additionalProperties": false
+            },
+            "createDate": {
+              "description": "Date and time when MongoDB Cloud created this instance. This parameter expresses its value in ISO 8601 format in UTC.",
+              "type": "string"
+            },
+            "groupId": {
+              "description": "Unique 24-hexadecimal character string that identifies the project.",
+              "example": "32b6e34b3d91647abb20e7b8",
+              "type": "string"
+            },
+            "id": {
+              "description": "Unique 24-hexadecimal digit string that identifies the instance.",
+              "example": "32b6e34b3d91647abb20e7b8",
+              "type": "string"
+            },
+            "mongoDBVersion": {
+              "description": "Version of MongoDB that the instance runs.",
+              "type": "string"
+            },
+            "name": {
+              "description": "Human-readable label that identifies the instance.",
+              "type": "string"
+            },
+            "providerSettings": {
+              "description": "Group of cloud provider settings that configure the provisioned MongoDB flex cluster.",
+              "properties": {
+                "backingProviderName": {
+                  "description": "Cloud service provider on which MongoDB Cloud provisioned the flex cluster.",
+                  "type": "string"
+                },
+                "diskSizeGB": {
+                  "description": "Storage capacity available to the flex cluster expressed in gigabytes.",
+                  "type": "number"
+                },
+                "providerName": {
+                  "description": "Human-readable label that identifies the provider type.",
+                  "type": "string"
+                },
+                "regionName": {
+                  "description": "Human-readable label that identifies the geographic location of your MongoDB flex cluster. The region you choose can affect network latency for clients accessing your databases. For a complete list of region names, see [AWS](https://docs.atlas.mongodb.com/reference/amazon-aws/#std-label-amazon-aws), [GCP](https://docs.atlas.mongodb.com/reference/google-gcp/), and [Azure](https://docs.atlas.mongodb.com/reference/microsoft-azure/).",
+                  "type": "string"
+                }
+              },
+              "title": "Cloud Service Provider Settings for a Flex Cluster",
+              "type": "object",
+              "additionalProperties": false
+            },
+            "stateName": {
+              "description": "Human-readable label that indicates any current activity being taken on this cluster by the Atlas control plane. With the exception of CREATING and DELETING states, clusters should always be available and have a Primary node even when in states indicating ongoing activity.\n\n - `IDLE`: Atlas is making no changes to this cluster and all changes requested via the UI or API can be assumed to have been applied.\n - `CREATING`: A cluster being provisioned for the very first time returns state CREATING until it is ready for connections. Ensure IP Access List and DB Users are configured before attempting to connect.\n - `UPDATING`: A change requested via the UI, API, AutoScaling, or other scheduled activity is taking place.\n - `DELETING`: The cluster is in the process of deletion and will soon be deleted.\n - `REPAIRING`: One or more nodes in the cluster are being returned to service by the Atlas control plane. Other nodes should continue to provide service as normal.",
+              "type": "string"
+            },
+            "versionReleaseSystem": {
+              "description": "Method by which the cluster maintains the MongoDB versions.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "providerSettings"
+          ],
+          "title": "Flex Cluster Description",
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/atlas.generated.mongodb.com/group_v1.json
+++ b/atlas.generated.mongodb.com/group_v1.json
@@ -1,0 +1,167 @@
+{
+  "description": "A group, managed by the MongoDB Kubernetes Atlas Operator.",
+  "properties": {
+    "spec": {
+      "description": "Specification of the group supporting the following versions:\n\n- v20250312\n\nAt most one versioned spec can be specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
+      "properties": {
+        "connectionSecretRef": {
+          "description": "SENSITIVE FIELD\n\nReference to a secret containing the credentials to setup the connection to Atlas.",
+          "properties": {
+            "name": {
+              "description": "Name of the secret containing the Atlas credentials.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "v20250312": {
+          "description": "The spec of the group resource for version v20250312.",
+          "properties": {
+            "entry": {
+              "description": "The entry fields of the group resource spec. These fields can be set for creating and updating groups.",
+              "properties": {
+                "name": {
+                  "description": "Human-readable label that identifies the project included in the MongoDB Cloud organization.",
+                  "type": "string"
+                },
+                "orgId": {
+                  "description": "Unique 24-hexadecimal digit string that identifies the MongoDB Cloud organization to which the project belongs.",
+                  "example": "32b6e34b3d91647abb20e7b8",
+                  "type": "string"
+                },
+                "regionUsageRestrictions": {
+                  "description": "Applies to Atlas for Government only.\n\nIn Commercial Atlas, this field will be rejected in requests and missing in responses.\n\nThis field sets restrictions on available regions in the project.\n\n`COMMERCIAL_FEDRAMP_REGIONS_ONLY`: Only allows deployments in FedRAMP Moderate regions.\n\n`GOV_REGIONS_ONLY`: Only allows deployments in GovCloud regions.",
+                  "type": "string"
+                },
+                "tags": {
+                  "description": "List that contains key-value pairs between 1 to 255 characters in length for tagging and categorizing the project.",
+                  "items": {
+                    "description": "Key-value pair that tags and categorizes a MongoDB Cloud organization, project, or cluster. For example, `environment : production`.",
+                    "properties": {
+                      "key": {
+                        "description": "Constant that defines the set of the tag. For example, `environment` in the `environment : production` tag.",
+                        "type": "string"
+                      },
+                      "value": {
+                        "description": "Variable that belongs to the set of the tag. For example, `production` in the `environment : production` tag.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "key",
+                      "value"
+                    ],
+                    "title": "Resource Tag",
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "withDefaultAlertsSettings": {
+                  "description": "Flag that indicates whether to create the project with default alert settings.",
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "name",
+                "orgId"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "projectOwnerId": {
+              "description": "Unique 24-hexadecimal digit string that identifies the MongoDB Cloud user to whom to grant the Project Owner role on the specified project. If you set this parameter, it overrides the default value of the oldest Organization Owner.",
+              "type": "string",
+              "x-kubernetes-validations": [
+                {
+                  "message": "projectOwnerId cannot be modified after creation",
+                  "rule": "self == oldSelf"
+                }
+              ]
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "Most recently observed read-only status of the group for the specified resource version. This data may not be up to date and is populated by the system. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
+      "properties": {
+        "conditions": {
+          "description": "Represents the latest available observations of a resource's current state.",
+          "items": {
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition.",
+                "type": "string"
+              },
+              "observedGeneration": {
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.",
+                "type": "integer"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "type",
+              "status"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "type"
+          ],
+          "x-kubernetes-list-type": "map"
+        },
+        "v20250312": {
+          "description": "The last observed Atlas state of the group resource for version v20250312.",
+          "properties": {
+            "clusterCount": {
+              "description": "Quantity of MongoDB Cloud clusters deployed in this project.",
+              "type": "integer"
+            },
+            "created": {
+              "description": "Date and time when MongoDB Cloud created this project. This parameter expresses its value in the ISO 8601 timestamp format in UTC.",
+              "type": "string"
+            },
+            "id": {
+              "description": "Unique 24-hexadecimal digit string that identifies the MongoDB Cloud project.",
+              "example": "32b6e34b3d91647abb20e7b8",
+              "type": "string"
+            }
+          },
+          "required": [
+            "clusterCount",
+            "created"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/atlas.generated.mongodb.com/ipaccesslistentry_v1.json
+++ b/atlas.generated.mongodb.com/ipaccesslistentry_v1.json
@@ -1,0 +1,174 @@
+{
+  "description": "A ipaccesslistentry, managed by the MongoDB Kubernetes Atlas Operator.",
+  "properties": {
+    "spec": {
+      "description": "Specification of the ipaccesslistentry supporting the following versions:\n\n- v20250312\n\nAt most one versioned spec can be specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
+      "properties": {
+        "connectionSecretRef": {
+          "description": "SENSITIVE FIELD\n\nReference to a secret containing the credentials to setup the connection to Atlas.",
+          "properties": {
+            "name": {
+              "description": "Name of the secret containing the Atlas credentials.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "v20250312": {
+          "description": "The spec of the ipaccesslistentry resource for version v20250312.",
+          "properties": {
+            "entry": {
+              "description": "The entry fields of the ipaccesslistentry resource spec. These fields can be set for creating and updating ipaccesslistentries.",
+              "properties": {
+                "awsSecurityGroup": {
+                  "description": "Unique string of the Amazon Web Services (AWS) security group that you want to add to the project's IP access list. Your IP access list entry can be one `awsSecurityGroup`, one `cidrBlock`, or one `ipAddress`. You must configure Virtual Private Connection (VPC) peering for your project before you can add an AWS security group to an IP access list. You cannot set AWS security groups as temporary access list entries. Don't set this parameter if you set `cidrBlock` or `ipAddress`.",
+                  "type": "string"
+                },
+                "cidrBlock": {
+                  "description": "Range of IP addresses in Classless Inter-Domain Routing (CIDR) notation that you want to add to the project's IP access list. Your IP access list entry can be one `awsSecurityGroup`, one `cidrBlock`, or one `ipAddress`. Don't set this parameter if you set `awsSecurityGroup` or `ipAddress`.",
+                  "type": "string"
+                },
+                "comment": {
+                  "description": "Remark that explains the purpose or scope of this IP access list entry.",
+                  "type": "string"
+                },
+                "deleteAfterDate": {
+                  "description": "Date and time after which MongoDB Cloud deletes the temporary access list entry. This parameter expresses its value in the ISO 8601 timestamp format in UTC and can include the time zone designation. The date must be later than the current date but no later than one week after you submit this request. The resource returns this parameter if you specified an expiration date when creating this IP access list entry.",
+                  "type": "string"
+                },
+                "ipAddress": {
+                  "description": "IP address that you want to add to the project's IP access list. Your IP access list entry can be one `awsSecurityGroup`, one `cidrBlock`, or one `ipAddress`. Don't set this parameter if you set `awsSecurityGroup` or `cidrBlock`.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "groupId": {
+              "description": "Unique 24-hexadecimal digit string that identifies your project. Use the [/groups](#tag/Projects/operation/listProjects) endpoint to retrieve all projects to which the authenticated user has access.\n\n**NOTE**: Groups and projects are synonymous terms. Your group id is the same as your project id. For existing groups, your group/project id remains the same. The resource and corresponding endpoints use the term groups.",
+              "example": "32b6e34b3d91647abb20e7b8",
+              "type": "string",
+              "x-kubernetes-validations": [
+                {
+                  "message": "groupId cannot be modified after creation",
+                  "rule": "self == oldSelf"
+                }
+              ]
+            },
+            "groupRef": {
+              "description": "A reference to a \"Group\" resource.\nThe value of \"$.status.v20250312.id\" will be used to set \"groupId\".\nMutually exclusive with the \"groupId\" property.",
+              "properties": {
+                "name": {
+                  "description": "Name of the \"Group\" resource.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "x-kubernetes-validations": [
+            {
+              "message": "groupId and groupRef are mutually exclusive; only one of them can be set",
+              "rule": "(has(self.groupId) && !has(self.groupRef)) || (!has(self.groupId) && has(self.groupRef))"
+            }
+          ],
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "x-kubernetes-validations": [
+        {
+          "message": "spec.connectionSecretRef must be set if spec.v20250312.groupId is set.",
+          "rule": "(has(self.v20250312.groupId) && has(self.connectionSecretRef)) || (!has(self.v20250312.groupId))"
+        }
+      ],
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "Most recently observed read-only status of the ipaccesslistentry for the specified resource version. This data may not be up to date and is populated by the system. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
+      "properties": {
+        "conditions": {
+          "description": "Represents the latest available observations of a resource's current state.",
+          "items": {
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition.",
+                "type": "string"
+              },
+              "observedGeneration": {
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.",
+                "type": "integer"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "type",
+              "status"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "type"
+          ],
+          "x-kubernetes-list-type": "map"
+        },
+        "v20250312": {
+          "description": "The last observed Atlas state of the ipaccesslistentry resource for version v20250312.",
+          "properties": {
+            "awsSecurityGroup": {
+              "description": "Unique string of the Amazon Web Services (AWS) security group that you want to add to the project's IP access list. Your IP access list entry can be one `awsSecurityGroup`, one `cidrBlock`, or one `ipAddress`. You must configure Virtual Private Connection (VPC) peering for your project before you can add an AWS security group to an IP access list. You cannot set AWS security groups as temporary access list entries. Don't set this parameter if you set `cidrBlock` or `ipAddress`.",
+              "type": "string"
+            },
+            "cidrBlock": {
+              "description": "Range of IP addresses in Classless Inter-Domain Routing (CIDR) notation that you want to add to the project's IP access list. Your IP access list entry can be one `awsSecurityGroup`, one `cidrBlock`, or one `ipAddress`. Don't set this parameter if you set `awsSecurityGroup` or `ipAddress`.",
+              "type": "string"
+            },
+            "comment": {
+              "description": "Remark that explains the purpose or scope of this IP access list entry.",
+              "type": "string"
+            },
+            "deleteAfterDate": {
+              "description": "Date and time after which MongoDB Cloud deletes the temporary access list entry. This parameter expresses its value in the ISO 8601 timestamp format in UTC and can include the time zone designation. The date must be later than the current date but no later than one week after you submit this request. The resource returns this parameter if you specified an expiration date when creating this IP access list entry.",
+              "type": "string"
+            },
+            "groupId": {
+              "description": "Unique 24-hexadecimal digit string that identifies the project that contains the IP access list to which you want to add one or more entries.",
+              "example": "32b6e34b3d91647abb20e7b8",
+              "type": "string"
+            },
+            "ipAddress": {
+              "description": "IP address that you want to add to the project's IP access list. Your IP access list entry can be one `awsSecurityGroup`, one `cidrBlock`, or one `ipAddress`. Don't set this parameter if you set `awsSecurityGroup` or `cidrBlock`.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/atlas.mongodb.com/atlasbackupcompliancepolicy_v1.json
+++ b/atlas.mongodb.com/atlasbackupcompliancepolicy_v1.json
@@ -1,0 +1,212 @@
+{
+  "description": "The AtlasBackupCompliancePolicy is a configuration that enforces specific backup and retention requirements",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "AtlasBackupCompliancePolicySpec is the specification of the desired backup compliance policy configuration.",
+      "properties": {
+        "authorizedEmail": {
+          "description": "Email address of the user authorized to update Backup Compliance Policy settings.",
+          "type": "string"
+        },
+        "authorizedUserFirstName": {
+          "description": "First name of the user authorized to update the Backup Compliance Policy settings.",
+          "type": "string"
+        },
+        "authorizedUserLastName": {
+          "description": "Last name of the user authorized to update the Backup Compliance Policy settings.",
+          "type": "string"
+        },
+        "copyProtectionEnabled": {
+          "description": "Flag that indicates whether to prevent cluster users from deleting backups copied to other regions, even if those additional snapshot regions are removed.",
+          "type": "boolean"
+        },
+        "encryptionAtRestEnabled": {
+          "description": "Flag that indicates whether to require Encryption at Rest using Customer Key Management for all clusters with a Backup Compliance Policy.",
+          "type": "boolean"
+        },
+        "onDemandPolicy": {
+          "description": "Specifications for on-demand policy.",
+          "properties": {
+            "retentionUnit": {
+              "description": "Scope of the backup policy item: days, weeks, or months.",
+              "enum": [
+                "days",
+                "weeks",
+                "months"
+              ],
+              "type": "string"
+            },
+            "retentionValue": {
+              "description": "Value to associate with RetentionUnit.",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "retentionUnit",
+            "retentionValue"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "overwriteBackupPolicies": {
+          "description": "Flag that indicates whether to overwrite non-complying backup policies with the new data protection settings.",
+          "type": "boolean"
+        },
+        "pointInTimeEnabled": {
+          "description": "Flag that indicates whether the cluster uses Continuous Cloud Backups with a Backup Compliance Policy.",
+          "type": "boolean"
+        },
+        "restoreWindowDays": {
+          "description": "Number of previous days from which you can restore with Continuous Cloud Backup with a Backup Compliance Policy.\nThis parameter applies only to Continuous Cloud Backups with a Backup Compliance Policy.",
+          "type": "integer"
+        },
+        "scheduledPolicyItems": {
+          "description": "List that contains the specifications for one scheduled policy.",
+          "items": {
+            "properties": {
+              "frequencyInterval": {
+                "description": "Frequency of the new backup policy item specified by FrequencyType. A value of 1 specifies the first instance of the corresponding FrequencyType.\nYou can set FrequencyInterval only to 12 for NVMe clusters.",
+                "enum": [
+                  1,
+                  2,
+                  3,
+                  4,
+                  5,
+                  6,
+                  7,
+                  8,
+                  9,
+                  10,
+                  11,
+                  12,
+                  13,
+                  14,
+                  15,
+                  16,
+                  17,
+                  18,
+                  19,
+                  20,
+                  21,
+                  22,
+                  23,
+                  24,
+                  25,
+                  26,
+                  27,
+                  28,
+                  40
+                ],
+                "type": "integer"
+              },
+              "frequencyType": {
+                "description": "Frequency associated with the backup policy item. You can specify only one each of hourly or daily backup policy items.",
+                "enum": [
+                  "hourly",
+                  "daily",
+                  "weekly",
+                  "monthly",
+                  "yearly"
+                ],
+                "type": "string"
+              },
+              "retentionUnit": {
+                "description": "Unit of time in which MongoDB Atlas measures snapshot retention.",
+                "enum": [
+                  "days",
+                  "weeks",
+                  "months",
+                  "years"
+                ],
+                "type": "string"
+              },
+              "retentionValue": {
+                "description": "Duration in days, weeks, months, or years that MongoDB Cloud retains the snapshot.\nFor less frequent policy items, MongoDB Cloud requires that you specify a value greater than or equal to the value specified for more frequent policy items.",
+                "type": "integer"
+              }
+            },
+            "required": [
+              "frequencyInterval",
+              "frequencyType",
+              "retentionUnit",
+              "retentionValue"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "authorizedEmail",
+        "authorizedUserFirstName",
+        "authorizedUserLastName"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "BackupCompliancePolicyStatus defines the observed state of AtlasBackupCompliancePolicy.",
+      "properties": {
+        "conditions": {
+          "description": "Conditions is the list of statuses showing the current state of the Atlas Custom Resource",
+          "items": {
+            "description": "Condition describes the state of an Atlas Custom Resource at a certain point.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another.\nRepresented in ISO 8601 format.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A message providing details about the transition.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition; one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of Atlas Custom Resource condition.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration indicates the generation of the resource specification of which the Atlas Operator is aware.\nThe Atlas Operator updates this field to the value of 'metadata.generation' as soon as it starts reconciliation of the resource.",
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "conditions"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/atlas.mongodb.com/atlasbackuppolicy_v1.json
+++ b/atlas.mongodb.com/atlasbackuppolicy_v1.json
@@ -1,0 +1,161 @@
+{
+  "description": "AtlasBackupPolicy is the Schema for the atlasbackuppolicies API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "AtlasBackupPolicySpec defines the target state of AtlasBackupPolicy.",
+      "properties": {
+        "items": {
+          "description": "A list of BackupPolicy items.",
+          "items": {
+            "properties": {
+              "frequencyInterval": {
+                "description": "Frequency of the new backup policy item specified by FrequencyType. A value of 1 specifies the first instance of the corresponding FrequencyType.\nYou can set FrequencyInterval only to 12 for NVMe clusters.",
+                "enum": [
+                  1,
+                  2,
+                  3,
+                  4,
+                  5,
+                  6,
+                  7,
+                  8,
+                  9,
+                  10,
+                  11,
+                  12,
+                  13,
+                  14,
+                  15,
+                  16,
+                  17,
+                  18,
+                  19,
+                  20,
+                  21,
+                  22,
+                  23,
+                  24,
+                  25,
+                  26,
+                  27,
+                  28,
+                  40
+                ],
+                "type": "integer"
+              },
+              "frequencyType": {
+                "description": "Frequency associated with the backup policy item. You can specify only one each of hourly or daily backup policy items.",
+                "enum": [
+                  "hourly",
+                  "daily",
+                  "weekly",
+                  "monthly",
+                  "yearly"
+                ],
+                "type": "string"
+              },
+              "retentionUnit": {
+                "description": "Unit of time in which MongoDB Atlas measures snapshot retention.",
+                "enum": [
+                  "days",
+                  "weeks",
+                  "months",
+                  "years"
+                ],
+                "type": "string"
+              },
+              "retentionValue": {
+                "description": "Duration in days, weeks, months, or years that MongoDB Cloud retains the snapshot.\nFor less frequent policy items, MongoDB Cloud requires that you specify a value greater than or equal to the value specified for more frequent policy items.",
+                "type": "integer"
+              }
+            },
+            "required": [
+              "frequencyInterval",
+              "frequencyType",
+              "retentionUnit",
+              "retentionValue"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "items"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "BackupPolicyStatus defines the observed state of AtlasBackupPolicy.",
+      "properties": {
+        "backupScheduleIDs": {
+          "description": "DeploymentID of the deployment using the backup policy",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "conditions": {
+          "description": "Conditions is the list of statuses showing the current state of the Atlas Custom Resource",
+          "items": {
+            "description": "Condition describes the state of an Atlas Custom Resource at a certain point.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another.\nRepresented in ISO 8601 format.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A message providing details about the transition.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition; one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of Atlas Custom Resource condition.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration indicates the generation of the resource specification of which the Atlas Operator is aware.\nThe Atlas Operator updates this field to the value of 'metadata.generation' as soon as it starts reconciliation of the resource.",
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "conditions"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/atlas.mongodb.com/atlasbackupschedule_v1.json
+++ b/atlas.mongodb.com/atlasbackupschedule_v1.json
@@ -1,0 +1,195 @@
+{
+  "description": "AtlasBackupSchedule is the Schema for the atlasbackupschedules API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "AtlasBackupScheduleSpec defines the target state of AtlasBackupSchedule.",
+      "properties": {
+        "autoExportEnabled": {
+          "default": false,
+          "description": "Specify true to enable automatic export of cloud backup snapshots to the AWS bucket. You must also define the export policy using export. If omitted, defaults to false.",
+          "type": "boolean"
+        },
+        "copySettings": {
+          "description": "Copy backups to other regions for increased resiliency and faster restores.",
+          "items": {
+            "properties": {
+              "cloudProvider": {
+                "default": "AWS",
+                "description": "Identifies the cloud provider that stores the snapshot copy.",
+                "enum": [
+                  "AWS",
+                  "GCP",
+                  "AZURE"
+                ],
+                "type": "string"
+              },
+              "frequencies": {
+                "description": "List that describes which types of snapshots to copy.",
+                "items": {
+                  "type": "string"
+                },
+                "minItems": 1,
+                "type": "array"
+              },
+              "regionName": {
+                "description": "Target region to copy snapshots belonging to replicationSpecId to.",
+                "type": "string"
+              },
+              "shouldCopyOplogs": {
+                "description": "Flag that indicates whether to copy the oplogs to the target region.",
+                "type": "boolean"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "export": {
+          "description": "Export policy for automatically exporting cloud backup snapshots to AWS bucket.",
+          "properties": {
+            "exportBucketId": {
+              "description": "Unique Atlas identifier of the AWS bucket which was granted access to export backup snapshot.",
+              "type": "string"
+            },
+            "frequencyType": {
+              "default": "monthly",
+              "description": "Human-readable label that indicates the rate at which the export policy item occurs.",
+              "enum": [
+                "monthly"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "exportBucketId",
+            "frequencyType"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "policy": {
+          "description": "A reference (name & namespace) for backup policy in the desired updated backup policy.",
+          "properties": {
+            "name": {
+              "description": "Name of the Kubernetes Resource",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "Namespace of the Kubernetes Resource",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "referenceHourOfDay": {
+          "description": "UTC Hour of day between 0 and 23, inclusive, representing which hour of the day that Atlas takes snapshots for backup policy items",
+          "format": "int64",
+          "maximum": 23,
+          "minimum": 0,
+          "type": "integer"
+        },
+        "referenceMinuteOfHour": {
+          "description": "UTC Minutes after ReferenceHourOfDay that Atlas takes snapshots for backup policy items. Must be between 0 and 59, inclusive.",
+          "format": "int64",
+          "maximum": 59,
+          "minimum": 0,
+          "type": "integer"
+        },
+        "restoreWindowDays": {
+          "default": 1,
+          "description": "Number of days back in time you can restore to with Continuous Cloud Backup accuracy. Must be a positive, non-zero integer. Applies to continuous cloud backups only.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "updateSnapshots": {
+          "description": "Specify true to apply the retention changes in the updated backup policy to snapshots that Atlas took previously.",
+          "type": "boolean"
+        },
+        "useOrgAndGroupNamesInExportPrefix": {
+          "description": "Specify true to use organization and project names instead of organization and project UUIDs in the path for the metadata files that Atlas uploads to your S3 bucket after it finishes exporting the snapshots",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "policy"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "BackupScheduleStatus defines the observed state of AtlasBackupSchedule.",
+      "properties": {
+        "conditions": {
+          "description": "Conditions is the list of statuses showing the current state of the Atlas Custom Resource",
+          "items": {
+            "description": "Condition describes the state of an Atlas Custom Resource at a certain point.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another.\nRepresented in ISO 8601 format.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A message providing details about the transition.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition; one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of Atlas Custom Resource condition.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "deploymentID": {
+          "description": "List of the human-readable names of all deployments utilizing this backup schedule.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration indicates the generation of the resource specification of which the Atlas Operator is aware.\nThe Atlas Operator updates this field to the value of 'metadata.generation' as soon as it starts reconciliation of the resource.",
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "conditions"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/atlas.mongodb.com/atlascustomrole_v1.json
+++ b/atlas.mongodb.com/atlascustomrole_v1.json
@@ -1,0 +1,210 @@
+{
+  "description": "AtlasCustomRole is the Schema for the AtlasCustomRole API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "AtlasCustomRoleSpec defines the target state of CustomRole in Atlas.",
+      "properties": {
+        "connectionSecret": {
+          "description": "Name of the secret containing Atlas API private and public keys.",
+          "properties": {
+            "name": {
+              "description": "Name of the resource being referred to\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "externalProjectRef": {
+          "description": "externalProjectRef holds the parent Atlas project ID.\nMutually exclusive with the \"projectRef\" field.",
+          "properties": {
+            "id": {
+              "description": "ID is the Atlas project ID.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "id"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "projectRef": {
+          "description": "projectRef is a reference to the parent AtlasProject resource.\nMutually exclusive with the \"externalProjectRef\" field.",
+          "properties": {
+            "name": {
+              "description": "Name of the Kubernetes Resource",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "Namespace of the Kubernetes Resource",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "role": {
+          "description": "Role represents a Custom Role in Atlas.",
+          "properties": {
+            "actions": {
+              "description": "List of the individual privilege actions that the role grants.",
+              "items": {
+                "properties": {
+                  "name": {
+                    "description": "Human-readable label that identifies the privilege action.",
+                    "type": "string"
+                  },
+                  "resources": {
+                    "description": "List of resources on which you grant the action.",
+                    "items": {
+                      "properties": {
+                        "cluster": {
+                          "description": "Flag that indicates whether to grant the action on the cluster resource. If true, MongoDB Cloud ignores Database and Collection parameters.",
+                          "type": "boolean"
+                        },
+                        "collection": {
+                          "description": "Human-readable label that identifies the collection on which you grant the action to one MongoDB user.",
+                          "type": "string"
+                        },
+                        "database": {
+                          "description": "Human-readable label that identifies the database on which you grant the action to one MongoDB user.",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "name",
+                  "resources"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "inheritedRoles": {
+              "description": "List of the built-in roles that this custom role inherits.",
+              "items": {
+                "properties": {
+                  "database": {
+                    "description": "Human-readable label that identifies the database on which someone grants the action to one MongoDB user.",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "Human-readable label that identifies the role inherited.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "database",
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "name": {
+              "description": "Human-readable label that identifies the role. This name must be unique for this custom role in this project.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "role"
+      ],
+      "type": "object",
+      "x-kubernetes-validations": [
+        {
+          "message": "must define only one project reference through externalProjectRef or projectRef",
+          "rule": "(has(self.externalProjectRef) && !has(self.projectRef)) || (!has(self.externalProjectRef) && has(self.projectRef))"
+        },
+        {
+          "message": "must define a local connection secret when referencing an external project",
+          "rule": "(has(self.externalProjectRef) && has(self.connectionSecret)) || !has(self.externalProjectRef)"
+        }
+      ],
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "AtlasCustomRoleStatus is a status for the AtlasCustomRole Custom resource.\nNot the one included in the AtlasProject",
+      "properties": {
+        "conditions": {
+          "description": "Conditions is the list of statuses showing the current state of the Atlas Custom Resource",
+          "items": {
+            "description": "Condition describes the state of an Atlas Custom Resource at a certain point.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another.\nRepresented in ISO 8601 format.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A message providing details about the transition.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition; one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of Atlas Custom Resource condition.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration indicates the generation of the resource specification of which the Atlas Operator is aware.\nThe Atlas Operator updates this field to the value of 'metadata.generation' as soon as it starts reconciliation of the resource.",
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "conditions"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/atlas.mongodb.com/atlasdatabaseuser_v1.json
+++ b/atlas.mongodb.com/atlasdatabaseuser_v1.json
@@ -1,0 +1,285 @@
+{
+  "description": "AtlasDatabaseUser is the Schema for the Atlas Database User API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "AtlasDatabaseUserSpec defines the target state of Database User in Atlas",
+      "properties": {
+        "awsIamType": {
+          "default": "NONE",
+          "description": "Human-readable label that indicates whether the new database user authenticates with Amazon Web Services (AWS).\nIdentity and Access Management (IAM) credentials associated with the user or the user's role",
+          "enum": [
+            "NONE",
+            "USER",
+            "ROLE"
+          ],
+          "type": "string"
+        },
+        "connectionSecret": {
+          "description": "Name of the secret containing Atlas API private and public keys.",
+          "properties": {
+            "name": {
+              "description": "Name of the resource being referred to\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "databaseName": {
+          "default": "admin",
+          "description": "DatabaseName is a Database against which Atlas authenticates the user.\nIf the user authenticates with AWS IAM, x.509, LDAP, or OIDC Workload this value should be '$external'.\nIf the user authenticates with SCRAM-SHA or OIDC Workforce, this value should be 'admin'.\nDefault value is 'admin'.",
+          "type": "string"
+        },
+        "deleteAfterDate": {
+          "description": "DeleteAfterDate is a timestamp in ISO 8601 date and time format in UTC after which Atlas deletes the user.\nThe specified date must be in the future and within one week.",
+          "type": "string"
+        },
+        "description": {
+          "description": "Description of this database user. Maximum 100 characters.",
+          "maxLength": 100,
+          "type": "string"
+        },
+        "externalProjectRef": {
+          "description": "externalProjectRef holds the parent Atlas project ID.\nMutually exclusive with the \"projectRef\" field.",
+          "properties": {
+            "id": {
+              "description": "ID is the Atlas project ID.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "id"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "labels": {
+          "description": "Labels is an array containing key-value pairs that tag and categorize the database user.\nEach key and value has a maximum length of 255 characters.",
+          "items": {
+            "description": "LabelSpec contains key-value pairs that tag and categorize the Cluster/DBUser",
+            "properties": {
+              "key": {
+                "description": "Key applied to tag and categorize this component.",
+                "maxLength": 255,
+                "type": "string"
+              },
+              "value": {
+                "description": "Value set to the Key applied to tag and categorize this component.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "key",
+              "value"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "oidcAuthType": {
+          "default": "NONE",
+          "description": "Human-readable label that indicates whether the new database Username with OIDC federated authentication.\nTo create a federated authentication group (Workforce), specify the value of IDP_GROUP in this field.\nTo create a federated authentication user (Workload), specify the value of USER in this field.",
+          "enum": [
+            "NONE",
+            "IDP_GROUP",
+            "USER"
+          ],
+          "type": "string"
+        },
+        "passwordSecretRef": {
+          "description": "PasswordSecret is a reference to the Secret keeping the user password.",
+          "properties": {
+            "name": {
+              "description": "Name is the name of the Kubernetes Resource",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "projectRef": {
+          "description": "projectRef is a reference to the parent AtlasProject resource.\nMutually exclusive with the \"externalProjectRef\" field.",
+          "properties": {
+            "name": {
+              "description": "Name of the Kubernetes Resource",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "Namespace of the Kubernetes Resource",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "roles": {
+          "description": "Roles is an array of this user's roles and the databases / collections on which the roles apply. A role allows\nthe user to perform particular actions on the specified database.",
+          "items": {
+            "description": "RoleSpec allows the user to perform particular actions on the specified database.\nA role on the admin database can include privileges that apply to the other databases as well.",
+            "properties": {
+              "collectionName": {
+                "description": "CollectionName is a collection for which the role applies.",
+                "type": "string"
+              },
+              "databaseName": {
+                "description": "DatabaseName is a database on which the user has the specified role. A role on the admin database can include\nprivileges that apply to the other databases.",
+                "type": "string"
+              },
+              "roleName": {
+                "description": "RoleName is a name of the role. This value can either be a built-in role or a custom role.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "databaseName",
+              "roleName"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "minItems": 1,
+          "type": "array"
+        },
+        "scopes": {
+          "description": "Scopes is an array of clusters and Atlas Data Lakes that this user has access to.",
+          "items": {
+            "description": "ScopeSpec if present a database user only have access to the indicated resource (Cluster or Atlas Data Lake)\nif none is given then it has access to all.\nIt's highly recommended to restrict the access of the database users only to a limited set of resources.",
+            "properties": {
+              "name": {
+                "description": "Name is a name of the cluster or Atlas Data Lake that the user has access to.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type is a type of resource that the user has access to.",
+                "enum": [
+                  "CLUSTER",
+                  "DATA_LAKE"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "username": {
+          "description": "Username is a username for authenticating to MongoDB\nHuman-readable label that represents the user that authenticates to MongoDB. The format of this label depends on the method of authentication:\nIn case of AWS IAM: the value should be AWS ARN for the IAM User/Role;\nIn case of OIDC Workload or Workforce: the value should be the Atlas OIDC IdP ID, followed by a '/', followed by the IdP group name;\nIn case of Plain text auth: the value can be anything.",
+          "maxLength": 1024,
+          "type": "string"
+        },
+        "x509Type": {
+          "default": "NONE",
+          "description": "X509Type is X.509 method by which the database authenticates the provided username.",
+          "enum": [
+            "NONE",
+            "MANAGED",
+            "CUSTOMER"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "roles",
+        "username"
+      ],
+      "type": "object",
+      "x-kubernetes-validations": [
+        {
+          "message": "must define only one project reference through externalProjectRef or projectRef",
+          "rule": "(has(self.externalProjectRef) && !has(self.projectRef)) || (!has(self.externalProjectRef) && has(self.projectRef))"
+        },
+        {
+          "message": "must define a local connection secret when referencing an external project",
+          "rule": "(has(self.externalProjectRef) && has(self.connectionSecret)) || !has(self.externalProjectRef)"
+        }
+      ],
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "AtlasDatabaseUserStatus defines the observed state of AtlasProject",
+      "properties": {
+        "conditions": {
+          "description": "Conditions is the list of statuses showing the current state of the Atlas Custom Resource",
+          "items": {
+            "description": "Condition describes the state of an Atlas Custom Resource at a certain point.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another.\nRepresented in ISO 8601 format.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A message providing details about the transition.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition; one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of Atlas Custom Resource condition.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "name": {
+          "description": "UserName is the current name of database user.",
+          "type": "string"
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration indicates the generation of the resource specification of which the Atlas Operator is aware.\nThe Atlas Operator updates this field to the value of 'metadata.generation' as soon as it starts reconciliation of the resource.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "passwordVersion": {
+          "description": "PasswordVersion is the 'ResourceVersion' of the password Secret that the Atlas Operator is aware of",
+          "type": "string"
+        }
+      },
+      "required": [
+        "conditions"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/atlas.mongodb.com/atlasdatafederation_v1.json
+++ b/atlas.mongodb.com/atlasdatafederation_v1.json
@@ -1,0 +1,364 @@
+{
+  "description": "AtlasDataFederation is the Schema for the Atlas Data Federation API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "DataFederationSpec defines the target state of AtlasDataFederation.",
+      "properties": {
+        "cloudProviderConfig": {
+          "description": "Configuration for the cloud provider where this Federated Database Instance is hosted.",
+          "properties": {
+            "aws": {
+              "description": "Configuration for running Data Federation in AWS.",
+              "properties": {
+                "roleId": {
+                  "description": "Unique identifier of the role that the data lake can use to access the data stores.Required if specifying cloudProviderConfig.",
+                  "type": "string"
+                },
+                "testS3Bucket": {
+                  "description": "Name of the S3 data bucket that the provided role ID is authorized to access.Required if specifying cloudProviderConfig.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "dataProcessRegion": {
+          "description": "Information about the cloud provider region to which the Federated Database Instance routes client connections.",
+          "properties": {
+            "cloudProvider": {
+              "description": "Name of the cloud service that hosts the Federated Database Instance's infrastructure.",
+              "enum": [
+                "AWS"
+              ],
+              "type": "string"
+            },
+            "region": {
+              "description": "Name of the region to which the data lake routes client connections.",
+              "enum": [
+                "SYDNEY_AUS",
+                "MUMBAI_IND",
+                "FRANKFURT_DEU",
+                "DUBLIN_IRL",
+                "LONDON_GBR",
+                "VIRGINIA_USA",
+                "OREGON_USA",
+                "SAOPAULO_BRA",
+                "SINGAPORE_SGP"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "name": {
+          "description": "Human-readable label that identifies the Federated Database Instance.",
+          "type": "string"
+        },
+        "privateEndpoints": {
+          "description": "Private endpoint for Federated Database Instances and Online Archives to add to the specified project.",
+          "items": {
+            "properties": {
+              "endpointId": {
+                "description": "Unique 22-character alphanumeric string that identifies the private endpoint.",
+                "type": "string"
+              },
+              "provider": {
+                "description": "Human-readable label that identifies the cloud service provider. Atlas Data Lake supports Amazon Web Services only.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Human-readable label that identifies the resource type associated with this private endpoint.",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "projectRef": {
+          "description": "Project is a reference to AtlasProject resource the deployment belongs to.",
+          "properties": {
+            "name": {
+              "description": "Name of the Kubernetes Resource",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "Namespace of the Kubernetes Resource",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "storage": {
+          "description": "Configuration information for each data store and its mapping to MongoDB Atlas databases.",
+          "properties": {
+            "databases": {
+              "description": "Array that contains the queryable databases and collections for this data lake.",
+              "items": {
+                "description": "Database associated with this data lake. Databases contain collections and views.",
+                "properties": {
+                  "collections": {
+                    "description": "Array of collections and data sources that map to a stores data store.",
+                    "items": {
+                      "description": "Collection maps to a stores data store.",
+                      "properties": {
+                        "dataSources": {
+                          "description": "Array that contains the data stores that map to a collection for this data lake.",
+                          "items": {
+                            "properties": {
+                              "allowInsecure": {
+                                "description": "Flag that validates the scheme in the specified URLs.\nIf true, allows insecure HTTP scheme, doesn't verify the server's certificate chain and hostname, and accepts any certificate with any hostname presented by the server.\nIf false, allows secure HTTPS scheme only.",
+                                "type": "boolean"
+                              },
+                              "collection": {
+                                "description": "Human-readable label that identifies the collection in the database. For creating a wildcard (*) collection, you must omit this parameter.",
+                                "type": "string"
+                              },
+                              "collectionRegex": {
+                                "description": "Regex pattern to use for creating the wildcard (*) collection.",
+                                "type": "string"
+                              },
+                              "database": {
+                                "description": "Human-readable label that identifies the database, which contains the collection in the cluster. You must omit this parameter to generate wildcard (*) collections for dynamically generated databases.",
+                                "type": "string"
+                              },
+                              "databaseRegex": {
+                                "description": "Regex pattern to use for creating the wildcard (*) database.",
+                                "type": "string"
+                              },
+                              "defaultFormat": {
+                                "description": "File format that MongoDB Cloud uses if it encounters a file without a file extension while searching storeName.",
+                                "enum": [
+                                  ".avro",
+                                  ".avro.bz2",
+                                  ".avro.gz",
+                                  ".bson",
+                                  ".bson.bz2",
+                                  ".bson.gz",
+                                  ".bsonx",
+                                  ".csv",
+                                  ".csv.bz2",
+                                  ".csv.gz",
+                                  ".json",
+                                  ".json.bz2",
+                                  ".json.gz",
+                                  ".orc",
+                                  ".parquet",
+                                  ".tsv",
+                                  ".tsv.bz2",
+                                  ".tsv.gz"
+                                ],
+                                "type": "string"
+                              },
+                              "path": {
+                                "description": "File path that controls how MongoDB Cloud searches for and parses files in the storeName before mapping them to a collection.\nSpecify / to capture all files and folders from the prefix path.",
+                                "type": "string"
+                              },
+                              "provenanceFieldName": {
+                                "description": "Name for the field that includes the provenance of the documents in the results. MongoDB Atlas returns different fields in the results for each supported provider.",
+                                "type": "string"
+                              },
+                              "storeName": {
+                                "description": "Human-readable label that identifies the data store that MongoDB Cloud maps to the collection.",
+                                "type": "string"
+                              },
+                              "urls": {
+                                "description": "URLs of the publicly accessible data files. You can't specify URLs that require authentication.\nAtlas Data Lake creates a partition for each URL. If empty or omitted, Data Lake uses the URLs from the store specified in the storeName parameter.",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "name": {
+                          "description": "Human-readable label that identifies the collection to which MongoDB Atlas maps the data in the data stores.",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
+                  "maxWildcardCollections": {
+                    "description": "Maximum number of wildcard collections in the database. This only applies to S3 data sources.\nMinimum value is 1, maximum value is 1000. Default value is 100.",
+                    "type": "integer"
+                  },
+                  "name": {
+                    "description": "Human-readable label that identifies the database to which the data lake maps data.",
+                    "type": "string"
+                  },
+                  "views": {
+                    "description": "Array of aggregation pipelines that apply to the collection. This only applies to S3 data sources.",
+                    "items": {
+                      "properties": {
+                        "name": {
+                          "description": "Human-readable label that identifies the view, which corresponds to an aggregation pipeline on a collection.",
+                          "type": "string"
+                        },
+                        "pipeline": {
+                          "description": "Aggregation pipeline stages to apply to the source collection.",
+                          "type": "string"
+                        },
+                        "source": {
+                          "description": "Human-readable label that identifies the source collection for the view.",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "stores": {
+              "description": "Array that contains the data stores for the data lake.",
+              "items": {
+                "description": "Store is a group of settings that define where the data is stored.",
+                "properties": {
+                  "additionalStorageClasses": {
+                    "description": "Collection of AWS S3 storage classes. Atlas Data Lake includes the files in these storage classes in the query results.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "bucket": {
+                    "description": "Human-readable label that identifies the AWS S3 bucket.\nThis label must exactly match the name of an S3 bucket that the data lake can access with the configured AWS Identity and Access Management (IAM) credentials.",
+                    "type": "string"
+                  },
+                  "delimiter": {
+                    "description": "The delimiter that separates path segments in the data store.\nMongoDB Atlas uses the delimiter to efficiently traverse S3 buckets with a hierarchical directory structure. You can specify any character supported by the S3 object keys as the delimiter.",
+                    "type": "string"
+                  },
+                  "includeTags": {
+                    "description": "Flag that indicates whether to use S3 tags on the files in the given path as additional partition attributes.\nIf set to true, data lake adds the S3 tags as additional partition attributes and adds new top-level BSON elements associating each tag to each document.",
+                    "type": "boolean"
+                  },
+                  "name": {
+                    "description": "Human-readable label that identifies the data store. The storeName field references this values as part of the mapping configuration.\nTo use MongoDB Atlas as a data store, the data lake requires a serverless instance or an M10 or higher cluster.",
+                    "type": "string"
+                  },
+                  "prefix": {
+                    "description": "Prefix that MongoDB Cloud applies when searching for files in the S3 bucket.\nThe data store prepends the value of prefix to the path to create the full path for files to ingest.\nIf omitted, MongoDB Cloud searches all files from the root of the S3 bucket.",
+                    "type": "string"
+                  },
+                  "provider": {
+                    "description": "The provider used for data stores.",
+                    "type": "string"
+                  },
+                  "public": {
+                    "description": "Flag that indicates whether the bucket is public.\nIf set to true, MongoDB Cloud doesn't use the configured AWS Identity and Access Management (IAM) role to access the S3 bucket.\nIf set to false, the configured AWS IAM role must include permissions to access the S3 bucket.",
+                    "type": "boolean"
+                  },
+                  "region": {
+                    "description": "Physical location where MongoDB Cloud deploys your AWS-hosted MongoDB cluster nodes. The region you choose can affect network latency for clients accessing your databases.\nWhen MongoDB Atlas deploys a dedicated cluster, it checks if a VPC or VPC connection exists for that provider and region. If not, MongoDB Atlas creates them as part of the deployment.\nTo limit a new VPC peering connection to one CIDR block and region, create the connection first. Deploy the cluster after the connection starts.",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "name",
+        "projectRef"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "DataFederationStatus defines the observed state of AtlasDataFederation.",
+      "properties": {
+        "conditions": {
+          "description": "Conditions is the list of statuses showing the current state of the Atlas Custom Resource",
+          "items": {
+            "description": "Condition describes the state of an Atlas Custom Resource at a certain point.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another.\nRepresented in ISO 8601 format.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A message providing details about the transition.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition; one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of Atlas Custom Resource condition.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "mongoDBVersion": {
+          "description": "MongoDBVersion is the version of MongoDB the cluster runs, in <major version>.<minor version> format.",
+          "type": "string"
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration indicates the generation of the resource specification of which the Atlas Operator is aware.\nThe Atlas Operator updates this field to the value of 'metadata.generation' as soon as it starts reconciliation of the resource.",
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "conditions"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/atlas.mongodb.com/atlasdeployment_v1.json
+++ b/atlas.mongodb.com/atlasdeployment_v1.json
@@ -1,0 +1,1341 @@
+{
+  "description": "AtlasDeployment is the Schema for the atlasdeployments API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "AtlasDeploymentSpec defines the target state of AtlasDeployment.\nOnly one of DeploymentSpec, AdvancedDeploymentSpec and ServerlessSpec should be defined.",
+      "properties": {
+        "backupRef": {
+          "description": "Reference to the backup schedule for the AtlasDeployment.",
+          "properties": {
+            "name": {
+              "description": "Name of the Kubernetes Resource",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "Namespace of the Kubernetes Resource",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "connectionSecret": {
+          "description": "Name of the secret containing Atlas API private and public keys.",
+          "properties": {
+            "name": {
+              "description": "Name of the resource being referred to\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "deploymentSpec": {
+          "description": "Configuration for the advanced (v1.5) deployment API https://www.mongodb.com/docs/atlas/reference/api/clusters/",
+          "properties": {
+            "backupEnabled": {
+              "description": "Flag that indicates if the deployment uses Cloud Backups for backups.\nApplicable only for M10+ deployments.",
+              "type": "boolean"
+            },
+            "biConnector": {
+              "description": "Configuration of BI Connector for Atlas on this deployment.\nThe MongoDB Connector for Business Intelligence for Atlas (BI Connector) is only available for M10 and larger deployments.",
+              "properties": {
+                "enabled": {
+                  "description": "Flag that indicates whether the Business Intelligence Connector for Atlas is enabled on the deployment.",
+                  "type": "boolean"
+                },
+                "readPreference": {
+                  "description": "Source from which the BI Connector for Atlas reads data. Each BI Connector for Atlas read preference contains a distinct combination of readPreference and readPreferenceTags options.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "clusterType": {
+              "description": "Type of the deployment that you want to create.\nThe parameter is required if replicationSpecs are set or if Global Deployments are deployed.",
+              "enum": [
+                "REPLICASET",
+                "SHARDED",
+                "GEOSHARDED"
+              ],
+              "type": "string"
+            },
+            "configServerManagementMode": {
+              "description": "Config Server Management Mode for creating or updating a sharded cluster.",
+              "enum": [
+                "ATLAS_MANAGED",
+                "FIXED_TO_DEDICATED"
+              ],
+              "type": "string"
+            },
+            "customZoneMapping": {
+              "description": "List that contains Global Cluster parameters that map zones to geographic regions.",
+              "items": {
+                "properties": {
+                  "location": {
+                    "description": "Code that represents a location that maps to a zone in your global cluster.\nMongoDB Atlas represents this location with a ISO 3166-2 location and subdivision codes when possible.",
+                    "type": "string"
+                  },
+                  "zone": {
+                    "description": "Human-readable label that identifies the zone in your global cluster. This zone maps to a location code.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "location",
+                  "zone"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "diskSizeGB": {
+              "description": "Capacity, in gigabytes, of the host's root volume.\nIncrease this number to add capacity, up to a maximum possible value of 4096 (i.e., 4 TB).\nThis value must be a positive integer.\nThe parameter is required if replicationSpecs are configured.",
+              "maximum": 4096,
+              "minimum": 0,
+              "type": "integer"
+            },
+            "encryptionAtRestProvider": {
+              "description": "Cloud service provider that offers Encryption at Rest.",
+              "enum": [
+                "AWS",
+                "GCP",
+                "AZURE",
+                "NONE"
+              ],
+              "type": "string"
+            },
+            "labels": {
+              "description": "Collection of key-value pairs that tag and categorize the deployment.\nEach key and value has a maximum length of 255 characters.\nDEPRECATED: Cluster labels are deprecated and will be removed in a future release. We strongly recommend that you use Resource Tags instead.",
+              "items": {
+                "description": "LabelSpec contains key-value pairs that tag and categorize the Cluster/DBUser",
+                "properties": {
+                  "key": {
+                    "description": "Key applied to tag and categorize this component.",
+                    "maxLength": 255,
+                    "type": "string"
+                  },
+                  "value": {
+                    "description": "Value set to the Key applied to tag and categorize this component.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "key",
+                  "value"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "managedNamespaces": {
+              "description": "List that contains information to create a managed namespace in a specified Global Cluster to create.",
+              "items": {
+                "description": "ManagedNamespace represents the information about managed namespace configuration.",
+                "properties": {
+                  "collection": {
+                    "description": "Human-readable label of the collection to manage for this Global Cluster.",
+                    "type": "string"
+                  },
+                  "customShardKey": {
+                    "description": "Database parameter used to divide the collection into shards. Global clusters require a compound shard key.\nThis compound shard key combines the location parameter and the user-selected custom key.",
+                    "type": "string"
+                  },
+                  "db": {
+                    "description": "Human-readable label of the database to manage for this Global Cluster.",
+                    "type": "string"
+                  },
+                  "isCustomShardKeyHashed": {
+                    "description": "Flag that indicates whether someone hashed the custom shard key for the specified collection.\nIf you set this value to false, MongoDB Cloud uses ranged sharding.",
+                    "type": "boolean"
+                  },
+                  "isShardKeyUnique": {
+                    "description": "Flag that indicates whether someone hashed the custom shard key.\nIf this parameter returns false, this cluster uses ranged sharding.",
+                    "type": "boolean"
+                  },
+                  "numInitialChunks": {
+                    "description": "Minimum number of chunks to create initially when sharding an empty collection with a hashed shard key.\nMaximum value is 8192.",
+                    "type": "integer"
+                  },
+                  "presplitHashedZones": {
+                    "description": "Flag that indicates whether MongoDB Cloud should create and distribute initial chunks for an empty or non-existing collection.\nMongoDB Cloud distributes data based on the defined zones and zone ranges for the collection.",
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "collection",
+                  "db"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "mongoDBMajorVersion": {
+              "description": "MongoDB major version of the cluster. Set to the binary major version.",
+              "type": "string"
+            },
+            "mongoDBVersion": {
+              "description": "Version of MongoDB that the cluster runs.",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the advanced deployment as it appears in Atlas.\nAfter Atlas creates the deployment, you can't change its name.\nCan only contain ASCII letters, numbers, and hyphens.",
+              "pattern": "^[a-zA-Z0-9][a-zA-Z0-9-]*$",
+              "type": "string",
+              "x-kubernetes-validations": [
+                {
+                  "message": "Name cannot be modified after deployment creation",
+                  "rule": "self == oldSelf"
+                }
+              ]
+            },
+            "paused": {
+              "description": "Flag that indicates whether the deployment should be paused.",
+              "type": "boolean"
+            },
+            "pitEnabled": {
+              "description": "Flag that indicates the deployment uses continuous cloud backups.",
+              "type": "boolean"
+            },
+            "replicationSpecs": {
+              "description": "Configuration for deployment regions.",
+              "items": {
+                "properties": {
+                  "numShards": {
+                    "description": "Positive integer that specifies the number of shards to deploy in each specified zone.\nIf you set this value to 1 and clusterType is SHARDED, MongoDB Cloud deploys a single-shard sharded cluster.\nDon't create a sharded cluster with a single shard for production environments.\nSingle-shard sharded clusters don't provide the same benefits as multi-shard configurations",
+                    "type": "integer"
+                  },
+                  "regionConfigs": {
+                    "description": "Hardware specifications for nodes set for a given region.\nEach regionConfigs object describes the region's priority in elections and the number and type of MongoDB nodes that MongoDB Cloud deploys to the region.\nEach regionConfigs object must have either an analyticsSpecs object, electableSpecs object, or readOnlySpecs object.\nTenant clusters only require electableSpecs. Dedicated clusters can specify any of these specifications, but must have at least one electableSpecs object within a replicationSpec.\nEvery hardware specification must use the same instanceSize.",
+                    "items": {
+                      "properties": {
+                        "analyticsSpecs": {
+                          "description": "Hardware specifications for analytics nodes deployed in the region.",
+                          "properties": {
+                            "diskIOPS": {
+                              "description": "Disk IOPS setting for AWS storage.\nSet only if you selected AWS as your cloud service provider.",
+                              "format": "int64",
+                              "type": "integer"
+                            },
+                            "ebsVolumeType": {
+                              "description": "Disk IOPS setting for AWS storage.\nSet only if you selected AWS as your cloud service provider.",
+                              "enum": [
+                                "STANDARD",
+                                "PROVISIONED"
+                              ],
+                              "type": "string"
+                            },
+                            "instanceSize": {
+                              "description": "Hardware specification for the instance sizes in this region.\nEach instance size has a default storage and memory capacity.\nThe instance size you select applies to all the data-bearing hosts in your instance size.",
+                              "type": "string"
+                            },
+                            "nodeCount": {
+                              "description": "Number of nodes of the given type for MongoDB Cloud to deploy to the region.",
+                              "type": "integer"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "autoScaling": {
+                          "description": "Options that determine how this cluster handles resource scaling.",
+                          "properties": {
+                            "compute": {
+                              "description": "Collection of settings that configure how a deployment might scale its deployment tier and whether the deployment can scale down.",
+                              "properties": {
+                                "enabled": {
+                                  "description": "Flag that indicates whether deployment tier auto-scaling is enabled. The default is false.",
+                                  "type": "boolean"
+                                },
+                                "maxInstanceSize": {
+                                  "description": "Maximum instance size to which your deployment can automatically scale (such as M40). Atlas requires this parameter if \"autoScaling.compute.enabled\" : true.",
+                                  "type": "string"
+                                },
+                                "minInstanceSize": {
+                                  "description": "Minimum instance size to which your deployment can automatically scale (such as M10). Atlas requires this parameter if \"autoScaling.compute.scaleDownEnabled\" : true.",
+                                  "type": "string"
+                                },
+                                "scaleDownEnabled": {
+                                  "description": "Flag that indicates whether the deployment tier may scale down. Atlas requires this parameter if \"autoScaling.compute.enabled\" : true.",
+                                  "type": "boolean"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "diskGB": {
+                              "description": "Flag that indicates whether disk auto-scaling is enabled. The default is true.",
+                              "properties": {
+                                "enabled": {
+                                  "description": "Flag that indicates whether this cluster enables disk auto-scaling.\nThe maximum memory allowed for the selected cluster tier and the oplog size can limit storage auto-scaling.",
+                                  "type": "boolean"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "backingProviderName": {
+                          "description": "Cloud service provider on which the host for a multi-tenant deployment is provisioned.\nThis setting only works when \"providerName\" : \"TENANT\" and \"providerSetting.instanceSizeName\" : M2 or M5.\nOtherwise, it should be equal to the \"providerName\" value.",
+                          "enum": [
+                            "AWS",
+                            "GCP",
+                            "AZURE"
+                          ],
+                          "type": "string"
+                        },
+                        "electableSpecs": {
+                          "description": "Hardware specifications for nodes deployed in the region.",
+                          "properties": {
+                            "diskIOPS": {
+                              "description": "Disk IOPS setting for AWS storage.\nSet only if you selected AWS as your cloud service provider.",
+                              "format": "int64",
+                              "type": "integer"
+                            },
+                            "ebsVolumeType": {
+                              "description": "Disk IOPS setting for AWS storage.\nSet only if you selected AWS as your cloud service provider.",
+                              "enum": [
+                                "STANDARD",
+                                "PROVISIONED"
+                              ],
+                              "type": "string"
+                            },
+                            "instanceSize": {
+                              "description": "Hardware specification for the instance sizes in this region.\nEach instance size has a default storage and memory capacity.\nThe instance size you select applies to all the data-bearing hosts in your instance size.",
+                              "type": "string"
+                            },
+                            "nodeCount": {
+                              "description": "Number of nodes of the given type for MongoDB Cloud to deploy to the region.",
+                              "type": "integer"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "priority": {
+                          "description": "Precedence is given to this region when a primary election occurs.\nIf your regionConfigs has only readOnlySpecs, analyticsSpecs, or both, set this value to 0.\nIf you have multiple regionConfigs objects (your cluster is multi-region or multi-cloud), they must have priorities in descending order.\nThe highest priority is 7",
+                          "type": "integer"
+                        },
+                        "providerName": {
+                          "enum": [
+                            "AWS",
+                            "GCP",
+                            "AZURE",
+                            "TENANT",
+                            "SERVERLESS"
+                          ],
+                          "type": "string"
+                        },
+                        "readOnlySpecs": {
+                          "description": "Hardware specifications for read only nodes deployed in the region.",
+                          "properties": {
+                            "diskIOPS": {
+                              "description": "Disk IOPS setting for AWS storage.\nSet only if you selected AWS as your cloud service provider.",
+                              "format": "int64",
+                              "type": "integer"
+                            },
+                            "ebsVolumeType": {
+                              "description": "Disk IOPS setting for AWS storage.\nSet only if you selected AWS as your cloud service provider.",
+                              "enum": [
+                                "STANDARD",
+                                "PROVISIONED"
+                              ],
+                              "type": "string"
+                            },
+                            "instanceSize": {
+                              "description": "Hardware specification for the instance sizes in this region.\nEach instance size has a default storage and memory capacity.\nThe instance size you select applies to all the data-bearing hosts in your instance size.",
+                              "type": "string"
+                            },
+                            "nodeCount": {
+                              "description": "Number of nodes of the given type for MongoDB Cloud to deploy to the region.",
+                              "type": "integer"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "regionName": {
+                          "description": "Physical location of your MongoDB deployment.\nThe region you choose can affect network latency for clients accessing your databases.",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
+                  "zoneName": {
+                    "description": "Human-readable label that identifies the zone in a Global Cluster.",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "rootCertType": {
+              "description": "Root Certificate Authority that MongoDB Atlas cluster uses.",
+              "type": "string"
+            },
+            "searchIndexes": {
+              "description": "An array of SearchIndex objects with fields that describe the search index.",
+              "items": {
+                "description": "SearchIndex is the CRD to configure part of the Atlas Search Index.",
+                "properties": {
+                  "DBName": {
+                    "description": "Human-readable label that identifies the database that contains the collection with one or more Atlas Search indexes.",
+                    "type": "string"
+                  },
+                  "collectionName": {
+                    "description": "Human-readable label that identifies the collection that contains one or more Atlas Search indexes.",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "Human-readable label that identifies this index. Must be unique for a deployment.",
+                    "type": "string"
+                  },
+                  "search": {
+                    "description": "Atlas search index configuration.",
+                    "properties": {
+                      "mappings": {
+                        "description": "Index specifications for the collection's fields.",
+                        "properties": {
+                          "dynamic": {
+                            "description": "Indicates whether the index uses static, default dynamic, or configurable dynamic mappings.\nSet to **true** to enable dynamic mapping with default type set or define object to specify the name of the configured type sets for dynamic mapping.\nIf you specify configurable dynamic mappings, you must define the referred type sets in the **typeSets** field.\nSet to **false** to use only static mappings through **mappings.fields**.\nSee https://www.mongodb.com/docs/atlas/atlas-search/define-field-mappings/#configure-a-typeset for more details.",
+                            "x-kubernetes-preserve-unknown-fields": true
+                          },
+                          "fields": {
+                            "description": "One or more field specifications for the Atlas Search index. Required if mapping.dynamic is omitted or set to false.",
+                            "x-kubernetes-preserve-unknown-fields": true
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "searchConfigurationRef": {
+                        "description": "A reference to the AtlasSearchIndexConfig custom resource.",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the Kubernetes Resource",
+                            "type": "string"
+                          },
+                          "namespace": {
+                            "description": "Namespace of the Kubernetes Resource",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "synonyms": {
+                        "description": "Rule sets that map words to their synonyms in this index.",
+                        "items": {
+                          "description": "Synonym represents \"Synonym\" type of Atlas Search Index.",
+                          "properties": {
+                            "analyzer": {
+                              "description": "Specific pre-defined method chosen to apply to the synonyms to be searched.",
+                              "enum": [
+                                "lucene.standard",
+                                "lucene.simple",
+                                "lucene.whitespace",
+                                "lucene.keyword",
+                                "lucene.arabic",
+                                "lucene.armenian",
+                                "lucene.basque",
+                                "lucene.bengali",
+                                "lucene.brazilian",
+                                "lucene.bulgarian",
+                                "lucene.catalan",
+                                "lucene.chinese",
+                                "lucene.cjk",
+                                "lucene.czech",
+                                "lucene.danish",
+                                "lucene.dutch",
+                                "lucene.english",
+                                "lucene.finnish",
+                                "lucene.french",
+                                "lucene.galician",
+                                "lucene.german",
+                                "lucene.greek",
+                                "lucene.hindi",
+                                "lucene.hungarian",
+                                "lucene.indonesian",
+                                "lucene.irish",
+                                "lucene.italian",
+                                "lucene.japanese",
+                                "lucene.korean",
+                                "lucene.kuromoji",
+                                "lucene.latvian",
+                                "lucene.lithuanian",
+                                "lucene.morfologik",
+                                "lucene.nori",
+                                "lucene.norwegian",
+                                "lucene.persian",
+                                "lucene.portuguese",
+                                "lucene.romanian",
+                                "lucene.russian",
+                                "lucene.smartcn",
+                                "lucene.sorani",
+                                "lucene.spanish",
+                                "lucene.swedish",
+                                "lucene.thai",
+                                "lucene.turkish",
+                                "lucene.ukrainian"
+                              ],
+                              "type": "string"
+                            },
+                            "name": {
+                              "description": "Human-readable label that identifies the synonym definition. Each name must be unique within the same index definition.",
+                              "type": "string"
+                            },
+                            "source": {
+                              "description": "Data set that stores the mapping one or more words map to one or more synonyms of those words.",
+                              "properties": {
+                                "collection": {
+                                  "description": "Human-readable label that identifies the MongoDB collection that stores words and their applicable synonyms.",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "collection"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": [
+                            "analyzer",
+                            "name",
+                            "source"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "required": [
+                      "mappings",
+                      "searchConfigurationRef"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": {
+                    "description": "Type of the index.",
+                    "enum": [
+                      "search",
+                      "vectorSearch"
+                    ],
+                    "type": "string"
+                  },
+                  "vectorSearch": {
+                    "description": "Atlas vector search index configuration.",
+                    "properties": {
+                      "fields": {
+                        "description": "Array of JSON objects. See examples https://dochub.mongodb.org/core/avs-vector-type",
+                        "x-kubernetes-preserve-unknown-fields": true
+                      }
+                    },
+                    "required": [
+                      "fields"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "required": [
+                  "DBName",
+                  "collectionName",
+                  "name",
+                  "type"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "searchNodes": {
+              "description": "Settings for Search Nodes for the cluster. Currently, at most one search node configuration may be defined.",
+              "items": {
+                "properties": {
+                  "instanceSize": {
+                    "description": "Hardware specification for the Search Node instance sizes.\nSee https://www.mongodb.com/docs/api/doc/atlas-admin-api-v2/operation/operation-creategroupclustersearchdeployment#operation-creategroupclustersearchdeployment-body-application-vnd-atlas-2024-05-30-json-specs-instancesize for available values",
+                    "type": "string"
+                  },
+                  "nodeCount": {
+                    "description": "Number of Search Nodes in the cluster.",
+                    "maximum": 32,
+                    "minimum": 2,
+                    "type": "integer"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "maxItems": 1,
+              "type": "array"
+            },
+            "tags": {
+              "description": "Key-value pairs for resource tagging.",
+              "items": {
+                "description": "TagSpec holds a key-value pair for resource tagging on this deployment.",
+                "properties": {
+                  "key": {
+                    "description": "Constant that defines the set of the tag.",
+                    "maxLength": 255,
+                    "minLength": 1,
+                    "pattern": "^[a-zA-Z0-9][a-zA-Z0-9 @_.+`;`-]*$",
+                    "type": "string"
+                  },
+                  "value": {
+                    "description": "Variable that belongs to the set of the tag.",
+                    "maxLength": 255,
+                    "minLength": 1,
+                    "pattern": "^[a-zA-Z0-9][a-zA-Z0-9 @_.+`;`-]*$",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "key",
+                  "value"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "maxItems": 50,
+              "type": "array"
+            },
+            "terminationProtectionEnabled": {
+              "default": false,
+              "description": "Flag that indicates whether termination protection is enabled on the cluster. If set to true, MongoDB Cloud won't delete the cluster. If set to false, MongoDB Cloud will delete the cluster.",
+              "type": "boolean"
+            },
+            "versionReleaseSystem": {
+              "description": "Method by which the cluster maintains the MongoDB versions.\nIf value is CONTINUOUS, you must not specify mongoDBMajorVersion.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "externalProjectRef": {
+          "description": "externalProjectRef holds the parent Atlas project ID.\nMutually exclusive with the \"projectRef\" field.",
+          "properties": {
+            "id": {
+              "description": "ID is the Atlas project ID.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "id"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "flexSpec": {
+          "description": "Configuration for the Flex cluster API. https://www.mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Flex-Clusters",
+          "properties": {
+            "name": {
+              "description": "Human-readable label that identifies the instance.",
+              "type": "string"
+            },
+            "providerSettings": {
+              "description": "Group of cloud provider settings that configure the provisioned MongoDB flex cluster.",
+              "properties": {
+                "backingProviderName": {
+                  "description": "Cloud service provider on which MongoDB Atlas provisions the flex cluster.",
+                  "enum": [
+                    "AWS",
+                    "GCP",
+                    "AZURE"
+                  ],
+                  "type": "string",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "Backing Provider cannot be modified after cluster creation",
+                      "rule": "self == oldSelf"
+                    }
+                  ]
+                },
+                "regionName": {
+                  "description": "Human-readable label that identifies the geographic location of your MongoDB flex cluster.\nThe region you choose can affect network latency for clients accessing your databases.",
+                  "type": "string",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "Region Name cannot be modified after cluster creation",
+                      "rule": "self == oldSelf"
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "backingProviderName",
+                "regionName"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "tags": {
+              "description": "List that contains key-value pairs between 1 and 255 characters in length for tagging and categorizing the instance.",
+              "items": {
+                "description": "TagSpec holds a key-value pair for resource tagging on this deployment.",
+                "properties": {
+                  "key": {
+                    "description": "Constant that defines the set of the tag.",
+                    "maxLength": 255,
+                    "minLength": 1,
+                    "pattern": "^[a-zA-Z0-9][a-zA-Z0-9 @_.+`;`-]*$",
+                    "type": "string"
+                  },
+                  "value": {
+                    "description": "Variable that belongs to the set of the tag.",
+                    "maxLength": 255,
+                    "minLength": 1,
+                    "pattern": "^[a-zA-Z0-9][a-zA-Z0-9 @_.+`;`-]*$",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "key",
+                  "value"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "maxItems": 50,
+              "type": "array"
+            },
+            "terminationProtectionEnabled": {
+              "default": false,
+              "description": "Flag that indicates whether termination protection is enabled on the cluster.\nIf set to true, MongoDB Cloud won't delete the cluster. If set to false, MongoDB Cloud will delete the cluster.",
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "name",
+            "providerSettings"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "processArgs": {
+          "description": "ProcessArgs allows modification of Advanced Configuration Options.",
+          "properties": {
+            "defaultReadConcern": {
+              "description": "String that indicates the default level of acknowledgment requested from MongoDB for read operations set for this cluster.",
+              "type": "string"
+            },
+            "defaultWriteConcern": {
+              "description": "String that indicates the default level of acknowledgment requested from MongoDB for write operations set for this cluster.",
+              "type": "string"
+            },
+            "failIndexKeyTooLong": {
+              "description": "Flag that indicates whether to fail the operation and return an error when you insert or update documents where all indexed entries exceed 1024 bytes.\nIf you set this to false, mongod writes documents that exceed this limit, but doesn't index them.",
+              "type": "boolean"
+            },
+            "javascriptEnabled": {
+              "description": "Flag that indicates whether the cluster allows execution of operations that perform server-side executions of JavaScript.",
+              "type": "boolean"
+            },
+            "minimumEnabledTlsProtocol": {
+              "description": "String that indicates the minimum TLS version that the cluster accepts for incoming connections.\nClusters using TLS 1.0 or 1.1 should consider setting TLS 1.2 as the minimum TLS protocol version.",
+              "type": "string"
+            },
+            "noTableScan": {
+              "description": "Flag that indicates whether the cluster disables executing any query that requires a collection scan to return results.",
+              "type": "boolean"
+            },
+            "oplogMinRetentionHours": {
+              "description": "Minimum retention window for cluster's oplog expressed in hours. A value of null indicates that the cluster uses the default minimum oplog window that MongoDB Cloud calculates.",
+              "type": "string"
+            },
+            "oplogSizeMB": {
+              "description": "Number that indicates the storage limit of a cluster's oplog expressed in megabytes.\nA value of null indicates that the cluster uses the default oplog size that Atlas calculates.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "sampleRefreshIntervalBIConnector": {
+              "description": "Number that indicates the documents per database to sample when gathering schema information.",
+              "format": "int64",
+              "type": "integer"
+            },
+            "sampleSizeBIConnector": {
+              "description": "Number that indicates the interval in seconds at which the mongosqld process re-samples data to create its relational schema.",
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "projectRef": {
+          "description": "projectRef is a reference to the parent AtlasProject resource.\nMutually exclusive with the \"externalProjectRef\" field.",
+          "properties": {
+            "name": {
+              "description": "Name of the Kubernetes Resource",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "Namespace of the Kubernetes Resource",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "serverlessSpec": {
+          "description": "Configuration for the serverless deployment API. https://www.mongodb.com/docs/atlas/reference/api/serverless-instances/\nDEPRECATED: Serverless instances are deprecated. See https://dochub.mongodb.org/core/atlas-flex-migration for details.",
+          "properties": {
+            "backupOptions": {
+              "description": "Serverless Backup Options",
+              "properties": {
+                "serverlessContinuousBackupEnabled": {
+                  "default": true,
+                  "description": "ServerlessContinuousBackupEnabled indicates whether the cluster uses continuous cloud backups.\nDEPRECATED: Serverless instances are deprecated, and no longer support continuous backup. See https://dochub.mongodb.org/core/atlas-flex-migration for details.",
+                  "type": "boolean"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "name": {
+              "description": "Name of the serverless deployment as it appears in Atlas.\nAfter Atlas creates the deployment, you can't change its name.\nCan only contain ASCII letters, numbers, and hyphens.",
+              "pattern": "^[a-zA-Z0-9][a-zA-Z0-9-]*$",
+              "type": "string"
+            },
+            "privateEndpoints": {
+              "description": "List that contains the private endpoint configurations for the Serverless instance.\nDEPRECATED: Serverless private endpoints are deprecated. See https://dochub.mongodb.org/core/atlas-flex-migration for details.",
+              "items": {
+                "description": "ServerlessPrivateEndpoint configures private endpoints for the Serverless instances.\nDEPRECATED: Serverless private endpoints are deprecated. See https://dochub.mongodb.org/core/atlas-flex-migration for details.",
+                "properties": {
+                  "cloudProviderEndpointID": {
+                    "description": "CloudProviderEndpointID is the identifier of the cloud provider endpoint.",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "Name is the name of the Serverless PrivateLink Service. Should be unique.",
+                    "type": "string"
+                  },
+                  "privateEndpointIpAddress": {
+                    "description": "PrivateEndpointIPAddress is the IPv4 address of the private endpoint in your Azure VNet that someone added to this private endpoint service.",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "providerSettings": {
+              "description": "Configuration for the provisioned hosts on which MongoDB runs. The available options are specific to the cloud service provider.",
+              "properties": {
+                "autoScaling": {
+                  "description": "Range of instance sizes to which your deployment can scale.\nDEPRECATED: The value of this field doesn't take any effect.",
+                  "properties": {
+                    "autoIndexingEnabled": {
+                      "description": "Flag that indicates whether autopilot mode for Performance Advisor is enabled.\nThe default is false.\nDEPRECATED: This flag is no longer supported.",
+                      "type": "boolean"
+                    },
+                    "compute": {
+                      "description": "Collection of settings that configure how a deployment might scale its deployment tier and whether the deployment can scale down.",
+                      "properties": {
+                        "enabled": {
+                          "description": "Flag that indicates whether deployment tier auto-scaling is enabled. The default is false.",
+                          "type": "boolean"
+                        },
+                        "maxInstanceSize": {
+                          "description": "Maximum instance size to which your deployment can automatically scale (such as M40). Atlas requires this parameter if \"autoScaling.compute.enabled\" : true.",
+                          "type": "string"
+                        },
+                        "minInstanceSize": {
+                          "description": "Minimum instance size to which your deployment can automatically scale (such as M10). Atlas requires this parameter if \"autoScaling.compute.scaleDownEnabled\" : true.",
+                          "type": "string"
+                        },
+                        "scaleDownEnabled": {
+                          "description": "Flag that indicates whether the deployment tier may scale down. Atlas requires this parameter if \"autoScaling.compute.enabled\" : true.",
+                          "type": "boolean"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "diskGBEnabled": {
+                      "description": "Flag that indicates whether disk auto-scaling is enabled. The default is true.",
+                      "type": "boolean"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "backingProviderName": {
+                  "description": "Cloud service provider on which the host for a multi-tenant deployment is provisioned.\nThis setting only works when \"providerSetting.providerName\" : \"TENANT\" and \"providerSetting.instanceSizeName\" : M2 or M5.",
+                  "enum": [
+                    "AWS",
+                    "GCP",
+                    "AZURE"
+                  ],
+                  "type": "string"
+                },
+                "diskIOPS": {
+                  "description": "Disk IOPS setting for AWS storage.\nSet only if you selected AWS as your cloud service provider.\nDEPRECATED: The value of this field doesn't take any effect.",
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "diskTypeName": {
+                  "description": "Type of disk if you selected Azure as your cloud service provider.\nDEPRECATED: The value of this field doesn't take any effect.",
+                  "type": "string"
+                },
+                "encryptEBSVolume": {
+                  "description": "Flag that indicates whether the Amazon EBS encryption feature encrypts the host's root volume for both data at rest within the volume and for data moving between the volume and the deployment.\nDEPRECATED: The value of this field doesn't take any effect.",
+                  "type": "boolean"
+                },
+                "instanceSizeName": {
+                  "description": "Atlas provides different deployment tiers, each with a default storage capacity and RAM size. The deployment you select is used for all the data-bearing hosts in your deployment tier.\nDEPRECATED: The value of this field doesn't take any effect.",
+                  "type": "string"
+                },
+                "providerName": {
+                  "description": "Cloud service provider on which Atlas provisions the hosts.",
+                  "enum": [
+                    "AWS",
+                    "GCP",
+                    "AZURE",
+                    "TENANT",
+                    "SERVERLESS"
+                  ],
+                  "type": "string"
+                },
+                "regionName": {
+                  "description": "Physical location of your MongoDB deployment.\nThe region you choose can affect network latency for clients accessing your databases.",
+                  "type": "string"
+                },
+                "volumeType": {
+                  "description": "Disk IOPS setting for AWS storage.\nSet only if you selected AWS as your cloud service provider.\nDEPRECATED: The value of this field doesn't take any effect.",
+                  "enum": [
+                    "STANDARD",
+                    "PROVISIONED"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "providerName"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "tags": {
+              "description": "Key-value pairs for resource tagging.",
+              "items": {
+                "description": "TagSpec holds a key-value pair for resource tagging on this deployment.",
+                "properties": {
+                  "key": {
+                    "description": "Constant that defines the set of the tag.",
+                    "maxLength": 255,
+                    "minLength": 1,
+                    "pattern": "^[a-zA-Z0-9][a-zA-Z0-9 @_.+`;`-]*$",
+                    "type": "string"
+                  },
+                  "value": {
+                    "description": "Variable that belongs to the set of the tag.",
+                    "maxLength": 255,
+                    "minLength": 1,
+                    "pattern": "^[a-zA-Z0-9][a-zA-Z0-9 @_.+`;`-]*$",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "key",
+                  "value"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "maxItems": 50,
+              "type": "array"
+            },
+            "terminationProtectionEnabled": {
+              "default": false,
+              "description": "Flag that indicates whether termination protection is enabled on the cluster. If set to true, MongoDB Cloud won't delete the cluster. If set to false, MongoDB Cloud will delete the cluster.",
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "name",
+            "providerSettings"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "upgradeToDedicated": {
+          "description": " upgradeToDedicated, when set to true, triggers the migration from a Flex to a\n Dedicated cluster. The user MUST provide the new dedicated cluster configuration.\n This flag is ignored if the cluster is already dedicated.",
+          "type": "boolean"
+        }
+      },
+      "type": "object",
+      "x-kubernetes-validations": [
+        {
+          "message": "must define only one project reference through externalProjectRef or projectRef",
+          "rule": "(has(self.externalProjectRef) && !has(self.projectRef)) || (!has(self.externalProjectRef) && has(self.projectRef))"
+        },
+        {
+          "message": "must define a local connection secret when referencing an external project",
+          "rule": "(has(self.externalProjectRef) && has(self.connectionSecret)) || !has(self.externalProjectRef)"
+        },
+        {
+          "fieldPath": ".serverlessSpec",
+          "message": "serverlessSpec cannot be added - serverless instances are deprecated",
+          "optionalOldSelf": true,
+          "rule": "!has(self.serverlessSpec) || (oldSelf.hasValue() && oldSelf.value().serverlessSpec != null)"
+        }
+      ],
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "AtlasDeploymentStatus defines the observed state of AtlasDeployment.",
+      "properties": {
+        "conditions": {
+          "description": "Conditions is the list of statuses showing the current state of the Atlas Custom Resource",
+          "items": {
+            "description": "Condition describes the state of an Atlas Custom Resource at a certain point.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another.\nRepresented in ISO 8601 format.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A message providing details about the transition.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition; one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of Atlas Custom Resource condition.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "connectionStrings": {
+          "description": "ConnectionStrings is a set of connection strings that your applications use to connect to this cluster.",
+          "properties": {
+            "private": {
+              "description": "Network-peering-endpoint-aware mongodb:// connection strings for each interface VPC endpoint you configured to connect to this cluster.\nAtlas returns this parameter only if you created a network peering connection to this cluster.",
+              "type": "string"
+            },
+            "privateEndpoint": {
+              "description": "Private endpoint connection strings.\nEach object describes the connection strings you can use to connect to this cluster through a private endpoint.\nAtlas returns this parameter only if you deployed a private endpoint to all regions to which you deployed this cluster's nodes.",
+              "items": {
+                "description": "PrivateEndpoint connection strings. Each object describes the connection strings\nyou can use to connect to this cluster through a private endpoint.\nAtlas returns this parameter only if you deployed a private endpoint to all regions\nto which you deployed this cluster's nodes.",
+                "properties": {
+                  "connectionString": {
+                    "description": "Private-endpoint-aware mongodb:// connection string for this private endpoint.",
+                    "type": "string"
+                  },
+                  "endpoints": {
+                    "description": "Private endpoint through which you connect to Atlas when you use connectionStrings.privateEndpoint[n].connectionString or connectionStrings.privateEndpoint[n].srvConnectionString.",
+                    "items": {
+                      "description": "Endpoint through which you connect to Atlas",
+                      "properties": {
+                        "endpointId": {
+                          "description": "Unique identifier of the private endpoint.",
+                          "type": "string"
+                        },
+                        "ip": {
+                          "description": "Private IP address of the private endpoint network interface you created in your Azure VNet.",
+                          "type": "string"
+                        },
+                        "providerName": {
+                          "description": "Cloud provider to which you deployed the private endpoint. Atlas returns AWS or AZURE.",
+                          "type": "string"
+                        },
+                        "region": {
+                          "description": "Region to which you deployed the private endpoint.",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
+                  "srvConnectionString": {
+                    "description": "Private-endpoint-aware mongodb+srv:// connection string for this private endpoint.",
+                    "type": "string"
+                  },
+                  "srvShardOptimizedConnectionString": {
+                    "description": "Private endpoint-aware connection string optimized for sharded clusters that uses the `mongodb+srv://` protocol to connect to MongoDB Cloud through a private endpoint.",
+                    "type": "string"
+                  },
+                  "type": {
+                    "description": "Type of MongoDB process that you connect to with the connection strings\n\nAtlas returns:\n\n\u2022 MONGOD for replica sets, or\n\n\u2022 MONGOS for sharded clusters",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "privateSrv": {
+              "description": "Network-peering-endpoint-aware mongodb+srv:// connection strings for each interface VPC endpoint you configured to connect to this cluster.\nAtlas returns this parameter only if you created a network peering connection to this cluster.\nUse this URI format if your driver supports it. If it doesn't, use connectionStrings.private.",
+              "type": "string"
+            },
+            "standard": {
+              "description": "Public mongodb:// connection string for this cluster.",
+              "type": "string"
+            },
+            "standardSrv": {
+              "description": "Public mongodb+srv:// connection string for this cluster.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "customZoneMapping": {
+          "description": "List that contains key value pairs to map zones to geographic regions.\nThese pairs map an ISO 3166-1a2 location code, with an ISO 3166-2 subdivision code when possible, to a unique 24-hexadecimal string that identifies the custom zone.",
+          "properties": {
+            "customZoneMapping": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "List that contains key value pairs to map zones to geographic regions.\nThese pairs map an ISO 3166-1a2 location code, with an ISO 3166-2 subdivision code when possible, to a unique 24-hexadecimal string that identifies the custom zone.",
+              "type": "object"
+            },
+            "zoneMappingErrMessage": {
+              "description": "Error message for failed Custom Zone Mapping.",
+              "type": "string"
+            },
+            "zoneMappingState": {
+              "description": "Status of the Custom Zone Mapping.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "managedNamespaces": {
+          "description": "List that contains a namespace for a Global Cluster. MongoDB Atlas manages this cluster.",
+          "items": {
+            "properties": {
+              "collection": {
+                "description": "Human-readable label of the collection to manage for this Global Cluster.",
+                "type": "string"
+              },
+              "customShardKey": {
+                "description": "Database parameter used to divide the collection into shards. Global clusters require a compound shard key.\nThis compound shard key combines the location parameter and the user-selected custom key.",
+                "type": "string"
+              },
+              "db": {
+                "description": "Human-readable label of the database to manage for this Global Cluster.",
+                "type": "string"
+              },
+              "errMessage": {
+                "description": "Error message for a failed Managed Namespace.",
+                "type": "string"
+              },
+              "isCustomShardKeyHashed": {
+                "description": "Flag that indicates whether someone hashed the custom shard key for the specified collection.\nIf you set this value to false, MongoDB Atlas uses ranged sharding.",
+                "type": "boolean"
+              },
+              "isShardKeyUnique": {
+                "description": "Flag that indicates whether someone hashed the custom shard key. If this parameter returns false, this cluster uses ranged sharding.",
+                "type": "boolean"
+              },
+              "numInitialChunks": {
+                "description": "Minimum number of chunks to create initially when sharding an empty collection with a hashed shard key.",
+                "type": "integer"
+              },
+              "presplitHashedZones": {
+                "description": "Flag that indicates whether MongoDB Cloud should create and distribute initial chunks for an empty or non-existing collection.\nMongoDB Atlas distributes data based on the defined zones and zone ranges for the collection.",
+                "type": "boolean"
+              },
+              "status": {
+                "description": "Status of the Managed Namespace.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "collection",
+              "db"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "mongoDBVersion": {
+          "description": "MongoDBVersion is the version of MongoDB the cluster runs, in <major version>.<minor version> format.",
+          "type": "string"
+        },
+        "mongoURIUpdated": {
+          "description": "MongoURIUpdated is a timestamp in ISO 8601 date and time format in UTC when the connection string was last updated.\nThe connection string changes if you update any of the other values.",
+          "type": "string"
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration indicates the generation of the resource specification of which the Atlas Operator is aware.\nThe Atlas Operator updates this field to the value of 'metadata.generation' as soon as it starts reconciliation of the resource.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "replicaSets": {
+          "description": "Details that explain how MongoDB Cloud replicates data on the specified MongoDB database.\nThis array has one object per shard representing node configurations in each shard. For replica sets there is only one object representing node configurations.",
+          "items": {
+            "properties": {
+              "id": {
+                "description": "Unique 24-hexadecimal digit string that identifies the replication object for a shard in a Cluster.",
+                "type": "string"
+              },
+              "zoneName": {
+                "description": "Human-readable label that describes the zone this shard belongs to in a Global Cluster.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "id"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "searchIndexes": {
+          "description": "SearchIndexes contains a list of search indexes statuses configured for a project.",
+          "items": {
+            "properties": {
+              "ID": {
+                "description": "Unique 24-hexadecimal digit string that identifies this Atlas Search index.",
+                "type": "string"
+              },
+              "message": {
+                "description": "Details on the status of the search index.",
+                "type": "string"
+              },
+              "name": {
+                "description": "Human-readable label that identifies this index.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Condition of the search index.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "ID",
+              "message",
+              "name",
+              "status"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "serverlessPrivateEndpoints": {
+          "description": "ServerlessPrivateEndpoints contains a list of private endpoints configured for the serverless deployment.",
+          "items": {
+            "properties": {
+              "_id": {
+                "description": "ID is the identifier of the Serverless PrivateLink Service.",
+                "type": "string"
+              },
+              "cloudProviderEndpointId": {
+                "description": "CloudProviderEndpointID is the identifier of the cloud provider endpoint.",
+                "type": "string"
+              },
+              "endpointServiceName": {
+                "description": "EndpointServiceName is the name of the PrivateLink endpoint service in AWS. Returns null while the endpoint service is being created.",
+                "type": "string"
+              },
+              "errorMessage": {
+                "description": "ErrorMessage is the error message if the Serverless PrivateLink Service failed to create or connect.",
+                "type": "string"
+              },
+              "name": {
+                "description": "Name is the name of the Serverless PrivateLink Service. Should be unique.",
+                "type": "string"
+              },
+              "privateEndpointIpAddress": {
+                "description": "PrivateEndpointIPAddress is the IPv4 address of the private endpoint in your Azure VNet that someone added to this private endpoint service.",
+                "type": "string"
+              },
+              "privateLinkServiceResourceId": {
+                "description": "PrivateLinkServiceResourceID is the root-relative path that identifies the Azure Private Link Service that MongoDB Cloud manages. MongoDB Cloud returns null while it creates the endpoint service.",
+                "type": "string"
+              },
+              "providerName": {
+                "description": "ProviderName is human-readable label that identifies the cloud provider. Values include AWS or AZURE.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the AWS Serverless PrivateLink connection.",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "stateName": {
+          "description": "StateName is the current state of the cluster.\nThe possible states are: IDLE, CREATING, UPDATING, DELETING, DELETED, REPAIRING",
+          "type": "string"
+        }
+      },
+      "required": [
+        "conditions"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/atlas.mongodb.com/atlasfederatedauth_v1.json
+++ b/atlas.mongodb.com/atlasfederatedauth_v1.json
@@ -1,0 +1,182 @@
+{
+  "description": "AtlasFederatedAuth is the Schema for the Atlasfederatedauth API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "AtlasFederatedAuthSpec defines the target state of AtlasFederatedAuth.",
+      "properties": {
+        "connectionSecretRef": {
+          "description": "Connection secret with API credentials for configuring the federation.\nThese credentials must have OrganizationOwner permissions.",
+          "properties": {
+            "name": {
+              "description": "Name of the Kubernetes Resource",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "Namespace of the Kubernetes Resource",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "dataAccessIdentityProviders": {
+          "description": "The collection of unique ids representing the identity providers that can be used for data access in this organization.\nCurrently connected data access identity providers missing from this field will be disconnected.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "domainAllowList": {
+          "description": "Approved domains that restrict users who can join the organization based on their email address.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "domainRestrictionEnabled": {
+          "default": false,
+          "description": "Prevent users in the federation from accessing organizations outside the federation, and creating new organizations.\nThis option applies to the entire federation.\nSee more information at https://www.mongodb.com/docs/atlas/security/federation-advanced-options/#restrict-user-membership-to-the-federation",
+          "type": "boolean"
+        },
+        "enabled": {
+          "default": false,
+          "type": "boolean"
+        },
+        "postAuthRoleGrants": {
+          "description": "Atlas roles that are granted to a user in this organization after authenticating.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "roleMappings": {
+          "description": "Map IDP groups to Atlas roles.",
+          "items": {
+            "description": "RoleMapping maps an external group from an identity provider to roles within Atlas.",
+            "properties": {
+              "externalGroupName": {
+                "description": "ExternalGroupName is the name of the IDP group to which this mapping applies.",
+                "maxLength": 200,
+                "minLength": 1,
+                "type": "string"
+              },
+              "roleAssignments": {
+                "description": "RoleAssignments define the roles within projects that should be given to members of the group.",
+                "items": {
+                  "properties": {
+                    "projectName": {
+                      "description": "The Atlas project in the same org in which the role should be given.",
+                      "type": "string"
+                    },
+                    "role": {
+                      "description": "The role in Atlas that should be given to group members.",
+                      "enum": [
+                        "ORG_MEMBER",
+                        "ORG_READ_ONLY",
+                        "ORG_BILLING_ADMIN",
+                        "ORG_GROUP_CREATOR",
+                        "ORG_OWNER",
+                        "ORG_BILLING_READ_ONLY",
+                        "GROUP_OWNER",
+                        "GROUP_READ_ONLY",
+                        "GROUP_DATA_ACCESS_ADMIN",
+                        "GROUP_DATA_ACCESS_READ_ONLY",
+                        "GROUP_DATA_ACCESS_READ_WRITE",
+                        "GROUP_CLUSTER_MANAGER",
+                        "GROUP_SEARCH_INDEX_EDITOR",
+                        "GROUP_DATABASE_ACCESS_ADMIN",
+                        "GROUP_BACKUP_MANAGER",
+                        "GROUP_STREAM_PROCESSING_OWNER",
+                        "ORG_STREAM_PROCESSING_ADMIN",
+                        "GROUP_OBSERVABILITY_VIEWER"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "ssoDebugEnabled": {
+          "default": false,
+          "type": "boolean"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "AtlasFederatedAuthStatus defines the observed state of AtlasFederatedAuth.",
+      "properties": {
+        "conditions": {
+          "description": "Conditions is the list of statuses showing the current state of the Atlas Custom Resource",
+          "items": {
+            "description": "Condition describes the state of an Atlas Custom Resource at a certain point.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another.\nRepresented in ISO 8601 format.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A message providing details about the transition.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition; one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of Atlas Custom Resource condition.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration indicates the generation of the resource specification of which the Atlas Operator is aware.\nThe Atlas Operator updates this field to the value of 'metadata.generation' as soon as it starts reconciliation of the resource.",
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "conditions"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/atlas.mongodb.com/atlasipaccesslist_v1.json
+++ b/atlas.mongodb.com/atlasipaccesslist_v1.json
@@ -1,0 +1,194 @@
+{
+  "description": "AtlasIPAccessList is the Schema for the atlasipaccesslists API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "AtlasIPAccessListSpec defines the target state of AtlasIPAccessList.",
+      "properties": {
+        "connectionSecret": {
+          "description": "Name of the secret containing Atlas API private and public keys.",
+          "properties": {
+            "name": {
+              "description": "Name of the resource being referred to\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "entries": {
+          "description": "Entries is the list of IP Access to be managed.",
+          "items": {
+            "properties": {
+              "awsSecurityGroup": {
+                "description": "Unique identifier of AWS security group in this access list entry.",
+                "type": "string"
+              },
+              "cidrBlock": {
+                "description": "Range of IP addresses in CIDR notation in this access list entry.",
+                "type": "string"
+              },
+              "comment": {
+                "description": "Comment associated with this access list entry.",
+                "type": "string"
+              },
+              "deleteAfterDate": {
+                "description": "Date and time after which Atlas deletes the temporary access list entry.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "ipAddress": {
+                "description": "Entry using an IP address in this access list entry.",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "x-kubernetes-validations": [
+              {
+                "message": "Only one of ipAddress, cidrBlock, or awsSecurityGroup may be set.",
+                "rule": "!(has(self.ipAddress) && (has(self.cidrBlock) || has(self.awsSecurityGroup))) && !(has(self.cidrBlock) && has(self.awsSecurityGroup))"
+              }
+            ],
+            "additionalProperties": false
+          },
+          "minItems": 1,
+          "type": "array"
+        },
+        "externalProjectRef": {
+          "description": "externalProjectRef holds the parent Atlas project ID.\nMutually exclusive with the \"projectRef\" field.",
+          "properties": {
+            "id": {
+              "description": "ID is the Atlas project ID.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "id"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "projectRef": {
+          "description": "projectRef is a reference to the parent AtlasProject resource.\nMutually exclusive with the \"externalProjectRef\" field.",
+          "properties": {
+            "name": {
+              "description": "Name of the Kubernetes Resource",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "Namespace of the Kubernetes Resource",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "entries"
+      ],
+      "type": "object",
+      "x-kubernetes-validations": [
+        {
+          "message": "must define only one project reference through externalProjectRef or projectRef",
+          "rule": "(has(self.externalProjectRef) && !has(self.projectRef)) || (!has(self.externalProjectRef) && has(self.projectRef))"
+        },
+        {
+          "message": "must define a local connection secret when referencing an external project",
+          "rule": "(has(self.externalProjectRef) && has(self.connectionSecret)) || !has(self.externalProjectRef)"
+        }
+      ],
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "AtlasIPAccessListStatus is the most recent observed status of the AtlasIPAccessList cluster. Read-only.",
+      "properties": {
+        "conditions": {
+          "description": "Conditions is the list of statuses showing the current state of the Atlas Custom Resource",
+          "items": {
+            "description": "Condition describes the state of an Atlas Custom Resource at a certain point.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another.\nRepresented in ISO 8601 format.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A message providing details about the transition.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition; one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of Atlas Custom Resource condition.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "entries": {
+          "description": "Status is the state of the ip access list",
+          "items": {
+            "properties": {
+              "entry": {
+                "description": "Entry is the ip access Atlas is managing",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status is the correspondent state of the entry",
+                "type": "string"
+              }
+            },
+            "required": [
+              "entry",
+              "status"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration indicates the generation of the resource specification of which the Atlas Operator is aware.\nThe Atlas Operator updates this field to the value of 'metadata.generation' as soon as it starts reconciliation of the resource.",
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "conditions"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/atlas.mongodb.com/atlasnetworkcontainer_v1.json
+++ b/atlas.mongodb.com/atlasnetworkcontainer_v1.json
@@ -1,0 +1,179 @@
+{
+  "description": "AtlasNetworkContainer is the Schema for the AtlasNetworkContainer API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "AtlasNetworkContainerSpec defines the target state of an AtlasNetworkContainer.",
+      "properties": {
+        "cidrBlock": {
+          "description": "Atlas CIDR. It needs to be set if ContainerID is not set.",
+          "type": "string"
+        },
+        "connectionSecret": {
+          "description": "Name of the secret containing Atlas API private and public keys.",
+          "properties": {
+            "name": {
+              "description": "Name of the resource being referred to\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "externalProjectRef": {
+          "description": "externalProjectRef holds the parent Atlas project ID.\nMutually exclusive with the \"projectRef\" field.",
+          "properties": {
+            "id": {
+              "description": "ID is the Atlas project ID.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "id"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "id": {
+          "description": "ID is the container identifier for an already existent network container to be managed by the operator.\nThis field can be used in conjunction with cidrBlock to update the cidrBlock of an existing container.\nThis field is immutable.",
+          "type": "string"
+        },
+        "projectRef": {
+          "description": "projectRef is a reference to the parent AtlasProject resource.\nMutually exclusive with the \"externalProjectRef\" field.",
+          "properties": {
+            "name": {
+              "description": "Name of the Kubernetes Resource",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "Namespace of the Kubernetes Resource",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "provider": {
+          "description": "Provider is the name of the cloud provider hosting the network container.",
+          "enum": [
+            "AWS",
+            "GCP",
+            "AZURE"
+          ],
+          "type": "string"
+        },
+        "region": {
+          "description": "ContainerRegion is the provider region name of Atlas network peer container in Atlas region format\nThis is required by AWS and Azure, but not used by GCP.\nThis field is immutable, Atlas does not admit network container changes.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "provider"
+      ],
+      "type": "object",
+      "x-kubernetes-validations": [
+        {
+          "message": "must define only one project reference through externalProjectRef or projectRef",
+          "rule": "(has(self.externalProjectRef) && !has(self.projectRef)) || (!has(self.externalProjectRef) && has(self.projectRef))"
+        },
+        {
+          "message": "must define a local connection secret when referencing an external project",
+          "rule": "(has(self.externalProjectRef) && has(self.connectionSecret)) || !has(self.externalProjectRef)"
+        },
+        {
+          "message": "must not set region for GCP containers",
+          "rule": "(self.provider == 'GCP' && !has(self.region)) || (self.provider != 'GCP')"
+        },
+        {
+          "message": "must set region for AWS and Azure containers",
+          "rule": "((self.provider == 'AWS' || self.provider == 'AZURE') && has(self.region)) || (self.provider == 'GCP')"
+        },
+        {
+          "message": "id is immutable",
+          "rule": "(self.id == oldSelf.id) || (!has(self.id) && !has(oldSelf.id))"
+        },
+        {
+          "message": "region is immutable",
+          "rule": "(self.region == oldSelf.region) || (!has(self.region) && !has(oldSelf.region))"
+        }
+      ],
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "AtlasNetworkContainerStatus is a status for the AtlasNetworkContainer Custom resource.\nNot the one included in the AtlasProject",
+      "properties": {
+        "conditions": {
+          "description": "Conditions is the list of statuses showing the current state of the Atlas Custom Resource",
+          "items": {
+            "description": "Condition describes the state of an Atlas Custom Resource at a certain point.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another.\nRepresented in ISO 8601 format.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A message providing details about the transition.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition; one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of Atlas Custom Resource condition.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "id": {
+          "description": "ID record the identifier of the container in Atlas",
+          "type": "string"
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration indicates the generation of the resource specification of which the Atlas Operator is aware.\nThe Atlas Operator updates this field to the value of 'metadata.generation' as soon as it starts reconciliation of the resource.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "provisioned": {
+          "description": "Provisioned is true when clusters have been deployed to the container before\nthe last reconciliation",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "conditions"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/atlas.mongodb.com/atlasnetworkpeering_v1.json
+++ b/atlas.mongodb.com/atlasnetworkpeering_v1.json
@@ -1,0 +1,309 @@
+{
+  "description": "AtlasNetworkPeering is the Schema for the AtlasNetworkPeering API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "AtlasNetworkPeeringSpec defines the target state of AtlasNetworkPeering.",
+      "properties": {
+        "awsConfiguration": {
+          "description": "AWSConfiguration is the specific AWS settings for network peering.",
+          "properties": {
+            "accepterRegionName": {
+              "description": "AccepterRegionName is the provider region name of user's vpc in AWS native region format.",
+              "type": "string"
+            },
+            "awsAccountId": {
+              "description": "AccountID of the user's vpc.",
+              "type": "string"
+            },
+            "routeTableCidrBlock": {
+              "description": "User VPC CIDR.",
+              "type": "string"
+            },
+            "vpcId": {
+              "description": "AWS VPC ID.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "accepterRegionName",
+            "awsAccountId",
+            "routeTableCidrBlock",
+            "vpcId"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "azureConfiguration": {
+          "description": "AzureConfiguration is the specific Azure settings for network peering.",
+          "properties": {
+            "azureDirectoryId": {
+              "description": "AzureDirectoryID is the unique identifier for an Azure AD directory.",
+              "type": "string"
+            },
+            "azureSubscriptionId": {
+              "description": "AzureSubscriptionID is the unique identifier of the Azure subscription in which the VNet resides.",
+              "type": "string"
+            },
+            "resourceGroupName": {
+              "description": "ResourceGroupName is the name of your Azure resource group.",
+              "type": "string"
+            },
+            "vNetName": {
+              "description": "VNetName is name of your Azure VNet. Its applicable only for Azure.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "azureDirectoryId",
+            "azureSubscriptionId",
+            "resourceGroupName",
+            "vNetName"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "connectionSecret": {
+          "description": "Name of the secret containing Atlas API private and public keys.",
+          "properties": {
+            "name": {
+              "description": "Name of the resource being referred to\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "containerRef": {
+          "description": "ContainerDualReference refers to a Network Container either by Kubernetes name or Atlas ID.",
+          "properties": {
+            "id": {
+              "description": "ID is the Atlas identifier of the Network Container Atlas resource this Peering Connection relies on.\nUse either name or ID, not both.",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the container Kubernetes resource, must be present in the same namespace.\nUse either name or ID, not both.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "externalProjectRef": {
+          "description": "externalProjectRef holds the parent Atlas project ID.\nMutually exclusive with the \"projectRef\" field.",
+          "properties": {
+            "id": {
+              "description": "ID is the Atlas project ID.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "id"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "gcpConfiguration": {
+          "description": "GCPConfiguration is the specific Google Cloud settings for network peering.",
+          "properties": {
+            "gcpProjectId": {
+              "description": "User GCP Project ID. Its applicable only for GCP.",
+              "type": "string"
+            },
+            "networkName": {
+              "description": "GCP Network Peer Name. Its applicable only for GCP.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "gcpProjectId",
+            "networkName"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "id": {
+          "description": "ID is the peering identifier for an already existent network peering to be managed by the operator.\nThis field is immutable.",
+          "type": "string"
+        },
+        "projectRef": {
+          "description": "projectRef is a reference to the parent AtlasProject resource.\nMutually exclusive with the \"externalProjectRef\" field.",
+          "properties": {
+            "name": {
+              "description": "Name of the Kubernetes Resource",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "Namespace of the Kubernetes Resource",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "provider": {
+          "description": "Name of the cloud service provider for which you want to create the network peering service.",
+          "enum": [
+            "AWS",
+            "GCP",
+            "AZURE"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "containerRef",
+        "provider"
+      ],
+      "type": "object",
+      "x-kubernetes-validations": [
+        {
+          "message": "must define only one project reference through externalProjectRef or projectRef",
+          "rule": "(has(self.externalProjectRef) && !has(self.projectRef)) || (!has(self.externalProjectRef) && has(self.projectRef))"
+        },
+        {
+          "message": "must define a local connection secret when referencing an external project",
+          "rule": "(has(self.externalProjectRef) && has(self.connectionSecret)) || !has(self.externalProjectRef)"
+        },
+        {
+          "message": "must either have a container Atlas id or Kubernetes name, but not both (or neither)",
+          "rule": "(has(self.containerRef.name) && !has(self.containerRef.id)) || (!has(self.containerRef.name) && has(self.containerRef.id))"
+        },
+        {
+          "message": "container ref name is immutable",
+          "rule": "(self.containerRef.name == oldSelf.containerRef.name) || (!has(self.containerRef.name) && !has(oldSelf.containerRef.name))"
+        },
+        {
+          "message": "container ref id is immutable",
+          "rule": "(self.containerRef.id == oldSelf.containerRef.id) || (!has(self.containerRef.id) && !has(oldSelf.containerRef.id))"
+        },
+        {
+          "message": "id is immutable",
+          "rule": "(self.id == oldSelf.id) || (!has(self.id) && !has(oldSelf.id))"
+        }
+      ],
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "AtlasNetworkPeeringStatus is a status for the AtlasNetworkPeering Custom resource.\nNot the one included in the AtlasProject",
+      "properties": {
+        "awsStatus": {
+          "description": "AWSStatus contains AWS only related status information",
+          "properties": {
+            "connectionId": {
+              "description": "ConnectionID is the AWS VPC peering connection ID",
+              "type": "string"
+            },
+            "vpcId": {
+              "description": "VpcID is AWS VPC id on the Atlas side",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "azureStatus": {
+          "description": "AzureStatus contains Azure only related status information",
+          "properties": {
+            "azureSubscriptionIDpcId": {
+              "description": "AzureSubscriptionID is Azure Subscription id on the Atlas side",
+              "type": "string"
+            },
+            "vNetName": {
+              "description": "VnetName is Azure network on the Atlas side",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "conditions": {
+          "description": "Conditions is the list of statuses showing the current state of the Atlas Custom Resource",
+          "items": {
+            "description": "Condition describes the state of an Atlas Custom Resource at a certain point.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another.\nRepresented in ISO 8601 format.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A message providing details about the transition.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition; one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of Atlas Custom Resource condition.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "gcpStatus": {
+          "description": "GCPStatus contains GCP only related status information",
+          "properties": {
+            "gcpProjectID": {
+              "description": "GCPProjectID is GCP project on the Atlas side",
+              "type": "string"
+            },
+            "networkName": {
+              "description": "NetworkName is GCP network on the Atlas side",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "id": {
+          "description": "ID recrods the identified of the peer created by Atlas",
+          "type": "string"
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration indicates the generation of the resource specification of which the Atlas Operator is aware.\nThe Atlas Operator updates this field to the value of 'metadata.generation' as soon as it starts reconciliation of the resource.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "status": {
+          "description": "Status describes the last status seen for the network peering setup",
+          "type": "string"
+        }
+      },
+      "required": [
+        "conditions"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/atlas.mongodb.com/atlasorgsettings_v1.json
+++ b/atlas.mongodb.com/atlasorgsettings_v1.json
@@ -1,0 +1,135 @@
+{
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "AtlasOrgSettingsSpec defines the desired state of AtlasOrgSettings.",
+      "properties": {
+        "apiAccessListRequired": {
+          "description": "ApiAccessListRequired Flag that indicates whether to require API operations to originate from an IP Address added to the API access list for the specified organization.",
+          "type": "boolean"
+        },
+        "connectionSecretRef": {
+          "description": "ConnectionSecretRef is the name of the Kubernetes Secret which contains the information about the way to connect to Atlas (Public & Private API keys).",
+          "properties": {
+            "name": {
+              "description": "Name of the resource being referred to\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "genAIFeaturesEnabled": {
+          "description": "GenAIFeaturesEnabled Flag that indicates whether this organization has access to generative AI features. This setting only applies to Atlas Commercial and is enabled by default.\nOnce this setting is turned on, Project Owners may be able to enable or disable individual AI features at the project level.",
+          "type": "boolean"
+        },
+        "maxServiceAccountSecretValidityInHours": {
+          "description": "MaxServiceAccountSecretValidityInHours Number that represents the maximum period before expiry in hours for new Atlas Admin API Service Account secrets within the specified organization.",
+          "type": "integer"
+        },
+        "multiFactorAuthRequired": {
+          "description": "MultiFactorAuthRequired Flag that indicates whether to require users to set up Multi-Factor Authentication (MFA) before accessing the specified organization.\nTo learn more, see: https://www.mongodb.com/docs/atlas/security-multi-factor-authentication/.",
+          "type": "boolean"
+        },
+        "orgID": {
+          "description": "OrgId Unique 24-hexadecimal digit string that identifies the organization that contains your projects.",
+          "type": "string"
+        },
+        "restrictEmployeeAccess": {
+          "description": "RestrictEmployeeAccess Flag that indicates whether to block MongoDB Support from accessing Atlas infrastructure and cluster logs for any deployment in the specified organization without explicit permission.\nOnce this setting is turned on, you can grant MongoDB Support a 24-hour bypass access to the Atlas deployment to resolve support issues.\nTo learn more, see: https://www.mongodb.com/docs/atlas/security-restrict-support-access/.",
+          "type": "boolean"
+        },
+        "securityContact": {
+          "description": "SecurityContact String that specifies a single email address for the specified organization to receive security-related notifications.\nSpecifying a security contact does not grant them authorization or access to Atlas for security decisions or approvals.\nAn empty string is valid and clears the existing security contact (if any).",
+          "type": "string"
+        },
+        "streamsCrossGroupEnabled": {
+          "description": "StreamsCrossGroupEnabled Flag that indicates whether a group's Atlas Stream Processing instances in this organization can create connections to other group's clusters in the same organization.",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "orgID"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "AtlasOrgSettingsStatus defines the observed state of AtlasOrgSettings.",
+      "properties": {
+        "conditions": {
+          "description": "Conditions holding the status details",
+          "items": {
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
+                "maxLength": 32768,
+                "type": "string"
+              },
+              "observedGeneration": {
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
+                "format": "int64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "reason": {
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
+                "maxLength": 1024,
+                "minLength": 1,
+                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
+                "type": "string"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "enum": [
+                  "True",
+                  "False",
+                  "Unknown"
+                ],
+                "type": "string"
+              },
+              "type": {
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
+                "maxLength": 316,
+                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "message",
+              "reason",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/atlas.mongodb.com/atlasprivateendpoint_v1.json
+++ b/atlas.mongodb.com/atlasprivateendpoint_v1.json
@@ -1,0 +1,321 @@
+{
+  "description": "The AtlasPrivateEndpoint custom resource definition (CRD) defines a desired [Private Endpoint](https://www.mongodb.com/docs/atlas/security-private-endpoint/#std-label-private-endpoint-overview) configuration for an Atlas project.\nIt allows a private connection between your cloud provider and Atlas that doesn't send information through a public network.\n\nYou can use private endpoints to create a unidirectional connection to Atlas clusters from your virtual network.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "AtlasPrivateEndpointSpec is the specification of the desired configuration of a project private endpoint",
+      "properties": {
+        "awsConfiguration": {
+          "description": "AWSConfiguration is the specific AWS settings for the private endpoint.",
+          "items": {
+            "description": "AWSPrivateEndpointConfiguration holds the AWS configuration done on customer network.",
+            "properties": {
+              "id": {
+                "description": "ID that identifies the private endpoint's network interface that someone added to this private endpoint service.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "id"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "id"
+          ],
+          "x-kubernetes-list-type": "map"
+        },
+        "azureConfiguration": {
+          "description": "AzureConfiguration is the specific Azure settings for the private endpoint.",
+          "items": {
+            "description": "AzurePrivateEndpointConfiguration holds the Azure configuration done on customer network.",
+            "properties": {
+              "id": {
+                "description": "ID that identifies the private endpoint's network interface that someone added to this private endpoint service.",
+                "type": "string"
+              },
+              "ipAddress": {
+                "description": "IP address of the private endpoint in your Azure VNet that someone added to this private endpoint service.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "ipAddress"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "id"
+          ],
+          "x-kubernetes-list-type": "map"
+        },
+        "connectionSecret": {
+          "description": "Name of the secret containing Atlas API private and public keys.",
+          "properties": {
+            "name": {
+              "description": "Name of the resource being referred to\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "externalProjectRef": {
+          "description": "externalProjectRef holds the parent Atlas project ID.\nMutually exclusive with the \"projectRef\" field.",
+          "properties": {
+            "id": {
+              "description": "ID is the Atlas project ID.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "id"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "gcpConfiguration": {
+          "description": "GCPConfiguration is the specific Google Cloud settings for the private endpoint.",
+          "items": {
+            "description": "GCPPrivateEndpointConfiguration holds the GCP configuration done on customer network.",
+            "properties": {
+              "endpoints": {
+                "description": "Endpoints is the list of individual private endpoints that comprise this endpoint group.",
+                "items": {
+                  "description": "GCPPrivateEndpoint holds the GCP forwarding rules configured on customer network.",
+                  "properties": {
+                    "ipAddress": {
+                      "description": "IP address to which this Google Cloud consumer forwarding rule resolves.",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name that identifies the Google Cloud consumer forwarding rule that you created.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "ipAddress",
+                    "name"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "groupName": {
+                "description": "GroupName is the label that identifies a set of endpoints.",
+                "type": "string"
+              },
+              "projectId": {
+                "description": "ProjectID that identifies the Google Cloud project in which you created the endpoints.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "endpoints",
+              "groupName",
+              "projectId"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "groupName"
+          ],
+          "x-kubernetes-list-type": "map"
+        },
+        "projectRef": {
+          "description": "projectRef is a reference to the parent AtlasProject resource.\nMutually exclusive with the \"externalProjectRef\" field.",
+          "properties": {
+            "name": {
+              "description": "Name of the Kubernetes Resource",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "Namespace of the Kubernetes Resource",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "provider": {
+          "description": "Name of the cloud service provider for which you want to create the private endpoint service.",
+          "enum": [
+            "AWS",
+            "GCP",
+            "AZURE"
+          ],
+          "type": "string"
+        },
+        "region": {
+          "description": "Region of the chosen cloud provider in which you want to create the private endpoint service.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "provider",
+        "region"
+      ],
+      "type": "object",
+      "x-kubernetes-validations": [
+        {
+          "message": "must define only one project reference through externalProjectRef or projectRef",
+          "rule": "(has(self.externalProjectRef) && !has(self.projectRef)) || (!has(self.externalProjectRef) && has(self.projectRef))"
+        },
+        {
+          "message": "must define a local connection secret when referencing an external project",
+          "rule": "(has(self.externalProjectRef) && has(self.connectionSecret)) || !has(self.externalProjectRef)"
+        }
+      ],
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "AtlasPrivateEndpointStatus is the most recent observed status of the AtlasPrivateEndpoint cluster. Read-only.",
+      "properties": {
+        "conditions": {
+          "description": "Conditions is the list of statuses showing the current state of the Atlas Custom Resource",
+          "items": {
+            "description": "Condition describes the state of an Atlas Custom Resource at a certain point.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another.\nRepresented in ISO 8601 format.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A message providing details about the transition.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition; one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of Atlas Custom Resource condition.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "endpoints": {
+          "description": "Endpoints are the status of the endpoints connected to the service",
+          "items": {
+            "description": "EndpointInterfaceStatus is the most recent observed status the interfaces attached to the configured service. Read-only.",
+            "properties": {
+              "ID": {
+                "description": "ID is the external identifier set on the specification to configure the interface",
+                "type": "string"
+              },
+              "InterfaceStatus": {
+                "description": "InterfaceStatus is the state of the private endpoint interface",
+                "type": "string"
+              },
+              "connectionName": {
+                "description": "ConnectionName is the label that Atlas generates that identifies the Azure private endpoint connection",
+                "type": "string"
+              },
+              "error": {
+                "description": "Error is the description of the failure occurred when configuring the private endpoint",
+                "type": "string"
+              },
+              "gcpForwardingRules": {
+                "description": "GCPForwardingRules is the status of the customer GCP private endpoint(forwarding rules)",
+                "items": {
+                  "description": "GCPForwardingRule is the most recent observed status the GCP forwarding rules configured for an interface. Read-only.",
+                  "properties": {
+                    "name": {
+                      "description": "Human-readable label that identifies the Google Cloud consumer forwarding rule that you created.",
+                      "type": "string"
+                    },
+                    "status": {
+                      "description": "State of the MongoDB Atlas endpoint group.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "error": {
+          "description": "Error is the description of the failure occurred when configuring the private endpoint",
+          "type": "string"
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration indicates the generation of the resource specification of which the Atlas Operator is aware.\nThe Atlas Operator updates this field to the value of 'metadata.generation' as soon as it starts reconciliation of the resource.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "resourceId": {
+          "description": "ResourceID is the root-relative path that identifies of the Atlas Azure Private Link Service",
+          "type": "string"
+        },
+        "serviceAttachmentNames": {
+          "description": "ServiceAttachmentNames is the list of URLs that identifies endpoints that Atlas can use to access one service across the private connection",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "serviceId": {
+          "description": "ServiceID is the unique identifier of the private endpoint service in Atlas",
+          "type": "string"
+        },
+        "serviceName": {
+          "description": "ServiceName is the unique identifier of the Amazon Web Services (AWS) PrivateLink endpoint service or Azure Private Link Service managed by Atlas",
+          "type": "string"
+        },
+        "serviceStatus": {
+          "description": "ServiceStatus is the state of the private endpoint service",
+          "type": "string"
+        }
+      },
+      "required": [
+        "conditions"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/atlas.mongodb.com/atlasproject_v1.json
+++ b/atlas.mongodb.com/atlasproject_v1.json
@@ -1,0 +1,1833 @@
+{
+  "description": "AtlasProject is the Schema for the atlasprojects API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "AtlasProjectSpec defines the target state of Project in Atlas",
+      "properties": {
+        "alertConfigurationSyncEnabled": {
+          "description": "AlertConfigurationSyncEnabled is a flag that enables/disables Alert Configurations sync for the current Project.\nIf true - project alert configurations will be synced according to AlertConfigurations.\nIf not - alert configurations will not be modified by the operator. They can be managed through the API, CLI, and UI.",
+          "type": "boolean"
+        },
+        "alertConfigurations": {
+          "description": "AlertConfiguration is a list of Alert Configurations configured for the current Project.\nIf you use this setting, you must also set spec.alertConfigurationSyncEnabled to true for Atlas Kubernetes\nOperator to modify project alert configurations.\nIf you omit or leave this setting empty, Atlas Kubernetes Operator doesn't alter the project's alert\nconfigurations. If creating a project, Atlas applies the default project alert configurations.",
+          "items": {
+            "properties": {
+              "enabled": {
+                "description": "If omitted, the configuration is disabled.",
+                "type": "boolean"
+              },
+              "eventTypeName": {
+                "description": "The type of event that will trigger an alert.",
+                "type": "string"
+              },
+              "matchers": {
+                "description": "You can filter using the matchers array only when the EventTypeName specifies an event for a host, replica set, or sharded cluster.",
+                "items": {
+                  "properties": {
+                    "fieldName": {
+                      "description": "Name of the field in the target object to match on.",
+                      "type": "string"
+                    },
+                    "operator": {
+                      "description": "The operator to test the field\u2019s value.",
+                      "type": "string"
+                    },
+                    "value": {
+                      "description": "Value to test with the specified operator.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "metricThreshold": {
+                "description": "MetricThreshold  causes an alert to be triggered.",
+                "properties": {
+                  "metricName": {
+                    "description": "Name of the metric to check.",
+                    "type": "string"
+                  },
+                  "mode": {
+                    "description": "This must be set to AVERAGE. Atlas computes the current metric value as an average.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "Operator to apply when checking the current metric value against the threshold value.",
+                    "type": "string"
+                  },
+                  "threshold": {
+                    "description": "Threshold value outside which an alert will be triggered.",
+                    "type": "string"
+                  },
+                  "units": {
+                    "description": "The units for the threshold value.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "threshold"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "notifications": {
+                "description": "Notifications are sending when an alert condition is detected.",
+                "items": {
+                  "properties": {
+                    "apiTokenRef": {
+                      "description": "Secret containing a Slack API token or Bot token. Populated for the SLACK notifications type. If the token later becomes invalid, Atlas sends an email to the project owner and eventually removes the token.",
+                      "properties": {
+                        "name": {
+                          "description": "Name of the Kubernetes Resource",
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "description": "Namespace of the Kubernetes Resource",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "channelName": {
+                      "description": "Slack channel name. Populated for the SLACK notifications type.",
+                      "type": "string"
+                    },
+                    "datadogAPIKeyRef": {
+                      "description": "Secret containing a Datadog API Key. Found in the Datadog dashboard. Populated for the DATADOG notifications type.",
+                      "properties": {
+                        "name": {
+                          "description": "Name of the Kubernetes Resource",
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "description": "Namespace of the Kubernetes Resource",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "datadogRegion": {
+                      "description": "Region that indicates which API URL to use.",
+                      "type": "string"
+                    },
+                    "delayMin": {
+                      "description": "Number of minutes to wait after an alert condition is detected before sending out the first notification.",
+                      "type": "integer"
+                    },
+                    "emailAddress": {
+                      "description": "Email address to which alert notifications are sent. Populated for the EMAIL notifications type.",
+                      "type": "string"
+                    },
+                    "emailEnabled": {
+                      "description": "Flag indicating if email notifications should be sent. Populated for ORG, GROUP, and USER notifications types.",
+                      "type": "boolean"
+                    },
+                    "flowName": {
+                      "description": "Flowdock flow name in lower-case letters.",
+                      "type": "string"
+                    },
+                    "flowdockApiTokenRef": {
+                      "description": "The Flowdock personal API token. Populated for the FLOWDOCK notifications type. If the token later becomes invalid, Atlas sends an email to the project owner and eventually removes the token.",
+                      "properties": {
+                        "name": {
+                          "description": "Name of the Kubernetes Resource",
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "description": "Namespace of the Kubernetes Resource",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "intervalMin": {
+                      "description": "Number of minutes to wait between successive notifications for unacknowledged alerts that are not resolved.",
+                      "type": "integer"
+                    },
+                    "mobileNumber": {
+                      "description": "Mobile number to which alert notifications are sent. Populated for the SMS notifications type.",
+                      "type": "string"
+                    },
+                    "opsGenieApiKeyRef": {
+                      "description": "OpsGenie API Key. Populated for the OPS_GENIE notifications type. If the key later becomes invalid, Atlas sends an email to the project owner and eventually removes the token.",
+                      "properties": {
+                        "name": {
+                          "description": "Name of the Kubernetes Resource",
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "description": "Namespace of the Kubernetes Resource",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "opsGenieRegion": {
+                      "description": "Region that indicates which API URL to use.",
+                      "type": "string"
+                    },
+                    "orgName": {
+                      "description": "Flowdock organization name in lower-case letters. This is the name that appears after www.flowdock.com/app/ in the URL string. Populated for the FLOWDOCK notifications type.",
+                      "type": "string"
+                    },
+                    "roles": {
+                      "description": "The following roles grant privileges within a project.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "serviceKeyRef": {
+                      "description": "PagerDuty service key. Populated for the PAGER_DUTY notifications type. If the key later becomes invalid, Atlas sends an email to the project owner and eventually removes the key.",
+                      "properties": {
+                        "name": {
+                          "description": "Name of the Kubernetes Resource",
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "description": "Namespace of the Kubernetes Resource",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "smsEnabled": {
+                      "description": "Flag indicating if text message notifications should be sent. Populated for ORG, GROUP, and USER notifications types.",
+                      "type": "boolean"
+                    },
+                    "teamId": {
+                      "description": "Unique identifier of a team.",
+                      "type": "string"
+                    },
+                    "teamName": {
+                      "description": "Label for the team that receives this notification.",
+                      "type": "string"
+                    },
+                    "typeName": {
+                      "description": "Type of alert notification.",
+                      "type": "string"
+                    },
+                    "username": {
+                      "description": "Name of the Atlas user to which to send notifications. Only a user in the project that owns the alert configuration is allowed here. Populated for the USER notifications type.",
+                      "type": "string"
+                    },
+                    "victorOpsSecretRef": {
+                      "description": "Secret containing a VictorOps API key and Routing key. Populated for the VICTOR_OPS notifications type. If the key later becomes invalid, Atlas sends an email to the project owner and eventually removes the key.",
+                      "properties": {
+                        "name": {
+                          "description": "Name of the Kubernetes Resource",
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "description": "Namespace of the Kubernetes Resource",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "severityOverride": {
+                "description": "SeverityOverride optionally overrides the default severity level for an alert.",
+                "enum": [
+                  "INFO",
+                  "WARNING",
+                  "ERROR",
+                  "CRITICAL"
+                ],
+                "type": "string"
+              },
+              "threshold": {
+                "description": "Threshold  causes an alert to be triggered.",
+                "properties": {
+                  "operator": {
+                    "description": "Operator to apply when checking the current metric value against the threshold value.\nIt accepts the following values: GREATER_THAN, LESS_THAN.",
+                    "type": "string"
+                  },
+                  "threshold": {
+                    "description": "Threshold value outside which an alert will be triggered.",
+                    "type": "string"
+                  },
+                  "units": {
+                    "description": "The units for the threshold value.",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "auditing": {
+          "description": "Auditing represents MongoDB Maintenance Windows.",
+          "properties": {
+            "auditAuthorizationSuccess": {
+              "description": "Indicates whether the auditing system captures successful authentication attempts for audit filters using the \"atype\" : \"authCheck\" auditing event.\nFor more information, see auditAuthorizationSuccess.",
+              "type": "boolean"
+            },
+            "auditFilter": {
+              "description": "JSON-formatted audit filter used by the project.",
+              "type": "string"
+            },
+            "enabled": {
+              "description": "Denotes whether the project associated with the {GROUP-ID} has database auditing enabled.",
+              "type": "boolean"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "backupCompliancePolicyRef": {
+          "description": "BackupCompliancePolicyRef is a reference to the backup compliance custom resource.",
+          "properties": {
+            "name": {
+              "description": "Name of the Kubernetes Resource",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "Namespace of the Kubernetes Resource",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "cloudProviderAccessRoles": {
+          "description": "CloudProviderAccessRoles is a list of Cloud Provider Access Roles configured for the current Project.\nDeprecated: This configuration was deprecated in favor of CloudProviderIntegrations",
+          "items": {
+            "description": "CloudProviderAccessRole define an integration to a cloud provider\nDEPRECATED: This type is deprecated in favor of CloudProviderIntegration",
+            "properties": {
+              "iamAssumedRoleArn": {
+                "description": "IamAssumedRoleArn is the ARN of the IAM role that is assumed by the Atlas cluster.",
+                "type": "string"
+              },
+              "providerName": {
+                "description": "ProviderName is the name of the cloud provider. Currently only AWS is supported.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "providerName"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "cloudProviderIntegrations": {
+          "description": "CloudProviderIntegrations is a list of Cloud Provider Integration configured for the current Project.",
+          "items": {
+            "description": "CloudProviderIntegration define an integration to a cloud provider",
+            "properties": {
+              "iamAssumedRoleArn": {
+                "description": "IamAssumedRoleArn is the ARN of the IAM role that is assumed by the Atlas cluster.",
+                "type": "string"
+              },
+              "providerName": {
+                "description": "ProviderName is the name of the cloud provider. Currently only AWS is supported.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "providerName"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "connectionSecretRef": {
+          "description": "ConnectionSecret is the name of the Kubernetes Secret which contains the information about the way to connect to\nAtlas (organization ID, API keys). The default Operator connection configuration will be used if not provided.",
+          "properties": {
+            "name": {
+              "description": "Name of the Kubernetes Resource",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "Namespace of the Kubernetes Resource",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "customRoles": {
+          "description": "CustomRoles lets you create and change custom roles in your cluster.\nUse custom roles to specify custom sets of actions that the Atlas built-in roles can't describe.\nDeprecated: Migrate to the AtlasCustomRoles custom resource in accordance with the migration guide\nat https://www.mongodb.com/docs/atlas/operator/current/migrate-parameter-to-resource/#std-label-ak8so-migrate-ptr",
+          "items": {
+            "description": "CustomRole lets you create and change a custom role in your cluster.\nUse custom roles to specify custom sets of actions that the Atlas built-in roles can't describe.\nDeprecated: Migrate to the AtlasCustomRoles custom resource in accordance with the migration guide\nat https://www.mongodb.com/docs/atlas/operator/current/migrate-parameter-to-resource/#std-label-ak8so-migrate-ptr",
+            "properties": {
+              "actions": {
+                "description": "List of the individual privilege actions that the role grants.",
+                "items": {
+                  "properties": {
+                    "name": {
+                      "description": "Human-readable label that identifies the privilege action.",
+                      "type": "string"
+                    },
+                    "resources": {
+                      "description": "List of resources on which you grant the action.",
+                      "items": {
+                        "properties": {
+                          "cluster": {
+                            "description": "Flag that indicates whether to grant the action on the cluster resource. If true, MongoDB Cloud ignores Database and Collection parameters.",
+                            "type": "boolean"
+                          },
+                          "collection": {
+                            "description": "Human-readable label that identifies the collection on which you grant the action to one MongoDB user.",
+                            "type": "string"
+                          },
+                          "database": {
+                            "description": "Human-readable label that identifies the database on which you grant the action to one MongoDB user.",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "resources"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "inheritedRoles": {
+                "description": "List of the built-in roles that this custom role inherits.",
+                "items": {
+                  "properties": {
+                    "database": {
+                      "description": "Human-readable label that identifies the database on which someone grants the action to one MongoDB user.",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Human-readable label that identifies the role inherited.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "database",
+                    "name"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "name": {
+                "description": "Human-readable label that identifies the role. This name must be unique for this custom role in this project.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "encryptionAtRest": {
+          "description": "EncryptionAtRest allows to set encryption for AWS, Azure and GCP providers.",
+          "properties": {
+            "awsKms": {
+              "description": "AwsKms specifies AWS KMS configuration details and whether Encryption at Rest is enabled for an Atlas project.",
+              "properties": {
+                "enabled": {
+                  "description": "Specifies whether Encryption at Rest is enabled for an Atlas project.\nTo disable Encryption at Rest, pass only this parameter with a value of false. When you disable Encryption at Rest, Atlas also removes the configuration details.",
+                  "type": "boolean"
+                },
+                "region": {
+                  "description": "The AWS region in which the AWS customer master key exists.",
+                  "type": "string"
+                },
+                "secretRef": {
+                  "description": "A reference to as Secret containing the AccessKeyID, SecretAccessKey, CustomerMasterKeyID and RoleID fields",
+                  "properties": {
+                    "name": {
+                      "description": "Name of the Kubernetes Resource",
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "description": "Namespace of the Kubernetes Resource",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "valid": {
+                  "description": "Specifies whether the encryption key set for the provider is valid and may be used to encrypt and decrypt data.",
+                  "type": "boolean"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "azureKeyVault": {
+              "description": "AzureKeyVault specifies Azure Key Vault configuration details and whether Encryption at Rest is enabled for an Atlas project.",
+              "properties": {
+                "azureEnvironment": {
+                  "description": "The Azure environment where the Azure account credentials reside. Valid values are the following: AZURE, AZURE_CHINA, AZURE_GERMANY",
+                  "type": "string"
+                },
+                "clientID": {
+                  "description": "The Client ID, also known as the application ID, for an Azure application associated with the Azure AD tenant.",
+                  "type": "string"
+                },
+                "enabled": {
+                  "description": "Specifies whether Encryption at Rest is enabled for an Atlas project.\nTo disable Encryption at Rest, pass only this parameter with a value of false. When you disable Encryption at Rest, Atlas also removes the configuration details.",
+                  "type": "boolean"
+                },
+                "resourceGroupName": {
+                  "description": "The name of the Azure Resource group that contains an Azure Key Vault.",
+                  "type": "string"
+                },
+                "secretRef": {
+                  "description": "A reference to as Secret containing the SubscriptionID, KeyVaultName, KeyIdentifier, Secret fields",
+                  "properties": {
+                    "name": {
+                      "description": "Name of the Kubernetes Resource",
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "description": "Namespace of the Kubernetes Resource",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "tenantID": {
+                  "description": "The unique identifier for an Azure AD tenant within an Azure subscription.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "googleCloudKms": {
+              "description": "GoogleCloudKms specifies GCP KMS configuration details and whether Encryption at Rest is enabled for an Atlas project.",
+              "properties": {
+                "enabled": {
+                  "description": "Specifies whether Encryption at Rest is enabled for an Atlas project.\nTo disable Encryption at Rest, pass only this parameter with a value of false. When you disable Encryption at Rest, Atlas also removes the configuration details.",
+                  "type": "boolean"
+                },
+                "secretRef": {
+                  "description": "A reference to as Secret containing the ServiceAccountKey, KeyVersionResourceID fields",
+                  "properties": {
+                    "name": {
+                      "description": "Name of the Kubernetes Resource",
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "description": "Namespace of the Kubernetes Resource",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "integrations": {
+          "description": "Integrations is a list of MongoDB Atlas integrations for the project.\nDeprecated: Migrate to the AtlasThirdPartyIntegration custom resource in accordance with the migration guide\nat https://www.mongodb.com/docs/atlas/operator/current/migrate-parameter-to-resource/#std-label-ak8so-migrate-ptr",
+          "items": {
+            "description": "Integration for the project between Atlas and a third party service.\nDeprecated: Migrate to the AtlasThirdPartyIntegration custom resource in accordance with the migration guide\nat https://www.mongodb.com/docs/atlas/operator/current/migrate-parameter-to-resource/#std-label-ak8so-migrate-ptr",
+            "properties": {
+              "accountId": {
+                "description": "Unique 40-hexadecimal digit string that identifies your New Relic account.",
+                "type": "string"
+              },
+              "apiKeyRef": {
+                "description": "Reference to a Kubernetes Secret containing your API Key for Datadog, OpsGenie or Victor Ops.",
+                "properties": {
+                  "name": {
+                    "description": "Name of the Kubernetes Resource",
+                    "type": "string"
+                  },
+                  "namespace": {
+                    "description": "Namespace of the Kubernetes Resource",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "apiTokenRef": {
+                "description": "Reference to a Kubernetes Secret containing the Key that allows Atlas to access your Slack account.",
+                "properties": {
+                  "name": {
+                    "description": "Name of the Kubernetes Resource",
+                    "type": "string"
+                  },
+                  "namespace": {
+                    "description": "Namespace of the Kubernetes Resource",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "channelName": {
+                "description": "Name of the Slack channel to which Atlas sends alert notifications.",
+                "type": "string"
+              },
+              "enabled": {
+                "description": "Flag that indicates whether someone has activated the Prometheus integration.",
+                "type": "boolean"
+              },
+              "flowName": {
+                "description": "DEPRECATED: Flowdock flow name.\nThis field has been removed from Atlas, and has no effect.",
+                "type": "string"
+              },
+              "licenseKeyRef": {
+                "description": "Reference to a Kubernetes Secret containing your Unique 40-hexadecimal digit string that identifies your New Relic license.",
+                "properties": {
+                  "name": {
+                    "description": "Name of the Kubernetes Resource",
+                    "type": "string"
+                  },
+                  "namespace": {
+                    "description": "Namespace of the Kubernetes Resource",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "microsoftTeamsWebhookUrl": {
+                "description": "Endpoint web address of the Microsoft Teams webhook to which Atlas sends notifications.",
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "orgName": {
+                "description": "DEPRECATED: Flowdock organization name.\nThis field has been removed from Atlas, and has no effect.",
+                "type": "string"
+              },
+              "passwordRef": {
+                "description": "Reference to a Kubernetes Secret containing the password to allow Atlas to access your Prometheus account.",
+                "properties": {
+                  "name": {
+                    "description": "Name of the Kubernetes Resource",
+                    "type": "string"
+                  },
+                  "namespace": {
+                    "description": "Namespace of the Kubernetes Resource",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "readTokenRef": {
+                "description": "Reference to a Kubernetes Secret containing the query key associated with your New Relic account.",
+                "properties": {
+                  "name": {
+                    "description": "Name of the Kubernetes Resource",
+                    "type": "string"
+                  },
+                  "namespace": {
+                    "description": "Namespace of the Kubernetes Resource",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "region": {
+                "description": "Region code indicating which regional API Atlas uses to access PagerDuty, Datadog, or OpsGenie.",
+                "type": "string"
+              },
+              "routingKeyRef": {
+                "description": "Reference to a Kubernetes Secret containing the Routing key associated with your Splunk On-Call account.\nUsed for Victor Ops.",
+                "properties": {
+                  "name": {
+                    "description": "Name of the Kubernetes Resource",
+                    "type": "string"
+                  },
+                  "namespace": {
+                    "description": "Namespace of the Kubernetes Resource",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "scheme": {
+                "type": "string"
+              },
+              "secretRef": {
+                "description": "Reference to a Kubernetes Secret containing the secret for your Webhook.",
+                "properties": {
+                  "name": {
+                    "description": "Name of the Kubernetes Resource",
+                    "type": "string"
+                  },
+                  "namespace": {
+                    "description": "Namespace of the Kubernetes Resource",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "serviceDiscovery": {
+                "description": "Desired method to discover the Prometheus service.",
+                "type": "string"
+              },
+              "serviceKeyRef": {
+                "description": "Reference to a Kubernetes Secret containing the service key associated with your PagerDuty account.",
+                "properties": {
+                  "name": {
+                    "description": "Name of the Kubernetes Resource",
+                    "type": "string"
+                  },
+                  "namespace": {
+                    "description": "Namespace of the Kubernetes Resource",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "teamName": {
+                "description": "Human-readable label that identifies your Slack team.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Third Party Integration type such as Slack, New Relic, etc.\nEach integration type requires a distinct set of configuration fields.\nFor example, if you set type to DATADOG, you must configure only datadog subfields.",
+                "enum": [
+                  "PAGER_DUTY",
+                  "SLACK",
+                  "DATADOG",
+                  "NEW_RELIC",
+                  "OPS_GENIE",
+                  "VICTOR_OPS",
+                  "FLOWDOCK",
+                  "WEBHOOK",
+                  "MICROSOFT_TEAMS",
+                  "PROMETHEUS"
+                ],
+                "type": "string"
+              },
+              "url": {
+                "description": "Endpoint web address to which Atlas sends notifications.\nUsed for Webhooks.",
+                "type": "string"
+              },
+              "username": {
+                "description": "Human-readable label that identifies your Prometheus incoming webhook.",
+                "type": "string"
+              },
+              "writeTokenRef": {
+                "description": "Reference to a Kubernetes Secret containing the insert key associated with your New Relic account.",
+                "properties": {
+                  "name": {
+                    "description": "Name of the Kubernetes Resource",
+                    "type": "string"
+                  },
+                  "namespace": {
+                    "description": "Namespace of the Kubernetes Resource",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "maintenanceWindow": {
+          "description": "MaintenanceWindow allows to specify a preferred time in the week to run maintenance operations. See more\ninformation at https://www.mongodb.com/docs/atlas/reference/api/maintenance-windows/",
+          "properties": {
+            "autoDefer": {
+              "description": "Flag indicating whether any scheduled project maintenance should be deferred automatically for one week.",
+              "type": "boolean"
+            },
+            "dayOfWeek": {
+              "description": "Day of the week when you would like the maintenance window to start as a 1-based integer.\nSunday 1, Monday 2, Tuesday 3, Wednesday 4, Thursday 5, Friday 6, Saturday 7.",
+              "maximum": 7,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "defer": {
+              "description": "Flag indicating whether the next scheduled project maintenance should be deferred for one week.\nCannot be specified if startASAP is true",
+              "type": "boolean"
+            },
+            "hourOfDay": {
+              "description": "Hour of the day when you would like the maintenance window to start.\nThis parameter uses the 24-hour clock, where midnight is 0, noon is 12.",
+              "maximum": 23,
+              "minimum": 0,
+              "type": "integer"
+            },
+            "startASAP": {
+              "description": "Flag indicating whether project maintenance has been directed to start immediately.\nCannot be specified if defer is true",
+              "type": "boolean"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "name": {
+          "description": "Name is the name of the Project that is created in Atlas by the Operator if it doesn't exist yet.\nThe name length must not exceed 64 characters. The name must contain only letters, numbers, spaces, dashes, and underscores.",
+          "type": "string",
+          "x-kubernetes-validations": [
+            {
+              "message": "Name cannot be modified after project creation",
+              "rule": "self == oldSelf"
+            }
+          ]
+        },
+        "networkPeers": {
+          "description": "NetworkPeers is a list of Network Peers configured for the current Project.\nDeprecated: Migrate to the AtlasNetworkPeering and AtlasNetworkContainer custom resources in accordance with\nthe migration guide at https://www.mongodb.com/docs/atlas/operator/current/migrate-parameter-to-resource/#std-label-ak8so-migrate-ptr",
+          "items": {
+            "description": "NetworkPeer configured for the current Project.\nDeprecated: Migrate to the AtlasNetworkPeering and AtlasNetworkContainer custom resources in accordance with\nthe migration guide at https://www.mongodb.com/docs/atlas/operator/current/migrate-parameter-to-resource/#std-label-ak8so-migrate-ptr",
+            "properties": {
+              "accepterRegionName": {
+                "description": "AccepterRegionName is the provider region name of user's VPC.",
+                "type": "string"
+              },
+              "atlasCidrBlock": {
+                "description": "Atlas CIDR. It needs to be set if ContainerID is not set.",
+                "type": "string"
+              },
+              "awsAccountId": {
+                "description": "AccountID of the user's VPC.",
+                "type": "string"
+              },
+              "azureDirectoryId": {
+                "description": "AzureDirectoryID is the unique identifier for an Azure AD directory.",
+                "type": "string"
+              },
+              "azureSubscriptionId": {
+                "description": "AzureSubscriptionID is the unique identifier of the Azure subscription in which the VNet resides.",
+                "type": "string"
+              },
+              "containerId": {
+                "description": "ID of the network peer container. If not set, operator will create a new container with ContainerRegion and AtlasCIDRBlock input.",
+                "type": "string"
+              },
+              "containerRegion": {
+                "description": "ContainerRegion is the provider region name of Atlas network peer container. If not set, AccepterRegionName is used.",
+                "type": "string"
+              },
+              "gcpProjectId": {
+                "description": "User GCP Project ID. Its applicable only for GCP.",
+                "type": "string"
+              },
+              "networkName": {
+                "description": "GCP Network Peer Name. Its applicable only for GCP.",
+                "type": "string"
+              },
+              "providerName": {
+                "description": "ProviderName is the name of the provider. If not set, it will be set to \"AWS\".",
+                "type": "string"
+              },
+              "resourceGroupName": {
+                "description": "ResourceGroupName is the name of your Azure resource group.",
+                "type": "string"
+              },
+              "routeTableCidrBlock": {
+                "description": "User VPC CIDR.",
+                "type": "string"
+              },
+              "vnetName": {
+                "description": "VNetName is name of your Azure VNet. Its applicable only for Azure.",
+                "type": "string"
+              },
+              "vpcId": {
+                "description": "AWS VPC ID.",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "privateEndpoints": {
+          "description": "PrivateEndpoints is a list of Private Endpoints configured for the current Project.\nDeprecated: Migrate to the AtlasPrivateEndpoint Custom Resource in accordance with the migration guide\nat https://www.mongodb.com/docs/atlas/operator/current/migrate-parameter-to-resource/#std-label-ak8so-migrate-ptr",
+          "items": {
+            "description": "PrivateEndpoint is a list of Private Endpoints configured for the current Project.\nDeprecated: Migrate to the AtlasPrivateEndpoint Custom Resource in accordance with the migration guide\nat https://www.mongodb.com/docs/atlas/operator/current/migrate-parameter-to-resource/#std-label-ak8so-migrate-ptr",
+            "properties": {
+              "endpointGroupName": {
+                "description": "Unique identifier of the endpoint group. The endpoint group encompasses all the endpoints that you created in Google Cloud.",
+                "type": "string"
+              },
+              "endpoints": {
+                "description": "Collection of individual private endpoints that comprise your endpoint group.",
+                "items": {
+                  "properties": {
+                    "endpointName": {
+                      "description": "Forwarding rule that corresponds to the endpoint you created in Google Cloud.",
+                      "type": "string"
+                    },
+                    "ipAddress": {
+                      "description": "Private IP address of the endpoint you created in Google Cloud.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "gcpProjectId": {
+                "description": "Unique identifier of the Google Cloud project in which you created your endpoints.",
+                "type": "string"
+              },
+              "id": {
+                "description": "Unique identifier of the private endpoint you created in your AWS VPC or Azure VNet.",
+                "type": "string"
+              },
+              "ip": {
+                "description": "Private IP address of the private endpoint network interface you created in your Azure VNet.",
+                "type": "string"
+              },
+              "provider": {
+                "description": "Cloud provider for which you want to retrieve a private endpoint service. Atlas accepts AWS, GCP, or AZURE.",
+                "enum": [
+                  "AWS",
+                  "GCP",
+                  "AZURE",
+                  "TENANT"
+                ],
+                "type": "string"
+              },
+              "region": {
+                "description": "Cloud provider region for which you want to create the private endpoint service.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "provider",
+              "region"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "projectIpAccessList": {
+          "description": "ProjectIPAccessList allows the use of the IP Access List for a Project. See more information at\nhttps://docs.atlas.mongodb.com/reference/api/ip-access-list/add-entries-to-access-list/\nDeprecated: Migrate to the AtlasIPAccessList Custom Resource in accordance with the migration guide\nat https://www.mongodb.com/docs/atlas/operator/current/migrate-parameter-to-resource/#std-label-ak8so-migrate-ptr",
+          "items": {
+            "description": "IPAccessList allows the use of the IP Access List for a Project. See more information at\nhttps://docs.atlas.mongodb.com/reference/api/ip-access-list/add-entries-to-access-list/\nDeprecated: Migrate to the AtlasIPAccessList Custom Resource in accordance with the migration guide\nat https://www.mongodb.com/docs/atlas/operator/current/migrate-parameter-to-resource/#std-label-ak8so-migrate-ptr",
+            "properties": {
+              "awsSecurityGroup": {
+                "description": "Unique identifier of AWS security group in this access list entry.",
+                "type": "string"
+              },
+              "cidrBlock": {
+                "description": "Range of IP addresses in CIDR notation in this access list entry.",
+                "type": "string"
+              },
+              "comment": {
+                "description": "Comment associated with this access list entry.",
+                "type": "string"
+              },
+              "deleteAfterDate": {
+                "description": "Timestamp in ISO 8601 date and time format in UTC after which Atlas deletes the temporary access list entry.",
+                "type": "string"
+              },
+              "ipAddress": {
+                "description": "Entry using an IP address in this access list entry.",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "regionUsageRestrictions": {
+          "default": "NONE",
+          "description": "RegionUsageRestrictions designate the project's AWS region when using Atlas for Government.\nThis parameter should not be used with commercial Atlas.\nIn Atlas for Government, not setting this field (defaulting to NONE) means the project is restricted to COMMERCIAL_FEDRAMP_REGIONS_ONLY.",
+          "enum": [
+            "NONE",
+            "GOV_REGIONS_ONLY",
+            "COMMERCIAL_FEDRAMP_REGIONS_ONLY"
+          ],
+          "type": "string"
+        },
+        "settings": {
+          "description": "Settings allows the configuration of the Project Settings.",
+          "properties": {
+            "isCollectDatabaseSpecificsStatisticsEnabled": {
+              "description": "Flag that indicates whether to collect database-specific metrics for the specified project.",
+              "type": "boolean"
+            },
+            "isDataExplorerEnabled": {
+              "description": "Flag that indicates whether to enable the Data Explorer for the specified project.",
+              "type": "boolean"
+            },
+            "isExtendedStorageSizesEnabled": {
+              "description": "Flag that indicates whether to enable extended storage sizes for the specified project.",
+              "type": "boolean"
+            },
+            "isPerformanceAdvisorEnabled": {
+              "description": "Flag that indicates whether to enable the Performance Advisor and Profiler for the specified project.",
+              "type": "boolean"
+            },
+            "isRealtimePerformancePanelEnabled": {
+              "description": "Flag that indicates whether to enable the Real Time Performance Panel for the specified project.",
+              "type": "boolean"
+            },
+            "isSchemaAdvisorEnabled": {
+              "description": "Flag that indicates whether to enable the Schema Advisor for the specified project.",
+              "type": "boolean"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "teams": {
+          "description": "Teams enable you to grant project access roles to multiple users.",
+          "items": {
+            "properties": {
+              "roles": {
+                "description": "Roles the users in the team has within the project.",
+                "items": {
+                  "enum": [
+                    "GROUP_OWNER",
+                    "GROUP_CLUSTER_MANAGER",
+                    "GROUP_DATA_ACCESS_ADMIN",
+                    "GROUP_DATA_ACCESS_READ_WRITE",
+                    "GROUP_DATA_ACCESS_READ_ONLY",
+                    "GROUP_READ_ONLY"
+                  ],
+                  "type": "string"
+                },
+                "minItems": 1,
+                "type": "array"
+              },
+              "teamRef": {
+                "description": "Reference to the AtlasTeam custom resource which will be assigned to the project.",
+                "properties": {
+                  "name": {
+                    "description": "Name of the Kubernetes Resource",
+                    "type": "string"
+                  },
+                  "namespace": {
+                    "description": "Namespace of the Kubernetes Resource",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "roles",
+              "teamRef"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "withDefaultAlertsSettings": {
+          "default": true,
+          "description": "Flag that indicates whether Atlas Kubernetes Operator creates a project with the default alert configurations.\nIf you use this setting, you must also set spec.alertConfigurationSyncEnabled to true for Atlas Kubernetes\nOperator to modify project alert configurations.\nIf you set this parameter to false when you create a project, Atlas doesn't add the default alert configurations\nto your project.\nThis setting has no effect on existing projects.",
+          "type": "boolean"
+        },
+        "x509CertRef": {
+          "description": "X509CertRef is a reference to the Kubernetes Secret which contains PEM-encoded CA certificate.\nAtlas Kubernetes Operator watches secrets only with the label atlas.mongodb.com/type=credentials to avoid\nwatching unnecessary secrets.",
+          "properties": {
+            "name": {
+              "description": "Name of the Kubernetes Resource",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "Namespace of the Kubernetes Resource",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "AtlasProjectStatus defines the observed state of AtlasProject",
+      "properties": {
+        "alertConfigurations": {
+          "description": "AlertConfigurations contains a list of alert configuration statuses",
+          "items": {
+            "properties": {
+              "acknowledgedUntil": {
+                "description": "The date through which the alert has been acknowledged. Will not be present if the alert has never been acknowledged.",
+                "type": "string"
+              },
+              "acknowledgementComment": {
+                "description": "The comment left by the user who acknowledged the alert. Will not be present if the alert has never been acknowledged.",
+                "type": "string"
+              },
+              "acknowledgingUsername": {
+                "description": "The username of the user who acknowledged the alert. Will not be present if the alert has never been acknowledged.",
+                "type": "string"
+              },
+              "alertConfigId": {
+                "description": "ID of the alert configuration that triggered this alert.",
+                "type": "string"
+              },
+              "clusterId": {
+                "description": "The ID of the cluster to which this alert applies. Only present for alerts of type BACKUP, REPLICA_SET, and CLUSTER.",
+                "type": "string"
+              },
+              "clusterName": {
+                "description": "The name the cluster to which this alert applies. Only present for alerts of type BACKUP, REPLICA_SET, and CLUSTER.",
+                "type": "string"
+              },
+              "created": {
+                "description": "Timestamp in ISO 8601 date and time format in UTC when this alert configuration was created.",
+                "type": "string"
+              },
+              "currentValue": {
+                "description": "CurrentValue represents current value of the metric that triggered the alert. Only present for alerts of type HOST_METRIC.",
+                "properties": {
+                  "number": {
+                    "description": "The value of the metric.",
+                    "type": "string"
+                  },
+                  "units": {
+                    "description": "The units for the value. Depends on the type of metric.",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "enabled": {
+                "description": "If omitted, the configuration is disabled.",
+                "type": "boolean"
+              },
+              "errorMessage": {
+                "description": "ErrorMessage is massage if the alert configuration is in an incorrect state.",
+                "type": "string"
+              },
+              "eventTypeName": {
+                "description": "The type of event that will trigger an alert.",
+                "type": "string"
+              },
+              "groupId": {
+                "description": "Unique identifier of the project that owns this alert configuration.",
+                "type": "string"
+              },
+              "hostId": {
+                "description": "ID of the host to which the metric pertains. Only present for alerts of type HOST, HOST_METRIC, and REPLICA_SET.",
+                "type": "string"
+              },
+              "hostnameAndPort": {
+                "description": "The hostname and port of each host to which the alert applies. Only present for alerts of type HOST, HOST_METRIC, and REPLICA_SET.",
+                "type": "string"
+              },
+              "id": {
+                "description": "Unique identifier.",
+                "type": "string"
+              },
+              "lastNotified": {
+                "description": "When the last notification was sent for this alert. Only present if notifications have been sent.",
+                "type": "string"
+              },
+              "matchers": {
+                "description": "You can filter using the matchers array only when the EventTypeName specifies an event for a host, replica set, or sharded cluster.",
+                "items": {
+                  "properties": {
+                    "fieldName": {
+                      "description": "Name of the field in the target object to match on.",
+                      "type": "string"
+                    },
+                    "operator": {
+                      "description": "The operator to test the field\u2019s value.",
+                      "type": "string"
+                    },
+                    "value": {
+                      "description": "Value to test with the specified operator.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "metricName": {
+                "description": "The name of the measurement whose value went outside the threshold. Only present if eventTypeName is set to OUTSIDE_METRIC_THRESHOLD.",
+                "type": "string"
+              },
+              "metricThreshold": {
+                "description": "MetricThreshold  causes an alert to be triggered.",
+                "properties": {
+                  "metricName": {
+                    "description": "Name of the metric to check.",
+                    "type": "string"
+                  },
+                  "mode": {
+                    "description": "This must be set to AVERAGE. Atlas computes the current metric value as an average.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "Operator to apply when checking the current metric value against the threshold value.",
+                    "type": "string"
+                  },
+                  "threshold": {
+                    "description": "Threshold value outside which an alert will be triggered.",
+                    "type": "string"
+                  },
+                  "units": {
+                    "description": "The units for the threshold value.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "threshold"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "notifications": {
+                "description": "Notifications are sending when an alert condition is detected.",
+                "items": {
+                  "properties": {
+                    "apiToken": {
+                      "description": "Slack API token or Bot token. Populated for the SLACK notifications type. If the token later becomes invalid, Atlas sends an email to the project owner and eventually removes the token.",
+                      "type": "string"
+                    },
+                    "channelName": {
+                      "description": "Slack channel name. Populated for the SLACK notifications type.",
+                      "type": "string"
+                    },
+                    "datadogApiKey": {
+                      "description": "Datadog API Key. Found in the Datadog dashboard. Populated for the DATADOG notifications type.",
+                      "type": "string"
+                    },
+                    "datadogRegion": {
+                      "description": "Region that indicates which API URL to use",
+                      "type": "string"
+                    },
+                    "delayMin": {
+                      "description": "Number of minutes to wait after an alert condition is detected before sending out the first notification.",
+                      "type": "integer"
+                    },
+                    "emailAddress": {
+                      "description": "Email address to which alert notifications are sent. Populated for the EMAIL notifications type.",
+                      "type": "string"
+                    },
+                    "emailEnabled": {
+                      "description": "Flag indicating if email notifications should be sent. Populated for ORG, GROUP, and USER notifications types.",
+                      "type": "boolean"
+                    },
+                    "flowName": {
+                      "description": "Flowdock flow namse in lower-case letters.",
+                      "type": "string"
+                    },
+                    "flowdockApiToken": {
+                      "description": "The Flowdock personal API token. Populated for the FLOWDOCK notifications type. If the token later becomes invalid, Atlas sends an email to the project owner and eventually removes the token.",
+                      "type": "string"
+                    },
+                    "intervalMin": {
+                      "description": "Number of minutes to wait between successive notifications for unacknowledged alerts that are not resolved.",
+                      "type": "integer"
+                    },
+                    "mobileNumber": {
+                      "description": "Mobile number to which alert notifications are sent. Populated for the SMS notifications type.",
+                      "type": "string"
+                    },
+                    "opsGenieApiKey": {
+                      "description": "Opsgenie API Key. Populated for the OPS_GENIE notifications type. If the key later becomes invalid, Atlas sends an email to the project owner and eventually removes the token.",
+                      "type": "string"
+                    },
+                    "opsGenieRegion": {
+                      "description": "Region that indicates which API URL to use.",
+                      "type": "string"
+                    },
+                    "orgName": {
+                      "description": "Flowdock organization name in lower-case letters. This is the name that appears after www.flowdock.com/app/ in the URL string. Populated for the FLOWDOCK notifications type.",
+                      "type": "string"
+                    },
+                    "roles": {
+                      "description": "The following roles grant privileges within a project.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "serviceKey": {
+                      "description": "PagerDuty service key. Populated for the PAGER_DUTY notifications type. If the key later becomes invalid, Atlas sends an email to the project owner and eventually removes the key.",
+                      "type": "string"
+                    },
+                    "smsEnabled": {
+                      "description": "Flag indicating if text message notifications should be sent. Populated for ORG, GROUP, and USER notifications types.",
+                      "type": "boolean"
+                    },
+                    "teamId": {
+                      "description": "Unique identifier of a team.",
+                      "type": "string"
+                    },
+                    "teamName": {
+                      "description": "Label for the team that receives this notification.",
+                      "type": "string"
+                    },
+                    "typeName": {
+                      "description": "Type of alert notification.",
+                      "type": "string"
+                    },
+                    "username": {
+                      "description": "Name of the Atlas user to which to send notifications. Only a user in the project that owns the alert configuration is allowed here. Populated for the USER notifications type.",
+                      "type": "string"
+                    },
+                    "victorOpsApiKey": {
+                      "description": "VictorOps API key. Populated for the VICTOR_OPS notifications type. If the key later becomes invalid, Atlas sends an email to the project owner and eventually removes the key.",
+                      "type": "string"
+                    },
+                    "victorOpsRoutingKey": {
+                      "description": "VictorOps routing key. Populated for the VICTOR_OPS notifications type. If the key later becomes invalid, Atlas sends an email to the project owner and eventually removes the key.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "replicaSetName": {
+                "description": "Name of the replica set. Only present for alerts of type HOST, HOST_METRIC, BACKUP, and REPLICA_SET.",
+                "type": "string"
+              },
+              "resolved": {
+                "description": "When the alert was closed. Only present if the status is CLOSED.",
+                "type": "string"
+              },
+              "severityOverride": {
+                "description": "Severity of the alert.",
+                "type": "string"
+              },
+              "sourceTypeName": {
+                "description": "For alerts of the type BACKUP, the type of server being backed up.",
+                "type": "string"
+              },
+              "status": {
+                "description": "The current state of the alert. Possible values are: TRACKING, OPEN, CLOSED, CANCELED",
+                "type": "string"
+              },
+              "threshold": {
+                "description": "Threshold  causes an alert to be triggered.",
+                "properties": {
+                  "operator": {
+                    "description": "Operator to apply when checking the current metric value against the threshold value. it accepts the following values: GREATER_THAN, LESS_THAN",
+                    "type": "string"
+                  },
+                  "threshold": {
+                    "description": "Threshold value outside which an alert will be triggered.",
+                    "type": "string"
+                  },
+                  "units": {
+                    "description": "The units for the threshold value",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "updated": {
+                "description": "Timestamp in ISO 8601 date and time format in UTC when this alert configuration was last updated.",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "authModes": {
+          "description": "AuthModes contains a list of configured authentication modes\n\"SCRAM\" is default authentication method and requires a password for each user\n\"X509\" signifies that self-managed X.509 authentication is configured",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "cloudProviderIntegrations": {
+          "description": "CloudProviderIntegrations contains a list of configured cloud provider access roles. AWS support only",
+          "items": {
+            "properties": {
+              "atlasAWSAccountArn": {
+                "description": "Amazon Resource Name that identifies the Amazon Web Services user account that MongoDB Atlas uses when it assumes the Identity and Access Management role.",
+                "type": "string"
+              },
+              "atlasAssumedRoleExternalId": {
+                "description": "Unique external ID that MongoDB Atlas uses when it assumes the IAM role in your Amazon Web Services account.",
+                "type": "string"
+              },
+              "authorizedDate": {
+                "description": "Date and time when someone authorized this role for the specified cloud service provider. This parameter expresses its value in the ISO 8601 timestamp format in UTC.",
+                "type": "string"
+              },
+              "createdDate": {
+                "description": "Date and time when someone created this role for the specified cloud service provider. This parameter expresses its value in the ISO 8601 timestamp format in UTC.",
+                "type": "string"
+              },
+              "errorMessage": {
+                "description": "Application error message returned.",
+                "type": "string"
+              },
+              "featureUsages": {
+                "description": "List that contains application features associated with this Amazon Web Services Identity and Access Management role.",
+                "items": {
+                  "properties": {
+                    "featureId": {
+                      "description": "Identifying characteristics about the data lake linked to this Amazon Web Services Identity and Access Management role.",
+                      "type": "string"
+                    },
+                    "featureType": {
+                      "description": "Human-readable label that describes one MongoDB Cloud feature linked to this Amazon Web Services Identity and Access Management role.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "iamAssumedRoleArn": {
+                "description": "Amazon Resource Name that identifies the Amazon Web Services Identity and Access Management role that MongoDB Cloud assumes when it accesses resources in your AWS account.",
+                "type": "string"
+              },
+              "providerName": {
+                "description": "Human-readable label that identifies the cloud provider of the role.",
+                "type": "string"
+              },
+              "roleId": {
+                "description": "Unique 24-hexadecimal digit string that identifies the role.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Provision status of the service account.\nValues are IN_PROGRESS, COMPLETE, FAILED, or NOT_INITIATED.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "atlasAssumedRoleExternalId",
+              "providerName"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "conditions": {
+          "description": "Conditions is the list of statuses showing the current state of the Atlas Custom Resource",
+          "items": {
+            "description": "Condition describes the state of an Atlas Custom Resource at a certain point.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another.\nRepresented in ISO 8601 format.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A message providing details about the transition.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition; one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of Atlas Custom Resource condition.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "customRoles": {
+          "description": "CustomRoles contains a list of custom roles statuses",
+          "items": {
+            "properties": {
+              "error": {
+                "description": "The message when the custom role is in the FAILED status",
+                "type": "string"
+              },
+              "name": {
+                "description": "Role name which is unique",
+                "type": "string"
+              },
+              "status": {
+                "description": "The status of the given custom role (OK or FAILED)",
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "status"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "expiredIpAccessList": {
+          "description": "The list of IP Access List entries that are expired due to 'deleteAfterDate' being less than the current date.\nNote, that this field is updated by the Atlas Operator only after specification changes",
+          "items": {
+            "description": "IPAccessList allows the use of the IP Access List for a Project. See more information at\nhttps://docs.atlas.mongodb.com/reference/api/ip-access-list/add-entries-to-access-list/\nDeprecated: Migrate to the AtlasIPAccessList Custom Resource in accordance with the migration guide\nat https://www.mongodb.com/docs/atlas/operator/current/migrate-parameter-to-resource/#std-label-ak8so-migrate-ptr",
+            "properties": {
+              "awsSecurityGroup": {
+                "description": "Unique identifier of AWS security group in this access list entry.",
+                "type": "string"
+              },
+              "cidrBlock": {
+                "description": "Range of IP addresses in CIDR notation in this access list entry.",
+                "type": "string"
+              },
+              "comment": {
+                "description": "Comment associated with this access list entry.",
+                "type": "string"
+              },
+              "deleteAfterDate": {
+                "description": "Timestamp in ISO 8601 date and time format in UTC after which Atlas deletes the temporary access list entry.",
+                "type": "string"
+              },
+              "ipAddress": {
+                "description": "Entry using an IP address in this access list entry.",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "id": {
+          "description": "The ID of the Atlas Project",
+          "type": "string"
+        },
+        "networkPeers": {
+          "description": "The list of network peers that are configured for current project",
+          "items": {
+            "properties": {
+              "atlasGcpProjectId": {
+                "description": "ProjectID of Atlas container. Applicable only for GCP. It's needed to add network peer connection.",
+                "type": "string"
+              },
+              "atlasNetworkName": {
+                "description": "Atlas Network Name. Applicable only for GCP. It's needed to add network peer connection.",
+                "type": "string"
+              },
+              "connectionId": {
+                "description": "Unique identifier of the network peer connection. Applicable only for AWS.",
+                "type": "string"
+              },
+              "containerId": {
+                "description": "ContainerID of Atlas network peer container.",
+                "type": "string"
+              },
+              "errorMessage": {
+                "description": "Error state of the network peer. Applicable only for GCP.",
+                "type": "string"
+              },
+              "errorState": {
+                "description": "Error state of the network peer. Applicable only for Azure.",
+                "type": "string"
+              },
+              "errorStateName": {
+                "description": "Error state of the network peer. Applicable only for AWS.",
+                "type": "string"
+              },
+              "gcpProjectId": {
+                "description": "ProjectID of the user's vpc. Applicable only for GCP.",
+                "type": "string"
+              },
+              "id": {
+                "description": "Unique identifier for NetworkPeer.",
+                "type": "string"
+              },
+              "providerName": {
+                "description": "Cloud provider for which you want to retrieve a network peer.",
+                "type": "string"
+              },
+              "region": {
+                "description": "Region for which you want to create the network peer. It isn't needed for GCP",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the network peer. Applicable only for GCP and Azure.",
+                "type": "string"
+              },
+              "statusName": {
+                "description": "Status of the network peer. Applicable only for AWS.",
+                "type": "string"
+              },
+              "vpc": {
+                "description": "VPC is general purpose field for storing the name of the VPC.\nVPC is vpcID for AWS, user networkName for GCP, and vnetName for Azure.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "providerName",
+              "region"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration indicates the generation of the resource specification of which the Atlas Operator is aware.\nThe Atlas Operator updates this field to the value of 'metadata.generation' as soon as it starts reconciliation of the resource.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "privateEndpoints": {
+          "description": "The list of private endpoints configured for current project",
+          "items": {
+            "properties": {
+              "endpoints": {
+                "description": "Collection of individual GCP private endpoints that comprise your network endpoint group.",
+                "items": {
+                  "properties": {
+                    "endpointName": {
+                      "description": "Human-readable label that identifies the Google Cloud consumer forwarding rule that you created.",
+                      "type": "string"
+                    },
+                    "ipAddress": {
+                      "description": "One Private Internet Protocol version 4 (IPv4) address to which this Google Cloud consumer forwarding rule resolves.",
+                      "type": "string"
+                    },
+                    "status": {
+                      "description": "State of the MongoDB Atlas endpoint group when MongoDB Cloud received this request.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "endpointName",
+                    "ipAddress",
+                    "status"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "id": {
+                "description": "Unique identifier for AWS or AZURE Private Link Connection.",
+                "type": "string"
+              },
+              "interfaceEndpointId": {
+                "description": "Unique identifier of the AWS or Azure Private Link Interface Endpoint.",
+                "type": "string"
+              },
+              "provider": {
+                "description": "Cloud provider for which you want to retrieve a private endpoint service. Atlas accepts AWS or AZURE.",
+                "type": "string"
+              },
+              "region": {
+                "description": "Cloud provider region for which you want to create the private endpoint service.",
+                "type": "string"
+              },
+              "serviceAttachmentNames": {
+                "description": "Unique alphanumeric and special character strings that identify the service attachments associated with the GCP Private Service Connect endpoint service.",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "serviceName": {
+                "description": "Name of the AWS or Azure Private Link Service that Atlas manages.",
+                "type": "string"
+              },
+              "serviceResourceId": {
+                "description": "Unique identifier of the Azure Private Link Service (for AWS the same as ID).",
+                "type": "string"
+              }
+            },
+            "required": [
+              "provider",
+              "region"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "prometheus": {
+          "description": "Prometheus contains the status for Prometheus integration\nincluding the prometheusDiscoveryURL",
+          "properties": {
+            "prometheusDiscoveryURL": {
+              "description": "URL from which Prometheus fetches the targets.",
+              "type": "string"
+            },
+            "scheme": {
+              "description": "Protocol scheme used for Prometheus requests.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "teams": {
+          "description": "Teams contains a list of teams assignment statuses",
+          "items": {
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "teamRef": {
+                "description": "ResourceRefNamespaced is a reference to a Kubernetes Resource that allows to configure the namespace",
+                "properties": {
+                  "name": {
+                    "description": "Name of the Kubernetes Resource",
+                    "type": "string"
+                  },
+                  "namespace": {
+                    "description": "Namespace of the Kubernetes Resource",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "teamRef"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "conditions"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/atlas.mongodb.com/atlassearchindexconfig_v1.json
+++ b/atlas.mongodb.com/atlassearchindexconfig_v1.json
@@ -1,0 +1,253 @@
+{
+  "description": "AtlasSearchIndexConfig is the Schema for the AtlasSearchIndexConfig API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "AtlasSearchIndexConfigSpec defines the target state of AtlasSearchIndexConfig.",
+      "properties": {
+        "analyzer": {
+          "description": "Specific pre-defined method chosen to convert database field text into searchable words. This conversion reduces the text of fields into the smallest units of text.\nThese units are called a term or token. This process, known as tokenization, involves a variety of changes made to the text in fields:\n- extracting words\n- removing punctuation\n- removing accents\n- hanging to lowercase\n- removing common words\n- reducing words to their root form (stemming)\n- changing words to their base form (lemmatization) MongoDB Cloud uses the selected process to build the Atlas Search index",
+          "enum": [
+            "lucene.standard",
+            "lucene.simple",
+            "lucene.whitespace",
+            "lucene.keyword",
+            "lucene.arabic",
+            "lucene.armenian",
+            "lucene.basque",
+            "lucene.bengali",
+            "lucene.brazilian",
+            "lucene.bulgarian",
+            "lucene.catalan",
+            "lucene.chinese",
+            "lucene.cjk",
+            "lucene.czech",
+            "lucene.danish",
+            "lucene.dutch",
+            "lucene.english",
+            "lucene.finnish",
+            "lucene.french",
+            "lucene.galician",
+            "lucene.german",
+            "lucene.greek",
+            "lucene.hindi",
+            "lucene.hungarian",
+            "lucene.indonesian",
+            "lucene.irish",
+            "lucene.italian",
+            "lucene.japanese",
+            "lucene.korean",
+            "lucene.kuromoji",
+            "lucene.latvian",
+            "lucene.lithuanian",
+            "lucene.morfologik",
+            "lucene.nori",
+            "lucene.norwegian",
+            "lucene.persian",
+            "lucene.portuguese",
+            "lucene.romanian",
+            "lucene.russian",
+            "lucene.smartcn",
+            "lucene.sorani",
+            "lucene.spanish",
+            "lucene.swedish",
+            "lucene.thai",
+            "lucene.turkish",
+            "lucene.ukrainian"
+          ],
+          "type": "string"
+        },
+        "analyzers": {
+          "description": "List of user-defined methods to convert database field text into searchable words.",
+          "items": {
+            "properties": {
+              "charFilters": {
+                "description": "Filters that examine text one character at a time and perform filtering operations.",
+                "x-kubernetes-preserve-unknown-fields": true
+              },
+              "name": {
+                "description": "Human-readable name that identifies the custom analyzer. Names must be unique within an index, and must not start with any of the following strings:\n\"lucene.\", \"builtin.\", \"mongodb.\"",
+                "type": "string"
+              },
+              "tokenFilters": {
+                "description": "Filter that performs operations such as:\n- Stemming, which reduces related words, such as \"talking\", \"talked\", and \"talks\" to their root word \"talk\".\n- Redaction, the removal of sensitive information from public documents",
+                "x-kubernetes-preserve-unknown-fields": true
+              },
+              "tokenizer": {
+                "description": "Tokenizer that you want to use to create tokens. Tokens determine how Atlas Search splits up text into discrete chunks for indexing.",
+                "properties": {
+                  "group": {
+                    "description": "Index of the character group within the matching expression to extract into tokens. Use `0` to extract all character groups.",
+                    "type": "integer"
+                  },
+                  "maxGram": {
+                    "description": "Characters to include in the longest token that Atlas Search creates.",
+                    "type": "integer"
+                  },
+                  "maxTokenLength": {
+                    "description": "Maximum number of characters in a single token. Tokens greater than this length are split at this length into multiple tokens.",
+                    "type": "integer"
+                  },
+                  "minGram": {
+                    "description": "Characters to include in the shortest token that Atlas Search creates.",
+                    "type": "integer"
+                  },
+                  "pattern": {
+                    "description": "Regular expression to match against.",
+                    "type": "string"
+                  },
+                  "type": {
+                    "description": "Human-readable label that identifies this tokenizer type.",
+                    "enum": [
+                      "whitespace",
+                      "uaxUrlEmail",
+                      "standard",
+                      "regexSplit",
+                      "regexCaptureGroup",
+                      "nGram",
+                      "keyword",
+                      "edgeGram"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "type"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "name",
+              "tokenizer"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "searchAnalyzer": {
+          "description": "Method applied to identify words when searching this index.",
+          "enum": [
+            "lucene.standard",
+            "lucene.simple",
+            "lucene.whitespace",
+            "lucene.keyword",
+            "lucene.arabic",
+            "lucene.armenian",
+            "lucene.basque",
+            "lucene.bengali",
+            "lucene.brazilian",
+            "lucene.bulgarian",
+            "lucene.catalan",
+            "lucene.chinese",
+            "lucene.cjk",
+            "lucene.czech",
+            "lucene.danish",
+            "lucene.dutch",
+            "lucene.english",
+            "lucene.finnish",
+            "lucene.french",
+            "lucene.galician",
+            "lucene.german",
+            "lucene.greek",
+            "lucene.hindi",
+            "lucene.hungarian",
+            "lucene.indonesian",
+            "lucene.irish",
+            "lucene.italian",
+            "lucene.japanese",
+            "lucene.korean",
+            "lucene.kuromoji",
+            "lucene.latvian",
+            "lucene.lithuanian",
+            "lucene.morfologik",
+            "lucene.nori",
+            "lucene.norwegian",
+            "lucene.persian",
+            "lucene.portuguese",
+            "lucene.romanian",
+            "lucene.russian",
+            "lucene.smartcn",
+            "lucene.sorani",
+            "lucene.spanish",
+            "lucene.swedish",
+            "lucene.thai",
+            "lucene.turkish",
+            "lucene.ukrainian"
+          ],
+          "type": "string"
+        },
+        "storedSource": {
+          "description": "Flag that indicates whether to store all fields (true) on Atlas Search. By default, Atlas doesn't store (false) the fields on Atlas Search.\nAlternatively, you can specify an object that only contains the list of fields to store (include) or not store (exclude) on Atlas Search.\nTo learn more, see documentation: https://www.mongodb.com/docs/atlas/atlas-search/stored-source-definition/",
+          "x-kubernetes-preserve-unknown-fields": true
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "AtlasSearchIndexConfigStatus defines the observed state of AtlasSearchIndexConfig.",
+      "properties": {
+        "conditions": {
+          "description": "Conditions is the list of statuses showing the current state of the Atlas Custom Resource",
+          "items": {
+            "description": "Condition describes the state of an Atlas Custom Resource at a certain point.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another.\nRepresented in ISO 8601 format.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A message providing details about the transition.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition; one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of Atlas Custom Resource condition.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration indicates the generation of the resource specification of which the Atlas Operator is aware.\nThe Atlas Operator updates this field to the value of 'metadata.generation' as soon as it starts reconciliation of the resource.",
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "conditions"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/atlas.mongodb.com/atlasstreamconnection_v1.json
+++ b/atlas.mongodb.com/atlasstreamconnection_v1.json
@@ -1,0 +1,249 @@
+{
+  "description": "AtlasStreamConnection is the Schema for the atlasstreamconnections API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "AtlasStreamConnectionSpec defines the target state of AtlasStreamConnection.",
+      "properties": {
+        "clusterConfig": {
+          "description": "The configuration to be used to connect to an Atlas Cluster.",
+          "properties": {
+            "name": {
+              "description": "Name of the cluster configured for this connection.",
+              "type": "string"
+            },
+            "role": {
+              "description": "The name of a built-in or Custom DB Role to connect to an Atlas Cluster.",
+              "properties": {
+                "name": {
+                  "description": "The name of the role to use. Can be a built-in role or a custom role.",
+                  "type": "string"
+                },
+                "type": {
+                  "description": "Type of the DB role. Can be either BUILT_IN or CUSTOM.",
+                  "enum": [
+                    "BUILT_IN",
+                    "CUSTOM"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name",
+                "type"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "name",
+            "role"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "kafkaConfig": {
+          "description": "The configuration to be used to connect to a Kafka Cluster.",
+          "properties": {
+            "authentication": {
+              "description": "User credentials required to connect to a Kafka Cluster. Includes the authentication type, as well as the parameters for that authentication mode.",
+              "properties": {
+                "credentials": {
+                  "description": "Reference to the secret containing th Username and Password of the account to connect to the Kafka cluster.",
+                  "properties": {
+                    "name": {
+                      "description": "Name of the Kubernetes Resource",
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "description": "Namespace of the Kubernetes Resource",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "mechanism": {
+                  "description": "Style of authentication. Can be one of PLAIN, SCRAM-256, or SCRAM-512.",
+                  "enum": [
+                    "PLAIN",
+                    "SCRAM-256",
+                    "SCRAM-512"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "credentials",
+                "mechanism"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "bootstrapServers": {
+              "description": "Comma separated list of server addresses",
+              "type": "string"
+            },
+            "config": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "A map of Kafka key-value pairs for optional configuration. This is a flat object, and keys can have '.' characters.",
+              "type": "object"
+            },
+            "security": {
+              "description": "Properties for the secure transport connection to Kafka. For SSL, this can include the trusted certificate to use.",
+              "properties": {
+                "certificate": {
+                  "description": "A trusted, public x509 certificate for connecting to Kafka over SSL.",
+                  "properties": {
+                    "name": {
+                      "description": "Name of the Kubernetes Resource",
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "description": "Namespace of the Kubernetes Resource",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "protocol": {
+                  "description": "Describes the transport type. Can be either PLAINTEXT or SSL.",
+                  "enum": [
+                    "PLAINTEXT",
+                    "SSL"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "protocol"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "authentication",
+            "bootstrapServers",
+            "security"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "name": {
+          "description": "Human-readable label that uniquely identifies the stream connection.",
+          "type": "string"
+        },
+        "type": {
+          "description": "Type of the connection. Can be either Cluster or Kafka.",
+          "enum": [
+            "Kafka",
+            "Cluster",
+            "Sample"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "type"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "AtlasStreamConnectionStatus defines the observed state of AtlasStreamConnection.",
+      "properties": {
+        "conditions": {
+          "description": "Conditions is the list of statuses showing the current state of the Atlas Custom Resource",
+          "items": {
+            "description": "Condition describes the state of an Atlas Custom Resource at a certain point.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another.\nRepresented in ISO 8601 format.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A message providing details about the transition.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition; one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of Atlas Custom Resource condition.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "instances": {
+          "description": "List of instances using the connection configuration",
+          "items": {
+            "description": "ResourceRefNamespaced is a reference to a Kubernetes Resource that allows to configure the namespace",
+            "properties": {
+              "name": {
+                "description": "Name of the Kubernetes Resource",
+                "type": "string"
+              },
+              "namespace": {
+                "description": "Namespace of the Kubernetes Resource",
+                "type": "string"
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration indicates the generation of the resource specification of which the Atlas Operator is aware.\nThe Atlas Operator updates this field to the value of 'metadata.generation' as soon as it starts reconciliation of the resource.",
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "conditions"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/atlas.mongodb.com/atlasstreaminstance_v1.json
+++ b/atlas.mongodb.com/atlasstreaminstance_v1.json
@@ -1,0 +1,205 @@
+{
+  "description": "AtlasStreamInstance is the Schema for the atlasstreaminstances API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "AtlasStreamInstanceSpec defines the target state of AtlasStreamInstance.",
+      "properties": {
+        "clusterConfig": {
+          "description": "The configuration to be used to connect to an Atlas Cluster.",
+          "properties": {
+            "provider": {
+              "default": "AWS",
+              "description": "Name of the cluster configured for this connection.",
+              "enum": [
+                "AWS",
+                "GCP",
+                "AZURE",
+                "TENANT",
+                "SERVERLESS"
+              ],
+              "type": "string"
+            },
+            "region": {
+              "description": "Name of the cloud provider region hosting Atlas Stream Processing.",
+              "type": "string"
+            },
+            "tier": {
+              "default": "SP10",
+              "description": "Selected tier for the Stream Instance. Configures Memory / VCPU allowances.",
+              "enum": [
+                "SP10",
+                "SP30",
+                "SP50"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "provider",
+            "region",
+            "tier"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "connectionRegistry": {
+          "description": "List of connections of the stream instance for the specified project.",
+          "items": {
+            "description": "ResourceRefNamespaced is a reference to a Kubernetes Resource that allows to configure the namespace",
+            "properties": {
+              "name": {
+                "description": "Name of the Kubernetes Resource",
+                "type": "string"
+              },
+              "namespace": {
+                "description": "Namespace of the Kubernetes Resource",
+                "type": "string"
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "name": {
+          "description": "Human-readable label that identifies the stream connection.",
+          "type": "string"
+        },
+        "projectRef": {
+          "description": "Project which the instance belongs to.",
+          "properties": {
+            "name": {
+              "description": "Name of the Kubernetes Resource",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "Namespace of the Kubernetes Resource",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "clusterConfig",
+        "name",
+        "projectRef"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "AtlasStreamInstanceStatus defines the observed state of AtlasStreamInstance.",
+      "properties": {
+        "conditions": {
+          "description": "Conditions is the list of statuses showing the current state of the Atlas Custom Resource",
+          "items": {
+            "description": "Condition describes the state of an Atlas Custom Resource at a certain point.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another.\nRepresented in ISO 8601 format.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A message providing details about the transition.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition; one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of Atlas Custom Resource condition.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "connections": {
+          "description": "List of connections configured in the stream instance.",
+          "items": {
+            "properties": {
+              "name": {
+                "description": "Human-readable label that uniquely identifies the stream connection",
+                "type": "string"
+              },
+              "resourceRef": {
+                "description": "Reference for the resource that contains connection configuration",
+                "properties": {
+                  "name": {
+                    "description": "Name of the Kubernetes Resource",
+                    "type": "string"
+                  },
+                  "namespace": {
+                    "description": "Namespace of the Kubernetes Resource",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "hostnames": {
+          "description": "List that contains the hostnames assigned to the stream instance.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "id": {
+          "description": "Unique 24-hexadecimal character string that identifies the instance",
+          "type": "string"
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration indicates the generation of the resource specification of which the Atlas Operator is aware.\nThe Atlas Operator updates this field to the value of 'metadata.generation' as soon as it starts reconciliation of the resource.",
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "conditions"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/atlas.mongodb.com/atlasteam_v1.json
+++ b/atlas.mongodb.com/atlasteam_v1.json
@@ -1,0 +1,120 @@
+{
+  "description": "AtlasTeam is the Schema for the Atlas Teams API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "TeamSpec defines the target state of a Team in Atlas.",
+      "properties": {
+        "name": {
+          "description": "The name of the team you want to create.",
+          "type": "string"
+        },
+        "usernames": {
+          "description": "Valid email addresses of users to add to the new team.",
+          "items": {
+            "format": "email",
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "name",
+        "usernames"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "TeamStatus defines the observed state of AtlasTeam.",
+      "properties": {
+        "conditions": {
+          "description": "Conditions is the list of statuses showing the current state of the Atlas Custom Resource",
+          "items": {
+            "description": "Condition describes the state of an Atlas Custom Resource at a certain point.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another.\nRepresented in ISO 8601 format.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A message providing details about the transition.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition; one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of Atlas Custom Resource condition.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "id": {
+          "description": "ID of the team",
+          "type": "string"
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration indicates the generation of the resource specification of which the Atlas Operator is aware.\nThe Atlas Operator updates this field to the value of 'metadata.generation' as soon as it starts reconciliation of the resource.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "projects": {
+          "description": "List of projects which the team is assigned",
+          "items": {
+            "properties": {
+              "id": {
+                "description": "Unique identifier of the project inside atlas",
+                "type": "string"
+              },
+              "name": {
+                "description": "Name given to the project",
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "name"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "conditions"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "spec"
+  ],
+  "type": "object"
+}

--- a/atlas.mongodb.com/atlasthirdpartyintegration_v1.json
+++ b/atlas.mongodb.com/atlasthirdpartyintegration_v1.json
@@ -1,0 +1,483 @@
+{
+  "description": "AtlasThirdPartyIntegration is the Schema for the atlas 3rd party integrations API.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "AtlasThirdPartyIntegrationSpec contains the expected configuration for an integration",
+      "properties": {
+        "connectionSecret": {
+          "description": "Name of the secret containing Atlas API private and public keys.",
+          "properties": {
+            "name": {
+              "description": "Name of the resource being referred to\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "datadog": {
+          "description": "Datadog contains the config fields for Datadog's Integration.",
+          "properties": {
+            "apiKeySecretRef": {
+              "description": "APIKeySecretRef holds the name of a secret containing the Datadog API key.",
+              "properties": {
+                "name": {
+                  "description": "Name of the resource being referred to\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "region": {
+              "description": "Region is the Datadog region",
+              "type": "string"
+            },
+            "sendCollectionLatencyMetrics": {
+              "default": "disabled",
+              "description": "SendCollectionLatencyMetrics toggles sending collection latency metrics.",
+              "enum": [
+                "enabled",
+                "disabled"
+              ],
+              "type": "string"
+            },
+            "sendDatabaseMetrics": {
+              "default": "disabled",
+              "description": "SendDatabaseMetrics toggles sending database metrics,\nincluding database and collection names",
+              "enum": [
+                "enabled",
+                "disabled"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "apiKeySecretRef",
+            "region"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "externalProjectRef": {
+          "description": "externalProjectRef holds the parent Atlas project ID.\nMutually exclusive with the \"projectRef\" field.",
+          "properties": {
+            "id": {
+              "description": "ID is the Atlas project ID.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "id"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "microsoftTeams": {
+          "description": "MicrosoftTeams contains the config fields for Microsoft Teams's Integration.",
+          "properties": {
+            "urlSecretRef": {
+              "description": "URLSecretRef holds the name of a secret containing the Microsoft Teams secret URL.",
+              "properties": {
+                "name": {
+                  "description": "Name of the resource being referred to\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "urlSecretRef"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "newRelic": {
+          "description": "NewRelic contains the config fields for New Relic's Integration.",
+          "properties": {
+            "credentialsSecretRef": {
+              "description": "CredentialsSecretRef holds the name of a secret containing new relic's credentials:\naccount id, license key, read and write tokens.",
+              "properties": {
+                "name": {
+                  "description": "Name of the resource being referred to\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "credentialsSecretRef"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "opsGenie": {
+          "description": "OpsGenie contains the config fields for Ops Genie's Integration.",
+          "properties": {
+            "apiKeySecretRef": {
+              "description": "APIKeySecretRef holds the name of a secret containing Ops Genie's API key.",
+              "properties": {
+                "name": {
+                  "description": "Name of the resource being referred to\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "region": {
+              "description": "Region is the Ops Genie region.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "apiKeySecretRef",
+            "region"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "pagerDuty": {
+          "description": "PagerDuty contains the config fields for PagerDuty's Integration.",
+          "properties": {
+            "region": {
+              "description": "Region is the Pager Duty region.",
+              "type": "string"
+            },
+            "serviceKeySecretRef": {
+              "description": "ServiceKeySecretRef holds the name of a secret containing Pager Duty service key.",
+              "properties": {
+                "name": {
+                  "description": "Name of the resource being referred to\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "region",
+            "serviceKeySecretRef"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "projectRef": {
+          "description": "projectRef is a reference to the parent AtlasProject resource.\nMutually exclusive with the \"externalProjectRef\" field.",
+          "properties": {
+            "name": {
+              "description": "Name of the Kubernetes Resource",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "Namespace of the Kubernetes Resource",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "prometheus": {
+          "description": "Prometheus contains the config fields for Prometheus's Integration.",
+          "properties": {
+            "enabled": {
+              "description": "Enabled is true when Prometheus integration is enabled.",
+              "type": "string"
+            },
+            "prometheusCredentialsSecretRef": {
+              "description": "PrometheusCredentialsSecretRef holds the name of a secret containing the Prometheus.\nusername & password",
+              "properties": {
+                "name": {
+                  "description": "Name of the resource being referred to\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "serviceDiscovery": {
+              "description": "ServiceDiscovery to be used by Prometheus.",
+              "enum": [
+                "file",
+                "http"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "enabled",
+            "prometheusCredentialsSecretRef",
+            "serviceDiscovery"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "slack": {
+          "description": "Slack contains the config fields for Slack's Integration.",
+          "properties": {
+            "apiTokenSecretRef": {
+              "description": "APITokenSecretRef holds the name of a secret containing the Slack API token.",
+              "properties": {
+                "name": {
+                  "description": "Name of the resource being referred to\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "channelName": {
+              "description": "ChannelName to be used by Prometheus.",
+              "type": "string"
+            },
+            "teamName": {
+              "description": "TeamName flags whether Prometheus integration is enabled.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "apiTokenSecretRef",
+            "channelName",
+            "teamName"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "type": {
+          "description": "Type of the integration.",
+          "enum": [
+            "DATADOG",
+            "MICROSOFT_TEAMS",
+            "NEW_RELIC",
+            "OPS_GENIE",
+            "PAGER_DUTY",
+            "PROMETHEUS",
+            "SLACK",
+            "VICTOR_OPS",
+            "WEBHOOK"
+          ],
+          "type": "string"
+        },
+        "victorOps": {
+          "description": "VictorOps contains the config fields for VictorOps's Integration.",
+          "properties": {
+            "apiKeySecretRef": {
+              "description": "APIKeySecretRef is the name of a secret containing Victor Ops API key.",
+              "properties": {
+                "name": {
+                  "description": "Name of the resource being referred to\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "routingKey": {
+              "description": "RoutingKey holds VictorOps routing key.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "apiKeySecretRef",
+            "routingKey"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "webhook": {
+          "description": "Webhook contains the config fields for Webhook's Integration.",
+          "properties": {
+            "urlSecretRef": {
+              "description": "URLSecretRef holds the name of a secret containing Webhook URL and secret.",
+              "properties": {
+                "name": {
+                  "description": "Name of the resource being referred to\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "urlSecretRef"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object",
+      "x-kubernetes-validations": [
+        {
+          "message": "must define only one project reference through externalProjectRef or projectRef",
+          "rule": "(has(self.externalProjectRef) && !has(self.projectRef)) || (!has(self.externalProjectRef) && has(self.projectRef))"
+        },
+        {
+          "message": "must define a local connection secret when referencing an external project",
+          "rule": "(has(self.externalProjectRef) && has(self.connectionSecret)) || !has(self.externalProjectRef)"
+        },
+        {
+          "message": "must define a type of integration",
+          "rule": "has(self.type) && self.type.size() != 0"
+        },
+        {
+          "message": "only DATADOG type may set datadog fields",
+          "rule": "!has(self.datadog) || (self.type == 'DATADOG' && has(self.datadog))"
+        },
+        {
+          "message": "only MICROSOFT_TEAMS type may set microsoftTeams fields",
+          "rule": "!has(self.microsoftTeams) || (self.type == 'MICROSOFT_TEAMS' && has(self.microsoftTeams))"
+        },
+        {
+          "message": "only NEW_RELIC type may set newRelic fields",
+          "rule": "!has(self.newRelic) || (self.type == 'NEW_RELIC' && has(self.newRelic))"
+        },
+        {
+          "message": "only OPS_GENIE type may set opsGenie fields",
+          "rule": "!has(self.opsGenie) || (self.type == 'OPS_GENIE' && has(self.opsGenie))"
+        },
+        {
+          "message": "only PROMETHEUS type may set prometheus fields",
+          "rule": "!has(self.prometheus) || (self.type == 'PROMETHEUS' && has(self.prometheus))"
+        },
+        {
+          "message": "only PAGER_DUTY type may set pagerDuty fields",
+          "rule": "!has(self.pagerDuty) || (self.type == 'PAGER_DUTY' && has(self.pagerDuty))"
+        },
+        {
+          "message": "only SLACK type may set slack fields",
+          "rule": "!has(self.slack) || (self.type == 'SLACK' && has(self.slack))"
+        },
+        {
+          "message": "only VICTOR_OPS type may set victorOps fields",
+          "rule": "!has(self.victorOps) || (self.type == 'VICTOR_OPS' && has(self.victorOps))"
+        },
+        {
+          "message": "only WEBHOOK type may set webhook fields",
+          "rule": "!has(self.webhook) || (self.type == 'WEBHOOK' && has(self.webhook))"
+        }
+      ],
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "AtlasThirdPartyIntegrationStatus holds the status of an integration",
+      "properties": {
+        "conditions": {
+          "description": "Conditions holding the status details",
+          "items": {
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
+                "maxLength": 32768,
+                "type": "string"
+              },
+              "observedGeneration": {
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
+                "format": "int64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "reason": {
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
+                "maxLength": 1024,
+                "minLength": 1,
+                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
+                "type": "string"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "enum": [
+                  "True",
+                  "False",
+                  "Unknown"
+                ],
+                "type": "string"
+              },
+              "type": {
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
+                "maxLength": 316,
+                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "message",
+              "reason",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "id": {
+          "description": "ID of the third party integration resource in Atlas",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}


### PR DESCRIPTION
## PR Checklist

- [x] I generated these CRs using the [CRD Extractor tool](https://github.com/datreeio/CRDs-catalog?tab=readme-ov-file#crd-extractor). If I used a different method, I have described the method in this PR.
- [ ] I am updating existing schemas and have specified the updated schema version.
- [x] I am adding new schemas and included a link to the GitHub repository that contains the source of these schemas.

Source: https://github.com/mongodb/mongodb-atlas-kubernetes
Generated with v2.14.1 release artifact:


```
  TMP=$(mktemp -d)
  curl -sL https://github.com/mongodb/mongodb-atlas-kubernetes/releases/download/v2.14.1/atlas-operator-all-in-one-2.14.1.tar.gz \
    | tar xz -C "$TMP"

  export FILENAME_FORMAT='{fullgroup}__{kind}_{version}'
    | grep 'JSON schema written to' \
    | awk '{ print $(NF) }' \
    | xargs -I {} sh -c 'f=$0; mkdir -p "$(dirname "$(echo "$f" | sed "s|__|/|")")" && mv "$f" "$(echo "$f" | sed "s|__|/|")"' '{}'
```