### PR TITLE
feat(crossplane): upgrade to resource versions based on 2.2.1

### DIFF
--- a/apiextensions.crossplane.io/compositeresourcedefinition_v1.json
+++ b/apiextensions.crossplane.io/compositeresourcedefinition_v1.json
@@ -1,5 +1,5 @@
 {
-  "description": "A CompositeResourceDefinition defines the schema for a new custom Kubernetes\nAPI.\n\nRead the Crossplane documentation for\n[more information about CustomResourceDefinitions](https://docs.crossplane.io/latest/concepts/composite-resource-definitions).",
+  "description": "A CompositeResourceDefinition defines the schema for a new custom Kubernetes\nAPI.\n\nRead the Crossplane documentation for\n[more information about CustomResourceDefinitions](https://docs.crossplane.io/latest/composition/composite-resource-definitions/).",
   "properties": {
     "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
@@ -182,6 +182,53 @@
             "name"
           ],
           "type": "object",
+          "additionalProperties": false
+        },
+        "defaultCompositionRevisionSelector": {
+          "description": "DefaultCompositionRevisionSelector refers to the CompositionRevision that will be used\nin case no compositionRevision selector is given.",
+          "properties": {
+            "matchExpressions": {
+              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+              "items": {
+                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                "properties": {
+                  "key": {
+                    "description": "key is the label key that the selector applies to.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  }
+                },
+                "required": [
+                  "key",
+                  "operator"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            },
+            "matchLabels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
           "additionalProperties": false
         },
         "defaultCompositionUpdatePolicy": {

--- a/apiextensions.crossplane.io/compositeresourcedefinition_v2.json
+++ b/apiextensions.crossplane.io/compositeresourcedefinition_v2.json
@@ -1,5 +1,5 @@
 {
-  "description": "A CompositeResourceDefinition defines the schema for a new custom Kubernetes\nAPI.\n\nRead the Crossplane documentation for\n[more information about CustomResourceDefinitions](https://docs.crossplane.io/latest/concepts/composite-resource-definitions).",
+  "description": "A CompositeResourceDefinition defines the schema for a new custom Kubernetes\nAPI.\n\nRead the Crossplane documentation for\n[more information about CustomResourceDefinitions](https://docs.crossplane.io/latest/composition/composite-resource-definitions/).",
   "properties": {
     "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
@@ -161,6 +161,53 @@
             "name"
           ],
           "type": "object",
+          "additionalProperties": false
+        },
+        "defaultCompositionRevisionSelector": {
+          "description": "DefaultCompositionRevisionSelector refers to the CompositionRevision that will be used\nin case no compositionRevision selector is given.",
+          "properties": {
+            "matchExpressions": {
+              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+              "items": {
+                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                "properties": {
+                  "key": {
+                    "description": "key is the label key that the selector applies to.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  }
+                },
+                "required": [
+                  "key",
+                  "operator"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            },
+            "matchLabels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
           "additionalProperties": false
         },
         "defaultCompositionUpdatePolicy": {

--- a/apiextensions.crossplane.io/composition_v1.json
+++ b/apiextensions.crossplane.io/composition_v1.json
@@ -1,5 +1,5 @@
 {
-  "description": "A Composition defines a collection of managed resources or functions that\nCrossplane uses to create and manage new composite resources.\n\nRead the Crossplane documentation for\n[more information about Compositions](https://docs.crossplane.io/latest/concepts/compositions).",
+  "description": "A Composition defines a collection of managed resources or functions that\nCrossplane uses to create and manage new composite resources.\n\nRead the Crossplane documentation for\n[more information about Compositions](https://docs.crossplane.io/latest/composition/compositions/).",
   "properties": {
     "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
@@ -173,10 +173,42 @@
                       "type": "object",
                       "x-kubernetes-validations": [
                         {
-                          "message": "Either name or matchLabels must be specified, but not both",
-                          "rule": "(has(self.name) && !has(self.matchLabels)) || (!has(self.name) && has(self.matchLabels))"
+                          "message": "name and matchLabels are mutually exclusive",
+                          "rule": "!(has(self.name) && has(self.matchLabels))"
                         }
                       ],
+                      "additionalProperties": false
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-map-keys": [
+                      "requirementName"
+                    ],
+                    "x-kubernetes-list-type": "map"
+                  },
+                  "requiredSchemas": {
+                    "description": "RequiredSchemas is a list of OpenAPI schemas that must be fetched before\nthis function is called.",
+                    "items": {
+                      "description": "RequiredSchemaSelector selects a required OpenAPI schema.",
+                      "properties": {
+                        "apiVersion": {
+                          "description": "APIVersion of the resource kind whose schema is required, e.g. \"example.org/v1\".",
+                          "type": "string"
+                        },
+                        "kind": {
+                          "description": "Kind of resource whose schema is required, e.g. \"MyResource\".",
+                          "type": "string"
+                        },
+                        "requirementName": {
+                          "description": "RequirementName is the unique name to identify this required schema\nin the Required Schemas map in the function request.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "apiVersion",
+                        "kind",
+                        "requirementName"
+                      ],
+                      "type": "object",
                       "additionalProperties": false
                     },
                     "type": "array",

--- a/apiextensions.crossplane.io/compositionrevision_v1.json
+++ b/apiextensions.crossplane.io/compositionrevision_v1.json
@@ -173,10 +173,42 @@
                       "type": "object",
                       "x-kubernetes-validations": [
                         {
-                          "message": "Either name or matchLabels must be specified, but not both",
-                          "rule": "(has(self.name) && !has(self.matchLabels)) || (!has(self.name) && has(self.matchLabels))"
+                          "message": "name and matchLabels are mutually exclusive",
+                          "rule": "!(has(self.name) && has(self.matchLabels))"
                         }
                       ],
+                      "additionalProperties": false
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-map-keys": [
+                      "requirementName"
+                    ],
+                    "x-kubernetes-list-type": "map"
+                  },
+                  "requiredSchemas": {
+                    "description": "RequiredSchemas is a list of OpenAPI schemas that must be fetched before\nthis function is called.",
+                    "items": {
+                      "description": "RequiredSchemaSelector selects a required OpenAPI schema.",
+                      "properties": {
+                        "apiVersion": {
+                          "description": "APIVersion of the resource kind whose schema is required, e.g. \"example.org/v1\".",
+                          "type": "string"
+                        },
+                        "kind": {
+                          "description": "Kind of resource whose schema is required, e.g. \"MyResource\".",
+                          "type": "string"
+                        },
+                        "requirementName": {
+                          "description": "RequirementName is the unique name to identify this required schema\nin the Required Schemas map in the function request.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "apiVersion",
+                        "kind",
+                        "requirementName"
+                      ],
+                      "type": "object",
                       "additionalProperties": false
                     },
                     "type": "array",

--- a/apiextensions.crossplane.io/environmentconfig_v1beta1.json
+++ b/apiextensions.crossplane.io/environmentconfig_v1beta1.json
@@ -1,5 +1,5 @@
 {
-  "description": "An EnvironmentConfig contains user-defined unstructured values for\nuse in a Composition.\n\nRead the Crossplane documentation for\n[more information about EnvironmentConfigs](https://docs.crossplane.io/latest/concepts/environment-configs).",
+  "description": "An EnvironmentConfig contains user-defined unstructured values for\nuse in a Composition.\n\nRead the Crossplane documentation for\n[more information about EnvironmentConfigs](https://docs.crossplane.io/latest/composition/environment-configs/).",
   "properties": {
     "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",

--- a/ops.crossplane.io/cronoperation_v1alpha1.json
+++ b/ops.crossplane.io/cronoperation_v1alpha1.json
@@ -168,10 +168,42 @@
                               "type": "object",
                               "x-kubernetes-validations": [
                                 {
-                                  "message": "Either name or matchLabels must be specified, but not both",
-                                  "rule": "(has(self.name) && !has(self.matchLabels)) || (!has(self.name) && has(self.matchLabels))"
+                                  "message": "name and matchLabels are mutually exclusive",
+                                  "rule": "!(has(self.name) && has(self.matchLabels))"
                                 }
                               ],
+                              "additionalProperties": false
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-map-keys": [
+                              "requirementName"
+                            ],
+                            "x-kubernetes-list-type": "map"
+                          },
+                          "requiredSchemas": {
+                            "description": "RequiredSchemas that will be fetched before this pipeline step\nis called for the first time.",
+                            "items": {
+                              "description": "RequiredSchemaSelector selects an OpenAPI schema that should be fetched\nbefore a pipeline step runs.",
+                              "properties": {
+                                "apiVersion": {
+                                  "description": "APIVersion of the resource kind whose schema is required, e.g. \"example.org/v1\".",
+                                  "type": "string"
+                                },
+                                "kind": {
+                                  "description": "Kind of resource whose schema is required, e.g. \"MyResource\".",
+                                  "type": "string"
+                                },
+                                "requirementName": {
+                                  "description": "RequirementName uniquely identifies this schema.\nThis name will be used as the key in RunFunctionRequest.required_schemas.",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "apiVersion",
+                                "kind",
+                                "requirementName"
+                              ],
+                              "type": "object",
                               "additionalProperties": false
                             },
                             "type": "array",

--- a/ops.crossplane.io/operation_v1alpha1.json
+++ b/ops.crossplane.io/operation_v1alpha1.json
@@ -142,10 +142,42 @@
                       "type": "object",
                       "x-kubernetes-validations": [
                         {
-                          "message": "Either name or matchLabels must be specified, but not both",
-                          "rule": "(has(self.name) && !has(self.matchLabels)) || (!has(self.name) && has(self.matchLabels))"
+                          "message": "name and matchLabels are mutually exclusive",
+                          "rule": "!(has(self.name) && has(self.matchLabels))"
                         }
                       ],
+                      "additionalProperties": false
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-map-keys": [
+                      "requirementName"
+                    ],
+                    "x-kubernetes-list-type": "map"
+                  },
+                  "requiredSchemas": {
+                    "description": "RequiredSchemas that will be fetched before this pipeline step\nis called for the first time.",
+                    "items": {
+                      "description": "RequiredSchemaSelector selects an OpenAPI schema that should be fetched\nbefore a pipeline step runs.",
+                      "properties": {
+                        "apiVersion": {
+                          "description": "APIVersion of the resource kind whose schema is required, e.g. \"example.org/v1\".",
+                          "type": "string"
+                        },
+                        "kind": {
+                          "description": "Kind of resource whose schema is required, e.g. \"MyResource\".",
+                          "type": "string"
+                        },
+                        "requirementName": {
+                          "description": "RequirementName uniquely identifies this schema.\nThis name will be used as the key in RunFunctionRequest.required_schemas.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "apiVersion",
+                        "kind",
+                        "requirementName"
+                      ],
+                      "type": "object",
                       "additionalProperties": false
                     },
                     "type": "array",

--- a/ops.crossplane.io/watchoperation_v1alpha1.json
+++ b/ops.crossplane.io/watchoperation_v1alpha1.json
@@ -168,10 +168,42 @@
                               "type": "object",
                               "x-kubernetes-validations": [
                                 {
-                                  "message": "Either name or matchLabels must be specified, but not both",
-                                  "rule": "(has(self.name) && !has(self.matchLabels)) || (!has(self.name) && has(self.matchLabels))"
+                                  "message": "name and matchLabels are mutually exclusive",
+                                  "rule": "!(has(self.name) && has(self.matchLabels))"
                                 }
                               ],
+                              "additionalProperties": false
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-map-keys": [
+                              "requirementName"
+                            ],
+                            "x-kubernetes-list-type": "map"
+                          },
+                          "requiredSchemas": {
+                            "description": "RequiredSchemas that will be fetched before this pipeline step\nis called for the first time.",
+                            "items": {
+                              "description": "RequiredSchemaSelector selects an OpenAPI schema that should be fetched\nbefore a pipeline step runs.",
+                              "properties": {
+                                "apiVersion": {
+                                  "description": "APIVersion of the resource kind whose schema is required, e.g. \"example.org/v1\".",
+                                  "type": "string"
+                                },
+                                "kind": {
+                                  "description": "Kind of resource whose schema is required, e.g. \"MyResource\".",
+                                  "type": "string"
+                                },
+                                "requirementName": {
+                                  "description": "RequirementName uniquely identifies this schema.\nThis name will be used as the key in RunFunctionRequest.required_schemas.",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "apiVersion",
+                                "kind",
+                                "requirementName"
+                              ],
+                              "type": "object",
                               "additionalProperties": false
                             },
                             "type": "array",

--- a/pkg.crossplane.io/configuration_v1.json
+++ b/pkg.crossplane.io/configuration_v1.json
@@ -1,5 +1,5 @@
 {
-  "description": "A Configuration installs an OCI compatible Crossplane package, extending\nCrossplane with support for new kinds of CompositeResourceDefinitions and\nCompositions.\n\nRead the Crossplane documentation for\n[more information about Configuration packages](https://docs.crossplane.io/latest/concepts/packages).",
+  "description": "A Configuration installs an OCI compatible Crossplane package, extending\nCrossplane with support for new kinds of CompositeResourceDefinitions and\nCompositions.\n\nRead the Crossplane documentation for\n[more information about Configuration packages]( https://docs.crossplane.io/latest/packages/configurations/).",
   "properties": {
     "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",

--- a/pkg.crossplane.io/deploymentruntimeconfig_v1beta1.json
+++ b/pkg.crossplane.io/deploymentruntimeconfig_v1beta1.json
@@ -1,5 +1,5 @@
 {
-  "description": "The DeploymentRuntimeConfig provides settings for the Kubernetes Deployment\nof a Provider or composition function package.\n\nRead the Crossplane documentation for\n[more information about DeploymentRuntimeConfigs](https://docs.crossplane.io/latest/concepts/providers/#runtime-configuration).",
+  "description": "The DeploymentRuntimeConfig provides settings for the Kubernetes Deployment\nof a Provider or composition function package.\n\nRead the Crossplane documentation for\n[more information about DeploymentRuntimeConfigs](https://docs.crossplane.io/latest/packages/providers/#runtime-configuration).",
   "properties": {
     "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
@@ -1847,7 +1847,7 @@
                                 "additionalProperties": false
                               },
                               "resizePolicy": {
-                                "description": "Resources resize policy for the container.",
+                                "description": "Resources resize policy for the container.\nThis field cannot be set on ephemeral containers.",
                                 "items": {
                                   "description": "ContainerResizePolicy represents resource resize policy for the container.",
                                   "properties": {
@@ -4776,7 +4776,7 @@
                                 "additionalProperties": false
                               },
                               "resizePolicy": {
-                                "description": "Resources resize policy for the container.",
+                                "description": "Resources resize policy for the container.\nThis field cannot be set on ephemeral containers.",
                                 "items": {
                                   "description": "ContainerResizePolicy represents resource resize policy for the container.",
                                   "properties": {
@@ -5396,7 +5396,7 @@
                           "x-kubernetes-list-type": "atomic"
                         },
                         "resourceClaims": {
-                          "description": "ResourceClaims defines which ResourceClaims must be allocated\nand reserved before the Pod is allowed to start. The resources\nwill be made available to those containers which consume them\nby name.\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable.",
+                          "description": "ResourceClaims defines which ResourceClaims must be allocated\nand reserved before the Pod is allowed to start. The resources\nwill be made available to those containers which consume them\nby name.\n\nThis is a stable field but requires that the\nDynamicResourceAllocation feature gate is enabled.\n\nThis field is immutable.",
                           "items": {
                             "description": "PodResourceClaim references exactly one ResourceClaim, either directly\nor by naming a ResourceClaimTemplate which is then turned into a ResourceClaim\nfor the pod.\n\nIt adds a name to it that uniquely identifies the ResourceClaim inside the Pod.\nContainers that need access to the ResourceClaim reference it with this name.",
                             "properties": {
@@ -5716,7 +5716,7 @@
                                 "type": "string"
                               },
                               "operator": {
-                                "description": "Operator represents a key's relationship to the value.\nValid operators are Exists and Equal. Defaults to Equal.\nExists is equivalent to wildcard for value, so that a pod can\ntolerate all taints of a particular category.",
+                                "description": "Operator represents a key's relationship to the value.\nValid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.\nExists is equivalent to wildcard for value, so that a pod can\ntolerate all taints of a particular category.\nLt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).",
                                 "type": "string"
                               },
                               "tolerationSeconds": {
@@ -6315,7 +6315,7 @@
                                             "additionalProperties": false
                                           },
                                           "resources": {
-                                            "description": "resources represents the minimum resources the volume should have.\nIf RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements\nthat are lower than previous value but must still be higher than capacity recorded in the\nstatus field of the claim.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources",
+                                            "description": "resources represents the minimum resources the volume should have.\nUsers are allowed to specify resource requirements\nthat are lower than previous value but must still be higher than capacity recorded in the\nstatus field of the claim.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources",
                                             "properties": {
                                               "limits": {
                                                 "additionalProperties": {
@@ -7026,6 +7026,13 @@
                                             "signerName": {
                                               "description": "Kubelet's generated CSRs will be addressed to this signer.",
                                               "type": "string"
+                                            },
+                                            "userAnnotations": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "description": "userAnnotations allow pod authors to pass additional information to\nthe signer implementation.  Kubernetes does not restrict or validate this\nmetadata in any way.\n\nThese values are copied verbatim into the `spec.unverifiedUserAnnotations` field of\nthe PodCertificateRequest objects that Kubelet creates.\n\nEntries are subject to the same validation as object metadata annotations,\nwith the addition that all keys must be domain-prefixed. No restrictions\nare placed on values, except an overall size limitation on the entire field.\n\nSigners should document the keys and values they support. Signers should\ndeny requests that contain keys they do not recognize.",
+                                              "type": "object"
                                             }
                                           },
                                           "required": [
@@ -7395,6 +7402,29 @@
                             "name"
                           ],
                           "x-kubernetes-list-type": "map"
+                        },
+                        "workloadRef": {
+                          "description": "WorkloadRef provides a reference to the Workload object that this Pod belongs to.\nThis field is used by the scheduler to identify the PodGroup and apply the\ncorrect group scheduling policies. The Workload object referenced\nby this field may not exist at the time the Pod is created.\nThis field is immutable, but a Workload object with the same name\nmay be recreated with different policies. Doing this during pod scheduling\nmay result in the placement not conforming to the expected policies.",
+                          "properties": {
+                            "name": {
+                              "description": "Name defines the name of the Workload object this Pod belongs to.\nWorkload must be in the same namespace as the Pod.\nIf it doesn't match any existing Workload, the Pod will remain unschedulable\nuntil a Workload object is created and observed by the kube-scheduler.\nIt must be a DNS subdomain.",
+                              "type": "string"
+                            },
+                            "podGroup": {
+                              "description": "PodGroup is the name of the PodGroup within the Workload that this Pod\nbelongs to. If it doesn't match any existing PodGroup within the Workload,\nthe Pod will remain unschedulable until the Workload object is recreated\nand observed by the kube-scheduler. It must be a DNS label.",
+                              "type": "string"
+                            },
+                            "podGroupReplicaKey": {
+                              "description": "PodGroupReplicaKey specifies the replica key of the PodGroup to which this\nPod belongs. It is used to distinguish pods belonging to different replicas\nof the same pod group. The pod group policy is applied separately to each replica.\nWhen set, it must be a DNS label.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name",
+                            "podGroup"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
                         }
                       },
                       "required": [

--- a/pkg.crossplane.io/function_v1.json
+++ b/pkg.crossplane.io/function_v1.json
@@ -1,5 +1,5 @@
 {
-  "description": "A Function installs an OCI compatible Crossplane package, extending\nCrossplane with support for a new kind of composition function.\n\nRead the Crossplane documentation for\n[more information about Functions](https://docs.crossplane.io/latest/concepts/composition-functions).",
+  "description": "A Function installs an OCI compatible Crossplane package, extending\nCrossplane with support for a new kind of composition function.\n\nRead the Crossplane documentation for\n[more information about Functions](https://docs.crossplane.io/latest/packages/functions/).",
   "properties": {
     "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",

--- a/pkg.crossplane.io/function_v1beta1.json
+++ b/pkg.crossplane.io/function_v1beta1.json
@@ -1,5 +1,5 @@
 {
-  "description": "A Function installs an OCI compatible Crossplane package, extending\nCrossplane with support for a new kind of composition function.\n\nRead the Crossplane documentation for\n[more information about Functions](https://docs.crossplane.io/latest/concepts/composition-functions).",
+  "description": "A Function installs an OCI compatible Crossplane package, extending\nCrossplane with support for a new kind of composition function.\n\nRead the Crossplane documentation for\n[more information about Functions](https://docs.crossplane.io/latest/packages/functions/).",
   "properties": {
     "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",

--- a/pkg.crossplane.io/imageconfig_v1beta1.json
+++ b/pkg.crossplane.io/imageconfig_v1beta1.json
@@ -91,6 +91,37 @@
           "type": "object",
           "additionalProperties": false
         },
+        "runtime": {
+          "description": "Runtime allows configuration of runtime options for the image.",
+          "properties": {
+            "configRef": {
+              "description": "ConfigReference references a RuntimeConfig resource that will be\nused to configure the package runtime.",
+              "properties": {
+                "apiVersion": {
+                  "default": "pkg.crossplane.io/v1beta1",
+                  "description": "API version of the referent.",
+                  "type": "string"
+                },
+                "kind": {
+                  "default": "DeploymentRuntimeConfig",
+                  "description": "Kind of the referent.",
+                  "type": "string"
+                },
+                "name": {
+                  "description": "Name of the RuntimeConfig.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
         "verification": {
           "description": "Verification contains the configuration for verifying the image.",
           "properties": {

--- a/pkg.crossplane.io/lock_v1beta1.json
+++ b/pkg.crossplane.io/lock_v1beta1.json
@@ -42,7 +42,7 @@
                   "type": "string"
                 },
                 "type": {
-                  "description": "Type is the type of package. Can be either Configuration or Provider.\nDeprecated: Specify an apiVersion and kind instead.",
+                  "description": "Type is the type of package. Can be either Configuration or Provider.\n\nDeprecated: Specify an apiVersion and kind instead.",
                   "enum": [
                     "Configuration",
                     "Provider",
@@ -73,7 +73,7 @@
             "type": "string"
           },
           "type": {
-            "description": "Type is the type of package.\nDeprecated: Specify an apiVersion and kind instead.",
+            "description": "Type is the type of package.\n\nDeprecated: Specify an apiVersion and kind instead.",
             "enum": [
               "Configuration",
               "Provider",

--- a/pkg.crossplane.io/provider_v1.json
+++ b/pkg.crossplane.io/provider_v1.json
@@ -1,5 +1,5 @@
 {
-  "description": "A Provider installs an OCI compatible Crossplane package, extending\nCrossplane with support for new kinds of managed resources.\n\nRead the Crossplane documentation for\n[more information about Providers](https://docs.crossplane.io/latest/concepts/providers).",
+  "description": "A Provider installs an OCI compatible Crossplane package, extending\nCrossplane with support for new kinds of managed resources.\n\nRead the Crossplane documentation for\n[more information about Providers](https://docs.crossplane.io/latest/packages/providers/).",
   "properties": {
     "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",

--- a/protection.crossplane.io/clusterusage_v1beta1.json
+++ b/protection.crossplane.io/clusterusage_v1beta1.json
@@ -1,5 +1,5 @@
 {
-  "description": "A ClusterUsage defines a deletion blocking relationship between two\nresources.\n\nUsages prevent accidental deletion of a single resource or deletion of\nresources with dependent resources.\n\nRead the Crossplane documentation for\n[more information about usages](https://docs.crossplane.io/latest/concepts/usages).",
+  "description": "A ClusterUsage defines a deletion blocking relationship between two\nresources.\n\nUsages prevent accidental deletion of a single resource or deletion of\nresources with dependent resources.\n\nRead the Crossplane documentation for\n[more information about usages](https://docs.crossplane.io/latest/managed-resources/usages/).",
   "properties": {
     "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",


### PR DESCRIPTION
The schemas are changed based on the operator version v2.2.1.

## PR Checklist

- [x] I generated these CRs using the [CRD Extractor tool](https://github.com/datreeio/CRDs-catalog?tab=readme-ov-file#crd-extractor). If I used a different method, I have described the method in this PR.
- [x] I am updating existing schemas and have specified the updated schema version.
- [ ] I am adding new schemas and included a link to the GitHub repository that contains the source of these schemas.
