### PR TITLE
feat(victoriametrics): upgrade to resource versions based on 0.63.1

### DIFF
--- a/operator.victoriametrics.com/vlcluster_v1.json
+++ b/operator.victoriametrics.com/vlcluster_v1.json
@@ -1,36 +1,27 @@
 {
-  "description": "VLCluster is fast, cost-effective and scalable logs database.",
   "properties": {
     "apiVersion": {
-      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
       "type": "string"
     },
     "kind": {
-      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
       "type": "string"
     },
     "metadata": {
       "type": "object"
     },
     "spec": {
-      "description": "VLClusterSpec defines the desired state of VLCluster",
       "properties": {
         "clusterDomainName": {
-          "description": "ClusterDomainName defines domain name suffix for in-cluster dns addresses\naka .cluster.local\nused by vlinsert and vlselect to build vlstorage address",
           "type": "string"
         },
         "clusterVersion": {
-          "description": "ClusterVersion defines default images tag for all components.\nit can be overwritten with component specific image.tag value.",
           "type": "string"
         },
         "imagePullSecrets": {
-          "description": "ImagePullSecrets An optional list of references to secrets in the same namespace\nto use for pulling images from registries\nsee https://kubernetes.io/docs/concepts/containers/images/#referring-to-an-imagepullsecrets-on-a-pod",
           "items": {
-            "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
             "properties": {
               "name": {
                 "default": "",
-                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                 "type": "string"
               }
             },
@@ -40,21 +31,53 @@
           },
           "type": "array"
         },
+        "license": {
+          "properties": {
+            "forceOffline": {
+              "type": "boolean"
+            },
+            "key": {
+              "type": "string"
+            },
+            "keyRef": {
+              "properties": {
+                "key": {
+                  "type": "string"
+                },
+                "name": {
+                  "default": "",
+                  "type": "string"
+                },
+                "optional": {
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "key"
+              ],
+              "type": "object",
+              "x-kubernetes-map-type": "atomic",
+              "additionalProperties": false
+            },
+            "reloadInterval": {
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
         "managedMetadata": {
-          "description": "ManagedMetadata defines metadata that will be added to the all objects\ncreated by operator for the given CustomResource",
           "properties": {
             "annotations": {
               "additionalProperties": {
                 "type": "string"
               },
-              "description": "Annotations is an unstructured key value map stored with a resource that may be\nset by external tools to store and retrieve arbitrary metadata. They are not\nqueryable and should be preserved when modifying objects.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations",
               "type": "object"
             },
             "labels": {
               "additionalProperties": {
                 "type": "string"
               },
-              "description": "Labels Map of string keys and values that can be used to organize and categorize\n(scope and select) objects.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels",
               "type": "object"
             }
           },
@@ -62,11 +85,9 @@
           "additionalProperties": false
         },
         "paused": {
-          "description": "Paused If set to true all actions on the underlying managed objects are not\ngoing to be performed, except for delete actions.",
           "type": "boolean"
         },
         "requestsLoadBalancer": {
-          "description": "RequestsLoadBalancer configures load-balancing for vlinsert and vlselect requests.\nIt helps to evenly spread load across pods.\nUsually it's not possible with Kubernetes TCP-based services.",
           "properties": {
             "disableInsertBalancing": {
               "type": "boolean"
@@ -78,7 +99,6 @@
               "type": "boolean"
             },
             "spec": {
-              "description": "VMAuthLoadBalancerSpec defines configuration spec for VMAuth used as load-balancer\nfor VMCluster component",
               "type": "object",
               "x-kubernetes-preserve-unknown-fields": true
             }
@@ -87,32 +107,28 @@
           "additionalProperties": false
         },
         "serviceAccountName": {
-          "description": "ServiceAccountName is the name of the ServiceAccount to use to run the\nVLSelect, VLInsert and VLStorage Pods.",
           "type": "string"
         },
         "useStrictSecurity": {
-          "description": "UseStrictSecurity enables strict security mode for component\nit restricts disk writes access\nuses non-root user out of the box\ndrops not needed security permissions",
           "type": "boolean"
         },
         "vlinsert": {
-          "description": "VLInsert defines vlinsert component configuration at victoria-logs cluster",
           "properties": {
             "affinity": {
-              "description": "Affinity If specified, the pod's scheduling constraints.",
               "type": "object",
               "x-kubernetes-preserve-unknown-fields": true
             },
+            "componentVersion": {
+              "type": "string"
+            },
             "configMaps": {
-              "description": "ConfigMaps is a list of ConfigMaps in the same namespace as the Application\nobject, which shall be mounted into the Application container\nat /etc/vm/configs/CONFIGMAP_NAME folder",
               "items": {
                 "type": "string"
               },
               "type": "array"
             },
             "containers": {
-              "description": "Containers property allows to inject additions sidecars or to patch existing containers.\nIt can be useful for proxies, backup, etc.",
               "items": {
-                "description": "A single application container that you want to run within a pod.",
                 "required": [
                   "name"
                 ],
@@ -122,21 +138,17 @@
               "type": "array"
             },
             "disableAutomountServiceAccountToken": {
-              "description": "DisableAutomountServiceAccountToken whether to disable serviceAccount auto mount by Kubernetes (available from v0.54.0).\nOperator will conditionally create volumes and volumeMounts for containers if it requires k8s API access.\nFor example, vmagent and vm-config-reloader requires k8s API access.\nOperator creates volumes with name: \"kube-api-access\", which can be used as volumeMount for extraContainers if needed.\nAnd also adds VolumeMounts at /var/run/secrets/kubernetes.io/serviceaccount.",
               "type": "boolean"
             },
             "disableSelfServiceScrape": {
-              "description": "DisableSelfServiceScrape controls creation of VMServiceScrape by operator\nfor the application.\nHas priority over `VM_DISABLESELFSERVICESCRAPECREATION` operator env variable",
               "type": "boolean"
             },
             "dnsConfig": {
-              "description": "Specifies the DNS parameters of a pod.\nParameters specified here will be merged to the generated DNS\nconfiguration based on DNSPolicy.",
               "items": {
                 "x-kubernetes-preserve-unknown-fields": true
               },
               "properties": {
                 "nameservers": {
-                  "description": "A list of DNS name server IP addresses.\nThis will be appended to the base nameservers generated from DNSPolicy.\nDuplicated nameservers will be removed.",
                   "items": {
                     "type": "string"
                   },
@@ -144,16 +156,12 @@
                   "x-kubernetes-list-type": "atomic"
                 },
                 "options": {
-                  "description": "A list of DNS resolver options.\nThis will be merged with the base options generated from DNSPolicy.\nDuplicated entries will be removed. Resolution options given in Options\nwill override those that appear in the base DNSPolicy.",
                   "items": {
-                    "description": "PodDNSConfigOption defines DNS resolver options of a pod.",
                     "properties": {
                       "name": {
-                        "description": "Name is this DNS resolver option's name.\nRequired.",
                         "type": "string"
                       },
                       "value": {
-                        "description": "Value is this DNS resolver option's value.",
                         "type": "string"
                       }
                     },
@@ -164,7 +172,6 @@
                   "x-kubernetes-list-type": "atomic"
                 },
                 "searches": {
-                  "description": "A list of DNS search domains for host-name lookup.\nThis will be appended to the base search paths generated from DNSPolicy.\nDuplicated search paths will be removed.",
                   "items": {
                     "type": "string"
                   },
@@ -176,27 +183,21 @@
               "additionalProperties": false
             },
             "dnsPolicy": {
-              "description": "DNSPolicy sets DNS policy for the pod",
               "type": "string"
             },
             "extraArgs": {
               "additionalProperties": {
                 "type": "string"
               },
-              "description": "ExtraArgs that will be passed to the application container\nfor example remoteWrite.tmpDataPath: /tmp",
               "type": "object"
             },
             "extraEnvs": {
-              "description": "ExtraEnvs that will be passed to the application container",
               "items": {
-                "description": "EnvVar represents an environment variable present in a Container.",
                 "properties": {
                   "name": {
-                    "description": "Name of the environment variable.\nMay consist of any printable ASCII characters except '='.",
                     "type": "string"
                   },
                   "value": {
-                    "description": "Variable references $(VAR_NAME) are expanded\nusing the previously defined environment variables in the container and\nany service environment variables. If a variable cannot be resolved,\nthe reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.\n\"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\".\nEscaped references will never be expanded, regardless of whether the variable\nexists or not.\nDefaults to \"\".",
                     "type": "string"
                   }
                 },
@@ -210,20 +211,15 @@
               "type": "array"
             },
             "extraEnvsFrom": {
-              "description": "ExtraEnvsFrom defines source of env variables for the application container\ncould either be secret or configmap",
               "items": {
-                "description": "EnvFromSource represents the source of a set of ConfigMaps or Secrets",
                 "properties": {
                   "configMapRef": {
-                    "description": "The ConfigMap to select from",
                     "properties": {
                       "name": {
                         "default": "",
-                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                         "type": "string"
                       },
                       "optional": {
-                        "description": "Specify whether the ConfigMap must be defined",
                         "type": "boolean"
                       }
                     },
@@ -232,19 +228,15 @@
                     "additionalProperties": false
                   },
                   "prefix": {
-                    "description": "Optional text to prepend to the name of each environment variable.\nMay consist of any printable ASCII characters except '='.",
                     "type": "string"
                   },
                   "secretRef": {
-                    "description": "The Secret to select from",
                     "properties": {
                       "name": {
                         "default": "",
-                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                         "type": "string"
                       },
                       "optional": {
-                        "description": "Specify whether the Secret must be defined",
                         "type": "boolean"
                       }
                     },
@@ -259,12 +251,9 @@
               "type": "array"
             },
             "host_aliases": {
-              "description": "HostAliasesUnderScore provides mapping for ip and hostname,\nthat would be propagated to pod,\ncannot be used with HostNetwork.\nHas Priority over hostAliases field",
               "items": {
-                "description": "HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the\npod's hosts file.",
                 "properties": {
                   "hostnames": {
-                    "description": "Hostnames for the above IP address.",
                     "items": {
                       "type": "string"
                     },
@@ -272,7 +261,6 @@
                     "x-kubernetes-list-type": "atomic"
                   },
                   "ip": {
-                    "description": "IP address of the host file entry.",
                     "type": "string"
                   }
                 },
@@ -285,12 +273,9 @@
               "type": "array"
             },
             "hostAliases": {
-              "description": "HostAliases provides mapping for ip and hostname,\nthat would be propagated to pod,\ncannot be used with HostNetwork.",
               "items": {
-                "description": "HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the\npod's hosts file.",
                 "properties": {
                   "hostnames": {
-                    "description": "Hostnames for the above IP address.",
                     "items": {
                       "type": "string"
                     },
@@ -298,7 +283,6 @@
                     "x-kubernetes-list-type": "atomic"
                   },
                   "ip": {
-                    "description": "IP address of the host file entry.",
                     "type": "string"
                   }
                 },
@@ -311,27 +295,21 @@
               "type": "array"
             },
             "hostNetwork": {
-              "description": "HostNetwork controls whether the pod may use the node network namespace",
               "type": "boolean"
             },
             "hpa": {
-              "description": "Configures horizontal pod autoscaling.",
               "type": "object",
               "x-kubernetes-preserve-unknown-fields": true
             },
             "image": {
-              "description": "Image - docker image settings\nif no specified operator uses default version from operator config",
               "properties": {
                 "pullPolicy": {
-                  "description": "PullPolicy describes how to pull docker image",
                   "type": "string"
                 },
                 "repository": {
-                  "description": "Repository contains name of docker image + it's repository if needed",
                   "type": "string"
                 },
                 "tag": {
-                  "description": "Tag contains desired docker image version",
                   "type": "string"
                 }
               },
@@ -339,13 +317,10 @@
               "additionalProperties": false
             },
             "imagePullSecrets": {
-              "description": "ImagePullSecrets An optional list of references to secrets in the same namespace\nto use for pulling images from registries\nsee https://kubernetes.io/docs/concepts/containers/images/#referring-to-an-imagepullsecrets-on-a-pod",
               "items": {
-                "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
                 "properties": {
                   "name": {
                     "default": "",
-                    "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                     "type": "string"
                   }
                 },
@@ -356,9 +331,7 @@
               "type": "array"
             },
             "initContainers": {
-              "description": "InitContainers allows adding initContainers to the pod definition.\nAny errors during the execution of an initContainer will lead to a restart of the Pod.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/",
               "items": {
-                "description": "A single application container that you want to run within a pod.",
                 "required": [
                   "name"
                 ],
@@ -368,12 +341,10 @@
               "type": "array"
             },
             "livenessProbe": {
-              "description": "LivenessProbe that will be added CRD pod",
               "type": "object",
               "x-kubernetes-preserve-unknown-fields": true
             },
             "logFormat": {
-              "description": "LogFormat for VLSelect to be configured with.\ndefault or json",
               "enum": [
                 "default",
                 "json"
@@ -381,7 +352,6 @@
               "type": "string"
             },
             "logLevel": {
-              "description": "LogLevel for VLSelect to be configured with.",
               "enum": [
                 "INFO",
                 "WARN",
@@ -392,7 +362,6 @@
               "type": "string"
             },
             "minReadySeconds": {
-              "description": "MinReadySeconds defines a minimum number of seconds to wait before starting update next pod\nif previous in healthy state\nHas no effect for VLogs and VMSingle",
               "format": "int32",
               "type": "integer"
             },
@@ -400,15 +369,12 @@
               "additionalProperties": {
                 "type": "string"
               },
-              "description": "NodeSelector Define which Nodes the Pods are scheduled on.",
               "type": "object"
             },
             "paused": {
-              "description": "Paused If set to true all actions on the underlying managed objects are not\ngoing to be performed, except for delete actions.",
               "type": "boolean"
             },
             "podDisruptionBudget": {
-              "description": "PodDisruptionBudget created by operator",
               "properties": {
                 "maxUnavailable": {
                   "anyOf": [
@@ -419,7 +385,6 @@
                       "type": "string"
                     }
                   ],
-                  "description": "An eviction is allowed if at most \"maxUnavailable\" pods selected by\n\"selector\" are unavailable after the eviction, i.e. even in absence of\nthe evicted pod. For example, one can prevent all voluntary evictions\nby specifying 0. This is a mutually exclusive setting with \"minAvailable\".",
                   "x-kubernetes-int-or-string": true
                 },
                 "minAvailable": {
@@ -431,18 +396,15 @@
                       "type": "string"
                     }
                   ],
-                  "description": "An eviction is allowed if at least \"minAvailable\" pods selected by\n\"selector\" will still be available after the eviction, i.e. even in the\nabsence of the evicted pod.  So for example you can prevent all voluntary\nevictions by specifying \"100%\".",
                   "x-kubernetes-int-or-string": true
                 },
                 "selectorLabels": {
                   "additionalProperties": {
                     "type": "string"
                   },
-                  "description": "replaces default labels selector generated by operator\nit's useful when you need to create custom budget",
                   "type": "object"
                 },
                 "unhealthyPodEvictionPolicy": {
-                  "description": "UnhealthyPodEvictionPolicy defines the criteria for when unhealthy pods\n\nValid policies are IfHealthyBudget and AlwaysAllow.\nIf no policy is specified, the default behavior will be used,\nwhich corresponds to the IfHealthyBudget policy.\nAvailable from operator v0.64.0",
                   "enum": [
                     "IfHealthyBudget",
                     "AlwaysAllow"
@@ -454,24 +416,20 @@
               "additionalProperties": false
             },
             "podMetadata": {
-              "description": "PodMetadata configures Labels and Annotations which are propagated to the VLSelect pods.",
               "properties": {
                 "annotations": {
                   "additionalProperties": {
                     "type": "string"
                   },
-                  "description": "Annotations is an unstructured key value map stored with a resource that may be\nset by external tools to store and retrieve arbitrary metadata. They are not\nqueryable and should be preserved when modifying objects.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations",
                   "type": "object"
                 },
                 "labels": {
                   "additionalProperties": {
                     "type": "string"
                   },
-                  "description": "Labels Map of string keys and values that can be used to organize and categorize\n(scope and select) objects. May match selectors of replication controllers\nand services.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels",
                   "type": "object"
                 },
                 "name": {
-                  "description": "Name must be unique within a namespace. Is required when creating resources, although\nsome resources may allow a client to request the generation of an appropriate name\nautomatically. Name is primarily intended for creation idempotence and configuration\ndefinition.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names",
                   "type": "string"
                 }
               },
@@ -479,20 +437,15 @@
               "additionalProperties": false
             },
             "port": {
-              "description": "Port listen address",
               "type": "string"
             },
             "priorityClassName": {
-              "description": "PriorityClassName class assigned to the Pods",
               "type": "string"
             },
             "readinessGates": {
-              "description": "ReadinessGates defines pod readiness gates",
               "items": {
-                "description": "PodReadinessGate contains the reference to a pod condition",
                 "properties": {
                   "conditionType": {
-                    "description": "ConditionType refers to a condition in the pod's condition list with matching type.",
                     "type": "string"
                   }
                 },
@@ -505,29 +458,22 @@
               "type": "array"
             },
             "readinessProbe": {
-              "description": "ReadinessProbe that will be added CRD pod",
               "type": "object",
               "x-kubernetes-preserve-unknown-fields": true
             },
             "replicaCount": {
-              "description": "ReplicaCount is the expected size of the Application.",
               "format": "int32",
               "type": "integer"
             },
             "resources": {
-              "description": "Resources container resource request and limits, https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/\nif not defined default resources from operator config will be used",
               "properties": {
                 "claims": {
-                  "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis field depends on the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
                   "items": {
-                    "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
                     "properties": {
                       "name": {
-                        "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
                         "type": "string"
                       },
                       "request": {
-                        "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
                         "type": "string"
                       }
                     },
@@ -556,7 +502,6 @@
                     "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                     "x-kubernetes-int-or-string": true
                   },
-                  "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
                   "type": "object"
                 },
                 "requests": {
@@ -572,7 +517,6 @@
                     "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                     "x-kubernetes-int-or-string": true
                   },
-                  "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
                   "type": "object"
                 }
               },
@@ -580,12 +524,10 @@
               "additionalProperties": false
             },
             "revisionHistoryLimitCount": {
-              "description": "The number of old ReplicaSets to retain to allow rollback in deployment or\nmaximum number of revisions that will be maintained in the Deployment revision history.\nHas no effect at StatefulSets\nDefaults to 10.",
               "format": "int32",
               "type": "integer"
             },
             "rollingUpdate": {
-              "description": "RollingUpdate - overrides deployment update params.",
               "properties": {
                 "maxSurge": {
                   "anyOf": [
@@ -596,7 +538,6 @@
                       "type": "string"
                     }
                   ],
-                  "description": "The maximum number of pods that can be scheduled above the desired number of\npods.\nValue can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).\nThis can not be 0 if MaxUnavailable is 0.\nAbsolute number is calculated from percentage by rounding up.\nDefaults to 25%.\nExample: when this is set to 30%, the new ReplicaSet can be scaled up immediately when\nthe rolling update starts, such that the total number of old and new pods do not exceed\n130% of desired pods. Once old pods have been killed,\nnew ReplicaSet can be scaled up further, ensuring that total number of pods running\nat any time during the update is at most 130% of desired pods.",
                   "x-kubernetes-int-or-string": true
                 },
                 "maxUnavailable": {
@@ -608,7 +549,6 @@
                       "type": "string"
                     }
                   ],
-                  "description": "The maximum number of pods that can be unavailable during the update.\nValue can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).\nAbsolute number is calculated from percentage by rounding down.\nThis can not be 0 if MaxSurge is 0.\nDefaults to 25%.\nExample: when this is set to 30%, the old ReplicaSet can be scaled down to 70% of desired pods\nimmediately when the rolling update starts. Once new pods are ready, old ReplicaSet\ncan be scaled down further, followed by scaling up the new ReplicaSet, ensuring\nthat the total number of pods available at all times during the update is at\nleast 70% of desired pods.",
                   "x-kubernetes-int-or-string": true
                 }
               },
@@ -616,27 +556,22 @@
               "additionalProperties": false
             },
             "runtimeClassName": {
-              "description": "RuntimeClassName - defines runtime class for kubernetes pod.\nhttps://kubernetes.io/docs/concepts/containers/runtime-class/",
               "type": "string"
             },
             "schedulerName": {
-              "description": "SchedulerName - defines kubernetes scheduler name",
               "type": "string"
             },
             "secrets": {
-              "description": "Secrets is a list of Secrets in the same namespace as the Application\nobject, which shall be mounted into the Application container\nat /etc/vm/secrets/SECRET_NAME folder",
               "items": {
                 "type": "string"
               },
               "type": "array"
             },
             "securityContext": {
-              "description": "SecurityContext holds pod-level security attributes and common container settings.\nThis defaults to the default PodSecurityContext.",
               "type": "object",
               "x-kubernetes-preserve-unknown-fields": true
             },
             "serviceScrapeSpec": {
-              "description": "ServiceScrapeSpec that will be added to vlselect VMServiceScrape spec",
               "required": [
                 "endpoints"
               ],
@@ -644,27 +579,22 @@
               "x-kubernetes-preserve-unknown-fields": true
             },
             "serviceSpec": {
-              "description": "ServiceSpec that will be added to vlselect service spec",
               "properties": {
                 "metadata": {
-                  "description": "EmbeddedObjectMetadata defines objectMeta for additional service.",
                   "properties": {
                     "annotations": {
                       "additionalProperties": {
                         "type": "string"
                       },
-                      "description": "Annotations is an unstructured key value map stored with a resource that may be\nset by external tools to store and retrieve arbitrary metadata. They are not\nqueryable and should be preserved when modifying objects.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations",
                       "type": "object"
                     },
                     "labels": {
                       "additionalProperties": {
                         "type": "string"
                       },
-                      "description": "Labels Map of string keys and values that can be used to organize and categorize\n(scope and select) objects. May match selectors of replication controllers\nand services.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels",
                       "type": "object"
                     },
                     "name": {
-                      "description": "Name must be unique within a namespace. Is required when creating resources, although\nsome resources may allow a client to request the generation of an appropriate name\nautomatically. Name is primarily intended for creation idempotence and configuration\ndefinition.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names",
                       "type": "string"
                     }
                   },
@@ -672,12 +602,10 @@
                   "additionalProperties": false
                 },
                 "spec": {
-                  "description": "ServiceSpec describes the attributes that a user creates on a service.\nMore info: https://kubernetes.io/docs/concepts/services-networking/service/",
                   "type": "object",
                   "x-kubernetes-preserve-unknown-fields": true
                 },
                 "useAsDefault": {
-                  "description": "UseAsDefault applies changes from given service definition to the main object Service\nChanging from headless service to clusterIP or loadbalancer may break cross-component communication",
                   "type": "boolean"
                 }
               },
@@ -688,65 +616,49 @@
               "additionalProperties": false
             },
             "startupProbe": {
-              "description": "StartupProbe that will be added to CRD pod",
               "type": "object",
               "x-kubernetes-preserve-unknown-fields": true
             },
             "syslogSpec": {
-              "description": "SyslogSpec defines syslog listener configuration",
               "properties": {
                 "tcpListeners": {
-                  "description": "TCPListeners defines syslog server TCP listener configuration",
                   "items": {
-                    "description": "SyslogTCPListener defines configuration for TCP syslog server listen",
                     "properties": {
                       "compressMethod": {
-                        "description": "CompressMethod for syslog messages\nsee https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#compression",
                         "pattern": "^(none|zstd|gzip|deflate)$",
                         "type": "string"
                       },
                       "decolorizeFields": {
-                        "description": "DecolorizeFields to remove ANSI color codes across logs\nsee https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#decolorizing-fields",
                         "type": "string"
                       },
                       "ignoreFields": {
-                        "description": "IgnoreFields to ignore at logs\nsee https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#dropping-fields",
                         "type": "string"
                       },
                       "listenPort": {
-                        "description": "ListenPort defines listen port",
                         "format": "int32",
                         "type": "integer"
                       },
                       "streamFields": {
-                        "description": "StreamFields to use as log stream labels\nsee https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#stream-fields",
                         "type": "string"
                       },
                       "tenantID": {
-                        "description": "TenantID for logs ingested in form of accountID:projectID\nsee https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#multiple-configs",
                         "type": "string"
                       },
                       "tlsConfig": {
-                        "description": "TLSServerConfig defines VictoriaMetrics TLS configuration for the application's server",
                         "properties": {
                           "certFile": {
-                            "description": "CertFile defines path to the pre-mounted file with certificate\nmutually exclusive with CertSecret",
                             "type": "string"
                           },
                           "certSecret": {
-                            "description": "CertSecretRef defines reference for secret with certificate content under given key\nmutually exclusive with CertFile",
                             "properties": {
                               "key": {
-                                "description": "The key of the secret to select from.  Must be a valid secret key.",
                                 "type": "string"
                               },
                               "name": {
                                 "default": "",
-                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                 "type": "string"
                               },
                               "optional": {
-                                "description": "Specify whether the Secret or its key must be defined",
                                 "type": "boolean"
                               }
                             },
@@ -758,23 +670,18 @@
                             "additionalProperties": false
                           },
                           "keyFile": {
-                            "description": "KeyFile defines path to the pre-mounted file with certificate key\nmutually exclusive with KeySecretRef",
                             "type": "string"
                           },
                           "keySecret": {
-                            "description": "Key defines reference for secret with certificate key content under given key\nmutually exclusive with KeyFile",
                             "properties": {
                               "key": {
-                                "description": "The key of the secret to select from.  Must be a valid secret key.",
                                 "type": "string"
                               },
                               "name": {
                                 "default": "",
-                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                 "type": "string"
                               },
                               "optional": {
-                                "description": "Specify whether the Secret or its key must be defined",
                                 "type": "boolean"
                               }
                             },
@@ -799,34 +706,26 @@
                   "type": "array"
                 },
                 "udpListeners": {
-                  "description": "UDPListeners defines syslog server UDP listener configuration",
                   "items": {
-                    "description": "SyslogUDPListener defines configuration for UDP syslog server listen",
                     "properties": {
                       "compressMethod": {
-                        "description": "CompressMethod for syslog messages\nsee https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#compression",
                         "pattern": "^(none|zstd|gzip|deflate)$",
                         "type": "string"
                       },
                       "decolorizeFields": {
-                        "description": "DecolorizeFields to remove ANSI color codes across logs\nsee https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#decolorizing-fields",
                         "type": "string"
                       },
                       "ignoreFields": {
-                        "description": "IgnoreFields to ignore at logs\nsee https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#dropping-fields",
                         "type": "string"
                       },
                       "listenPort": {
-                        "description": "ListenPort defines listen port",
                         "format": "int32",
                         "type": "integer"
                       },
                       "streamFields": {
-                        "description": "StreamFields to use as log stream labels\nsee https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#stream-fields",
                         "type": "string"
                       },
                       "tenantID": {
-                        "description": "TenantID for logs ingested in form of accountID:projectID\nsee https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#multiple-configs",
                         "type": "string"
                       }
                     },
@@ -843,34 +742,26 @@
               "additionalProperties": false
             },
             "terminationGracePeriodSeconds": {
-              "description": "TerminationGracePeriodSeconds period for container graceful termination",
               "format": "int64",
               "type": "integer"
             },
             "tolerations": {
-              "description": "Tolerations If specified, the pod's tolerations.",
               "items": {
-                "description": "The pod this Toleration is attached to tolerates any taint that matches\nthe triple <key,value,effect> using the matching operator <operator>.",
                 "properties": {
                   "effect": {
-                    "description": "Effect indicates the taint effect to match. Empty means match all taint effects.\nWhen specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
                     "type": "string"
                   },
                   "key": {
-                    "description": "Key is the taint key that the toleration applies to. Empty means match all taint keys.\nIf the key is empty, operator must be Exists; this combination means to match all values and all keys.",
                     "type": "string"
                   },
                   "operator": {
-                    "description": "Operator represents a key's relationship to the value.\nValid operators are Exists and Equal. Defaults to Equal.\nExists is equivalent to wildcard for value, so that a pod can\ntolerate all taints of a particular category.",
                     "type": "string"
                   },
                   "tolerationSeconds": {
-                    "description": "TolerationSeconds represents the period of time the toleration (which must be\nof effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,\nit is not set, which means tolerate the taint forever (do not evict). Zero and\nnegative values will be treated as 0 (evict immediately) by the system.",
                     "format": "int64",
                     "type": "integer"
                   },
                   "value": {
-                    "description": "Value is the taint value the toleration matches to.\nIf the operator is Exists, the value should be empty, otherwise just a regular string.",
                     "type": "string"
                   }
                 },
@@ -880,9 +771,7 @@
               "type": "array"
             },
             "topologySpreadConstraints": {
-              "description": "TopologySpreadConstraints embedded kubernetes pod configuration option,\ncontrols how pods are spread across your cluster among failure-domains\nsuch as regions, zones, nodes, and other user-defined topology domains\nhttps://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/",
               "items": {
-                "description": "TopologySpreadConstraint specifies how to spread matching pods among the given topology.",
                 "required": [
                   "maxSkew",
                   "topologyKey",
@@ -894,7 +783,6 @@
               "type": "array"
             },
             "updateStrategy": {
-              "description": "UpdateStrategy - overrides default update strategy.",
               "enum": [
                 "Recreate",
                 "RollingUpdate"
@@ -902,44 +790,33 @@
               "type": "string"
             },
             "useDefaultResources": {
-              "description": "UseDefaultResources controls resource settings\nBy default, operator sets built-in resource requirements",
               "type": "boolean"
             },
             "useStrictSecurity": {
-              "description": "UseStrictSecurity enables strict security mode for component\nit restricts disk writes access\nuses non-root user out of the box\ndrops not needed security permissions",
               "type": "boolean"
             },
             "volumeMounts": {
-              "description": "VolumeMounts allows configuration of additional VolumeMounts on the output Deployment/StatefulSet definition.\nVolumeMounts specified will be appended to other VolumeMounts in the Application container",
               "items": {
-                "description": "VolumeMount describes a mounting of a Volume within a container.",
                 "properties": {
                   "mountPath": {
-                    "description": "Path within the container at which the volume should be mounted.  Must\nnot contain ':'.",
                     "type": "string"
                   },
                   "mountPropagation": {
-                    "description": "mountPropagation determines how mounts are propagated from the host\nto container and the other way around.\nWhen not set, MountPropagationNone is used.\nThis field is beta in 1.10.\nWhen RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified\n(which defaults to None).",
                     "type": "string"
                   },
                   "name": {
-                    "description": "This must match the Name of a Volume.",
                     "type": "string"
                   },
                   "readOnly": {
-                    "description": "Mounted read-only if true, read-write otherwise (false or unspecified).\nDefaults to false.",
                     "type": "boolean"
                   },
                   "recursiveReadOnly": {
-                    "description": "RecursiveReadOnly specifies whether read-only mounts should be handled\nrecursively.\n\nIf ReadOnly is false, this field has no meaning and must be unspecified.\n\nIf ReadOnly is true, and this field is set to Disabled, the mount is not made\nrecursively read-only.  If this field is set to IfPossible, the mount is made\nrecursively read-only, if it is supported by the container runtime.  If this\nfield is set to Enabled, the mount is made recursively read-only if it is\nsupported by the container runtime, otherwise the pod will not be started and\nan error will be generated to indicate the reason.\n\nIf this field is set to IfPossible or Enabled, MountPropagation must be set to\nNone (or be unspecified, which defaults to None).\n\nIf this field is not specified, it is treated as an equivalent of Disabled.",
                     "type": "string"
                   },
                   "subPath": {
-                    "description": "Path within the volume from which the container's volume should be mounted.\nDefaults to \"\" (volume's root).",
                     "type": "string"
                   },
                   "subPathExpr": {
-                    "description": "Expanded path within the volume from which the container's volume should be mounted.\nBehaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.\nDefaults to \"\" (volume's root).\nSubPathExpr and SubPath are mutually exclusive.",
                     "type": "string"
                   }
                 },
@@ -953,9 +830,7 @@
               "type": "array"
             },
             "volumes": {
-              "description": "Volumes allows configuration of additional volumes on the output Deployment/StatefulSet definition.\nVolumes specified will be appended to other volumes that are generated.\n/ +optional",
               "items": {
-                "description": "Volume represents a named volume in a pod that may be accessed by any container in the pod.",
                 "required": [
                   "name"
                 ],
@@ -963,30 +838,187 @@
                 "x-kubernetes-preserve-unknown-fields": true
               },
               "type": "array"
+            },
+            "vpa": {
+              "properties": {
+                "recommenders": {
+                  "items": {
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "resourcePolicy": {
+                  "properties": {
+                    "containerPolicies": {
+                      "items": {
+                        "properties": {
+                          "containerName": {
+                            "type": "string"
+                          },
+                          "controlledResources": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "controlledValues": {
+                            "enum": [
+                              "RequestsAndLimits",
+                              "RequestsOnly"
+                            ],
+                            "type": "string"
+                          },
+                          "maxAllowed": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          },
+                          "minAllowed": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          },
+                          "mode": {
+                            "enum": [
+                              "Auto",
+                              "Off"
+                            ],
+                            "type": "string"
+                          },
+                          "oomBumpUpRatio": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "oomMinBumpUp": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                            "x-kubernetes-int-or-string": true
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "updatePolicy": {
+                  "properties": {
+                    "evictionRequirements": {
+                      "items": {
+                        "properties": {
+                          "changeRequirement": {
+                            "enum": [
+                              "TargetHigherThanRequests",
+                              "TargetLowerThanRequests"
+                            ],
+                            "type": "string"
+                          },
+                          "resources": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "changeRequirement",
+                          "resources"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "minReplicas": {
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "updateMode": {
+                      "enum": [
+                        "Off",
+                        "Initial",
+                        "Recreate",
+                        "InPlaceOrRecreate",
+                        "Auto"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
             }
           },
           "type": "object",
           "additionalProperties": false
         },
         "vlselect": {
-          "description": "VLSelect defines vlselect component configuration at victoria-logs cluster",
           "properties": {
             "affinity": {
-              "description": "Affinity If specified, the pod's scheduling constraints.",
               "type": "object",
               "x-kubernetes-preserve-unknown-fields": true
             },
+            "componentVersion": {
+              "type": "string"
+            },
             "configMaps": {
-              "description": "ConfigMaps is a list of ConfigMaps in the same namespace as the Application\nobject, which shall be mounted into the Application container\nat /etc/vm/configs/CONFIGMAP_NAME folder",
               "items": {
                 "type": "string"
               },
               "type": "array"
             },
             "containers": {
-              "description": "Containers property allows to inject additions sidecars or to patch existing containers.\nIt can be useful for proxies, backup, etc.",
               "items": {
-                "description": "A single application container that you want to run within a pod.",
                 "required": [
                   "name"
                 ],
@@ -996,21 +1028,17 @@
               "type": "array"
             },
             "disableAutomountServiceAccountToken": {
-              "description": "DisableAutomountServiceAccountToken whether to disable serviceAccount auto mount by Kubernetes (available from v0.54.0).\nOperator will conditionally create volumes and volumeMounts for containers if it requires k8s API access.\nFor example, vmagent and vm-config-reloader requires k8s API access.\nOperator creates volumes with name: \"kube-api-access\", which can be used as volumeMount for extraContainers if needed.\nAnd also adds VolumeMounts at /var/run/secrets/kubernetes.io/serviceaccount.",
               "type": "boolean"
             },
             "disableSelfServiceScrape": {
-              "description": "DisableSelfServiceScrape controls creation of VMServiceScrape by operator\nfor the application.\nHas priority over `VM_DISABLESELFSERVICESCRAPECREATION` operator env variable",
               "type": "boolean"
             },
             "dnsConfig": {
-              "description": "Specifies the DNS parameters of a pod.\nParameters specified here will be merged to the generated DNS\nconfiguration based on DNSPolicy.",
               "items": {
                 "x-kubernetes-preserve-unknown-fields": true
               },
               "properties": {
                 "nameservers": {
-                  "description": "A list of DNS name server IP addresses.\nThis will be appended to the base nameservers generated from DNSPolicy.\nDuplicated nameservers will be removed.",
                   "items": {
                     "type": "string"
                   },
@@ -1018,16 +1046,12 @@
                   "x-kubernetes-list-type": "atomic"
                 },
                 "options": {
-                  "description": "A list of DNS resolver options.\nThis will be merged with the base options generated from DNSPolicy.\nDuplicated entries will be removed. Resolution options given in Options\nwill override those that appear in the base DNSPolicy.",
                   "items": {
-                    "description": "PodDNSConfigOption defines DNS resolver options of a pod.",
                     "properties": {
                       "name": {
-                        "description": "Name is this DNS resolver option's name.\nRequired.",
                         "type": "string"
                       },
                       "value": {
-                        "description": "Value is this DNS resolver option's value.",
                         "type": "string"
                       }
                     },
@@ -1038,7 +1062,6 @@
                   "x-kubernetes-list-type": "atomic"
                 },
                 "searches": {
-                  "description": "A list of DNS search domains for host-name lookup.\nThis will be appended to the base search paths generated from DNSPolicy.\nDuplicated search paths will be removed.",
                   "items": {
                     "type": "string"
                   },
@@ -1050,27 +1073,21 @@
               "additionalProperties": false
             },
             "dnsPolicy": {
-              "description": "DNSPolicy sets DNS policy for the pod",
               "type": "string"
             },
             "extraArgs": {
               "additionalProperties": {
                 "type": "string"
               },
-              "description": "ExtraArgs that will be passed to the application container\nfor example remoteWrite.tmpDataPath: /tmp",
               "type": "object"
             },
             "extraEnvs": {
-              "description": "ExtraEnvs that will be passed to the application container",
               "items": {
-                "description": "EnvVar represents an environment variable present in a Container.",
                 "properties": {
                   "name": {
-                    "description": "Name of the environment variable.\nMay consist of any printable ASCII characters except '='.",
                     "type": "string"
                   },
                   "value": {
-                    "description": "Variable references $(VAR_NAME) are expanded\nusing the previously defined environment variables in the container and\nany service environment variables. If a variable cannot be resolved,\nthe reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.\n\"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\".\nEscaped references will never be expanded, regardless of whether the variable\nexists or not.\nDefaults to \"\".",
                     "type": "string"
                   }
                 },
@@ -1084,20 +1101,15 @@
               "type": "array"
             },
             "extraEnvsFrom": {
-              "description": "ExtraEnvsFrom defines source of env variables for the application container\ncould either be secret or configmap",
               "items": {
-                "description": "EnvFromSource represents the source of a set of ConfigMaps or Secrets",
                 "properties": {
                   "configMapRef": {
-                    "description": "The ConfigMap to select from",
                     "properties": {
                       "name": {
                         "default": "",
-                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                         "type": "string"
                       },
                       "optional": {
-                        "description": "Specify whether the ConfigMap must be defined",
                         "type": "boolean"
                       }
                     },
@@ -1106,19 +1118,15 @@
                     "additionalProperties": false
                   },
                   "prefix": {
-                    "description": "Optional text to prepend to the name of each environment variable.\nMay consist of any printable ASCII characters except '='.",
                     "type": "string"
                   },
                   "secretRef": {
-                    "description": "The Secret to select from",
                     "properties": {
                       "name": {
                         "default": "",
-                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                         "type": "string"
                       },
                       "optional": {
-                        "description": "Specify whether the Secret must be defined",
                         "type": "boolean"
                       }
                     },
@@ -1133,12 +1141,9 @@
               "type": "array"
             },
             "extraStorageNodes": {
-              "description": "ExtraStorageNodes - defines additional storage nodes to VLSelect",
               "items": {
-                "description": "VLStorageNode defines slice of additional vlstorage nodes",
                 "properties": {
                   "addr": {
-                    "description": "Addr defines storage node address",
                     "type": "string"
                   }
                 },
@@ -1151,12 +1156,9 @@
               "type": "array"
             },
             "host_aliases": {
-              "description": "HostAliasesUnderScore provides mapping for ip and hostname,\nthat would be propagated to pod,\ncannot be used with HostNetwork.\nHas Priority over hostAliases field",
               "items": {
-                "description": "HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the\npod's hosts file.",
                 "properties": {
                   "hostnames": {
-                    "description": "Hostnames for the above IP address.",
                     "items": {
                       "type": "string"
                     },
@@ -1164,7 +1166,6 @@
                     "x-kubernetes-list-type": "atomic"
                   },
                   "ip": {
-                    "description": "IP address of the host file entry.",
                     "type": "string"
                   }
                 },
@@ -1177,12 +1178,9 @@
               "type": "array"
             },
             "hostAliases": {
-              "description": "HostAliases provides mapping for ip and hostname,\nthat would be propagated to pod,\ncannot be used with HostNetwork.",
               "items": {
-                "description": "HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the\npod's hosts file.",
                 "properties": {
                   "hostnames": {
-                    "description": "Hostnames for the above IP address.",
                     "items": {
                       "type": "string"
                     },
@@ -1190,7 +1188,6 @@
                     "x-kubernetes-list-type": "atomic"
                   },
                   "ip": {
-                    "description": "IP address of the host file entry.",
                     "type": "string"
                   }
                 },
@@ -1203,27 +1200,21 @@
               "type": "array"
             },
             "hostNetwork": {
-              "description": "HostNetwork controls whether the pod may use the node network namespace",
               "type": "boolean"
             },
             "hpa": {
-              "description": "Configures horizontal pod autoscaling.",
               "type": "object",
               "x-kubernetes-preserve-unknown-fields": true
             },
             "image": {
-              "description": "Image - docker image settings\nif no specified operator uses default version from operator config",
               "properties": {
                 "pullPolicy": {
-                  "description": "PullPolicy describes how to pull docker image",
                   "type": "string"
                 },
                 "repository": {
-                  "description": "Repository contains name of docker image + it's repository if needed",
                   "type": "string"
                 },
                 "tag": {
-                  "description": "Tag contains desired docker image version",
                   "type": "string"
                 }
               },
@@ -1231,13 +1222,10 @@
               "additionalProperties": false
             },
             "imagePullSecrets": {
-              "description": "ImagePullSecrets An optional list of references to secrets in the same namespace\nto use for pulling images from registries\nsee https://kubernetes.io/docs/concepts/containers/images/#referring-to-an-imagepullsecrets-on-a-pod",
               "items": {
-                "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
                 "properties": {
                   "name": {
                     "default": "",
-                    "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                     "type": "string"
                   }
                 },
@@ -1248,9 +1236,7 @@
               "type": "array"
             },
             "initContainers": {
-              "description": "InitContainers allows adding initContainers to the pod definition.\nAny errors during the execution of an initContainer will lead to a restart of the Pod.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/",
               "items": {
-                "description": "A single application container that you want to run within a pod.",
                 "required": [
                   "name"
                 ],
@@ -1260,12 +1246,10 @@
               "type": "array"
             },
             "livenessProbe": {
-              "description": "LivenessProbe that will be added CRD pod",
               "type": "object",
               "x-kubernetes-preserve-unknown-fields": true
             },
             "logFormat": {
-              "description": "LogFormat for VLSelect to be configured with.\ndefault or json",
               "enum": [
                 "default",
                 "json"
@@ -1273,7 +1257,6 @@
               "type": "string"
             },
             "logLevel": {
-              "description": "LogLevel for VLSelect to be configured with.",
               "enum": [
                 "INFO",
                 "WARN",
@@ -1284,7 +1267,6 @@
               "type": "string"
             },
             "minReadySeconds": {
-              "description": "MinReadySeconds defines a minimum number of seconds to wait before starting update next pod\nif previous in healthy state\nHas no effect for VLogs and VMSingle",
               "format": "int32",
               "type": "integer"
             },
@@ -1292,15 +1274,12 @@
               "additionalProperties": {
                 "type": "string"
               },
-              "description": "NodeSelector Define which Nodes the Pods are scheduled on.",
               "type": "object"
             },
             "paused": {
-              "description": "Paused If set to true all actions on the underlying managed objects are not\ngoing to be performed, except for delete actions.",
               "type": "boolean"
             },
             "podDisruptionBudget": {
-              "description": "PodDisruptionBudget created by operator",
               "properties": {
                 "maxUnavailable": {
                   "anyOf": [
@@ -1311,7 +1290,6 @@
                       "type": "string"
                     }
                   ],
-                  "description": "An eviction is allowed if at most \"maxUnavailable\" pods selected by\n\"selector\" are unavailable after the eviction, i.e. even in absence of\nthe evicted pod. For example, one can prevent all voluntary evictions\nby specifying 0. This is a mutually exclusive setting with \"minAvailable\".",
                   "x-kubernetes-int-or-string": true
                 },
                 "minAvailable": {
@@ -1323,18 +1301,15 @@
                       "type": "string"
                     }
                   ],
-                  "description": "An eviction is allowed if at least \"minAvailable\" pods selected by\n\"selector\" will still be available after the eviction, i.e. even in the\nabsence of the evicted pod.  So for example you can prevent all voluntary\nevictions by specifying \"100%\".",
                   "x-kubernetes-int-or-string": true
                 },
                 "selectorLabels": {
                   "additionalProperties": {
                     "type": "string"
                   },
-                  "description": "replaces default labels selector generated by operator\nit's useful when you need to create custom budget",
                   "type": "object"
                 },
                 "unhealthyPodEvictionPolicy": {
-                  "description": "UnhealthyPodEvictionPolicy defines the criteria for when unhealthy pods\n\nValid policies are IfHealthyBudget and AlwaysAllow.\nIf no policy is specified, the default behavior will be used,\nwhich corresponds to the IfHealthyBudget policy.\nAvailable from operator v0.64.0",
                   "enum": [
                     "IfHealthyBudget",
                     "AlwaysAllow"
@@ -1346,24 +1321,20 @@
               "additionalProperties": false
             },
             "podMetadata": {
-              "description": "PodMetadata configures Labels and Annotations which are propagated to the VLSelect pods.",
               "properties": {
                 "annotations": {
                   "additionalProperties": {
                     "type": "string"
                   },
-                  "description": "Annotations is an unstructured key value map stored with a resource that may be\nset by external tools to store and retrieve arbitrary metadata. They are not\nqueryable and should be preserved when modifying objects.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations",
                   "type": "object"
                 },
                 "labels": {
                   "additionalProperties": {
                     "type": "string"
                   },
-                  "description": "Labels Map of string keys and values that can be used to organize and categorize\n(scope and select) objects. May match selectors of replication controllers\nand services.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels",
                   "type": "object"
                 },
                 "name": {
-                  "description": "Name must be unique within a namespace. Is required when creating resources, although\nsome resources may allow a client to request the generation of an appropriate name\nautomatically. Name is primarily intended for creation idempotence and configuration\ndefinition.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names",
                   "type": "string"
                 }
               },
@@ -1371,20 +1342,15 @@
               "additionalProperties": false
             },
             "port": {
-              "description": "Port listen address",
               "type": "string"
             },
             "priorityClassName": {
-              "description": "PriorityClassName class assigned to the Pods",
               "type": "string"
             },
             "readinessGates": {
-              "description": "ReadinessGates defines pod readiness gates",
               "items": {
-                "description": "PodReadinessGate contains the reference to a pod condition",
                 "properties": {
                   "conditionType": {
-                    "description": "ConditionType refers to a condition in the pod's condition list with matching type.",
                     "type": "string"
                   }
                 },
@@ -1397,29 +1363,22 @@
               "type": "array"
             },
             "readinessProbe": {
-              "description": "ReadinessProbe that will be added CRD pod",
               "type": "object",
               "x-kubernetes-preserve-unknown-fields": true
             },
             "replicaCount": {
-              "description": "ReplicaCount is the expected size of the Application.",
               "format": "int32",
               "type": "integer"
             },
             "resources": {
-              "description": "Resources container resource request and limits, https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/\nif not defined default resources from operator config will be used",
               "properties": {
                 "claims": {
-                  "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis field depends on the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
                   "items": {
-                    "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
                     "properties": {
                       "name": {
-                        "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
                         "type": "string"
                       },
                       "request": {
-                        "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
                         "type": "string"
                       }
                     },
@@ -1448,7 +1407,6 @@
                     "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                     "x-kubernetes-int-or-string": true
                   },
-                  "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
                   "type": "object"
                 },
                 "requests": {
@@ -1464,7 +1422,6 @@
                     "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                     "x-kubernetes-int-or-string": true
                   },
-                  "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
                   "type": "object"
                 }
               },
@@ -1472,12 +1429,10 @@
               "additionalProperties": false
             },
             "revisionHistoryLimitCount": {
-              "description": "The number of old ReplicaSets to retain to allow rollback in deployment or\nmaximum number of revisions that will be maintained in the Deployment revision history.\nHas no effect at StatefulSets\nDefaults to 10.",
               "format": "int32",
               "type": "integer"
             },
             "rollingUpdate": {
-              "description": "RollingUpdate - overrides deployment update params.",
               "properties": {
                 "maxSurge": {
                   "anyOf": [
@@ -1488,7 +1443,6 @@
                       "type": "string"
                     }
                   ],
-                  "description": "The maximum number of pods that can be scheduled above the desired number of\npods.\nValue can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).\nThis can not be 0 if MaxUnavailable is 0.\nAbsolute number is calculated from percentage by rounding up.\nDefaults to 25%.\nExample: when this is set to 30%, the new ReplicaSet can be scaled up immediately when\nthe rolling update starts, such that the total number of old and new pods do not exceed\n130% of desired pods. Once old pods have been killed,\nnew ReplicaSet can be scaled up further, ensuring that total number of pods running\nat any time during the update is at most 130% of desired pods.",
                   "x-kubernetes-int-or-string": true
                 },
                 "maxUnavailable": {
@@ -1500,7 +1454,6 @@
                       "type": "string"
                     }
                   ],
-                  "description": "The maximum number of pods that can be unavailable during the update.\nValue can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).\nAbsolute number is calculated from percentage by rounding down.\nThis can not be 0 if MaxSurge is 0.\nDefaults to 25%.\nExample: when this is set to 30%, the old ReplicaSet can be scaled down to 70% of desired pods\nimmediately when the rolling update starts. Once new pods are ready, old ReplicaSet\ncan be scaled down further, followed by scaling up the new ReplicaSet, ensuring\nthat the total number of pods available at all times during the update is at\nleast 70% of desired pods.",
                   "x-kubernetes-int-or-string": true
                 }
               },
@@ -1508,27 +1461,22 @@
               "additionalProperties": false
             },
             "runtimeClassName": {
-              "description": "RuntimeClassName - defines runtime class for kubernetes pod.\nhttps://kubernetes.io/docs/concepts/containers/runtime-class/",
               "type": "string"
             },
             "schedulerName": {
-              "description": "SchedulerName - defines kubernetes scheduler name",
               "type": "string"
             },
             "secrets": {
-              "description": "Secrets is a list of Secrets in the same namespace as the Application\nobject, which shall be mounted into the Application container\nat /etc/vm/secrets/SECRET_NAME folder",
               "items": {
                 "type": "string"
               },
               "type": "array"
             },
             "securityContext": {
-              "description": "SecurityContext holds pod-level security attributes and common container settings.\nThis defaults to the default PodSecurityContext.",
               "type": "object",
               "x-kubernetes-preserve-unknown-fields": true
             },
             "serviceScrapeSpec": {
-              "description": "ServiceScrapeSpec that will be added to vlselect VMServiceScrape spec",
               "required": [
                 "endpoints"
               ],
@@ -1536,27 +1484,22 @@
               "x-kubernetes-preserve-unknown-fields": true
             },
             "serviceSpec": {
-              "description": "ServiceSpec that will be added to vlselect service spec",
               "properties": {
                 "metadata": {
-                  "description": "EmbeddedObjectMetadata defines objectMeta for additional service.",
                   "properties": {
                     "annotations": {
                       "additionalProperties": {
                         "type": "string"
                       },
-                      "description": "Annotations is an unstructured key value map stored with a resource that may be\nset by external tools to store and retrieve arbitrary metadata. They are not\nqueryable and should be preserved when modifying objects.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations",
                       "type": "object"
                     },
                     "labels": {
                       "additionalProperties": {
                         "type": "string"
                       },
-                      "description": "Labels Map of string keys and values that can be used to organize and categorize\n(scope and select) objects. May match selectors of replication controllers\nand services.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels",
                       "type": "object"
                     },
                     "name": {
-                      "description": "Name must be unique within a namespace. Is required when creating resources, although\nsome resources may allow a client to request the generation of an appropriate name\nautomatically. Name is primarily intended for creation idempotence and configuration\ndefinition.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names",
                       "type": "string"
                     }
                   },
@@ -1564,12 +1507,10 @@
                   "additionalProperties": false
                 },
                 "spec": {
-                  "description": "ServiceSpec describes the attributes that a user creates on a service.\nMore info: https://kubernetes.io/docs/concepts/services-networking/service/",
                   "type": "object",
                   "x-kubernetes-preserve-unknown-fields": true
                 },
                 "useAsDefault": {
-                  "description": "UseAsDefault applies changes from given service definition to the main object Service\nChanging from headless service to clusterIP or loadbalancer may break cross-component communication",
                   "type": "boolean"
                 }
               },
@@ -1580,39 +1521,30 @@
               "additionalProperties": false
             },
             "startupProbe": {
-              "description": "StartupProbe that will be added to CRD pod",
               "type": "object",
               "x-kubernetes-preserve-unknown-fields": true
             },
             "terminationGracePeriodSeconds": {
-              "description": "TerminationGracePeriodSeconds period for container graceful termination",
               "format": "int64",
               "type": "integer"
             },
             "tolerations": {
-              "description": "Tolerations If specified, the pod's tolerations.",
               "items": {
-                "description": "The pod this Toleration is attached to tolerates any taint that matches\nthe triple <key,value,effect> using the matching operator <operator>.",
                 "properties": {
                   "effect": {
-                    "description": "Effect indicates the taint effect to match. Empty means match all taint effects.\nWhen specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
                     "type": "string"
                   },
                   "key": {
-                    "description": "Key is the taint key that the toleration applies to. Empty means match all taint keys.\nIf the key is empty, operator must be Exists; this combination means to match all values and all keys.",
                     "type": "string"
                   },
                   "operator": {
-                    "description": "Operator represents a key's relationship to the value.\nValid operators are Exists and Equal. Defaults to Equal.\nExists is equivalent to wildcard for value, so that a pod can\ntolerate all taints of a particular category.",
                     "type": "string"
                   },
                   "tolerationSeconds": {
-                    "description": "TolerationSeconds represents the period of time the toleration (which must be\nof effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,\nit is not set, which means tolerate the taint forever (do not evict). Zero and\nnegative values will be treated as 0 (evict immediately) by the system.",
                     "format": "int64",
                     "type": "integer"
                   },
                   "value": {
-                    "description": "Value is the taint value the toleration matches to.\nIf the operator is Exists, the value should be empty, otherwise just a regular string.",
                     "type": "string"
                   }
                 },
@@ -1622,9 +1554,7 @@
               "type": "array"
             },
             "topologySpreadConstraints": {
-              "description": "TopologySpreadConstraints embedded kubernetes pod configuration option,\ncontrols how pods are spread across your cluster among failure-domains\nsuch as regions, zones, nodes, and other user-defined topology domains\nhttps://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/",
               "items": {
-                "description": "TopologySpreadConstraint specifies how to spread matching pods among the given topology.",
                 "required": [
                   "maxSkew",
                   "topologyKey",
@@ -1636,7 +1566,6 @@
               "type": "array"
             },
             "updateStrategy": {
-              "description": "UpdateStrategy - overrides default update strategy.",
               "enum": [
                 "Recreate",
                 "RollingUpdate"
@@ -1644,44 +1573,33 @@
               "type": "string"
             },
             "useDefaultResources": {
-              "description": "UseDefaultResources controls resource settings\nBy default, operator sets built-in resource requirements",
               "type": "boolean"
             },
             "useStrictSecurity": {
-              "description": "UseStrictSecurity enables strict security mode for component\nit restricts disk writes access\nuses non-root user out of the box\ndrops not needed security permissions",
               "type": "boolean"
             },
             "volumeMounts": {
-              "description": "VolumeMounts allows configuration of additional VolumeMounts on the output Deployment/StatefulSet definition.\nVolumeMounts specified will be appended to other VolumeMounts in the Application container",
               "items": {
-                "description": "VolumeMount describes a mounting of a Volume within a container.",
                 "properties": {
                   "mountPath": {
-                    "description": "Path within the container at which the volume should be mounted.  Must\nnot contain ':'.",
                     "type": "string"
                   },
                   "mountPropagation": {
-                    "description": "mountPropagation determines how mounts are propagated from the host\nto container and the other way around.\nWhen not set, MountPropagationNone is used.\nThis field is beta in 1.10.\nWhen RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified\n(which defaults to None).",
                     "type": "string"
                   },
                   "name": {
-                    "description": "This must match the Name of a Volume.",
                     "type": "string"
                   },
                   "readOnly": {
-                    "description": "Mounted read-only if true, read-write otherwise (false or unspecified).\nDefaults to false.",
                     "type": "boolean"
                   },
                   "recursiveReadOnly": {
-                    "description": "RecursiveReadOnly specifies whether read-only mounts should be handled\nrecursively.\n\nIf ReadOnly is false, this field has no meaning and must be unspecified.\n\nIf ReadOnly is true, and this field is set to Disabled, the mount is not made\nrecursively read-only.  If this field is set to IfPossible, the mount is made\nrecursively read-only, if it is supported by the container runtime.  If this\nfield is set to Enabled, the mount is made recursively read-only if it is\nsupported by the container runtime, otherwise the pod will not be started and\nan error will be generated to indicate the reason.\n\nIf this field is set to IfPossible or Enabled, MountPropagation must be set to\nNone (or be unspecified, which defaults to None).\n\nIf this field is not specified, it is treated as an equivalent of Disabled.",
                     "type": "string"
                   },
                   "subPath": {
-                    "description": "Path within the volume from which the container's volume should be mounted.\nDefaults to \"\" (volume's root).",
                     "type": "string"
                   },
                   "subPathExpr": {
-                    "description": "Expanded path within the volume from which the container's volume should be mounted.\nBehaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.\nDefaults to \"\" (volume's root).\nSubPathExpr and SubPath are mutually exclusive.",
                     "type": "string"
                   }
                 },
@@ -1695,9 +1613,7 @@
               "type": "array"
             },
             "volumes": {
-              "description": "Volumes allows configuration of additional volumes on the output Deployment/StatefulSet definition.\nVolumes specified will be appended to other volumes that are generated.\n/ +optional",
               "items": {
-                "description": "Volume represents a named volume in a pod that may be accessed by any container in the pod.",
                 "required": [
                   "name"
                 ],
@@ -1705,39 +1621,194 @@
                 "x-kubernetes-preserve-unknown-fields": true
               },
               "type": "array"
+            },
+            "vpa": {
+              "properties": {
+                "recommenders": {
+                  "items": {
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "resourcePolicy": {
+                  "properties": {
+                    "containerPolicies": {
+                      "items": {
+                        "properties": {
+                          "containerName": {
+                            "type": "string"
+                          },
+                          "controlledResources": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "controlledValues": {
+                            "enum": [
+                              "RequestsAndLimits",
+                              "RequestsOnly"
+                            ],
+                            "type": "string"
+                          },
+                          "maxAllowed": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          },
+                          "minAllowed": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          },
+                          "mode": {
+                            "enum": [
+                              "Auto",
+                              "Off"
+                            ],
+                            "type": "string"
+                          },
+                          "oomBumpUpRatio": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "oomMinBumpUp": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                            "x-kubernetes-int-or-string": true
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "updatePolicy": {
+                  "properties": {
+                    "evictionRequirements": {
+                      "items": {
+                        "properties": {
+                          "changeRequirement": {
+                            "enum": [
+                              "TargetHigherThanRequests",
+                              "TargetLowerThanRequests"
+                            ],
+                            "type": "string"
+                          },
+                          "resources": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "changeRequirement",
+                          "resources"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "minReplicas": {
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "updateMode": {
+                      "enum": [
+                        "Off",
+                        "Initial",
+                        "Recreate",
+                        "InPlaceOrRecreate",
+                        "Auto"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
             }
           },
           "type": "object",
           "additionalProperties": false
         },
         "vlstorage": {
-          "description": "VLStorage defines vlstorage component configuration at victoria-logs cluster",
           "properties": {
             "affinity": {
-              "description": "Affinity If specified, the pod's scheduling constraints.",
               "type": "object",
               "x-kubernetes-preserve-unknown-fields": true
             },
             "claimTemplates": {
-              "description": "ClaimTemplates allows adding additional VolumeClaimTemplates for StatefulSet",
               "items": {
-                "description": "PersistentVolumeClaim is a user's request for and claim to a persistent volume",
                 "type": "object",
                 "x-kubernetes-preserve-unknown-fields": true
               },
               "type": "array"
             },
+            "componentVersion": {
+              "type": "string"
+            },
             "configMaps": {
-              "description": "ConfigMaps is a list of ConfigMaps in the same namespace as the Application\nobject, which shall be mounted into the Application container\nat /etc/vm/configs/CONFIGMAP_NAME folder",
               "items": {
                 "type": "string"
               },
               "type": "array"
             },
             "containers": {
-              "description": "Containers property allows to inject additions sidecars or to patch existing containers.\nIt can be useful for proxies, backup, etc.",
               "items": {
-                "description": "A single application container that you want to run within a pod.",
                 "required": [
                   "name"
                 ],
@@ -1747,21 +1818,17 @@
               "type": "array"
             },
             "disableAutomountServiceAccountToken": {
-              "description": "DisableAutomountServiceAccountToken whether to disable serviceAccount auto mount by Kubernetes (available from v0.54.0).\nOperator will conditionally create volumes and volumeMounts for containers if it requires k8s API access.\nFor example, vmagent and vm-config-reloader requires k8s API access.\nOperator creates volumes with name: \"kube-api-access\", which can be used as volumeMount for extraContainers if needed.\nAnd also adds VolumeMounts at /var/run/secrets/kubernetes.io/serviceaccount.",
               "type": "boolean"
             },
             "disableSelfServiceScrape": {
-              "description": "DisableSelfServiceScrape controls creation of VMServiceScrape by operator\nfor the application.\nHas priority over `VM_DISABLESELFSERVICESCRAPECREATION` operator env variable",
               "type": "boolean"
             },
             "dnsConfig": {
-              "description": "Specifies the DNS parameters of a pod.\nParameters specified here will be merged to the generated DNS\nconfiguration based on DNSPolicy.",
               "items": {
                 "x-kubernetes-preserve-unknown-fields": true
               },
               "properties": {
                 "nameservers": {
-                  "description": "A list of DNS name server IP addresses.\nThis will be appended to the base nameservers generated from DNSPolicy.\nDuplicated nameservers will be removed.",
                   "items": {
                     "type": "string"
                   },
@@ -1769,16 +1836,12 @@
                   "x-kubernetes-list-type": "atomic"
                 },
                 "options": {
-                  "description": "A list of DNS resolver options.\nThis will be merged with the base options generated from DNSPolicy.\nDuplicated entries will be removed. Resolution options given in Options\nwill override those that appear in the base DNSPolicy.",
                   "items": {
-                    "description": "PodDNSConfigOption defines DNS resolver options of a pod.",
                     "properties": {
                       "name": {
-                        "description": "Name is this DNS resolver option's name.\nRequired.",
                         "type": "string"
                       },
                       "value": {
-                        "description": "Value is this DNS resolver option's value.",
                         "type": "string"
                       }
                     },
@@ -1789,7 +1852,6 @@
                   "x-kubernetes-list-type": "atomic"
                 },
                 "searches": {
-                  "description": "A list of DNS search domains for host-name lookup.\nThis will be appended to the base search paths generated from DNSPolicy.\nDuplicated search paths will be removed.",
                   "items": {
                     "type": "string"
                   },
@@ -1801,27 +1863,21 @@
               "additionalProperties": false
             },
             "dnsPolicy": {
-              "description": "DNSPolicy sets DNS policy for the pod",
               "type": "string"
             },
             "extraArgs": {
               "additionalProperties": {
                 "type": "string"
               },
-              "description": "ExtraArgs that will be passed to the application container\nfor example remoteWrite.tmpDataPath: /tmp",
               "type": "object"
             },
             "extraEnvs": {
-              "description": "ExtraEnvs that will be passed to the application container",
               "items": {
-                "description": "EnvVar represents an environment variable present in a Container.",
                 "properties": {
                   "name": {
-                    "description": "Name of the environment variable.\nMay consist of any printable ASCII characters except '='.",
                     "type": "string"
                   },
                   "value": {
-                    "description": "Variable references $(VAR_NAME) are expanded\nusing the previously defined environment variables in the container and\nany service environment variables. If a variable cannot be resolved,\nthe reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.\n\"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\".\nEscaped references will never be expanded, regardless of whether the variable\nexists or not.\nDefaults to \"\".",
                     "type": "string"
                   }
                 },
@@ -1835,20 +1891,15 @@
               "type": "array"
             },
             "extraEnvsFrom": {
-              "description": "ExtraEnvsFrom defines source of env variables for the application container\ncould either be secret or configmap",
               "items": {
-                "description": "EnvFromSource represents the source of a set of ConfigMaps or Secrets",
                 "properties": {
                   "configMapRef": {
-                    "description": "The ConfigMap to select from",
                     "properties": {
                       "name": {
                         "default": "",
-                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                         "type": "string"
                       },
                       "optional": {
-                        "description": "Specify whether the ConfigMap must be defined",
                         "type": "boolean"
                       }
                     },
@@ -1857,19 +1908,15 @@
                     "additionalProperties": false
                   },
                   "prefix": {
-                    "description": "Optional text to prepend to the name of each environment variable.\nMay consist of any printable ASCII characters except '='.",
                     "type": "string"
                   },
                   "secretRef": {
-                    "description": "The Secret to select from",
                     "properties": {
                       "name": {
                         "default": "",
-                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                         "type": "string"
                       },
                       "optional": {
-                        "description": "Specify whether the Secret must be defined",
                         "type": "boolean"
                       }
                     },
@@ -1884,17 +1931,13 @@
               "type": "array"
             },
             "futureRetention": {
-              "description": "FutureRetention for the stored logs\nLog entries with timestamps bigger than now+futureRetention are rejected during data ingestion; see https://docs.victoriametrics.com/victorialogs/#retention",
               "pattern": "^[0-9]+(h|d|w|y)?$",
               "type": "string"
             },
             "host_aliases": {
-              "description": "HostAliasesUnderScore provides mapping for ip and hostname,\nthat would be propagated to pod,\ncannot be used with HostNetwork.\nHas Priority over hostAliases field",
               "items": {
-                "description": "HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the\npod's hosts file.",
                 "properties": {
                   "hostnames": {
-                    "description": "Hostnames for the above IP address.",
                     "items": {
                       "type": "string"
                     },
@@ -1902,7 +1945,6 @@
                     "x-kubernetes-list-type": "atomic"
                   },
                   "ip": {
-                    "description": "IP address of the host file entry.",
                     "type": "string"
                   }
                 },
@@ -1915,12 +1957,9 @@
               "type": "array"
             },
             "hostAliases": {
-              "description": "HostAliases provides mapping for ip and hostname,\nthat would be propagated to pod,\ncannot be used with HostNetwork.",
               "items": {
-                "description": "HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the\npod's hosts file.",
                 "properties": {
                   "hostnames": {
-                    "description": "Hostnames for the above IP address.",
                     "items": {
                       "type": "string"
                     },
@@ -1928,7 +1967,6 @@
                     "x-kubernetes-list-type": "atomic"
                   },
                   "ip": {
-                    "description": "IP address of the host file entry.",
                     "type": "string"
                   }
                 },
@@ -1941,22 +1979,590 @@
               "type": "array"
             },
             "hostNetwork": {
-              "description": "HostNetwork controls whether the pod may use the node network namespace",
               "type": "boolean"
             },
+            "hpa": {
+              "properties": {
+                "behaviour": {
+                  "properties": {
+                    "scaleDown": {
+                      "properties": {
+                        "policies": {
+                          "items": {
+                            "properties": {
+                              "periodSeconds": {
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "type": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "format": "int32",
+                                "type": "integer"
+                              }
+                            },
+                            "required": [
+                              "periodSeconds",
+                              "type",
+                              "value"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array",
+                          "x-kubernetes-list-type": "atomic"
+                        },
+                        "selectPolicy": {
+                          "type": "string"
+                        },
+                        "stabilizationWindowSeconds": {
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "tolerance": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                          "x-kubernetes-int-or-string": true
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "scaleUp": {
+                      "properties": {
+                        "policies": {
+                          "items": {
+                            "properties": {
+                              "periodSeconds": {
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "type": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "format": "int32",
+                                "type": "integer"
+                              }
+                            },
+                            "required": [
+                              "periodSeconds",
+                              "type",
+                              "value"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array",
+                          "x-kubernetes-list-type": "atomic"
+                        },
+                        "selectPolicy": {
+                          "type": "string"
+                        },
+                        "stabilizationWindowSeconds": {
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "tolerance": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                          "x-kubernetes-int-or-string": true
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "maxReplicas": {
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "metrics": {
+                  "items": {
+                    "properties": {
+                      "containerResource": {
+                        "properties": {
+                          "container": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "target": {
+                            "properties": {
+                              "averageUtilization": {
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "averageValue": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "type": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "required": [
+                              "type"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "container",
+                          "name",
+                          "target"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "external": {
+                        "properties": {
+                          "metric": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "selector": {
+                                "properties": {
+                                  "matchExpressions": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              }
+                            },
+                            "required": [
+                              "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "target": {
+                            "properties": {
+                              "averageUtilization": {
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "averageValue": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "type": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "required": [
+                              "type"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "metric",
+                          "target"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "object": {
+                        "properties": {
+                          "describedObject": {
+                            "properties": {
+                              "apiVersion": {
+                                "type": "string"
+                              },
+                              "kind": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "kind",
+                              "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "metric": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "selector": {
+                                "properties": {
+                                  "matchExpressions": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              }
+                            },
+                            "required": [
+                              "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "target": {
+                            "properties": {
+                              "averageUtilization": {
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "averageValue": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "type": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "required": [
+                              "type"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "describedObject",
+                          "metric",
+                          "target"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "pods": {
+                        "properties": {
+                          "metric": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "selector": {
+                                "properties": {
+                                  "matchExpressions": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              }
+                            },
+                            "required": [
+                              "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "target": {
+                            "properties": {
+                              "averageUtilization": {
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "averageValue": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "type": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "required": [
+                              "type"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "metric",
+                          "target"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "resource": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "target": {
+                            "properties": {
+                              "averageUtilization": {
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "averageValue": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "type": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "required": [
+                              "type"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "target"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "type"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "minReplicas": {
+                  "format": "int32",
+                  "type": "integer"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
             "image": {
-              "description": "Image - docker image settings\nif no specified operator uses default version from operator config",
               "properties": {
                 "pullPolicy": {
-                  "description": "PullPolicy describes how to pull docker image",
                   "type": "string"
                 },
                 "repository": {
-                  "description": "Repository contains name of docker image + it's repository if needed",
                   "type": "string"
                 },
                 "tag": {
-                  "description": "Tag contains desired docker image version",
                   "type": "string"
                 }
               },
@@ -1964,13 +2570,10 @@
               "additionalProperties": false
             },
             "imagePullSecrets": {
-              "description": "ImagePullSecrets An optional list of references to secrets in the same namespace\nto use for pulling images from registries\nsee https://kubernetes.io/docs/concepts/containers/images/#referring-to-an-imagepullsecrets-on-a-pod",
               "items": {
-                "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
                 "properties": {
                   "name": {
                     "default": "",
-                    "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                     "type": "string"
                   }
                 },
@@ -1981,9 +2584,7 @@
               "type": "array"
             },
             "initContainers": {
-              "description": "InitContainers allows adding initContainers to the pod definition.\nAny errors during the execution of an initContainer will lead to a restart of the Pod.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/",
               "items": {
-                "description": "A single application container that you want to run within a pod.",
                 "required": [
                   "name"
                 ],
@@ -1993,12 +2594,10 @@
               "type": "array"
             },
             "livenessProbe": {
-              "description": "LivenessProbe that will be added CRD pod",
               "type": "object",
               "x-kubernetes-preserve-unknown-fields": true
             },
             "logFormat": {
-              "description": "LogFormat for VLStorage to be configured with.\ndefault or json",
               "enum": [
                 "default",
                 "json"
@@ -2006,11 +2605,9 @@
               "type": "string"
             },
             "logIngestedRows": {
-              "description": "Whether to log all the ingested log entries; this can be useful for debugging of data ingestion; see https://docs.victoriametrics.com/victorialogs/data-ingestion/",
               "type": "boolean"
             },
             "logLevel": {
-              "description": "LogLevel for VLStorage to be configured with.",
               "enum": [
                 "INFO",
                 "WARN",
@@ -2021,11 +2618,9 @@
               "type": "string"
             },
             "logNewStreams": {
-              "description": "LogNewStreams Whether to log creation of new streams; this can be useful for debugging of high cardinality issues with log streams; see https://docs.victoriametrics.com/victorialogs/keyconcepts/#stream-fields",
               "type": "boolean"
             },
             "maintenanceInsertNodeIDs": {
-              "description": "MaintenanceInsertNodeIDs - excludes given node ids from insert requests routing, must contain pod suffixes - for pod-0, id will be 0 and etc.\nlets say, you have pod-0, pod-1, pod-2, pod-3. to exclude pod-0 and pod-3 from insert routing, define nodeIDs: [0,3].\nUseful at storage expanding, when you want to rebalance some data at cluster.",
               "items": {
                 "format": "int32",
                 "type": "integer"
@@ -2033,7 +2628,6 @@
               "type": "array"
             },
             "maintenanceSelectNodeIDs": {
-              "description": "MaintenanceInsertNodeIDs - excludes given node ids from select requests routing, must contain pod suffixes - for pod-0, id will be 0 and etc.",
               "items": {
                 "format": "int32",
                 "type": "integer"
@@ -2041,7 +2635,6 @@
               "type": "array"
             },
             "minReadySeconds": {
-              "description": "MinReadySeconds defines a minimum number of seconds to wait before starting update next pod\nif previous in healthy state\nHas no effect for VLogs and VMSingle",
               "format": "int32",
               "type": "integer"
             },
@@ -2049,22 +2642,17 @@
               "additionalProperties": {
                 "type": "string"
               },
-              "description": "NodeSelector Define which Nodes the Pods are scheduled on.",
               "type": "object"
             },
             "paused": {
-              "description": "Paused If set to true all actions on the underlying managed objects are not\ngoing to be performed, except for delete actions.",
               "type": "boolean"
             },
             "persistentVolumeClaimRetentionPolicy": {
-              "description": "PersistentVolumeClaimRetentionPolicy allows configuration of PVC retention policy",
               "properties": {
                 "whenDeleted": {
-                  "description": "WhenDeleted specifies what happens to PVCs created from StatefulSet\nVolumeClaimTemplates when the StatefulSet is deleted. The default policy\nof `Retain` causes PVCs to not be affected by StatefulSet deletion. The\n`Delete` policy causes those PVCs to be deleted.",
                   "type": "string"
                 },
                 "whenScaled": {
-                  "description": "WhenScaled specifies what happens to PVCs created from StatefulSet\nVolumeClaimTemplates when the StatefulSet is scaled down. The default\npolicy of `Retain` causes PVCs to not be affected by a scaledown. The\n`Delete` policy causes the associated PVCs for any excess pods above\nthe replica count to be deleted.",
                   "type": "string"
                 }
               },
@@ -2072,7 +2660,6 @@
               "additionalProperties": false
             },
             "podDisruptionBudget": {
-              "description": "PodDisruptionBudget created by operator",
               "properties": {
                 "maxUnavailable": {
                   "anyOf": [
@@ -2083,7 +2670,6 @@
                       "type": "string"
                     }
                   ],
-                  "description": "An eviction is allowed if at most \"maxUnavailable\" pods selected by\n\"selector\" are unavailable after the eviction, i.e. even in absence of\nthe evicted pod. For example, one can prevent all voluntary evictions\nby specifying 0. This is a mutually exclusive setting with \"minAvailable\".",
                   "x-kubernetes-int-or-string": true
                 },
                 "minAvailable": {
@@ -2095,18 +2681,15 @@
                       "type": "string"
                     }
                   ],
-                  "description": "An eviction is allowed if at least \"minAvailable\" pods selected by\n\"selector\" will still be available after the eviction, i.e. even in the\nabsence of the evicted pod.  So for example you can prevent all voluntary\nevictions by specifying \"100%\".",
                   "x-kubernetes-int-or-string": true
                 },
                 "selectorLabels": {
                   "additionalProperties": {
                     "type": "string"
                   },
-                  "description": "replaces default labels selector generated by operator\nit's useful when you need to create custom budget",
                   "type": "object"
                 },
                 "unhealthyPodEvictionPolicy": {
-                  "description": "UnhealthyPodEvictionPolicy defines the criteria for when unhealthy pods\n\nValid policies are IfHealthyBudget and AlwaysAllow.\nIf no policy is specified, the default behavior will be used,\nwhich corresponds to the IfHealthyBudget policy.\nAvailable from operator v0.64.0",
                   "enum": [
                     "IfHealthyBudget",
                     "AlwaysAllow"
@@ -2118,24 +2701,20 @@
               "additionalProperties": false
             },
             "podMetadata": {
-              "description": "PodMetadata configures Labels and Annotations which are propagated to the VLStorage pods.",
               "properties": {
                 "annotations": {
                   "additionalProperties": {
                     "type": "string"
                   },
-                  "description": "Annotations is an unstructured key value map stored with a resource that may be\nset by external tools to store and retrieve arbitrary metadata. They are not\nqueryable and should be preserved when modifying objects.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations",
                   "type": "object"
                 },
                 "labels": {
                   "additionalProperties": {
                     "type": "string"
                   },
-                  "description": "Labels Map of string keys and values that can be used to organize and categorize\n(scope and select) objects. May match selectors of replication controllers\nand services.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels",
                   "type": "object"
                 },
                 "name": {
-                  "description": "Name must be unique within a namespace. Is required when creating resources, although\nsome resources may allow a client to request the generation of an appropriate name\nautomatically. Name is primarily intended for creation idempotence and configuration\ndefinition.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names",
                   "type": "string"
                 }
               },
@@ -2143,20 +2722,15 @@
               "additionalProperties": false
             },
             "port": {
-              "description": "Port listen address",
               "type": "string"
             },
             "priorityClassName": {
-              "description": "PriorityClassName class assigned to the Pods",
               "type": "string"
             },
             "readinessGates": {
-              "description": "ReadinessGates defines pod readiness gates",
               "items": {
-                "description": "PodReadinessGate contains the reference to a pod condition",
                 "properties": {
                   "conditionType": {
-                    "description": "ConditionType refers to a condition in the pod's condition list with matching type.",
                     "type": "string"
                   }
                 },
@@ -2169,29 +2743,22 @@
               "type": "array"
             },
             "readinessProbe": {
-              "description": "ReadinessProbe that will be added CRD pod",
               "type": "object",
               "x-kubernetes-preserve-unknown-fields": true
             },
             "replicaCount": {
-              "description": "ReplicaCount is the expected size of the Application.",
               "format": "int32",
               "type": "integer"
             },
             "resources": {
-              "description": "Resources container resource request and limits, https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/\nif not defined default resources from operator config will be used",
               "properties": {
                 "claims": {
-                  "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis field depends on the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
                   "items": {
-                    "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
                     "properties": {
                       "name": {
-                        "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
                         "type": "string"
                       },
                       "request": {
-                        "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
                         "type": "string"
                       }
                     },
@@ -2220,7 +2787,6 @@
                     "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                     "x-kubernetes-int-or-string": true
                   },
-                  "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
                   "type": "object"
                 },
                 "requests": {
@@ -2236,7 +2802,6 @@
                     "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                     "x-kubernetes-int-or-string": true
                   },
-                  "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
                   "type": "object"
                 }
               },
@@ -2244,25 +2809,20 @@
               "additionalProperties": false
             },
             "retentionMaxDiskSpaceUsageBytes": {
-              "description": "RetentionMaxDiskSpaceUsageBytes for the stored logs\nVictoriaLogs keeps at least two last days of data in order to guarantee that the logs for the last day can be returned in queries.\nThis means that the total disk space usage may exceed the -retention.maxDiskSpaceUsageBytes,\nif the size of the last two days of data exceeds the -retention.maxDiskSpaceUsageBytes.\nhttps://docs.victoriametrics.com/victorialogs/#retention-by-disk-space-usage",
               "type": "string"
             },
             "retentionPeriod": {
-              "description": "RetentionPeriod for the stored logs\nhttps://docs.victoriametrics.com/victorialogs/#retention",
               "pattern": "^[0-9]+(h|d|w|y)?$",
               "type": "string"
             },
             "revisionHistoryLimitCount": {
-              "description": "The number of old ReplicaSets to retain to allow rollback in deployment or\nmaximum number of revisions that will be maintained in the Deployment revision history.\nHas no effect at StatefulSets\nDefaults to 10.",
               "format": "int32",
               "type": "integer"
             },
             "rollingUpdateStrategy": {
-              "description": "RollingUpdateStrategy defines strategy for application updates\nDefault is OnDelete, in this case operator handles update process\nCan be changed for RollingUpdate",
               "type": "string"
             },
             "rollingUpdateStrategyBehavior": {
-              "description": "RollingUpdateStrategyBehavior defines customized behavior for rolling updates.\nIt applies if the RollingUpdateStrategy is set to OnDelete, which is the default.",
               "properties": {
                 "maxUnavailable": {
                   "anyOf": [
@@ -2273,7 +2833,6 @@
                       "type": "string"
                     }
                   ],
-                  "description": "MaxUnavailable defines the maximum number of pods that can be unavailable during the update.\nIt can be specified as an absolute number (e.g. 2) or a percentage of the total pods (e.g. \"50%\").\nFor example, if set to 100%, all pods will be upgraded at once, minimizing downtime when needed.",
                   "x-kubernetes-int-or-string": true
                 }
               },
@@ -2281,27 +2840,22 @@
               "additionalProperties": false
             },
             "runtimeClassName": {
-              "description": "RuntimeClassName - defines runtime class for kubernetes pod.\nhttps://kubernetes.io/docs/concepts/containers/runtime-class/",
               "type": "string"
             },
             "schedulerName": {
-              "description": "SchedulerName - defines kubernetes scheduler name",
               "type": "string"
             },
             "secrets": {
-              "description": "Secrets is a list of Secrets in the same namespace as the Application\nobject, which shall be mounted into the Application container\nat /etc/vm/secrets/SECRET_NAME folder",
               "items": {
                 "type": "string"
               },
               "type": "array"
             },
             "securityContext": {
-              "description": "SecurityContext holds pod-level security attributes and common container settings.\nThis defaults to the default PodSecurityContext.",
               "type": "object",
               "x-kubernetes-preserve-unknown-fields": true
             },
             "serviceScrapeSpec": {
-              "description": "ServiceScrapeSpec that will be added to vlselect VMServiceScrape spec",
               "required": [
                 "endpoints"
               ],
@@ -2309,27 +2863,22 @@
               "x-kubernetes-preserve-unknown-fields": true
             },
             "serviceSpec": {
-              "description": "ServiceSpec that will be added to vlselect service spec",
               "properties": {
                 "metadata": {
-                  "description": "EmbeddedObjectMetadata defines objectMeta for additional service.",
                   "properties": {
                     "annotations": {
                       "additionalProperties": {
                         "type": "string"
                       },
-                      "description": "Annotations is an unstructured key value map stored with a resource that may be\nset by external tools to store and retrieve arbitrary metadata. They are not\nqueryable and should be preserved when modifying objects.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations",
                       "type": "object"
                     },
                     "labels": {
                       "additionalProperties": {
                         "type": "string"
                       },
-                      "description": "Labels Map of string keys and values that can be used to organize and categorize\n(scope and select) objects. May match selectors of replication controllers\nand services.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels",
                       "type": "object"
                     },
                     "name": {
-                      "description": "Name must be unique within a namespace. Is required when creating resources, although\nsome resources may allow a client to request the generation of an appropriate name\nautomatically. Name is primarily intended for creation idempotence and configuration\ndefinition.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names",
                       "type": "string"
                     }
                   },
@@ -2337,12 +2886,10 @@
                   "additionalProperties": false
                 },
                 "spec": {
-                  "description": "ServiceSpec describes the attributes that a user creates on a service.\nMore info: https://kubernetes.io/docs/concepts/services-networking/service/",
                   "type": "object",
                   "x-kubernetes-preserve-unknown-fields": true
                 },
                 "useAsDefault": {
-                  "description": "UseAsDefault applies changes from given service definition to the main object Service\nChanging from headless service to clusterIP or loadbalancer may break cross-component communication",
                   "type": "boolean"
                 }
               },
@@ -2353,22 +2900,14 @@
               "additionalProperties": false
             },
             "startupProbe": {
-              "description": "StartupProbe that will be added to CRD pod",
               "type": "object",
               "x-kubernetes-preserve-unknown-fields": true
             },
             "storage": {
-              "description": "Storage configures persistent volume for VLStorage",
               "properties": {
-                "disableMountSubPath": {
-                  "description": "Deprecated: subPath usage will be disabled by default in a future release, this option will become unnecessary.\nDisableMountSubPath allows to remove any subPath usage in volume mounts.",
-                  "type": "boolean"
-                },
                 "emptyDir": {
-                  "description": "EmptyDirVolumeSource to be used by the Prometheus StatefulSets. If specified, used in place of any volumeClaimTemplate. More\ninfo: https://kubernetes.io/docs/concepts/storage/volumes/#emptydir",
                   "properties": {
                     "medium": {
-                      "description": "medium represents what type of storage medium should back this directory.\nThe default is \"\" which means to use the node's default medium.\nMust be an empty string (default) or Memory.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
                       "type": "string"
                     },
                     "sizeLimit": {
@@ -2380,7 +2919,6 @@
                           "type": "string"
                         }
                       ],
-                      "description": "sizeLimit is the total amount of local storage required for this EmptyDir volume.\nThe size limit is also applicable for memory medium.\nThe maximum usage on memory medium EmptyDir would be the minimum value between\nthe SizeLimit specified here and the sum of memory limits of all containers in a pod.\nThe default is nil which means that the limit is undefined.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
                       "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                       "x-kubernetes-int-or-string": true
                     }
@@ -2389,7 +2927,6 @@
                   "additionalProperties": false
                 },
                 "volumeClaimTemplate": {
-                  "description": "A PVC spec to be used by the StatefulSets/Deployments.",
                   "type": "object",
                   "x-kubernetes-preserve-unknown-fields": true
                 }
@@ -2398,38 +2935,29 @@
               "additionalProperties": false
             },
             "storageDataPath": {
-              "description": "StorageDataPath - path to storage data",
               "type": "string"
             },
             "terminationGracePeriodSeconds": {
-              "description": "TerminationGracePeriodSeconds period for container graceful termination",
               "format": "int64",
               "type": "integer"
             },
             "tolerations": {
-              "description": "Tolerations If specified, the pod's tolerations.",
               "items": {
-                "description": "The pod this Toleration is attached to tolerates any taint that matches\nthe triple <key,value,effect> using the matching operator <operator>.",
                 "properties": {
                   "effect": {
-                    "description": "Effect indicates the taint effect to match. Empty means match all taint effects.\nWhen specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
                     "type": "string"
                   },
                   "key": {
-                    "description": "Key is the taint key that the toleration applies to. Empty means match all taint keys.\nIf the key is empty, operator must be Exists; this combination means to match all values and all keys.",
                     "type": "string"
                   },
                   "operator": {
-                    "description": "Operator represents a key's relationship to the value.\nValid operators are Exists and Equal. Defaults to Equal.\nExists is equivalent to wildcard for value, so that a pod can\ntolerate all taints of a particular category.",
                     "type": "string"
                   },
                   "tolerationSeconds": {
-                    "description": "TolerationSeconds represents the period of time the toleration (which must be\nof effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,\nit is not set, which means tolerate the taint forever (do not evict). Zero and\nnegative values will be treated as 0 (evict immediately) by the system.",
                     "format": "int64",
                     "type": "integer"
                   },
                   "value": {
-                    "description": "Value is the taint value the toleration matches to.\nIf the operator is Exists, the value should be empty, otherwise just a regular string.",
                     "type": "string"
                   }
                 },
@@ -2439,9 +2967,7 @@
               "type": "array"
             },
             "topologySpreadConstraints": {
-              "description": "TopologySpreadConstraints embedded kubernetes pod configuration option,\ncontrols how pods are spread across your cluster among failure-domains\nsuch as regions, zones, nodes, and other user-defined topology domains\nhttps://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/",
               "items": {
-                "description": "TopologySpreadConstraint specifies how to spread matching pods among the given topology.",
                 "required": [
                   "maxSkew",
                   "topologyKey",
@@ -2453,44 +2979,33 @@
               "type": "array"
             },
             "useDefaultResources": {
-              "description": "UseDefaultResources controls resource settings\nBy default, operator sets built-in resource requirements",
               "type": "boolean"
             },
             "useStrictSecurity": {
-              "description": "UseStrictSecurity enables strict security mode for component\nit restricts disk writes access\nuses non-root user out of the box\ndrops not needed security permissions",
               "type": "boolean"
             },
             "volumeMounts": {
-              "description": "VolumeMounts allows configuration of additional VolumeMounts on the output Deployment/StatefulSet definition.\nVolumeMounts specified will be appended to other VolumeMounts in the Application container",
               "items": {
-                "description": "VolumeMount describes a mounting of a Volume within a container.",
                 "properties": {
                   "mountPath": {
-                    "description": "Path within the container at which the volume should be mounted.  Must\nnot contain ':'.",
                     "type": "string"
                   },
                   "mountPropagation": {
-                    "description": "mountPropagation determines how mounts are propagated from the host\nto container and the other way around.\nWhen not set, MountPropagationNone is used.\nThis field is beta in 1.10.\nWhen RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified\n(which defaults to None).",
                     "type": "string"
                   },
                   "name": {
-                    "description": "This must match the Name of a Volume.",
                     "type": "string"
                   },
                   "readOnly": {
-                    "description": "Mounted read-only if true, read-write otherwise (false or unspecified).\nDefaults to false.",
                     "type": "boolean"
                   },
                   "recursiveReadOnly": {
-                    "description": "RecursiveReadOnly specifies whether read-only mounts should be handled\nrecursively.\n\nIf ReadOnly is false, this field has no meaning and must be unspecified.\n\nIf ReadOnly is true, and this field is set to Disabled, the mount is not made\nrecursively read-only.  If this field is set to IfPossible, the mount is made\nrecursively read-only, if it is supported by the container runtime.  If this\nfield is set to Enabled, the mount is made recursively read-only if it is\nsupported by the container runtime, otherwise the pod will not be started and\nan error will be generated to indicate the reason.\n\nIf this field is set to IfPossible or Enabled, MountPropagation must be set to\nNone (or be unspecified, which defaults to None).\n\nIf this field is not specified, it is treated as an equivalent of Disabled.",
                     "type": "string"
                   },
                   "subPath": {
-                    "description": "Path within the volume from which the container's volume should be mounted.\nDefaults to \"\" (volume's root).",
                     "type": "string"
                   },
                   "subPathExpr": {
-                    "description": "Expanded path within the volume from which the container's volume should be mounted.\nBehaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.\nDefaults to \"\" (volume's root).\nSubPathExpr and SubPath are mutually exclusive.",
                     "type": "string"
                   }
                 },
@@ -2504,9 +3019,7 @@
               "type": "array"
             },
             "volumes": {
-              "description": "Volumes allows configuration of additional volumes on the output Deployment/StatefulSet definition.\nVolumes specified will be appended to other volumes that are generated.\n/ +optional",
               "items": {
-                "description": "Volume represents a named volume in a pod that may be accessed by any container in the pod.",
                 "required": [
                   "name"
                 ],
@@ -2514,6 +3027,165 @@
                 "x-kubernetes-preserve-unknown-fields": true
               },
               "type": "array"
+            },
+            "vpa": {
+              "properties": {
+                "recommenders": {
+                  "items": {
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "resourcePolicy": {
+                  "properties": {
+                    "containerPolicies": {
+                      "items": {
+                        "properties": {
+                          "containerName": {
+                            "type": "string"
+                          },
+                          "controlledResources": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "controlledValues": {
+                            "enum": [
+                              "RequestsAndLimits",
+                              "RequestsOnly"
+                            ],
+                            "type": "string"
+                          },
+                          "maxAllowed": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          },
+                          "minAllowed": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          },
+                          "mode": {
+                            "enum": [
+                              "Auto",
+                              "Off"
+                            ],
+                            "type": "string"
+                          },
+                          "oomBumpUpRatio": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "oomMinBumpUp": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                            "x-kubernetes-int-or-string": true
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "updatePolicy": {
+                  "properties": {
+                    "evictionRequirements": {
+                      "items": {
+                        "properties": {
+                          "changeRequirement": {
+                            "enum": [
+                              "TargetHigherThanRequests",
+                              "TargetLowerThanRequests"
+                            ],
+                            "type": "string"
+                          },
+                          "resources": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "changeRequirement",
+                          "resources"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "minReplicas": {
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "updateMode": {
+                      "enum": [
+                        "Off",
+                        "Initial",
+                        "Recreate",
+                        "InPlaceOrRecreate",
+                        "Auto"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
             }
           },
           "type": "object",
@@ -2524,42 +3196,33 @@
       "additionalProperties": false
     },
     "status": {
-      "description": "VLClusterStatus defines the observed state of VLCluster",
       "properties": {
         "conditions": {
-          "description": "Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"",
           "items": {
-            "description": "Condition defines status condition of the resource",
             "properties": {
               "lastTransitionTime": {
-                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.",
                 "format": "date-time",
                 "type": "string"
               },
               "lastUpdateTime": {
-                "description": "LastUpdateTime is the last time of given type update.\nThis value is used for status TTL update and removal",
                 "format": "date-time",
                 "type": "string"
               },
               "message": {
-                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
                 "maxLength": 32768,
                 "type": "string"
               },
               "observedGeneration": {
-                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
                 "format": "int64",
                 "minimum": 0,
                 "type": "integer"
               },
               "reason": {
-                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
                 "maxLength": 1024,
                 "minLength": 1,
                 "type": "string"
               },
               "status": {
-                "description": "status of the condition, one of True, False, Unknown.",
                 "enum": [
                   "True",
                   "False",
@@ -2568,7 +3231,6 @@
                 "type": "string"
               },
               "type": {
-                "description": "Type of condition in CamelCase or in name.namespace.resource.victoriametrics.com/CamelCase.",
                 "maxLength": 316,
                 "type": "string"
               }
@@ -2589,17 +3251,17 @@
           ],
           "x-kubernetes-list-type": "map"
         },
+        "lastAppliedSpec": {
+          "x-kubernetes-preserve-unknown-fields": true
+        },
         "observedGeneration": {
-          "description": "ObservedGeneration defines current generation picked by operator for the\nreconcile",
           "format": "int64",
           "type": "integer"
         },
         "reason": {
-          "description": "Reason defines human readable error reason",
           "type": "string"
         },
         "updateStatus": {
-          "description": "UpdateStatus defines a status for update rollout",
           "type": "string"
         }
       },

--- a/operator.victoriametrics.com/vlogs_v1beta1.json
+++ b/operator.victoriametrics.com/vlogs_v1beta1.json
@@ -1,19 +1,15 @@
 {
-  "description": "VLogs is fast, cost-effective and scalable logs database.\nVLogs is the Schema for the vlogs API",
   "properties": {
     "apiVersion": {
-      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
       "type": "string"
     },
     "kind": {
-      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
       "type": "string"
     },
     "metadata": {
       "type": "object"
     },
     "spec": {
-      "description": "VLogsSpec defines the desired state of VLogs\nVLogs is deprecated, migrate to the VLSingle",
       "required": [
         "retentionPeriod"
       ],
@@ -21,42 +17,33 @@
       "x-kubernetes-preserve-unknown-fields": true
     },
     "status": {
-      "description": "VLogsStatus defines the observed state of VLogs",
       "properties": {
         "conditions": {
-          "description": "Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"",
           "items": {
-            "description": "Condition defines status condition of the resource",
             "properties": {
               "lastTransitionTime": {
-                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.",
                 "format": "date-time",
                 "type": "string"
               },
               "lastUpdateTime": {
-                "description": "LastUpdateTime is the last time of given type update.\nThis value is used for status TTL update and removal",
                 "format": "date-time",
                 "type": "string"
               },
               "message": {
-                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
                 "maxLength": 32768,
                 "type": "string"
               },
               "observedGeneration": {
-                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
                 "format": "int64",
                 "minimum": 0,
                 "type": "integer"
               },
               "reason": {
-                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
                 "maxLength": 1024,
                 "minLength": 1,
                 "type": "string"
               },
               "status": {
-                "description": "status of the condition, one of True, False, Unknown.",
                 "enum": [
                   "True",
                   "False",
@@ -65,7 +52,6 @@
                 "type": "string"
               },
               "type": {
-                "description": "Type of condition in CamelCase or in name.namespace.resource.victoriametrics.com/CamelCase.",
                 "maxLength": 316,
                 "type": "string"
               }
@@ -86,17 +72,17 @@
           ],
           "x-kubernetes-list-type": "map"
         },
+        "lastAppliedSpec": {
+          "x-kubernetes-preserve-unknown-fields": true
+        },
         "observedGeneration": {
-          "description": "ObservedGeneration defines current generation picked by operator for the\nreconcile",
           "format": "int64",
           "type": "integer"
         },
         "reason": {
-          "description": "Reason defines human readable error reason",
           "type": "string"
         },
         "updateStatus": {
-          "description": "UpdateStatus defines a status for update rollout",
           "type": "string"
         }
       },

--- a/operator.victoriametrics.com/vlsingle_v1.json
+++ b/operator.victoriametrics.com/vlsingle_v1.json
@@ -1,36 +1,31 @@
 {
-  "description": "VLSingle is fast, cost-effective and scalable logs database.\nVLSingle is the Schema for the API",
   "properties": {
     "apiVersion": {
-      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
       "type": "string"
     },
     "kind": {
-      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
       "type": "string"
     },
     "metadata": {
       "type": "object"
     },
     "spec": {
-      "description": "VLSingleSpec defines the desired state of VLSingle",
       "properties": {
         "affinity": {
-          "description": "Affinity If specified, the pod's scheduling constraints.",
           "type": "object",
           "x-kubernetes-preserve-unknown-fields": true
         },
+        "componentVersion": {
+          "type": "string"
+        },
         "configMaps": {
-          "description": "ConfigMaps is a list of ConfigMaps in the same namespace as the Application\nobject, which shall be mounted into the Application container\nat /etc/vm/configs/CONFIGMAP_NAME folder",
           "items": {
             "type": "string"
           },
           "type": "array"
         },
         "containers": {
-          "description": "Containers property allows to inject additions sidecars or to patch existing containers.\nIt can be useful for proxies, backup, etc.",
           "items": {
-            "description": "A single application container that you want to run within a pod.",
             "required": [
               "name"
             ],
@@ -40,21 +35,17 @@
           "type": "array"
         },
         "disableAutomountServiceAccountToken": {
-          "description": "DisableAutomountServiceAccountToken whether to disable serviceAccount auto mount by Kubernetes (available from v0.54.0).\nOperator will conditionally create volumes and volumeMounts for containers if it requires k8s API access.\nFor example, vmagent and vm-config-reloader requires k8s API access.\nOperator creates volumes with name: \"kube-api-access\", which can be used as volumeMount for extraContainers if needed.\nAnd also adds VolumeMounts at /var/run/secrets/kubernetes.io/serviceaccount.",
           "type": "boolean"
         },
         "disableSelfServiceScrape": {
-          "description": "DisableSelfServiceScrape controls creation of VMServiceScrape by operator\nfor the application.\nHas priority over `VM_DISABLESELFSERVICESCRAPECREATION` operator env variable",
           "type": "boolean"
         },
         "dnsConfig": {
-          "description": "Specifies the DNS parameters of a pod.\nParameters specified here will be merged to the generated DNS\nconfiguration based on DNSPolicy.",
           "items": {
             "x-kubernetes-preserve-unknown-fields": true
           },
           "properties": {
             "nameservers": {
-              "description": "A list of DNS name server IP addresses.\nThis will be appended to the base nameservers generated from DNSPolicy.\nDuplicated nameservers will be removed.",
               "items": {
                 "type": "string"
               },
@@ -62,16 +53,12 @@
               "x-kubernetes-list-type": "atomic"
             },
             "options": {
-              "description": "A list of DNS resolver options.\nThis will be merged with the base options generated from DNSPolicy.\nDuplicated entries will be removed. Resolution options given in Options\nwill override those that appear in the base DNSPolicy.",
               "items": {
-                "description": "PodDNSConfigOption defines DNS resolver options of a pod.",
                 "properties": {
                   "name": {
-                    "description": "Name is this DNS resolver option's name.\nRequired.",
                     "type": "string"
                   },
                   "value": {
-                    "description": "Value is this DNS resolver option's value.",
                     "type": "string"
                   }
                 },
@@ -82,7 +69,6 @@
               "x-kubernetes-list-type": "atomic"
             },
             "searches": {
-              "description": "A list of DNS search domains for host-name lookup.\nThis will be appended to the base search paths generated from DNSPolicy.\nDuplicated search paths will be removed.",
               "items": {
                 "type": "string"
               },
@@ -94,27 +80,21 @@
           "additionalProperties": false
         },
         "dnsPolicy": {
-          "description": "DNSPolicy sets DNS policy for the pod",
           "type": "string"
         },
         "extraArgs": {
           "additionalProperties": {
             "type": "string"
           },
-          "description": "ExtraArgs that will be passed to the application container\nfor example remoteWrite.tmpDataPath: /tmp",
           "type": "object"
         },
         "extraEnvs": {
-          "description": "ExtraEnvs that will be passed to the application container",
           "items": {
-            "description": "EnvVar represents an environment variable present in a Container.",
             "properties": {
               "name": {
-                "description": "Name of the environment variable.\nMay consist of any printable ASCII characters except '='.",
                 "type": "string"
               },
               "value": {
-                "description": "Variable references $(VAR_NAME) are expanded\nusing the previously defined environment variables in the container and\nany service environment variables. If a variable cannot be resolved,\nthe reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.\n\"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\".\nEscaped references will never be expanded, regardless of whether the variable\nexists or not.\nDefaults to \"\".",
                 "type": "string"
               }
             },
@@ -128,20 +108,15 @@
           "type": "array"
         },
         "extraEnvsFrom": {
-          "description": "ExtraEnvsFrom defines source of env variables for the application container\ncould either be secret or configmap",
           "items": {
-            "description": "EnvFromSource represents the source of a set of ConfigMaps or Secrets",
             "properties": {
               "configMapRef": {
-                "description": "The ConfigMap to select from",
                 "properties": {
                   "name": {
                     "default": "",
-                    "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                     "type": "string"
                   },
                   "optional": {
-                    "description": "Specify whether the ConfigMap must be defined",
                     "type": "boolean"
                   }
                 },
@@ -150,19 +125,15 @@
                 "additionalProperties": false
               },
               "prefix": {
-                "description": "Optional text to prepend to the name of each environment variable.\nMay consist of any printable ASCII characters except '='.",
                 "type": "string"
               },
               "secretRef": {
-                "description": "The Secret to select from",
                 "properties": {
                   "name": {
                     "default": "",
-                    "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                     "type": "string"
                   },
                   "optional": {
-                    "description": "Specify whether the Secret must be defined",
                     "type": "boolean"
                   }
                 },
@@ -177,17 +148,13 @@
           "type": "array"
         },
         "futureRetention": {
-          "description": "FutureRetention for the stored logs\nLog entries with timestamps bigger than now+futureRetention are rejected during data ingestion; see https://docs.victoriametrics.com/victorialogs/#retention",
           "pattern": "^[0-9]+(h|d|y)?$",
           "type": "string"
         },
         "host_aliases": {
-          "description": "HostAliasesUnderScore provides mapping for ip and hostname,\nthat would be propagated to pod,\ncannot be used with HostNetwork.\nHas Priority over hostAliases field",
           "items": {
-            "description": "HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the\npod's hosts file.",
             "properties": {
               "hostnames": {
-                "description": "Hostnames for the above IP address.",
                 "items": {
                   "type": "string"
                 },
@@ -195,7 +162,6 @@
                 "x-kubernetes-list-type": "atomic"
               },
               "ip": {
-                "description": "IP address of the host file entry.",
                 "type": "string"
               }
             },
@@ -208,12 +174,9 @@
           "type": "array"
         },
         "hostAliases": {
-          "description": "HostAliases provides mapping for ip and hostname,\nthat would be propagated to pod,\ncannot be used with HostNetwork.",
           "items": {
-            "description": "HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the\npod's hosts file.",
             "properties": {
               "hostnames": {
-                "description": "Hostnames for the above IP address.",
                 "items": {
                   "type": "string"
                 },
@@ -221,7 +184,6 @@
                 "x-kubernetes-list-type": "atomic"
               },
               "ip": {
-                "description": "IP address of the host file entry.",
                 "type": "string"
               }
             },
@@ -234,22 +196,17 @@
           "type": "array"
         },
         "hostNetwork": {
-          "description": "HostNetwork controls whether the pod may use the node network namespace",
           "type": "boolean"
         },
         "image": {
-          "description": "Image - docker image settings\nif no specified operator uses default version from operator config",
           "properties": {
             "pullPolicy": {
-              "description": "PullPolicy describes how to pull docker image",
               "type": "string"
             },
             "repository": {
-              "description": "Repository contains name of docker image + it's repository if needed",
               "type": "string"
             },
             "tag": {
-              "description": "Tag contains desired docker image version",
               "type": "string"
             }
           },
@@ -257,13 +214,10 @@
           "additionalProperties": false
         },
         "imagePullSecrets": {
-          "description": "ImagePullSecrets An optional list of references to secrets in the same namespace\nto use for pulling images from registries\nsee https://kubernetes.io/docs/concepts/containers/images/#referring-to-an-imagepullsecrets-on-a-pod",
           "items": {
-            "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
             "properties": {
               "name": {
                 "default": "",
-                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                 "type": "string"
               }
             },
@@ -274,9 +228,7 @@
           "type": "array"
         },
         "initContainers": {
-          "description": "InitContainers allows adding initContainers to the pod definition.\nAny errors during the execution of an initContainer will lead to a restart of the Pod.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/",
           "items": {
-            "description": "A single application container that you want to run within a pod.",
             "required": [
               "name"
             ],
@@ -285,13 +237,46 @@
           },
           "type": "array"
         },
+        "license": {
+          "properties": {
+            "forceOffline": {
+              "type": "boolean"
+            },
+            "key": {
+              "type": "string"
+            },
+            "keyRef": {
+              "properties": {
+                "key": {
+                  "type": "string"
+                },
+                "name": {
+                  "default": "",
+                  "type": "string"
+                },
+                "optional": {
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "key"
+              ],
+              "type": "object",
+              "x-kubernetes-map-type": "atomic",
+              "additionalProperties": false
+            },
+            "reloadInterval": {
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
         "livenessProbe": {
-          "description": "LivenessProbe that will be added CRD pod",
           "type": "object",
           "x-kubernetes-preserve-unknown-fields": true
         },
         "logFormat": {
-          "description": "LogFormat for VLSingle to be configured with.",
           "enum": [
             "default",
             "json"
@@ -299,11 +284,9 @@
           "type": "string"
         },
         "logIngestedRows": {
-          "description": "Whether to log all the ingested log entries; this can be useful for debugging of data ingestion; see https://docs.victoriametrics.com/victorialogs/data-ingestion/",
           "type": "boolean"
         },
         "logLevel": {
-          "description": "LogLevel for VictoriaLogs to be configured with.",
           "enum": [
             "INFO",
             "WARN",
@@ -314,24 +297,20 @@
           "type": "string"
         },
         "logNewStreams": {
-          "description": "LogNewStreams Whether to log creation of new streams; this can be useful for debugging of high cardinality issues with log streams; see https://docs.victoriametrics.com/victorialogs/keyconcepts/#stream-fields",
           "type": "boolean"
         },
         "managedMetadata": {
-          "description": "ManagedMetadata defines metadata that will be added to the all objects\ncreated by operator for the given CustomResource",
           "properties": {
             "annotations": {
               "additionalProperties": {
                 "type": "string"
               },
-              "description": "Annotations is an unstructured key value map stored with a resource that may be\nset by external tools to store and retrieve arbitrary metadata. They are not\nqueryable and should be preserved when modifying objects.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations",
               "type": "object"
             },
             "labels": {
               "additionalProperties": {
                 "type": "string"
               },
-              "description": "Labels Map of string keys and values that can be used to organize and categorize\n(scope and select) objects.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels",
               "type": "object"
             }
           },
@@ -339,7 +318,6 @@
           "additionalProperties": false
         },
         "minReadySeconds": {
-          "description": "MinReadySeconds defines a minimum number of seconds to wait before starting update next pod\nif previous in healthy state\nHas no effect for VLogs and VMSingle",
           "format": "int32",
           "type": "integer"
         },
@@ -347,32 +325,26 @@
           "additionalProperties": {
             "type": "string"
           },
-          "description": "NodeSelector Define which Nodes the Pods are scheduled on.",
           "type": "object"
         },
         "paused": {
-          "description": "Paused If set to true all actions on the underlying managed objects are not\ngoing to be performed, except for delete actions.",
           "type": "boolean"
         },
         "podMetadata": {
-          "description": "PodMetadata configures Labels and Annotations which are propagated to the VLSingle pods.",
           "properties": {
             "annotations": {
               "additionalProperties": {
                 "type": "string"
               },
-              "description": "Annotations is an unstructured key value map stored with a resource that may be\nset by external tools to store and retrieve arbitrary metadata. They are not\nqueryable and should be preserved when modifying objects.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations",
               "type": "object"
             },
             "labels": {
               "additionalProperties": {
                 "type": "string"
               },
-              "description": "Labels Map of string keys and values that can be used to organize and categorize\n(scope and select) objects. May match selectors of replication controllers\nand services.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels",
               "type": "object"
             },
             "name": {
-              "description": "Name must be unique within a namespace. Is required when creating resources, although\nsome resources may allow a client to request the generation of an appropriate name\nautomatically. Name is primarily intended for creation idempotence and configuration\ndefinition.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names",
               "type": "string"
             }
           },
@@ -380,20 +352,15 @@
           "additionalProperties": false
         },
         "port": {
-          "description": "Port listen address",
           "type": "string"
         },
         "priorityClassName": {
-          "description": "PriorityClassName class assigned to the Pods",
           "type": "string"
         },
         "readinessGates": {
-          "description": "ReadinessGates defines pod readiness gates",
           "items": {
-            "description": "PodReadinessGate contains the reference to a pod condition",
             "properties": {
               "conditionType": {
-                "description": "ConditionType refers to a condition in the pod's condition list with matching type.",
                 "type": "string"
               }
             },
@@ -406,29 +373,22 @@
           "type": "array"
         },
         "readinessProbe": {
-          "description": "ReadinessProbe that will be added CRD pod",
           "type": "object",
           "x-kubernetes-preserve-unknown-fields": true
         },
         "replicaCount": {
-          "description": "ReplicaCount is the expected size of the Application.",
           "format": "int32",
           "type": "integer"
         },
         "resources": {
-          "description": "Resources container resource request and limits, https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/\nif not defined default resources from operator config will be used",
           "properties": {
             "claims": {
-              "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis field depends on the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
               "items": {
-                "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
                 "properties": {
                   "name": {
-                    "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
                     "type": "string"
                   },
                   "request": {
-                    "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
                     "type": "string"
                   }
                 },
@@ -457,7 +417,6 @@
                 "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                 "x-kubernetes-int-or-string": true
               },
-              "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
               "type": "object"
             },
             "requests": {
@@ -473,7 +432,6 @@
                 "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                 "x-kubernetes-int-or-string": true
               },
-              "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
               "type": "object"
             }
           },
@@ -481,45 +439,36 @@
           "additionalProperties": false
         },
         "retentionMaxDiskSpaceUsageBytes": {
-          "description": "RetentionMaxDiskSpaceUsageBytes for the stored logs\nVictoriaLogs keeps at least two last days of data in order to guarantee that the logs for the last day can be returned in queries.\nThis means that the total disk space usage may exceed the -retention.maxDiskSpaceUsageBytes,\nif the size of the last two days of data exceeds the -retention.maxDiskSpaceUsageBytes.\nhttps://docs.victoriametrics.com/victorialogs/#retention-by-disk-space-usage",
           "type": "string"
         },
         "retentionPeriod": {
-          "description": "RetentionPeriod for the stored logs\nhttps://docs.victoriametrics.com/victorialogs/#retention",
           "pattern": "^[0-9]+(h|d|w|y)?$",
           "type": "string"
         },
         "revisionHistoryLimitCount": {
-          "description": "The number of old ReplicaSets to retain to allow rollback in deployment or\nmaximum number of revisions that will be maintained in the Deployment revision history.\nHas no effect at StatefulSets\nDefaults to 10.",
           "format": "int32",
           "type": "integer"
         },
         "runtimeClassName": {
-          "description": "RuntimeClassName - defines runtime class for kubernetes pod.\nhttps://kubernetes.io/docs/concepts/containers/runtime-class/",
           "type": "string"
         },
         "schedulerName": {
-          "description": "SchedulerName - defines kubernetes scheduler name",
           "type": "string"
         },
         "secrets": {
-          "description": "Secrets is a list of Secrets in the same namespace as the Application\nobject, which shall be mounted into the Application container\nat /etc/vm/secrets/SECRET_NAME folder",
           "items": {
             "type": "string"
           },
           "type": "array"
         },
         "securityContext": {
-          "description": "SecurityContext holds pod-level security attributes and common container settings.\nThis defaults to the default PodSecurityContext.",
           "type": "object",
           "x-kubernetes-preserve-unknown-fields": true
         },
         "serviceAccountName": {
-          "description": "ServiceAccountName is the name of the ServiceAccount to use to run the pods",
           "type": "string"
         },
         "serviceScrapeSpec": {
-          "description": "ServiceScrapeSpec that will be added to vlsingle VMServiceScrape spec",
           "required": [
             "endpoints"
           ],
@@ -527,27 +476,22 @@
           "x-kubernetes-preserve-unknown-fields": true
         },
         "serviceSpec": {
-          "description": "ServiceSpec that will be added to vlsingle service spec",
           "properties": {
             "metadata": {
-              "description": "EmbeddedObjectMetadata defines objectMeta for additional service.",
               "properties": {
                 "annotations": {
                   "additionalProperties": {
                     "type": "string"
                   },
-                  "description": "Annotations is an unstructured key value map stored with a resource that may be\nset by external tools to store and retrieve arbitrary metadata. They are not\nqueryable and should be preserved when modifying objects.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations",
                   "type": "object"
                 },
                 "labels": {
                   "additionalProperties": {
                     "type": "string"
                   },
-                  "description": "Labels Map of string keys and values that can be used to organize and categorize\n(scope and select) objects. May match selectors of replication controllers\nand services.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels",
                   "type": "object"
                 },
                 "name": {
-                  "description": "Name must be unique within a namespace. Is required when creating resources, although\nsome resources may allow a client to request the generation of an appropriate name\nautomatically. Name is primarily intended for creation idempotence and configuration\ndefinition.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names",
                   "type": "string"
                 }
               },
@@ -555,12 +499,10 @@
               "additionalProperties": false
             },
             "spec": {
-              "description": "ServiceSpec describes the attributes that a user creates on a service.\nMore info: https://kubernetes.io/docs/concepts/services-networking/service/",
               "type": "object",
               "x-kubernetes-preserve-unknown-fields": true
             },
             "useAsDefault": {
-              "description": "UseAsDefault applies changes from given service definition to the main object Service\nChanging from headless service to clusterIP or loadbalancer may break cross-component communication",
               "type": "boolean"
             }
           },
@@ -571,15 +513,12 @@
           "additionalProperties": false
         },
         "startupProbe": {
-          "description": "StartupProbe that will be added to CRD pod",
           "type": "object",
           "x-kubernetes-preserve-unknown-fields": true
         },
         "storage": {
-          "description": "Storage is the definition of how storage will be used by the VLSingle\nby default it`s empty dir",
           "properties": {
             "accessModes": {
-              "description": "accessModes contains the desired access modes the volume should have.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1",
               "items": {
                 "type": "string"
               },
@@ -587,18 +526,14 @@
               "x-kubernetes-list-type": "atomic"
             },
             "dataSource": {
-              "description": "dataSource field can be used to specify either:\n* An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)\n* An existing PVC (PersistentVolumeClaim)\nIf the provisioner or an external controller can support the specified data source,\nit will create a new volume based on the contents of the specified data source.\nWhen the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,\nand dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.\nIf the namespace is specified, then dataSourceRef will not be copied to dataSource.",
               "properties": {
                 "apiGroup": {
-                  "description": "APIGroup is the group for the resource being referenced.\nIf APIGroup is not specified, the specified Kind must be in the core API group.\nFor any other third-party types, APIGroup is required.",
                   "type": "string"
                 },
                 "kind": {
-                  "description": "Kind is the type of resource being referenced",
                   "type": "string"
                 },
                 "name": {
-                  "description": "Name is the name of resource being referenced",
                   "type": "string"
                 }
               },
@@ -611,22 +546,17 @@
               "additionalProperties": false
             },
             "dataSourceRef": {
-              "description": "dataSourceRef specifies the object from which to populate the volume with data, if a non-empty\nvolume is desired. This may be any object from a non-empty API group (non\ncore object) or a PersistentVolumeClaim object.\nWhen this field is specified, volume binding will only succeed if the type of\nthe specified object matches some installed volume populator or dynamic\nprovisioner.\nThis field will replace the functionality of the dataSource field and as such\nif both fields are non-empty, they must have the same value. For backwards\ncompatibility, when namespace isn't specified in dataSourceRef,\nboth fields (dataSource and dataSourceRef) will be set to the same\nvalue automatically if one of them is empty and the other is non-empty.\nWhen namespace is specified in dataSourceRef,\ndataSource isn't set to the same value and must be empty.\nThere are three important differences between dataSource and dataSourceRef:\n* While dataSource only allows two specific types of objects, dataSourceRef\n  allows any non-core object, as well as PersistentVolumeClaim objects.\n* While dataSource ignores disallowed values (dropping them), dataSourceRef\n  preserves all values, and generates an error if a disallowed value is\n  specified.\n* While dataSource only allows local objects, dataSourceRef allows objects\n  in any namespaces.\n(Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.\n(Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.",
               "properties": {
                 "apiGroup": {
-                  "description": "APIGroup is the group for the resource being referenced.\nIf APIGroup is not specified, the specified Kind must be in the core API group.\nFor any other third-party types, APIGroup is required.",
                   "type": "string"
                 },
                 "kind": {
-                  "description": "Kind is the type of resource being referenced",
                   "type": "string"
                 },
                 "name": {
-                  "description": "Name is the name of resource being referenced",
                   "type": "string"
                 },
                 "namespace": {
-                  "description": "Namespace is the namespace of resource being referenced\nNote that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.\n(Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.",
                   "type": "string"
                 }
               },
@@ -638,7 +568,6 @@
               "additionalProperties": false
             },
             "resources": {
-              "description": "resources represents the minimum resources the volume should have.\nIf RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements\nthat are lower than previous value but must still be higher than capacity recorded in the\nstatus field of the claim.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources",
               "properties": {
                 "limits": {
                   "additionalProperties": {
@@ -653,7 +582,6 @@
                     "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                     "x-kubernetes-int-or-string": true
                   },
-                  "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
                   "type": "object"
                 },
                 "requests": {
@@ -669,7 +597,6 @@
                     "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                     "x-kubernetes-int-or-string": true
                   },
-                  "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
                   "type": "object"
                 }
               },
@@ -677,23 +604,17 @@
               "additionalProperties": false
             },
             "selector": {
-              "description": "selector is a label query over volumes to consider for binding.",
               "properties": {
                 "matchExpressions": {
-                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
                   "items": {
-                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
                     "properties": {
                       "key": {
-                        "description": "key is the label key that the selector applies to.",
                         "type": "string"
                       },
                       "operator": {
-                        "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
                         "type": "string"
                       },
                       "values": {
-                        "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
                         "items": {
                           "type": "string"
                         },
@@ -715,7 +636,6 @@
                   "additionalProperties": {
                     "type": "string"
                   },
-                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                   "type": "object"
                 }
               },
@@ -724,19 +644,15 @@
               "additionalProperties": false
             },
             "storageClassName": {
-              "description": "storageClassName is the name of the StorageClass required by the claim.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1",
               "type": "string"
             },
             "volumeAttributesClassName": {
-              "description": "volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.\nIf specified, the CSI driver will create or update the volume with the attributes defined\nin the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,\nit can be changed after the claim is created. An empty string or nil value indicates that no\nVolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,\nthis field can be reset to its previous value (including nil) to cancel the modification.\nIf the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be\nset to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource\nexists.\nMore info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/",
               "type": "string"
             },
             "volumeMode": {
-              "description": "volumeMode defines what type of volume is required by the claim.\nValue of Filesystem is implied when not included in claim spec.",
               "type": "string"
             },
             "volumeName": {
-              "description": "volumeName is the binding reference to the PersistentVolume backing this claim.",
               "type": "string"
             }
           },
@@ -744,28 +660,23 @@
           "additionalProperties": false
         },
         "storageDataPath": {
-          "description": "StorageDataPath disables spec.storage option and overrides arg for victoria-logs binary --storageDataPath,\nits users responsibility to mount proper device into given path.",
           "type": "string"
         },
         "storageMetadata": {
-          "description": "StorageMeta defines annotations and labels attached to PVC for given vlsingle CR",
           "properties": {
             "annotations": {
               "additionalProperties": {
                 "type": "string"
               },
-              "description": "Annotations is an unstructured key value map stored with a resource that may be\nset by external tools to store and retrieve arbitrary metadata. They are not\nqueryable and should be preserved when modifying objects.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations",
               "type": "object"
             },
             "labels": {
               "additionalProperties": {
                 "type": "string"
               },
-              "description": "Labels Map of string keys and values that can be used to organize and categorize\n(scope and select) objects. May match selectors of replication controllers\nand services.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels",
               "type": "object"
             },
             "name": {
-              "description": "Name must be unique within a namespace. Is required when creating resources, although\nsome resources may allow a client to request the generation of an appropriate name\nautomatically. Name is primarily intended for creation idempotence and configuration\ndefinition.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names",
               "type": "string"
             }
           },
@@ -773,60 +684,45 @@
           "additionalProperties": false
         },
         "syslogSpec": {
-          "description": "SyslogSpec defines syslog listener configuration",
           "properties": {
             "tcpListeners": {
-              "description": "TCPListeners defines syslog server TCP listener configuration",
               "items": {
-                "description": "SyslogTCPListener defines configuration for TCP syslog server listen",
                 "properties": {
                   "compressMethod": {
-                    "description": "CompressMethod for syslog messages\nsee https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#compression",
                     "pattern": "^(none|zstd|gzip|deflate)$",
                     "type": "string"
                   },
                   "decolorizeFields": {
-                    "description": "DecolorizeFields to remove ANSI color codes across logs\nsee https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#decolorizing-fields",
                     "type": "string"
                   },
                   "ignoreFields": {
-                    "description": "IgnoreFields to ignore at logs\nsee https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#dropping-fields",
                     "type": "string"
                   },
                   "listenPort": {
-                    "description": "ListenPort defines listen port",
                     "format": "int32",
                     "type": "integer"
                   },
                   "streamFields": {
-                    "description": "StreamFields to use as log stream labels\nsee https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#stream-fields",
                     "type": "string"
                   },
                   "tenantID": {
-                    "description": "TenantID for logs ingested in form of accountID:projectID\nsee https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#multiple-configs",
                     "type": "string"
                   },
                   "tlsConfig": {
-                    "description": "TLSServerConfig defines VictoriaMetrics TLS configuration for the application's server",
                     "properties": {
                       "certFile": {
-                        "description": "CertFile defines path to the pre-mounted file with certificate\nmutually exclusive with CertSecret",
                         "type": "string"
                       },
                       "certSecret": {
-                        "description": "CertSecretRef defines reference for secret with certificate content under given key\nmutually exclusive with CertFile",
                         "properties": {
                           "key": {
-                            "description": "The key of the secret to select from.  Must be a valid secret key.",
                             "type": "string"
                           },
                           "name": {
                             "default": "",
-                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                             "type": "string"
                           },
                           "optional": {
-                            "description": "Specify whether the Secret or its key must be defined",
                             "type": "boolean"
                           }
                         },
@@ -838,23 +734,18 @@
                         "additionalProperties": false
                       },
                       "keyFile": {
-                        "description": "KeyFile defines path to the pre-mounted file with certificate key\nmutually exclusive with KeySecretRef",
                         "type": "string"
                       },
                       "keySecret": {
-                        "description": "Key defines reference for secret with certificate key content under given key\nmutually exclusive with KeyFile",
                         "properties": {
                           "key": {
-                            "description": "The key of the secret to select from.  Must be a valid secret key.",
                             "type": "string"
                           },
                           "name": {
                             "default": "",
-                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                             "type": "string"
                           },
                           "optional": {
-                            "description": "Specify whether the Secret or its key must be defined",
                             "type": "boolean"
                           }
                         },
@@ -879,34 +770,26 @@
               "type": "array"
             },
             "udpListeners": {
-              "description": "UDPListeners defines syslog server UDP listener configuration",
               "items": {
-                "description": "SyslogUDPListener defines configuration for UDP syslog server listen",
                 "properties": {
                   "compressMethod": {
-                    "description": "CompressMethod for syslog messages\nsee https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#compression",
                     "pattern": "^(none|zstd|gzip|deflate)$",
                     "type": "string"
                   },
                   "decolorizeFields": {
-                    "description": "DecolorizeFields to remove ANSI color codes across logs\nsee https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#decolorizing-fields",
                     "type": "string"
                   },
                   "ignoreFields": {
-                    "description": "IgnoreFields to ignore at logs\nsee https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#dropping-fields",
                     "type": "string"
                   },
                   "listenPort": {
-                    "description": "ListenPort defines listen port",
                     "format": "int32",
                     "type": "integer"
                   },
                   "streamFields": {
-                    "description": "StreamFields to use as log stream labels\nsee https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#stream-fields",
                     "type": "string"
                   },
                   "tenantID": {
-                    "description": "TenantID for logs ingested in form of accountID:projectID\nsee https://docs.victoriametrics.com/victorialogs/data-ingestion/syslog/#multiple-configs",
                     "type": "string"
                   }
                 },
@@ -923,34 +806,26 @@
           "additionalProperties": false
         },
         "terminationGracePeriodSeconds": {
-          "description": "TerminationGracePeriodSeconds period for container graceful termination",
           "format": "int64",
           "type": "integer"
         },
         "tolerations": {
-          "description": "Tolerations If specified, the pod's tolerations.",
           "items": {
-            "description": "The pod this Toleration is attached to tolerates any taint that matches\nthe triple <key,value,effect> using the matching operator <operator>.",
             "properties": {
               "effect": {
-                "description": "Effect indicates the taint effect to match. Empty means match all taint effects.\nWhen specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
                 "type": "string"
               },
               "key": {
-                "description": "Key is the taint key that the toleration applies to. Empty means match all taint keys.\nIf the key is empty, operator must be Exists; this combination means to match all values and all keys.",
                 "type": "string"
               },
               "operator": {
-                "description": "Operator represents a key's relationship to the value.\nValid operators are Exists and Equal. Defaults to Equal.\nExists is equivalent to wildcard for value, so that a pod can\ntolerate all taints of a particular category.",
                 "type": "string"
               },
               "tolerationSeconds": {
-                "description": "TolerationSeconds represents the period of time the toleration (which must be\nof effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,\nit is not set, which means tolerate the taint forever (do not evict). Zero and\nnegative values will be treated as 0 (evict immediately) by the system.",
                 "format": "int64",
                 "type": "integer"
               },
               "value": {
-                "description": "Value is the taint value the toleration matches to.\nIf the operator is Exists, the value should be empty, otherwise just a regular string.",
                 "type": "string"
               }
             },
@@ -960,9 +835,7 @@
           "type": "array"
         },
         "topologySpreadConstraints": {
-          "description": "TopologySpreadConstraints embedded kubernetes pod configuration option,\ncontrols how pods are spread across your cluster among failure-domains\nsuch as regions, zones, nodes, and other user-defined topology domains\nhttps://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/",
           "items": {
-            "description": "TopologySpreadConstraint specifies how to spread matching pods among the given topology.",
             "required": [
               "maxSkew",
               "topologyKey",
@@ -974,44 +847,33 @@
           "type": "array"
         },
         "useDefaultResources": {
-          "description": "UseDefaultResources controls resource settings\nBy default, operator sets built-in resource requirements",
           "type": "boolean"
         },
         "useStrictSecurity": {
-          "description": "UseStrictSecurity enables strict security mode for component\nit restricts disk writes access\nuses non-root user out of the box\ndrops not needed security permissions",
           "type": "boolean"
         },
         "volumeMounts": {
-          "description": "VolumeMounts allows configuration of additional VolumeMounts on the output Deployment/StatefulSet definition.\nVolumeMounts specified will be appended to other VolumeMounts in the Application container",
           "items": {
-            "description": "VolumeMount describes a mounting of a Volume within a container.",
             "properties": {
               "mountPath": {
-                "description": "Path within the container at which the volume should be mounted.  Must\nnot contain ':'.",
                 "type": "string"
               },
               "mountPropagation": {
-                "description": "mountPropagation determines how mounts are propagated from the host\nto container and the other way around.\nWhen not set, MountPropagationNone is used.\nThis field is beta in 1.10.\nWhen RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified\n(which defaults to None).",
                 "type": "string"
               },
               "name": {
-                "description": "This must match the Name of a Volume.",
                 "type": "string"
               },
               "readOnly": {
-                "description": "Mounted read-only if true, read-write otherwise (false or unspecified).\nDefaults to false.",
                 "type": "boolean"
               },
               "recursiveReadOnly": {
-                "description": "RecursiveReadOnly specifies whether read-only mounts should be handled\nrecursively.\n\nIf ReadOnly is false, this field has no meaning and must be unspecified.\n\nIf ReadOnly is true, and this field is set to Disabled, the mount is not made\nrecursively read-only.  If this field is set to IfPossible, the mount is made\nrecursively read-only, if it is supported by the container runtime.  If this\nfield is set to Enabled, the mount is made recursively read-only if it is\nsupported by the container runtime, otherwise the pod will not be started and\nan error will be generated to indicate the reason.\n\nIf this field is set to IfPossible or Enabled, MountPropagation must be set to\nNone (or be unspecified, which defaults to None).\n\nIf this field is not specified, it is treated as an equivalent of Disabled.",
                 "type": "string"
               },
               "subPath": {
-                "description": "Path within the volume from which the container's volume should be mounted.\nDefaults to \"\" (volume's root).",
                 "type": "string"
               },
               "subPathExpr": {
-                "description": "Expanded path within the volume from which the container's volume should be mounted.\nBehaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.\nDefaults to \"\" (volume's root).\nSubPathExpr and SubPath are mutually exclusive.",
                 "type": "string"
               }
             },
@@ -1025,9 +887,7 @@
           "type": "array"
         },
         "volumes": {
-          "description": "Volumes allows configuration of additional volumes on the output Deployment/StatefulSet definition.\nVolumes specified will be appended to other volumes that are generated.\n/ +optional",
           "items": {
-            "description": "Volume represents a named volume in a pod that may be accessed by any container in the pod.",
             "required": [
               "name"
             ],
@@ -1041,42 +901,33 @@
       "additionalProperties": false
     },
     "status": {
-      "description": "VLSingleStatus defines the observed state of VLSingle",
       "properties": {
         "conditions": {
-          "description": "Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"",
           "items": {
-            "description": "Condition defines status condition of the resource",
             "properties": {
               "lastTransitionTime": {
-                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.",
                 "format": "date-time",
                 "type": "string"
               },
               "lastUpdateTime": {
-                "description": "LastUpdateTime is the last time of given type update.\nThis value is used for status TTL update and removal",
                 "format": "date-time",
                 "type": "string"
               },
               "message": {
-                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
                 "maxLength": 32768,
                 "type": "string"
               },
               "observedGeneration": {
-                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
                 "format": "int64",
                 "minimum": 0,
                 "type": "integer"
               },
               "reason": {
-                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
                 "maxLength": 1024,
                 "minLength": 1,
                 "type": "string"
               },
               "status": {
-                "description": "status of the condition, one of True, False, Unknown.",
                 "enum": [
                   "True",
                   "False",
@@ -1085,7 +936,6 @@
                 "type": "string"
               },
               "type": {
-                "description": "Type of condition in CamelCase or in name.namespace.resource.victoriametrics.com/CamelCase.",
                 "maxLength": 316,
                 "type": "string"
               }
@@ -1106,17 +956,17 @@
           ],
           "x-kubernetes-list-type": "map"
         },
+        "lastAppliedSpec": {
+          "x-kubernetes-preserve-unknown-fields": true
+        },
         "observedGeneration": {
-          "description": "ObservedGeneration defines current generation picked by operator for the\nreconcile",
           "format": "int64",
           "type": "integer"
         },
         "reason": {
-          "description": "Reason defines human readable error reason",
           "type": "string"
         },
         "updateStatus": {
-          "description": "UpdateStatus defines a status for update rollout",
           "type": "string"
         }
       },

--- a/operator.victoriametrics.com/vmagent_v1beta1.json
+++ b/operator.victoriametrics.com/vmagent_v1beta1.json
@@ -1,42 +1,26 @@
 {
-  "description": "VMAgent - is a tiny but brave agent, which helps you collect metrics from various sources and stores them in VictoriaMetrics\nor any other Prometheus-compatible storage system that supports the remote_write protocol.",
   "properties": {
     "apiVersion": {
-      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
       "type": "string"
     },
     "kind": {
-      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
       "type": "string"
     },
     "metadata": {
       "type": "object"
     },
     "spec": {
-      "description": "VMAgentSpec defines the desired state of VMAgent",
       "properties": {
-        "aPIServerConfig": {
-          "description": "APIServerConfig allows specifying a host and auth methods to access apiserver.\nIf left empty, VMAgent is assumed to run inside of the cluster\nand will discover API servers automatically and use the pod's CA certificate\nand bearer token file at /var/run/secrets/kubernetes.io/serviceaccount/.\naPIServerConfig is deprecated use apiServerConfig instead",
-          "required": [
-            "host"
-          ],
-          "type": "object",
-          "x-kubernetes-preserve-unknown-fields": true
-        },
         "additionalScrapeConfigs": {
-          "description": "AdditionalScrapeConfigs As scrape configs are appended, the user is responsible to make sure it\nis valid. Note that using this feature may expose the possibility to\nbreak upgrades of VMAgent. It is advised to review VMAgent release\nnotes to ensure that no incompatible scrape configs are going to break\nVMAgent after the upgrade.",
           "properties": {
             "key": {
-              "description": "The key of the secret to select from.  Must be a valid secret key.",
               "type": "string"
             },
             "name": {
               "default": "",
-              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
               "type": "string"
             },
             "optional": {
-              "description": "Specify whether the Secret or its key must be defined",
               "type": "boolean"
             }
           },
@@ -48,30 +32,23 @@
           "additionalProperties": false
         },
         "affinity": {
-          "description": "Affinity If specified, the pod's scheduling constraints.",
           "type": "object",
           "x-kubernetes-preserve-unknown-fields": true
         },
         "apiServerConfig": {
-          "description": "APIServerConfig allows specifying a host and auth methods to access apiserver.\nIf left empty, VMAgent is assumed to run inside of the cluster\nand will discover API servers automatically and use the pod's CA certificate\nand bearer token file at /var/run/secrets/kubernetes.io/serviceaccount/.",
           "properties": {
             "authorization": {
-              "description": "Authorization configures generic authorization params",
               "properties": {
                 "credentials": {
-                  "description": "Reference to the secret with value for authorization",
                   "properties": {
                     "key": {
-                      "description": "The key of the secret to select from.  Must be a valid secret key.",
                       "type": "string"
                     },
                     "name": {
                       "default": "",
-                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                       "type": "string"
                     },
                     "optional": {
-                      "description": "Specify whether the Secret or its key must be defined",
                       "type": "boolean"
                     }
                   },
@@ -83,11 +60,9 @@
                   "additionalProperties": false
                 },
                 "credentialsFile": {
-                  "description": "File with value for authorization",
                   "type": "string"
                 },
                 "type": {
-                  "description": "Type of authorization, default to bearer",
                   "type": "string"
                 }
               },
@@ -95,22 +70,17 @@
               "additionalProperties": false
             },
             "basicAuth": {
-              "description": "BasicAuth allow an endpoint to authenticate over basic authentication",
               "properties": {
                 "password": {
-                  "description": "Password defines reference for secret with password value\nThe secret needs to be in the same namespace as scrape object",
                   "properties": {
                     "key": {
-                      "description": "The key of the secret to select from.  Must be a valid secret key.",
                       "type": "string"
                     },
                     "name": {
                       "default": "",
-                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                       "type": "string"
                     },
                     "optional": {
-                      "description": "Specify whether the Secret or its key must be defined",
                       "type": "boolean"
                     }
                   },
@@ -122,23 +92,18 @@
                   "additionalProperties": false
                 },
                 "password_file": {
-                  "description": "PasswordFile defines path to password file at disk\nmust be pre-mounted",
                   "type": "string"
                 },
                 "username": {
-                  "description": "Username defines reference for secret with username value\nThe secret needs to be in the same namespace as scrape object",
                   "properties": {
                     "key": {
-                      "description": "The key of the secret to select from.  Must be a valid secret key.",
                       "type": "string"
                     },
                     "name": {
                       "default": "",
-                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                       "type": "string"
                     },
                     "optional": {
-                      "description": "Specify whether the Secret or its key must be defined",
                       "type": "boolean"
                     }
                   },
@@ -154,37 +119,28 @@
               "additionalProperties": false
             },
             "bearerToken": {
-              "description": "Bearer token for accessing apiserver.",
               "type": "string"
             },
             "bearerTokenFile": {
-              "description": "File to read bearer token for accessing apiserver.",
               "type": "string"
             },
             "host": {
-              "description": "Host of apiserver.\nA valid string consisting of a hostname or IP followed by an optional port number",
               "type": "string"
             },
             "tlsConfig": {
-              "description": "TLSConfig Config to use for accessing apiserver.",
               "properties": {
                 "ca": {
-                  "description": "Struct containing the CA cert to use for the targets.",
                   "properties": {
                     "configMap": {
-                      "description": "ConfigMap containing data to use for the targets.",
                       "properties": {
                         "key": {
-                          "description": "The key to select.",
                           "type": "string"
                         },
                         "name": {
                           "default": "",
-                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                           "type": "string"
                         },
                         "optional": {
-                          "description": "Specify whether the ConfigMap or its key must be defined",
                           "type": "boolean"
                         }
                       },
@@ -196,19 +152,15 @@
                       "additionalProperties": false
                     },
                     "secret": {
-                      "description": "Secret containing data to use for the targets.",
                       "properties": {
                         "key": {
-                          "description": "The key of the secret to select from.  Must be a valid secret key.",
                           "type": "string"
                         },
                         "name": {
                           "default": "",
-                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                           "type": "string"
                         },
                         "optional": {
-                          "description": "Specify whether the Secret or its key must be defined",
                           "type": "boolean"
                         }
                       },
@@ -224,26 +176,20 @@
                   "additionalProperties": false
                 },
                 "caFile": {
-                  "description": "Path to the CA cert in the container to use for the targets.",
                   "type": "string"
                 },
                 "cert": {
-                  "description": "Struct containing the client cert file for the targets.",
                   "properties": {
                     "configMap": {
-                      "description": "ConfigMap containing data to use for the targets.",
                       "properties": {
                         "key": {
-                          "description": "The key to select.",
                           "type": "string"
                         },
                         "name": {
                           "default": "",
-                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                           "type": "string"
                         },
                         "optional": {
-                          "description": "Specify whether the ConfigMap or its key must be defined",
                           "type": "boolean"
                         }
                       },
@@ -255,19 +201,15 @@
                       "additionalProperties": false
                     },
                     "secret": {
-                      "description": "Secret containing data to use for the targets.",
                       "properties": {
                         "key": {
-                          "description": "The key of the secret to select from.  Must be a valid secret key.",
                           "type": "string"
                         },
                         "name": {
                           "default": "",
-                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                           "type": "string"
                         },
                         "optional": {
-                          "description": "Specify whether the Secret or its key must be defined",
                           "type": "boolean"
                         }
                       },
@@ -283,31 +225,24 @@
                   "additionalProperties": false
                 },
                 "certFile": {
-                  "description": "Path to the client cert file in the container for the targets.",
                   "type": "string"
                 },
                 "insecureSkipVerify": {
-                  "description": "Disable target certificate validation.",
                   "type": "boolean"
                 },
                 "keyFile": {
-                  "description": "Path to the client key file in the container for the targets.",
                   "type": "string"
                 },
                 "keySecret": {
-                  "description": "Secret containing the client key file for the targets.",
                   "properties": {
                     "key": {
-                      "description": "The key of the secret to select from.  Must be a valid secret key.",
                       "type": "string"
                     },
                     "name": {
                       "default": "",
-                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                       "type": "string"
                     },
                     "optional": {
-                      "description": "Specify whether the Secret or its key must be defined",
                       "type": "boolean"
                     }
                   },
@@ -319,7 +254,6 @@
                   "additionalProperties": false
                 },
                 "serverName": {
-                  "description": "Used to verify the hostname for the targets.",
                   "type": "string"
                 }
               },
@@ -334,7 +268,6 @@
           "additionalProperties": false
         },
         "arbitraryFSAccessThroughSMs": {
-          "description": "ArbitraryFSAccessThroughSMs configures whether configuration\nbased on EndpointAuth can access arbitrary files on the file system\nof the VMAgent container e.g. bearer token files, basic auth, tls certs",
           "properties": {
             "deny": {
               "type": "boolean"
@@ -344,28 +277,21 @@
           "additionalProperties": false
         },
         "claimTemplates": {
-          "description": "ClaimTemplates allows adding additional VolumeClaimTemplates for VMAgent in StatefulMode",
           "items": {
-            "description": "PersistentVolumeClaim is a user's request for and claim to a persistent volume",
             "properties": {
               "apiVersion": {
-                "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
                 "type": "string"
               },
               "kind": {
-                "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
                 "type": "string"
               },
               "metadata": {
-                "description": "Standard object's metadata.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
                 "type": "object",
                 "x-kubernetes-preserve-unknown-fields": true
               },
               "spec": {
-                "description": "spec defines the desired characteristics of a volume requested by a pod author.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
                 "properties": {
                   "accessModes": {
-                    "description": "accessModes contains the desired access modes the volume should have.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1",
                     "items": {
                       "type": "string"
                     },
@@ -373,18 +299,14 @@
                     "x-kubernetes-list-type": "atomic"
                   },
                   "dataSource": {
-                    "description": "dataSource field can be used to specify either:\n* An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)\n* An existing PVC (PersistentVolumeClaim)\nIf the provisioner or an external controller can support the specified data source,\nit will create a new volume based on the contents of the specified data source.\nWhen the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,\nand dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.\nIf the namespace is specified, then dataSourceRef will not be copied to dataSource.",
                     "properties": {
                       "apiGroup": {
-                        "description": "APIGroup is the group for the resource being referenced.\nIf APIGroup is not specified, the specified Kind must be in the core API group.\nFor any other third-party types, APIGroup is required.",
                         "type": "string"
                       },
                       "kind": {
-                        "description": "Kind is the type of resource being referenced",
                         "type": "string"
                       },
                       "name": {
-                        "description": "Name is the name of resource being referenced",
                         "type": "string"
                       }
                     },
@@ -397,22 +319,17 @@
                     "additionalProperties": false
                   },
                   "dataSourceRef": {
-                    "description": "dataSourceRef specifies the object from which to populate the volume with data, if a non-empty\nvolume is desired. This may be any object from a non-empty API group (non\ncore object) or a PersistentVolumeClaim object.\nWhen this field is specified, volume binding will only succeed if the type of\nthe specified object matches some installed volume populator or dynamic\nprovisioner.\nThis field will replace the functionality of the dataSource field and as such\nif both fields are non-empty, they must have the same value. For backwards\ncompatibility, when namespace isn't specified in dataSourceRef,\nboth fields (dataSource and dataSourceRef) will be set to the same\nvalue automatically if one of them is empty and the other is non-empty.\nWhen namespace is specified in dataSourceRef,\ndataSource isn't set to the same value and must be empty.\nThere are three important differences between dataSource and dataSourceRef:\n* While dataSource only allows two specific types of objects, dataSourceRef\n  allows any non-core object, as well as PersistentVolumeClaim objects.\n* While dataSource ignores disallowed values (dropping them), dataSourceRef\n  preserves all values, and generates an error if a disallowed value is\n  specified.\n* While dataSource only allows local objects, dataSourceRef allows objects\n  in any namespaces.\n(Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.\n(Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.",
                     "properties": {
                       "apiGroup": {
-                        "description": "APIGroup is the group for the resource being referenced.\nIf APIGroup is not specified, the specified Kind must be in the core API group.\nFor any other third-party types, APIGroup is required.",
                         "type": "string"
                       },
                       "kind": {
-                        "description": "Kind is the type of resource being referenced",
                         "type": "string"
                       },
                       "name": {
-                        "description": "Name is the name of resource being referenced",
                         "type": "string"
                       },
                       "namespace": {
-                        "description": "Namespace is the namespace of resource being referenced\nNote that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.\n(Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.",
                         "type": "string"
                       }
                     },
@@ -424,7 +341,6 @@
                     "additionalProperties": false
                   },
                   "resources": {
-                    "description": "resources represents the minimum resources the volume should have.\nIf RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements\nthat are lower than previous value but must still be higher than capacity recorded in the\nstatus field of the claim.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources",
                     "properties": {
                       "limits": {
                         "additionalProperties": {
@@ -439,7 +355,6 @@
                           "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                           "x-kubernetes-int-or-string": true
                         },
-                        "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
                         "type": "object"
                       },
                       "requests": {
@@ -455,7 +370,6 @@
                           "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                           "x-kubernetes-int-or-string": true
                         },
-                        "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
                         "type": "object"
                       }
                     },
@@ -463,23 +377,17 @@
                     "additionalProperties": false
                   },
                   "selector": {
-                    "description": "selector is a label query over volumes to consider for binding.",
                     "properties": {
                       "matchExpressions": {
-                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
                         "items": {
-                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
                           "properties": {
                             "key": {
-                              "description": "key is the label key that the selector applies to.",
                               "type": "string"
                             },
                             "operator": {
-                              "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
                               "type": "string"
                             },
                             "values": {
-                              "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
                               "items": {
                                 "type": "string"
                               },
@@ -501,7 +409,6 @@
                         "additionalProperties": {
                           "type": "string"
                         },
-                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                         "type": "object"
                       }
                     },
@@ -510,19 +417,15 @@
                     "additionalProperties": false
                   },
                   "storageClassName": {
-                    "description": "storageClassName is the name of the StorageClass required by the claim.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1",
                     "type": "string"
                   },
                   "volumeAttributesClassName": {
-                    "description": "volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.\nIf specified, the CSI driver will create or update the volume with the attributes defined\nin the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,\nit can be changed after the claim is created. An empty string or nil value indicates that no\nVolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,\nthis field can be reset to its previous value (including nil) to cancel the modification.\nIf the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be\nset to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource\nexists.\nMore info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/",
                     "type": "string"
                   },
                   "volumeMode": {
-                    "description": "volumeMode defines what type of volume is required by the claim.\nValue of Filesystem is implied when not included in claim spec.",
                     "type": "string"
                   },
                   "volumeName": {
-                    "description": "volumeName is the binding reference to the PersistentVolume backing this claim.",
                     "type": "string"
                   }
                 },
@@ -530,10 +433,8 @@
                 "additionalProperties": false
               },
               "status": {
-                "description": "status represents the current information/status of a persistent volume claim.\nRead-only.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
                 "properties": {
                   "accessModes": {
-                    "description": "accessModes contains the actual access modes the volume backing the PVC has.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1",
                     "items": {
                       "type": "string"
                     },
@@ -542,10 +443,8 @@
                   },
                   "allocatedResourceStatuses": {
                     "additionalProperties": {
-                      "description": "When a controller receives persistentvolume claim update with ClaimResourceStatus for a resource\nthat it does not recognizes, then it should ignore that update and let other controllers\nhandle it.",
                       "type": "string"
                     },
-                    "description": "allocatedResourceStatuses stores status of resource being resized for the given PVC.\nKey names follow standard Kubernetes label syntax. Valid values are either:\n\t* Un-prefixed keys:\n\t\t- storage - the capacity of the volume.\n\t* Custom resources must use implementation-defined prefixed names such as \"example.com/my-custom-resource\"\nApart from above values - keys that are unprefixed or have kubernetes.io prefix are considered\nreserved and hence may not be used.\n\nClaimResourceStatus can be in any of following states:\n\t- ControllerResizeInProgress:\n\t\tState set when resize controller starts resizing the volume in control-plane.\n\t- ControllerResizeFailed:\n\t\tState set when resize has failed in resize controller with a terminal error.\n\t- NodeResizePending:\n\t\tState set when resize controller has finished resizing the volume but further resizing of\n\t\tvolume is needed on the node.\n\t- NodeResizeInProgress:\n\t\tState set when kubelet starts resizing the volume.\n\t- NodeResizeFailed:\n\t\tState set when resizing has failed in kubelet with a terminal error. Transient errors don't set\n\t\tNodeResizeFailed.\nFor example: if expanding a PVC for more capacity - this field can be one of the following states:\n\t- pvc.status.allocatedResourceStatus['storage'] = \"ControllerResizeInProgress\"\n     - pvc.status.allocatedResourceStatus['storage'] = \"ControllerResizeFailed\"\n     - pvc.status.allocatedResourceStatus['storage'] = \"NodeResizePending\"\n     - pvc.status.allocatedResourceStatus['storage'] = \"NodeResizeInProgress\"\n     - pvc.status.allocatedResourceStatus['storage'] = \"NodeResizeFailed\"\nWhen this field is not set, it means that no resize operation is in progress for the given PVC.\n\nA controller that receives PVC update with previously unknown resourceName or ClaimResourceStatus\nshould ignore the update for the purpose it was designed. For example - a controller that\nonly is responsible for resizing capacity of the volume, should ignore PVC updates that change other valid\nresources associated with PVC.\n\nThis is an alpha field and requires enabling RecoverVolumeExpansionFailure feature.",
                     "type": "object",
                     "x-kubernetes-map-type": "granular"
                   },
@@ -562,7 +461,6 @@
                       "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                       "x-kubernetes-int-or-string": true
                     },
-                    "description": "allocatedResources tracks the resources allocated to a PVC including its capacity.\nKey names follow standard Kubernetes label syntax. Valid values are either:\n\t* Un-prefixed keys:\n\t\t- storage - the capacity of the volume.\n\t* Custom resources must use implementation-defined prefixed names such as \"example.com/my-custom-resource\"\nApart from above values - keys that are unprefixed or have kubernetes.io prefix are considered\nreserved and hence may not be used.\n\nCapacity reported here may be larger than the actual capacity when a volume expansion operation\nis requested.\nFor storage quota, the larger value from allocatedResources and PVC.spec.resources is used.\nIf allocatedResources is not set, PVC.spec.resources alone is used for quota calculation.\nIf a volume expansion capacity request is lowered, allocatedResources is only\nlowered if there are no expansion operations in progress and if the actual volume capacity\nis equal or lower than the requested capacity.\n\nA controller that receives PVC update with previously unknown resourceName\nshould ignore the update for the purpose it was designed. For example - a controller that\nonly is responsible for resizing capacity of the volume, should ignore PVC updates that change other valid\nresources associated with PVC.\n\nThis is an alpha field and requires enabling RecoverVolumeExpansionFailure feature.",
                     "type": "object"
                   },
                   "capacity": {
@@ -578,38 +476,29 @@
                       "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                       "x-kubernetes-int-or-string": true
                     },
-                    "description": "capacity represents the actual resources of the underlying volume.",
                     "type": "object"
                   },
                   "conditions": {
-                    "description": "conditions is the current Condition of persistent volume claim. If underlying persistent volume is being\nresized then the Condition will be set to 'Resizing'.",
                     "items": {
-                      "description": "PersistentVolumeClaimCondition contains details about state of pvc",
                       "properties": {
                         "lastProbeTime": {
-                          "description": "lastProbeTime is the time we probed the condition.",
                           "format": "date-time",
                           "type": "string"
                         },
                         "lastTransitionTime": {
-                          "description": "lastTransitionTime is the time the condition transitioned from one status to another.",
                           "format": "date-time",
                           "type": "string"
                         },
                         "message": {
-                          "description": "message is the human-readable message indicating details about last transition.",
                           "type": "string"
                         },
                         "reason": {
-                          "description": "reason is a unique, this should be a short, machine understandable string that gives the reason\nfor condition's last transition. If it reports \"Resizing\" that means the underlying\npersistent volume is being resized.",
                           "type": "string"
                         },
                         "status": {
-                          "description": "Status is the status of the condition.\nCan be True, False, Unknown.\nMore info: https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-claim-v1/#:~:text=state%20of%20pvc-,conditions.status,-(string)%2C%20required",
                           "type": "string"
                         },
                         "type": {
-                          "description": "Type is the type of the condition.\nMore info: https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-claim-v1/#:~:text=set%20to%20%27ResizeStarted%27.-,PersistentVolumeClaimCondition,-contains%20details%20about",
                           "type": "string"
                         }
                       },
@@ -627,18 +516,14 @@
                     "x-kubernetes-list-type": "map"
                   },
                   "currentVolumeAttributesClassName": {
-                    "description": "currentVolumeAttributesClassName is the current name of the VolumeAttributesClass the PVC is using.\nWhen unset, there is no VolumeAttributeClass applied to this PersistentVolumeClaim",
                     "type": "string"
                   },
                   "modifyVolumeStatus": {
-                    "description": "ModifyVolumeStatus represents the status object of ControllerModifyVolume operation.\nWhen this is unset, there is no ModifyVolume operation being attempted.",
                     "properties": {
                       "status": {
-                        "description": "status is the status of the ControllerModifyVolume operation. It can be in any of following states:\n - Pending\n   Pending indicates that the PersistentVolumeClaim cannot be modified due to unmet requirements, such as\n   the specified VolumeAttributesClass not existing.\n - InProgress\n   InProgress indicates that the volume is being modified.\n - Infeasible\n  Infeasible indicates that the request has been rejected as invalid by the CSI driver. To\n\t  resolve the error, a valid VolumeAttributesClass needs to be specified.\nNote: New statuses can be added in the future. Consumers should check for unknown statuses and fail appropriately.",
                         "type": "string"
                       },
                       "targetVolumeAttributesClassName": {
-                        "description": "targetVolumeAttributesClassName is the name of the VolumeAttributesClass the PVC currently being reconciled",
                         "type": "string"
                       }
                     },
@@ -649,7 +534,6 @@
                     "additionalProperties": false
                   },
                   "phase": {
-                    "description": "phase represents the current phase of PersistentVolumeClaim.",
                     "type": "string"
                   }
                 },
@@ -662,27 +546,25 @@
           },
           "type": "array"
         },
+        "componentVersion": {
+          "type": "string"
+        },
         "configMaps": {
-          "description": "ConfigMaps is a list of ConfigMaps in the same namespace as the Application\nobject, which shall be mounted into the Application container\nat /etc/vm/configs/CONFIGMAP_NAME folder",
           "items": {
             "type": "string"
           },
           "type": "array"
         },
         "configReloadAuthKeySecret": {
-          "description": "ConfigReloadAuthKeySecret defines optional secret reference authKey for /-/reload API requests.\nGiven secret reference will be added to the application and vm-config-reloader as volume\navailable since v0.57.0 version",
           "properties": {
             "key": {
-              "description": "The key of the secret to select from.  Must be a valid secret key.",
               "type": "string"
             },
             "name": {
               "default": "",
-              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
               "type": "string"
             },
             "optional": {
-              "description": "Specify whether the Secret or its key must be defined",
               "type": "boolean"
             }
           },
@@ -697,27 +579,23 @@
           "additionalProperties": {
             "type": "string"
           },
-          "description": "ConfigReloaderExtraArgs that will be passed to  VMAuths config-reloader container\nfor example resyncInterval: \"30s\"",
           "type": "object"
         },
+        "configReloaderImage": {
+          "type": "string"
+        },
         "configReloaderImageTag": {
-          "description": "ConfigReloaderImageTag defines image:tag for config-reloader container",
           "type": "string"
         },
         "configReloaderResources": {
-          "description": "ConfigReloaderResources config-reloader container resource request and limits, https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/\nif not defined default resources from operator config will be used",
           "properties": {
             "claims": {
-              "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis field depends on the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
               "items": {
-                "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
                 "properties": {
                   "name": {
-                    "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
                     "type": "string"
                   },
                   "request": {
-                    "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
                     "type": "string"
                   }
                 },
@@ -746,7 +624,6 @@
                 "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                 "x-kubernetes-int-or-string": true
               },
-              "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
               "type": "object"
             },
             "requests": {
@@ -762,7 +639,6 @@
                 "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                 "x-kubernetes-int-or-string": true
               },
-              "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
               "type": "object"
             }
           },
@@ -770,9 +646,7 @@
           "additionalProperties": false
         },
         "containers": {
-          "description": "Containers property allows to inject additions sidecars or to patch existing containers.\nIt can be useful for proxies, backup, etc.",
           "items": {
-            "description": "A single application container that you want to run within a pod.",
             "required": [
               "name"
             ],
@@ -782,25 +656,51 @@
           "type": "array"
         },
         "daemonSetMode": {
-          "description": "DaemonSetMode enables DaemonSet deployment mode instead of Deployment.\nSupports only VMPodScrape\n(available from v0.55.0).\nCannot be used with statefulMode",
           "type": "boolean"
         },
+        "daemonSetRollingUpdateStrategyBehavior": {
+          "properties": {
+            "maxSurge": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "string"
+                }
+              ],
+              "x-kubernetes-int-or-string": true
+            },
+            "maxUnavailable": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "string"
+                }
+              ],
+              "x-kubernetes-int-or-string": true
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "daemonSetUpdateStrategy": {
+          "type": "string"
+        },
         "disableAutomountServiceAccountToken": {
-          "description": "DisableAutomountServiceAccountToken whether to disable serviceAccount auto mount by Kubernetes (available from v0.54.0).\nOperator will conditionally create volumes and volumeMounts for containers if it requires k8s API access.\nFor example, vmagent and vm-config-reloader requires k8s API access.\nOperator creates volumes with name: \"kube-api-access\", which can be used as volumeMount for extraContainers if needed.\nAnd also adds VolumeMounts at /var/run/secrets/kubernetes.io/serviceaccount.",
           "type": "boolean"
         },
         "disableSelfServiceScrape": {
-          "description": "DisableSelfServiceScrape controls creation of VMServiceScrape by operator\nfor the application.\nHas priority over `VM_DISABLESELFSERVICESCRAPECREATION` operator env variable",
           "type": "boolean"
         },
         "dnsConfig": {
-          "description": "Specifies the DNS parameters of a pod.\nParameters specified here will be merged to the generated DNS\nconfiguration based on DNSPolicy.",
           "items": {
             "x-kubernetes-preserve-unknown-fields": true
           },
           "properties": {
             "nameservers": {
-              "description": "A list of DNS name server IP addresses.\nThis will be appended to the base nameservers generated from DNSPolicy.\nDuplicated nameservers will be removed.",
               "items": {
                 "type": "string"
               },
@@ -808,16 +708,12 @@
               "x-kubernetes-list-type": "atomic"
             },
             "options": {
-              "description": "A list of DNS resolver options.\nThis will be merged with the base options generated from DNSPolicy.\nDuplicated entries will be removed. Resolution options given in Options\nwill override those that appear in the base DNSPolicy.",
               "items": {
-                "description": "PodDNSConfigOption defines DNS resolver options of a pod.",
                 "properties": {
                   "name": {
-                    "description": "Name is this DNS resolver option's name.\nRequired.",
                     "type": "string"
                   },
                   "value": {
-                    "description": "Value is this DNS resolver option's value.",
                     "type": "string"
                   }
                 },
@@ -828,7 +724,6 @@
               "x-kubernetes-list-type": "atomic"
             },
             "searches": {
-              "description": "A list of DNS search domains for host-name lookup.\nThis will be appended to the base search paths generated from DNSPolicy.\nDuplicated search paths will be removed.",
               "items": {
                 "type": "string"
               },
@@ -840,42 +735,36 @@
           "additionalProperties": false
         },
         "dnsPolicy": {
-          "description": "DNSPolicy sets DNS policy for the pod",
           "type": "string"
         },
         "enableKubernetesAPISelectors": {
-          "description": "EnableKubernetesAPISelectors instructs vmagent to use CRD scrape objects spec.selectors for\nKubernetes API list and watch requests.\nhttps://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#list-and-watch-filtering\nIt could be useful to reduce Kubernetes API server resource usage for serving less than 100 CRD scrape objects in total.",
           "type": "boolean"
         },
         "enforcedNamespaceLabel": {
-          "description": "EnforcedNamespaceLabel enforces adding a namespace label of origin for each alert\nand metric that is user created. The label value will always be the namespace of the object that is\nbeing created.",
+          "type": "string"
+        },
+        "externalLabelName": {
           "type": "string"
         },
         "externalLabels": {
           "additionalProperties": {
             "type": "string"
           },
-          "description": "ExternalLabels The labels to add to any time series scraped by vmagent.\nit doesn't affect metrics ingested directly by push API's",
           "type": "object"
         },
         "extraArgs": {
           "additionalProperties": {
             "type": "string"
           },
-          "description": "ExtraArgs that will be passed to the application container\nfor example remoteWrite.tmpDataPath: /tmp",
           "type": "object"
         },
         "extraEnvs": {
-          "description": "ExtraEnvs that will be passed to the application container",
           "items": {
-            "description": "EnvVar represents an environment variable present in a Container.",
             "properties": {
               "name": {
-                "description": "Name of the environment variable.\nMay consist of any printable ASCII characters except '='.",
                 "type": "string"
               },
               "value": {
-                "description": "Variable references $(VAR_NAME) are expanded\nusing the previously defined environment variables in the container and\nany service environment variables. If a variable cannot be resolved,\nthe reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.\n\"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\".\nEscaped references will never be expanded, regardless of whether the variable\nexists or not.\nDefaults to \"\".",
                 "type": "string"
               }
             },
@@ -889,20 +778,15 @@
           "type": "array"
         },
         "extraEnvsFrom": {
-          "description": "ExtraEnvsFrom defines source of env variables for the application container\ncould either be secret or configmap",
           "items": {
-            "description": "EnvFromSource represents the source of a set of ConfigMaps or Secrets",
             "properties": {
               "configMapRef": {
-                "description": "The ConfigMap to select from",
                 "properties": {
                   "name": {
                     "default": "",
-                    "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                     "type": "string"
                   },
                   "optional": {
-                    "description": "Specify whether the ConfigMap must be defined",
                     "type": "boolean"
                   }
                 },
@@ -911,19 +795,15 @@
                 "additionalProperties": false
               },
               "prefix": {
-                "description": "Optional text to prepend to the name of each environment variable.\nMay consist of any printable ASCII characters except '='.",
                 "type": "string"
               },
               "secretRef": {
-                "description": "The Secret to select from",
                 "properties": {
                   "name": {
                     "default": "",
-                    "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                     "type": "string"
                   },
                   "optional": {
-                    "description": "Specify whether the Secret must be defined",
                     "type": "boolean"
                   }
                 },
@@ -938,66 +818,52 @@
           "type": "array"
         },
         "globalScrapeMetricRelabelConfigs": {
-          "description": "GlobalScrapeMetricRelabelConfigs is a global metric relabel configuration, which is applied to each scrape job.",
           "items": {
-            "description": "RelabelConfig allows dynamic rewriting of the label set\nMore info: https://docs.victoriametrics.com/victoriametrics/#relabeling",
             "properties": {
               "action": {
-                "description": "Action to perform based on regex matching. Default is 'replace'",
                 "type": "string"
               },
               "if": {
-                "description": "If represents metricsQL match expression (or list of expressions): '{__name__=~\"foo_.*\"}'",
                 "x-kubernetes-preserve-unknown-fields": true
               },
               "labels": {
                 "additionalProperties": {
                   "type": "string"
                 },
-                "description": "Labels is used together with Match for `action: graphite`",
                 "type": "object"
               },
               "match": {
-                "description": "Match is used together with Labels for `action: graphite`",
                 "type": "string"
               },
               "modulus": {
-                "description": "Modulus to take of the hash of the source label values.",
                 "format": "int64",
                 "type": "integer"
               },
               "regex": {
-                "description": "Regular expression against which the extracted value is matched. Default is '(.*)'\nvictoriaMetrics supports multiline regex joined with |\nhttps://docs.victoriametrics.com/victoriametrics/vmagent/#relabeling-enhancements",
                 "x-kubernetes-preserve-unknown-fields": true
               },
               "replacement": {
-                "description": "Replacement value against which a regex replace is performed if the\nregular expression matches. Regex capture groups are available. Default is '$1'",
                 "type": "string"
               },
               "separator": {
-                "description": "Separator placed between concatenated source label values. default is ';'.",
                 "type": "string"
               },
               "source_labels": {
-                "description": "UnderScoreSourceLabels - additional form of source labels source_labels\nfor compatibility with original relabel config.\nif set  both sourceLabels and source_labels, sourceLabels has priority.\nfor details https://github.com/VictoriaMetrics/operator/issues/131",
                 "items": {
                   "type": "string"
                 },
                 "type": "array"
               },
               "sourceLabels": {
-                "description": "The source labels select values from existing labels. Their content is concatenated\nusing the configured separator and matched against the configured regular expression\nfor the replace, keep, and drop actions.",
                 "items": {
                   "type": "string"
                 },
                 "type": "array"
               },
               "target_label": {
-                "description": "UnderScoreTargetLabel - additional form of target label - target_label\nfor compatibility with original relabel config.\nif set  both targetLabel and target_label, targetLabel has priority.\nfor details https://github.com/VictoriaMetrics/operator/issues/131",
                 "type": "string"
               },
               "targetLabel": {
-                "description": "Label to which the resulting value is written in a replace action.\nIt is mandatory for replace actions. Regex capture groups are available.",
                 "type": "string"
               }
             },
@@ -1007,66 +873,52 @@
           "type": "array"
         },
         "globalScrapeRelabelConfigs": {
-          "description": "GlobalScrapeRelabelConfigs is a global relabel configuration, which is applied to each samples of each scrape job during service discovery.",
           "items": {
-            "description": "RelabelConfig allows dynamic rewriting of the label set\nMore info: https://docs.victoriametrics.com/victoriametrics/#relabeling",
             "properties": {
               "action": {
-                "description": "Action to perform based on regex matching. Default is 'replace'",
                 "type": "string"
               },
               "if": {
-                "description": "If represents metricsQL match expression (or list of expressions): '{__name__=~\"foo_.*\"}'",
                 "x-kubernetes-preserve-unknown-fields": true
               },
               "labels": {
                 "additionalProperties": {
                   "type": "string"
                 },
-                "description": "Labels is used together with Match for `action: graphite`",
                 "type": "object"
               },
               "match": {
-                "description": "Match is used together with Labels for `action: graphite`",
                 "type": "string"
               },
               "modulus": {
-                "description": "Modulus to take of the hash of the source label values.",
                 "format": "int64",
                 "type": "integer"
               },
               "regex": {
-                "description": "Regular expression against which the extracted value is matched. Default is '(.*)'\nvictoriaMetrics supports multiline regex joined with |\nhttps://docs.victoriametrics.com/victoriametrics/vmagent/#relabeling-enhancements",
                 "x-kubernetes-preserve-unknown-fields": true
               },
               "replacement": {
-                "description": "Replacement value against which a regex replace is performed if the\nregular expression matches. Regex capture groups are available. Default is '$1'",
                 "type": "string"
               },
               "separator": {
-                "description": "Separator placed between concatenated source label values. default is ';'.",
                 "type": "string"
               },
               "source_labels": {
-                "description": "UnderScoreSourceLabels - additional form of source labels source_labels\nfor compatibility with original relabel config.\nif set  both sourceLabels and source_labels, sourceLabels has priority.\nfor details https://github.com/VictoriaMetrics/operator/issues/131",
                 "items": {
                   "type": "string"
                 },
                 "type": "array"
               },
               "sourceLabels": {
-                "description": "The source labels select values from existing labels. Their content is concatenated\nusing the configured separator and matched against the configured regular expression\nfor the replace, keep, and drop actions.",
                 "items": {
                   "type": "string"
                 },
                 "type": "array"
               },
               "target_label": {
-                "description": "UnderScoreTargetLabel - additional form of target label - target_label\nfor compatibility with original relabel config.\nif set  both targetLabel and target_label, targetLabel has priority.\nfor details https://github.com/VictoriaMetrics/operator/issues/131",
                 "type": "string"
               },
               "targetLabel": {
-                "description": "Label to which the resulting value is written in a replace action.\nIt is mandatory for replace actions. Regex capture groups are available.",
                 "type": "string"
               }
             },
@@ -1076,12 +928,9 @@
           "type": "array"
         },
         "host_aliases": {
-          "description": "HostAliasesUnderScore provides mapping for ip and hostname,\nthat would be propagated to pod,\ncannot be used with HostNetwork.\nHas Priority over hostAliases field",
           "items": {
-            "description": "HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the\npod's hosts file.",
             "properties": {
               "hostnames": {
-                "description": "Hostnames for the above IP address.",
                 "items": {
                   "type": "string"
                 },
@@ -1089,7 +938,6 @@
                 "x-kubernetes-list-type": "atomic"
               },
               "ip": {
-                "description": "IP address of the host file entry.",
                 "type": "string"
               }
             },
@@ -1102,12 +950,9 @@
           "type": "array"
         },
         "hostAliases": {
-          "description": "HostAliases provides mapping for ip and hostname,\nthat would be propagated to pod,\ncannot be used with HostNetwork.",
           "items": {
-            "description": "HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the\npod's hosts file.",
             "properties": {
               "hostnames": {
-                "description": "Hostnames for the above IP address.",
                 "items": {
                   "type": "string"
                 },
@@ -1115,7 +960,6 @@
                 "x-kubernetes-list-type": "atomic"
               },
               "ip": {
-                "description": "IP address of the host file entry.",
                 "type": "string"
               }
             },
@@ -1128,26 +972,593 @@
           "type": "array"
         },
         "hostNetwork": {
-          "description": "HostNetwork controls whether the pod may use the node network namespace",
           "type": "boolean"
         },
+        "hpa": {
+          "properties": {
+            "behaviour": {
+              "properties": {
+                "scaleDown": {
+                  "properties": {
+                    "policies": {
+                      "items": {
+                        "properties": {
+                          "periodSeconds": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "type": {
+                            "type": "string"
+                          },
+                          "value": {
+                            "format": "int32",
+                            "type": "integer"
+                          }
+                        },
+                        "required": [
+                          "periodSeconds",
+                          "type",
+                          "value"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
+                    },
+                    "selectPolicy": {
+                      "type": "string"
+                    },
+                    "stabilizationWindowSeconds": {
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "tolerance": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                      "x-kubernetes-int-or-string": true
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "scaleUp": {
+                  "properties": {
+                    "policies": {
+                      "items": {
+                        "properties": {
+                          "periodSeconds": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "type": {
+                            "type": "string"
+                          },
+                          "value": {
+                            "format": "int32",
+                            "type": "integer"
+                          }
+                        },
+                        "required": [
+                          "periodSeconds",
+                          "type",
+                          "value"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
+                    },
+                    "selectPolicy": {
+                      "type": "string"
+                    },
+                    "stabilizationWindowSeconds": {
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "tolerance": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                      "x-kubernetes-int-or-string": true
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "maxReplicas": {
+              "format": "int32",
+              "type": "integer"
+            },
+            "metrics": {
+              "items": {
+                "properties": {
+                  "containerResource": {
+                    "properties": {
+                      "container": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "target": {
+                        "properties": {
+                          "averageUtilization": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "averageValue": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "type": {
+                            "type": "string"
+                          },
+                          "value": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                            "x-kubernetes-int-or-string": true
+                          }
+                        },
+                        "required": [
+                          "type"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "container",
+                      "name",
+                      "target"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "external": {
+                    "properties": {
+                      "metric": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "selector": {
+                            "properties": {
+                              "matchExpressions": {
+                                "items": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "name"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "target": {
+                        "properties": {
+                          "averageUtilization": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "averageValue": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "type": {
+                            "type": "string"
+                          },
+                          "value": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                            "x-kubernetes-int-or-string": true
+                          }
+                        },
+                        "required": [
+                          "type"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "metric",
+                      "target"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "object": {
+                    "properties": {
+                      "describedObject": {
+                        "properties": {
+                          "apiVersion": {
+                            "type": "string"
+                          },
+                          "kind": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "kind",
+                          "name"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "metric": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "selector": {
+                            "properties": {
+                              "matchExpressions": {
+                                "items": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "name"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "target": {
+                        "properties": {
+                          "averageUtilization": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "averageValue": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "type": {
+                            "type": "string"
+                          },
+                          "value": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                            "x-kubernetes-int-or-string": true
+                          }
+                        },
+                        "required": [
+                          "type"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "describedObject",
+                      "metric",
+                      "target"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "pods": {
+                    "properties": {
+                      "metric": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "selector": {
+                            "properties": {
+                              "matchExpressions": {
+                                "items": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "name"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "target": {
+                        "properties": {
+                          "averageUtilization": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "averageValue": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "type": {
+                            "type": "string"
+                          },
+                          "value": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                            "x-kubernetes-int-or-string": true
+                          }
+                        },
+                        "required": [
+                          "type"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "metric",
+                      "target"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "resource": {
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "target": {
+                        "properties": {
+                          "averageUtilization": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "averageValue": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "type": {
+                            "type": "string"
+                          },
+                          "value": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                            "x-kubernetes-int-or-string": true
+                          }
+                        },
+                        "required": [
+                          "type"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "name",
+                      "target"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "type"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "minReplicas": {
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
         "ignoreNamespaceSelectors": {
-          "description": "IgnoreNamespaceSelectors if set to true will ignore NamespaceSelector settings from\nscrape objects, and they will only discover endpoints\nwithin their current namespace.  Defaults to false.",
           "type": "boolean"
         },
         "image": {
-          "description": "Image - docker image settings\nif no specified operator uses default version from operator config",
           "properties": {
             "pullPolicy": {
-              "description": "PullPolicy describes how to pull docker image",
               "type": "string"
             },
             "repository": {
-              "description": "Repository contains name of docker image + it's repository if needed",
               "type": "string"
             },
             "tag": {
-              "description": "Tag contains desired docker image version",
               "type": "string"
             }
           },
@@ -1155,13 +1566,10 @@
           "additionalProperties": false
         },
         "imagePullSecrets": {
-          "description": "ImagePullSecrets An optional list of references to secrets in the same namespace\nto use for pulling images from registries\nsee https://kubernetes.io/docs/concepts/containers/images/#referring-to-an-imagepullsecrets-on-a-pod",
           "items": {
-            "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
             "properties": {
               "name": {
                 "default": "",
-                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                 "type": "string"
               }
             },
@@ -1172,13 +1580,10 @@
           "type": "array"
         },
         "ingestOnlyMode": {
-          "description": "IngestOnlyMode switches vmagent into unmanaged mode\nit disables any config generation for scraping\nCurrently it prevents vmagent from managing tls and auth options for remote write",
           "type": "boolean"
         },
         "initContainers": {
-          "description": "InitContainers allows adding initContainers to the pod definition.\nAny errors during the execution of an initContainer will lead to a restart of the Pod.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/",
           "items": {
-            "description": "A single application container that you want to run within a pod.",
             "required": [
               "name"
             ],
@@ -1188,66 +1593,52 @@
           "type": "array"
         },
         "inlineRelabelConfig": {
-          "description": "InlineRelabelConfig - defines GlobalRelabelConfig for vmagent, can be defined directly at CRD.",
           "items": {
-            "description": "RelabelConfig allows dynamic rewriting of the label set\nMore info: https://docs.victoriametrics.com/victoriametrics/#relabeling",
             "properties": {
               "action": {
-                "description": "Action to perform based on regex matching. Default is 'replace'",
                 "type": "string"
               },
               "if": {
-                "description": "If represents metricsQL match expression (or list of expressions): '{__name__=~\"foo_.*\"}'",
                 "x-kubernetes-preserve-unknown-fields": true
               },
               "labels": {
                 "additionalProperties": {
                   "type": "string"
                 },
-                "description": "Labels is used together with Match for `action: graphite`",
                 "type": "object"
               },
               "match": {
-                "description": "Match is used together with Labels for `action: graphite`",
                 "type": "string"
               },
               "modulus": {
-                "description": "Modulus to take of the hash of the source label values.",
                 "format": "int64",
                 "type": "integer"
               },
               "regex": {
-                "description": "Regular expression against which the extracted value is matched. Default is '(.*)'\nvictoriaMetrics supports multiline regex joined with |\nhttps://docs.victoriametrics.com/victoriametrics/vmagent/#relabeling-enhancements",
                 "x-kubernetes-preserve-unknown-fields": true
               },
               "replacement": {
-                "description": "Replacement value against which a regex replace is performed if the\nregular expression matches. Regex capture groups are available. Default is '$1'",
                 "type": "string"
               },
               "separator": {
-                "description": "Separator placed between concatenated source label values. default is ';'.",
                 "type": "string"
               },
               "source_labels": {
-                "description": "UnderScoreSourceLabels - additional form of source labels source_labels\nfor compatibility with original relabel config.\nif set  both sourceLabels and source_labels, sourceLabels has priority.\nfor details https://github.com/VictoriaMetrics/operator/issues/131",
                 "items": {
                   "type": "string"
                 },
                 "type": "array"
               },
               "sourceLabels": {
-                "description": "The source labels select values from existing labels. Their content is concatenated\nusing the configured separator and matched against the configured regular expression\nfor the replace, keep, and drop actions.",
                 "items": {
                   "type": "string"
                 },
                 "type": "array"
               },
               "target_label": {
-                "description": "UnderScoreTargetLabel - additional form of target label - target_label\nfor compatibility with original relabel config.\nif set  both targetLabel and target_label, targetLabel has priority.\nfor details https://github.com/VictoriaMetrics/operator/issues/131",
                 "type": "string"
               },
               "targetLabel": {
-                "description": "Label to which the resulting value is written in a replace action.\nIt is mandatory for replace actions. Regex capture groups are available.",
                 "type": "string"
               }
             },
@@ -1257,26 +1648,20 @@
           "type": "array"
         },
         "inlineScrapeConfig": {
-          "description": "InlineScrapeConfig As scrape configs are appended, the user is responsible to make sure it\nis valid. Note that using this feature may expose the possibility to\nbreak upgrades of VMAgent. It is advised to review VMAgent release\nnotes to ensure that no incompatible scrape configs are going to break\nVMAgent after the upgrade.\nit should be defined as single yaml file.\ninlineScrapeConfig: |\n    - job_name: \"prometheus\"\n      static_configs:\n      - targets: [\"localhost:9090\"]",
           "type": "string"
         },
         "insertPorts": {
-          "description": "InsertPorts - additional listen ports for data ingestion.",
           "properties": {
             "graphitePort": {
-              "description": "GraphitePort listen port",
               "type": "string"
             },
             "influxPort": {
-              "description": "InfluxPort listen port",
               "type": "string"
             },
             "openTSDBHTTPPort": {
-              "description": "OpenTSDBHTTPPort for http connections.",
               "type": "string"
             },
             "openTSDBPort": {
-              "description": "OpenTSDBPort for tcp and udp listen",
               "type": "string"
             }
           },
@@ -1284,30 +1669,23 @@
           "additionalProperties": false
         },
         "license": {
-          "description": "License allows to configure license key to be used for enterprise features.\nUsing license key is supported starting from VictoriaMetrics v1.94.0.\nSee [here](https://docs.victoriametrics.com/victoriametrics/enterprise/)",
           "properties": {
             "forceOffline": {
-              "description": "Enforce offline verification of the license key.",
               "type": "boolean"
             },
             "key": {
-              "description": "Enterprise license key. This flag is available only in [VictoriaMetrics enterprise](https://docs.victoriametrics.com/victoriametrics/enterprise/).\nTo request a trial license, [go to](https://victoriametrics.com/products/enterprise/trial)",
               "type": "string"
             },
             "keyRef": {
-              "description": "KeyRef is reference to secret with license key for enterprise features.",
               "properties": {
                 "key": {
-                  "description": "The key of the secret to select from.  Must be a valid secret key.",
                   "type": "string"
                 },
                 "name": {
                   "default": "",
-                  "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                   "type": "string"
                 },
                 "optional": {
-                  "description": "Specify whether the Secret or its key must be defined",
                   "type": "boolean"
                 }
               },
@@ -1319,7 +1697,6 @@
               "additionalProperties": false
             },
             "reloadInterval": {
-              "description": "Interval to be used for checking for license key changes. Note that this is only applicable when using KeyRef.",
               "type": "string"
             }
           },
@@ -1327,12 +1704,10 @@
           "additionalProperties": false
         },
         "livenessProbe": {
-          "description": "LivenessProbe that will be added CRD pod",
           "type": "object",
           "x-kubernetes-preserve-unknown-fields": true
         },
         "logFormat": {
-          "description": "LogFormat for VMAgent to be configured with.",
           "enum": [
             "default",
             "json"
@@ -1340,7 +1715,6 @@
           "type": "string"
         },
         "logLevel": {
-          "description": "LogLevel for VMAgent to be configured with.\nINFO, WARN, ERROR, FATAL, PANIC",
           "enum": [
             "INFO",
             "WARN",
@@ -1351,20 +1725,17 @@
           "type": "string"
         },
         "managedMetadata": {
-          "description": "ManagedMetadata defines metadata that will be added to the all objects\ncreated by operator for the given CustomResource",
           "properties": {
             "annotations": {
               "additionalProperties": {
                 "type": "string"
               },
-              "description": "Annotations is an unstructured key value map stored with a resource that may be\nset by external tools to store and retrieve arbitrary metadata. They are not\nqueryable and should be preserved when modifying objects.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations",
               "type": "object"
             },
             "labels": {
               "additionalProperties": {
                 "type": "string"
               },
-              "description": "Labels Map of string keys and values that can be used to organize and categorize\n(scope and select) objects.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels",
               "type": "object"
             }
           },
@@ -1372,36 +1743,27 @@
           "additionalProperties": false
         },
         "maxScrapeInterval": {
-          "description": "MaxScrapeInterval allows limiting maximum scrape interval for VMServiceScrape, VMPodScrape and other scrapes\nIf interval is higher than defined limit, `maxScrapeInterval` will be used.",
           "type": "string"
         },
         "minReadySeconds": {
-          "description": "MinReadySeconds defines a minimum number of seconds to wait before starting update next pod\nif previous in healthy state\nHas no effect for VLogs and VMSingle",
           "format": "int32",
           "type": "integer"
         },
         "minScrapeInterval": {
-          "description": "MinScrapeInterval allows limiting minimal scrape interval for VMServiceScrape, VMPodScrape and other scrapes\nIf interval is lower than defined limit, `minScrapeInterval` will be used.",
           "type": "string"
         },
         "nodeScrapeNamespaceSelector": {
-          "description": "NodeScrapeNamespaceSelector defines Namespaces to be selected for VMNodeScrape discovery.\nWorks in combination with Selector.\nNamespaceSelector nil - only objects at VMAgent namespace.\nSelector nil - only objects at NamespaceSelector namespaces.\nIf both nil - behaviour controlled by selectAllByDefault",
           "properties": {
             "matchExpressions": {
-              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
               "items": {
-                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
                 "properties": {
                   "key": {
-                    "description": "key is the label key that the selector applies to.",
                     "type": "string"
                   },
                   "operator": {
-                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
                     "type": "string"
                   },
                   "values": {
-                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
                     "items": {
                       "type": "string"
                     },
@@ -1423,7 +1785,6 @@
               "additionalProperties": {
                 "type": "string"
               },
-              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
               "type": "object"
             }
           },
@@ -1432,66 +1793,52 @@
           "additionalProperties": false
         },
         "nodeScrapeRelabelTemplate": {
-          "description": "NodeScrapeRelabelTemplate defines relabel config, that will be added to each VMNodeScrape.\nit's useful for adding specific labels to all targets",
           "items": {
-            "description": "RelabelConfig allows dynamic rewriting of the label set\nMore info: https://docs.victoriametrics.com/victoriametrics/#relabeling",
             "properties": {
               "action": {
-                "description": "Action to perform based on regex matching. Default is 'replace'",
                 "type": "string"
               },
               "if": {
-                "description": "If represents metricsQL match expression (or list of expressions): '{__name__=~\"foo_.*\"}'",
                 "x-kubernetes-preserve-unknown-fields": true
               },
               "labels": {
                 "additionalProperties": {
                   "type": "string"
                 },
-                "description": "Labels is used together with Match for `action: graphite`",
                 "type": "object"
               },
               "match": {
-                "description": "Match is used together with Labels for `action: graphite`",
                 "type": "string"
               },
               "modulus": {
-                "description": "Modulus to take of the hash of the source label values.",
                 "format": "int64",
                 "type": "integer"
               },
               "regex": {
-                "description": "Regular expression against which the extracted value is matched. Default is '(.*)'\nvictoriaMetrics supports multiline regex joined with |\nhttps://docs.victoriametrics.com/victoriametrics/vmagent/#relabeling-enhancements",
                 "x-kubernetes-preserve-unknown-fields": true
               },
               "replacement": {
-                "description": "Replacement value against which a regex replace is performed if the\nregular expression matches. Regex capture groups are available. Default is '$1'",
                 "type": "string"
               },
               "separator": {
-                "description": "Separator placed between concatenated source label values. default is ';'.",
                 "type": "string"
               },
               "source_labels": {
-                "description": "UnderScoreSourceLabels - additional form of source labels source_labels\nfor compatibility with original relabel config.\nif set  both sourceLabels and source_labels, sourceLabels has priority.\nfor details https://github.com/VictoriaMetrics/operator/issues/131",
                 "items": {
                   "type": "string"
                 },
                 "type": "array"
               },
               "sourceLabels": {
-                "description": "The source labels select values from existing labels. Their content is concatenated\nusing the configured separator and matched against the configured regular expression\nfor the replace, keep, and drop actions.",
                 "items": {
                   "type": "string"
                 },
                 "type": "array"
               },
               "target_label": {
-                "description": "UnderScoreTargetLabel - additional form of target label - target_label\nfor compatibility with original relabel config.\nif set  both targetLabel and target_label, targetLabel has priority.\nfor details https://github.com/VictoriaMetrics/operator/issues/131",
                 "type": "string"
               },
               "targetLabel": {
-                "description": "Label to which the resulting value is written in a replace action.\nIt is mandatory for replace actions. Regex capture groups are available.",
                 "type": "string"
               }
             },
@@ -1501,23 +1848,17 @@
           "type": "array"
         },
         "nodeScrapeSelector": {
-          "description": "NodeScrapeSelector defines VMNodeScrape to be selected for scraping.\nWorks in combination with NamespaceSelector.\nNamespaceSelector nil - only objects at VMAgent namespace.\nSelector nil - only objects at NamespaceSelector namespaces.\nIf both nil - behaviour controlled by selectAllByDefault",
           "properties": {
             "matchExpressions": {
-              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
               "items": {
-                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
                 "properties": {
                   "key": {
-                    "description": "key is the label key that the selector applies to.",
                     "type": "string"
                   },
                   "operator": {
-                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
                     "type": "string"
                   },
                   "values": {
-                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
                     "items": {
                       "type": "string"
                     },
@@ -1539,7 +1880,6 @@
               "additionalProperties": {
                 "type": "string"
               },
-              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
               "type": "object"
             }
           },
@@ -1551,30 +1891,23 @@
           "additionalProperties": {
             "type": "string"
           },
-          "description": "NodeSelector Define which Nodes the Pods are scheduled on.",
           "type": "object"
         },
         "overrideHonorLabels": {
-          "description": "OverrideHonorLabels if set to true overrides all user configured honor_labels.\nIf HonorLabels is set in scrape objects  to true, this overrides honor_labels to false.",
           "type": "boolean"
         },
         "overrideHonorTimestamps": {
-          "description": "OverrideHonorTimestamps allows to globally enforce honoring timestamps in all scrape configs.",
           "type": "boolean"
         },
         "paused": {
-          "description": "Paused If set to true all actions on the underlying managed objects are not\ngoing to be performed, except for delete actions.",
           "type": "boolean"
         },
         "persistentVolumeClaimRetentionPolicy": {
-          "description": "PersistentVolumeClaimRetentionPolicy allows configuration of PVC retention policy",
           "properties": {
             "whenDeleted": {
-              "description": "WhenDeleted specifies what happens to PVCs created from StatefulSet\nVolumeClaimTemplates when the StatefulSet is deleted. The default policy\nof `Retain` causes PVCs to not be affected by StatefulSet deletion. The\n`Delete` policy causes those PVCs to be deleted.",
               "type": "string"
             },
             "whenScaled": {
-              "description": "WhenScaled specifies what happens to PVCs created from StatefulSet\nVolumeClaimTemplates when the StatefulSet is scaled down. The default\npolicy of `Retain` causes PVCs to not be affected by a scaledown. The\n`Delete` policy causes the associated PVCs for any excess pods above\nthe replica count to be deleted.",
               "type": "string"
             }
           },
@@ -1582,7 +1915,6 @@
           "additionalProperties": false
         },
         "podDisruptionBudget": {
-          "description": "PodDisruptionBudget created by operator",
           "properties": {
             "maxUnavailable": {
               "anyOf": [
@@ -1593,7 +1925,6 @@
                   "type": "string"
                 }
               ],
-              "description": "An eviction is allowed if at most \"maxUnavailable\" pods selected by\n\"selector\" are unavailable after the eviction, i.e. even in absence of\nthe evicted pod. For example, one can prevent all voluntary evictions\nby specifying 0. This is a mutually exclusive setting with \"minAvailable\".",
               "x-kubernetes-int-or-string": true
             },
             "minAvailable": {
@@ -1605,18 +1936,15 @@
                   "type": "string"
                 }
               ],
-              "description": "An eviction is allowed if at least \"minAvailable\" pods selected by\n\"selector\" will still be available after the eviction, i.e. even in the\nabsence of the evicted pod.  So for example you can prevent all voluntary\nevictions by specifying \"100%\".",
               "x-kubernetes-int-or-string": true
             },
             "selectorLabels": {
               "additionalProperties": {
                 "type": "string"
               },
-              "description": "replaces default labels selector generated by operator\nit's useful when you need to create custom budget",
               "type": "object"
             },
             "unhealthyPodEvictionPolicy": {
-              "description": "UnhealthyPodEvictionPolicy defines the criteria for when unhealthy pods\n\nValid policies are IfHealthyBudget and AlwaysAllow.\nIf no policy is specified, the default behavior will be used,\nwhich corresponds to the IfHealthyBudget policy.\nAvailable from operator v0.64.0",
               "enum": [
                 "IfHealthyBudget",
                 "AlwaysAllow"
@@ -1628,24 +1956,20 @@
           "additionalProperties": false
         },
         "podMetadata": {
-          "description": "PodMetadata configures Labels and Annotations which are propagated to the vmagent pods.",
           "properties": {
             "annotations": {
               "additionalProperties": {
                 "type": "string"
               },
-              "description": "Annotations is an unstructured key value map stored with a resource that may be\nset by external tools to store and retrieve arbitrary metadata. They are not\nqueryable and should be preserved when modifying objects.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations",
               "type": "object"
             },
             "labels": {
               "additionalProperties": {
                 "type": "string"
               },
-              "description": "Labels Map of string keys and values that can be used to organize and categorize\n(scope and select) objects. May match selectors of replication controllers\nand services.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels",
               "type": "object"
             },
             "name": {
-              "description": "Name must be unique within a namespace. Is required when creating resources, although\nsome resources may allow a client to request the generation of an appropriate name\nautomatically. Name is primarily intended for creation idempotence and configuration\ndefinition.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names",
               "type": "string"
             }
           },
@@ -1653,23 +1977,17 @@
           "additionalProperties": false
         },
         "podScrapeNamespaceSelector": {
-          "description": "PodScrapeNamespaceSelector defines Namespaces to be selected for VMPodScrape discovery.\nWorks in combination with Selector.\nNamespaceSelector nil - only objects at VMAgent namespace.\nSelector nil - only objects at NamespaceSelector namespaces.\nIf both nil - behaviour controlled by selectAllByDefault",
           "properties": {
             "matchExpressions": {
-              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
               "items": {
-                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
                 "properties": {
                   "key": {
-                    "description": "key is the label key that the selector applies to.",
                     "type": "string"
                   },
                   "operator": {
-                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
                     "type": "string"
                   },
                   "values": {
-                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
                     "items": {
                       "type": "string"
                     },
@@ -1691,7 +2009,6 @@
               "additionalProperties": {
                 "type": "string"
               },
-              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
               "type": "object"
             }
           },
@@ -1700,66 +2017,52 @@
           "additionalProperties": false
         },
         "podScrapeRelabelTemplate": {
-          "description": "PodScrapeRelabelTemplate defines relabel config, that will be added to each VMPodScrape.\nit's useful for adding specific labels to all targets",
           "items": {
-            "description": "RelabelConfig allows dynamic rewriting of the label set\nMore info: https://docs.victoriametrics.com/victoriametrics/#relabeling",
             "properties": {
               "action": {
-                "description": "Action to perform based on regex matching. Default is 'replace'",
                 "type": "string"
               },
               "if": {
-                "description": "If represents metricsQL match expression (or list of expressions): '{__name__=~\"foo_.*\"}'",
                 "x-kubernetes-preserve-unknown-fields": true
               },
               "labels": {
                 "additionalProperties": {
                   "type": "string"
                 },
-                "description": "Labels is used together with Match for `action: graphite`",
                 "type": "object"
               },
               "match": {
-                "description": "Match is used together with Labels for `action: graphite`",
                 "type": "string"
               },
               "modulus": {
-                "description": "Modulus to take of the hash of the source label values.",
                 "format": "int64",
                 "type": "integer"
               },
               "regex": {
-                "description": "Regular expression against which the extracted value is matched. Default is '(.*)'\nvictoriaMetrics supports multiline regex joined with |\nhttps://docs.victoriametrics.com/victoriametrics/vmagent/#relabeling-enhancements",
                 "x-kubernetes-preserve-unknown-fields": true
               },
               "replacement": {
-                "description": "Replacement value against which a regex replace is performed if the\nregular expression matches. Regex capture groups are available. Default is '$1'",
                 "type": "string"
               },
               "separator": {
-                "description": "Separator placed between concatenated source label values. default is ';'.",
                 "type": "string"
               },
               "source_labels": {
-                "description": "UnderScoreSourceLabels - additional form of source labels source_labels\nfor compatibility with original relabel config.\nif set  both sourceLabels and source_labels, sourceLabels has priority.\nfor details https://github.com/VictoriaMetrics/operator/issues/131",
                 "items": {
                   "type": "string"
                 },
                 "type": "array"
               },
               "sourceLabels": {
-                "description": "The source labels select values from existing labels. Their content is concatenated\nusing the configured separator and matched against the configured regular expression\nfor the replace, keep, and drop actions.",
                 "items": {
                   "type": "string"
                 },
                 "type": "array"
               },
               "target_label": {
-                "description": "UnderScoreTargetLabel - additional form of target label - target_label\nfor compatibility with original relabel config.\nif set  both targetLabel and target_label, targetLabel has priority.\nfor details https://github.com/VictoriaMetrics/operator/issues/131",
                 "type": "string"
               },
               "targetLabel": {
-                "description": "Label to which the resulting value is written in a replace action.\nIt is mandatory for replace actions. Regex capture groups are available.",
                 "type": "string"
               }
             },
@@ -1769,23 +2072,17 @@
           "type": "array"
         },
         "podScrapeSelector": {
-          "description": "PodScrapeSelector defines PodScrapes to be selected for target discovery.\nWorks in combination with NamespaceSelector.\nNamespaceSelector nil - only objects at VMAgent namespace.\nSelector nil - only objects at NamespaceSelector namespaces.\nIf both nil - behaviour controlled by selectAllByDefault",
           "properties": {
             "matchExpressions": {
-              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
               "items": {
-                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
                 "properties": {
                   "key": {
-                    "description": "key is the label key that the selector applies to.",
                     "type": "string"
                   },
                   "operator": {
-                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
                     "type": "string"
                   },
                   "values": {
-                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
                     "items": {
                       "type": "string"
                     },
@@ -1807,7 +2104,6 @@
               "additionalProperties": {
                 "type": "string"
               },
-              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
               "type": "object"
             }
           },
@@ -1816,31 +2112,23 @@
           "additionalProperties": false
         },
         "port": {
-          "description": "Port listen address",
           "type": "string"
         },
         "priorityClassName": {
-          "description": "PriorityClassName class assigned to the Pods",
           "type": "string"
         },
         "probeNamespaceSelector": {
-          "description": "ProbeNamespaceSelector defines Namespaces to be selected for VMProbe discovery.\nWorks in combination with Selector.\nNamespaceSelector nil - only objects at VMAgent namespace.\nSelector nil - only objects at NamespaceSelector namespaces.\nIf both nil - behaviour controlled by selectAllByDefault",
           "properties": {
             "matchExpressions": {
-              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
               "items": {
-                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
                 "properties": {
                   "key": {
-                    "description": "key is the label key that the selector applies to.",
                     "type": "string"
                   },
                   "operator": {
-                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
                     "type": "string"
                   },
                   "values": {
-                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
                     "items": {
                       "type": "string"
                     },
@@ -1862,7 +2150,6 @@
               "additionalProperties": {
                 "type": "string"
               },
-              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
               "type": "object"
             }
           },
@@ -1871,66 +2158,52 @@
           "additionalProperties": false
         },
         "probeScrapeRelabelTemplate": {
-          "description": "ProbeScrapeRelabelTemplate defines relabel config, that will be added to each VMProbeScrape.\nit's useful for adding specific labels to all targets",
           "items": {
-            "description": "RelabelConfig allows dynamic rewriting of the label set\nMore info: https://docs.victoriametrics.com/victoriametrics/#relabeling",
             "properties": {
               "action": {
-                "description": "Action to perform based on regex matching. Default is 'replace'",
                 "type": "string"
               },
               "if": {
-                "description": "If represents metricsQL match expression (or list of expressions): '{__name__=~\"foo_.*\"}'",
                 "x-kubernetes-preserve-unknown-fields": true
               },
               "labels": {
                 "additionalProperties": {
                   "type": "string"
                 },
-                "description": "Labels is used together with Match for `action: graphite`",
                 "type": "object"
               },
               "match": {
-                "description": "Match is used together with Labels for `action: graphite`",
                 "type": "string"
               },
               "modulus": {
-                "description": "Modulus to take of the hash of the source label values.",
                 "format": "int64",
                 "type": "integer"
               },
               "regex": {
-                "description": "Regular expression against which the extracted value is matched. Default is '(.*)'\nvictoriaMetrics supports multiline regex joined with |\nhttps://docs.victoriametrics.com/victoriametrics/vmagent/#relabeling-enhancements",
                 "x-kubernetes-preserve-unknown-fields": true
               },
               "replacement": {
-                "description": "Replacement value against which a regex replace is performed if the\nregular expression matches. Regex capture groups are available. Default is '$1'",
                 "type": "string"
               },
               "separator": {
-                "description": "Separator placed between concatenated source label values. default is ';'.",
                 "type": "string"
               },
               "source_labels": {
-                "description": "UnderScoreSourceLabels - additional form of source labels source_labels\nfor compatibility with original relabel config.\nif set  both sourceLabels and source_labels, sourceLabels has priority.\nfor details https://github.com/VictoriaMetrics/operator/issues/131",
                 "items": {
                   "type": "string"
                 },
                 "type": "array"
               },
               "sourceLabels": {
-                "description": "The source labels select values from existing labels. Their content is concatenated\nusing the configured separator and matched against the configured regular expression\nfor the replace, keep, and drop actions.",
                 "items": {
                   "type": "string"
                 },
                 "type": "array"
               },
               "target_label": {
-                "description": "UnderScoreTargetLabel - additional form of target label - target_label\nfor compatibility with original relabel config.\nif set  both targetLabel and target_label, targetLabel has priority.\nfor details https://github.com/VictoriaMetrics/operator/issues/131",
                 "type": "string"
               },
               "targetLabel": {
-                "description": "Label to which the resulting value is written in a replace action.\nIt is mandatory for replace actions. Regex capture groups are available.",
                 "type": "string"
               }
             },
@@ -1940,23 +2213,17 @@
           "type": "array"
         },
         "probeSelector": {
-          "description": "ProbeSelector defines VMProbe to be selected for target probing.\nWorks in combination with NamespaceSelector.\nNamespaceSelector nil - only objects at VMAgent namespace.\nSelector nil - only objects at NamespaceSelector namespaces.\nIf both nil - behaviour controlled by selectAllByDefault",
           "properties": {
             "matchExpressions": {
-              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
               "items": {
-                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
                 "properties": {
                   "key": {
-                    "description": "key is the label key that the selector applies to.",
                     "type": "string"
                   },
                   "operator": {
-                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
                     "type": "string"
                   },
                   "values": {
-                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
                     "items": {
                       "type": "string"
                     },
@@ -1978,7 +2245,6 @@
               "additionalProperties": {
                 "type": "string"
               },
-              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
               "type": "object"
             }
           },
@@ -1987,12 +2253,9 @@
           "additionalProperties": false
         },
         "readinessGates": {
-          "description": "ReadinessGates defines pod readiness gates",
           "items": {
-            "description": "PodReadinessGate contains the reference to a pod condition",
             "properties": {
               "conditionType": {
-                "description": "ConditionType refers to a condition in the pod's condition list with matching type.",
                 "type": "string"
               }
             },
@@ -2005,24 +2268,19 @@
           "type": "array"
         },
         "readinessProbe": {
-          "description": "ReadinessProbe that will be added CRD pod",
           "type": "object",
           "x-kubernetes-preserve-unknown-fields": true
         },
         "relabelConfig": {
-          "description": "RelabelConfig ConfigMap with global relabel config -remoteWrite.relabelConfig\nThis relabeling is applied to all the collected metrics before sending them to remote storage.",
           "properties": {
             "key": {
-              "description": "The key to select.",
               "type": "string"
             },
             "name": {
               "default": "",
-              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
               "type": "string"
             },
             "optional": {
-              "description": "Specify whether the ConfigMap or its key must be defined",
               "type": "boolean"
             }
           },
@@ -2034,35 +2292,26 @@
           "additionalProperties": false
         },
         "remoteWrite": {
-          "description": "RemoteWrite list of victoria metrics /some other remote write system\nfor vm it must looks like: http://victoria-metrics-single:8428/api/v1/write\nor for cluster different url\nhttps://docs.victoriametrics.com/victoriametrics/vmagent/#splitting-data-streams-among-multiple-systems",
           "items": {
-            "description": "VMAgentRemoteWriteSpec defines the remote storage configuration for VmAgent",
             "properties": {
               "aws": {
-                "description": "AWS describes params specific to AWS cloud",
                 "properties": {
                   "ec2Endpoint": {
-                    "description": "EC2Endpoint is an optional AWS EC2 API endpoint to use for the corresponding -remoteWrite.url if -remoteWrite.aws.useSigv4 is set",
                     "type": "string"
                   },
                   "region": {
-                    "description": "Region is an optional AWS region to use for the corresponding -remoteWrite.url if -remoteWrite.aws.useSigv4 is set",
                     "type": "string"
                   },
                   "roleARN": {
-                    "description": "RoleARN is an optional AWS region to use for the corresponding -remoteWrite.url if -remoteWrite.aws.useSigv4 is set",
                     "type": "string"
                   },
                   "service": {
-                    "description": "Service is an optional AWS Service to use for the corresponding -remoteWrite.url if -remoteWrite.aws.useSigv4 is set",
                     "type": "string"
                   },
                   "stsEndpoint": {
-                    "description": "STSEndpoint is an optional AWS STS API endpoint to use for the corresponding -remoteWrite.url if -remoteWrite.aws.useSigv4 is set",
                     "type": "string"
                   },
                   "useSigv4": {
-                    "description": "UseSigv4 enables SigV4 request signing for the corresponding -remoteWrite.url",
                     "type": "boolean"
                   }
                 },
@@ -2070,22 +2319,17 @@
                 "additionalProperties": false
               },
               "basicAuth": {
-                "description": "BasicAuth allow an endpoint to authenticate over basic authentication",
                 "properties": {
                   "password": {
-                    "description": "Password defines reference for secret with password value\nThe secret needs to be in the same namespace as scrape object",
                     "properties": {
                       "key": {
-                        "description": "The key of the secret to select from.  Must be a valid secret key.",
                         "type": "string"
                       },
                       "name": {
                         "default": "",
-                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                         "type": "string"
                       },
                       "optional": {
-                        "description": "Specify whether the Secret or its key must be defined",
                         "type": "boolean"
                       }
                     },
@@ -2097,23 +2341,18 @@
                     "additionalProperties": false
                   },
                   "password_file": {
-                    "description": "PasswordFile defines path to password file at disk\nmust be pre-mounted",
                     "type": "string"
                   },
                   "username": {
-                    "description": "Username defines reference for secret with username value\nThe secret needs to be in the same namespace as scrape object",
                     "properties": {
                       "key": {
-                        "description": "The key of the secret to select from.  Must be a valid secret key.",
                         "type": "string"
                       },
                       "name": {
                         "default": "",
-                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                         "type": "string"
                       },
                       "optional": {
-                        "description": "Specify whether the Secret or its key must be defined",
                         "type": "boolean"
                       }
                     },
@@ -2129,19 +2368,15 @@
                 "additionalProperties": false
               },
               "bearerTokenSecret": {
-                "description": "Optional bearer auth token to use for -remoteWrite.url",
                 "properties": {
                   "key": {
-                    "description": "The key of the secret to select from.  Must be a valid secret key.",
                     "type": "string"
                   },
                   "name": {
                     "default": "",
-                    "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                     "type": "string"
                   },
                   "optional": {
-                    "description": "Specify whether the Secret or its key must be defined",
                     "type": "boolean"
                   }
                 },
@@ -2153,77 +2388,61 @@
                 "additionalProperties": false
               },
               "forceVMProto": {
-                "description": "ForceVMProto forces using VictoriaMetrics protocol for sending data to -remoteWrite.url",
                 "type": "boolean"
               },
               "headers": {
-                "description": "Headers allow configuring custom http headers\nMust be in form of semicolon separated header with value\ne.g.\nheaderName: headerValue\nvmagent supports since 1.79.0 version",
                 "items": {
                   "type": "string"
                 },
                 "type": "array"
               },
               "inlineUrlRelabelConfig": {
-                "description": "InlineUrlRelabelConfig defines relabeling config for remoteWriteURL, it can be defined at crd spec.",
                 "items": {
-                  "description": "RelabelConfig allows dynamic rewriting of the label set\nMore info: https://docs.victoriametrics.com/victoriametrics/#relabeling",
                   "properties": {
                     "action": {
-                      "description": "Action to perform based on regex matching. Default is 'replace'",
                       "type": "string"
                     },
                     "if": {
-                      "description": "If represents metricsQL match expression (or list of expressions): '{__name__=~\"foo_.*\"}'",
                       "x-kubernetes-preserve-unknown-fields": true
                     },
                     "labels": {
                       "additionalProperties": {
                         "type": "string"
                       },
-                      "description": "Labels is used together with Match for `action: graphite`",
                       "type": "object"
                     },
                     "match": {
-                      "description": "Match is used together with Labels for `action: graphite`",
                       "type": "string"
                     },
                     "modulus": {
-                      "description": "Modulus to take of the hash of the source label values.",
                       "format": "int64",
                       "type": "integer"
                     },
                     "regex": {
-                      "description": "Regular expression against which the extracted value is matched. Default is '(.*)'\nvictoriaMetrics supports multiline regex joined with |\nhttps://docs.victoriametrics.com/victoriametrics/vmagent/#relabeling-enhancements",
                       "x-kubernetes-preserve-unknown-fields": true
                     },
                     "replacement": {
-                      "description": "Replacement value against which a regex replace is performed if the\nregular expression matches. Regex capture groups are available. Default is '$1'",
                       "type": "string"
                     },
                     "separator": {
-                      "description": "Separator placed between concatenated source label values. default is ';'.",
                       "type": "string"
                     },
                     "source_labels": {
-                      "description": "UnderScoreSourceLabels - additional form of source labels source_labels\nfor compatibility with original relabel config.\nif set  both sourceLabels and source_labels, sourceLabels has priority.\nfor details https://github.com/VictoriaMetrics/operator/issues/131",
                       "items": {
                         "type": "string"
                       },
                       "type": "array"
                     },
                     "sourceLabels": {
-                      "description": "The source labels select values from existing labels. Their content is concatenated\nusing the configured separator and matched against the configured regular expression\nfor the replace, keep, and drop actions.",
                       "items": {
                         "type": "string"
                       },
                       "type": "array"
                     },
                     "target_label": {
-                      "description": "UnderScoreTargetLabel - additional form of target label - target_label\nfor compatibility with original relabel config.\nif set  both targetLabel and target_label, targetLabel has priority.\nfor details https://github.com/VictoriaMetrics/operator/issues/131",
                       "type": "string"
                     },
                     "targetLabel": {
-                      "description": "Label to which the resulting value is written in a replace action.\nIt is mandatory for replace actions. Regex capture groups are available.",
                       "type": "string"
                     }
                   },
@@ -2233,29 +2452,22 @@
                 "type": "array"
               },
               "maxDiskUsage": {
-                "description": "MaxDiskUsage defines the maximum file-based buffer size in bytes for the given remoteWrite\nIt overrides global configuration defined at remoteWriteSettings.maxDiskUsagePerURL",
                 "x-kubernetes-preserve-unknown-fields": true
               },
               "oauth2": {
-                "description": "OAuth2 defines auth configuration",
                 "properties": {
                   "client_id": {
-                    "description": "The secret or configmap containing the OAuth2 client id",
                     "properties": {
                       "configMap": {
-                        "description": "ConfigMap containing data to use for the targets.",
                         "properties": {
                           "key": {
-                            "description": "The key to select.",
                             "type": "string"
                           },
                           "name": {
                             "default": "",
-                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                             "type": "string"
                           },
                           "optional": {
-                            "description": "Specify whether the ConfigMap or its key must be defined",
                             "type": "boolean"
                           }
                         },
@@ -2267,19 +2479,15 @@
                         "additionalProperties": false
                       },
                       "secret": {
-                        "description": "Secret containing data to use for the targets.",
                         "properties": {
                           "key": {
-                            "description": "The key of the secret to select from.  Must be a valid secret key.",
                             "type": "string"
                           },
                           "name": {
                             "default": "",
-                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                             "type": "string"
                           },
                           "optional": {
-                            "description": "Specify whether the Secret or its key must be defined",
                             "type": "boolean"
                           }
                         },
@@ -2295,19 +2503,15 @@
                     "additionalProperties": false
                   },
                   "client_secret": {
-                    "description": "The secret containing the OAuth2 client secret",
                     "properties": {
                       "key": {
-                        "description": "The key of the secret to select from.  Must be a valid secret key.",
                         "type": "string"
                       },
                       "name": {
                         "default": "",
-                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                         "type": "string"
                       },
                       "optional": {
-                        "description": "Specify whether the Secret or its key must be defined",
                         "type": "boolean"
                       }
                     },
@@ -2319,33 +2523,27 @@
                     "additionalProperties": false
                   },
                   "client_secret_file": {
-                    "description": "ClientSecretFile defines path for client secret file.",
                     "type": "string"
                   },
                   "endpoint_params": {
                     "additionalProperties": {
                       "type": "string"
                     },
-                    "description": "Parameters to append to the token URL",
                     "type": "object"
                   },
                   "proxy_url": {
-                    "description": "The proxy URL for token_url connection\n( available from v0.55.0).\nIs only supported by Scrape objects family",
                     "type": "string"
                   },
                   "scopes": {
-                    "description": "OAuth2 scopes used for the token request",
                     "items": {
                       "type": "string"
                     },
                     "type": "array"
                   },
                   "tls_config": {
-                    "description": "TLSConfig for token_url connection\n( available from v0.55.0).\nIs only supported by Scrape objects family",
                     "x-kubernetes-preserve-unknown-fields": true
                   },
                   "token_url": {
-                    "description": "The URL to fetch the token from",
                     "minLength": 1,
                     "type": "string"
                   }
@@ -2358,31 +2556,28 @@
                 "additionalProperties": false
               },
               "proxyURL": {
-                "description": "ProxyURL for -remoteWrite.url. Supported proxies: http, https, socks5. Example: socks5://proxy:1234",
                 "type": "string"
               },
+              "queues": {
+                "format": "int32",
+                "type": "integer"
+              },
               "sendTimeout": {
-                "description": "Timeout for sending a single block of data to -remoteWrite.url (default 1m0s)",
                 "pattern": "[0-9]+(ms|s|m|h)",
                 "type": "string"
               },
               "streamAggrConfig": {
-                "description": "StreamAggrConfig defines stream aggregation configuration for VMAgent for -remoteWrite.url",
                 "properties": {
                   "configmap": {
-                    "description": "ConfigMap with stream aggregation rules",
                     "properties": {
                       "key": {
-                        "description": "The key to select.",
                         "type": "string"
                       },
                       "name": {
                         "default": "",
-                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                         "type": "string"
                       },
                       "optional": {
-                        "description": "Specify whether the ConfigMap or its key must be defined",
                         "type": "boolean"
                       }
                     },
@@ -2394,143 +2589,112 @@
                     "additionalProperties": false
                   },
                   "dedupInterval": {
-                    "description": "Allows setting different de-duplication intervals per each configured remote storage",
                     "type": "string"
                   },
                   "dropInput": {
-                    "description": "Allow drop all the input samples after the aggregation",
                     "type": "boolean"
                   },
                   "dropInputLabels": {
-                    "description": "labels to drop from samples for aggregator before stream de-duplication and aggregation",
                     "items": {
                       "type": "string"
                     },
                     "type": "array"
                   },
                   "enableWindows": {
-                    "description": "EnableWindows enables aggregating data in separate windows ( available from v0.54.0).",
                     "type": "boolean"
                   },
                   "ignoreFirstIntervals": {
-                    "description": "IgnoreFirstIntervals instructs to ignore first interval",
                     "type": "integer"
                   },
                   "ignoreFirstSampleInterval": {
-                    "description": "IgnoreFirstSampleInterval sets interval for total and prometheus_total during which first samples will be ignored",
                     "type": "string"
                   },
                   "ignoreOldSamples": {
-                    "description": "IgnoreOldSamples instructs to ignore samples with old timestamps outside the current aggregation interval.",
                     "type": "boolean"
                   },
                   "keepInput": {
-                    "description": "Allows writing both raw and aggregate data",
                     "type": "boolean"
                   },
                   "rules": {
-                    "description": "Stream aggregation rules",
                     "items": {
-                      "description": "StreamAggrRule defines the rule in stream aggregation config",
                       "properties": {
                         "by": {
-                          "description": "By is an optional list of labels for grouping input series.\n\nSee also Without.\n\nIf neither By nor Without are set, then the Outputs are calculated\nindividually per each input time series.",
                           "items": {
                             "type": "string"
                           },
                           "type": "array"
                         },
                         "dedup_interval": {
-                          "description": "DedupInterval is an optional interval for deduplication.",
                           "type": "string"
                         },
                         "drop_input_labels": {
-                          "description": "DropInputLabels is an optional list with labels, which must be dropped before further processing of input samples.\n\nLabels are dropped before de-duplication and aggregation.",
                           "items": {
                             "type": "string"
                           },
                           "type": "array"
                         },
                         "enable_windows": {
-                          "description": "EnableWindows enables aggregating data in separate windows",
                           "type": "boolean"
                         },
                         "flush_on_shutdown": {
-                          "description": "FlushOnShutdown defines whether to flush the aggregation state on process termination\nor config reload. Is `false` by default.\nIt is not recommended changing this setting, unless unfinished aggregations states\nare preferred to missing data points.",
                           "type": "boolean"
                         },
                         "ignore_first_intervals": {
                           "type": "integer"
                         },
                         "ignore_old_samples": {
-                          "description": "IgnoreOldSamples instructs to ignore samples with old timestamps outside the current aggregation interval.",
                           "type": "boolean"
                         },
                         "ignoreFirstSampleInterval": {
-                          "description": "IgnoreFirstSampleInterval sets interval for total and prometheus_total during which first samples will be ignored",
                           "type": "string"
                         },
                         "input_relabel_configs": {
-                          "description": "InputRelabelConfigs is an optional relabeling rules, which are applied on the input\nbefore aggregation.",
                           "items": {
-                            "description": "RelabelConfig allows dynamic rewriting of the label set\nMore info: https://docs.victoriametrics.com/victoriametrics/#relabeling",
                             "properties": {
                               "action": {
-                                "description": "Action to perform based on regex matching. Default is 'replace'",
                                 "type": "string"
                               },
                               "if": {
-                                "description": "If represents metricsQL match expression (or list of expressions): '{__name__=~\"foo_.*\"}'",
                                 "x-kubernetes-preserve-unknown-fields": true
                               },
                               "labels": {
                                 "additionalProperties": {
                                   "type": "string"
                                 },
-                                "description": "Labels is used together with Match for `action: graphite`",
                                 "type": "object"
                               },
                               "match": {
-                                "description": "Match is used together with Labels for `action: graphite`",
                                 "type": "string"
                               },
                               "modulus": {
-                                "description": "Modulus to take of the hash of the source label values.",
                                 "format": "int64",
                                 "type": "integer"
                               },
                               "regex": {
-                                "description": "Regular expression against which the extracted value is matched. Default is '(.*)'\nvictoriaMetrics supports multiline regex joined with |\nhttps://docs.victoriametrics.com/victoriametrics/vmagent/#relabeling-enhancements",
                                 "x-kubernetes-preserve-unknown-fields": true
                               },
                               "replacement": {
-                                "description": "Replacement value against which a regex replace is performed if the\nregular expression matches. Regex capture groups are available. Default is '$1'",
                                 "type": "string"
                               },
                               "separator": {
-                                "description": "Separator placed between concatenated source label values. default is ';'.",
                                 "type": "string"
                               },
                               "source_labels": {
-                                "description": "UnderScoreSourceLabels - additional form of source labels source_labels\nfor compatibility with original relabel config.\nif set  both sourceLabels and source_labels, sourceLabels has priority.\nfor details https://github.com/VictoriaMetrics/operator/issues/131",
                                 "items": {
                                   "type": "string"
                                 },
                                 "type": "array"
                               },
                               "sourceLabels": {
-                                "description": "The source labels select values from existing labels. Their content is concatenated\nusing the configured separator and matched against the configured regular expression\nfor the replace, keep, and drop actions.",
                                 "items": {
                                   "type": "string"
                                 },
                                 "type": "array"
                               },
                               "target_label": {
-                                "description": "UnderScoreTargetLabel - additional form of target label - target_label\nfor compatibility with original relabel config.\nif set  both targetLabel and target_label, targetLabel has priority.\nfor details https://github.com/VictoriaMetrics/operator/issues/131",
                                 "type": "string"
                               },
                               "targetLabel": {
-                                "description": "Label to which the resulting value is written in a replace action.\nIt is mandatory for replace actions. Regex capture groups are available.",
                                 "type": "string"
                               }
                             },
@@ -2540,82 +2704,64 @@
                           "type": "array"
                         },
                         "interval": {
-                          "description": "Interval is the interval between aggregations.",
                           "type": "string"
                         },
                         "keep_metric_names": {
-                          "description": "KeepMetricNames instructs to leave metric names as is for the output time series without adding any suffix.",
                           "type": "boolean"
                         },
                         "match": {
-                          "description": "Match is a label selector (or list of label selectors) for filtering time series for the given selector.\n\nIf the match isn't set, then all the input time series are processed.",
                           "x-kubernetes-preserve-unknown-fields": true
                         },
                         "no_align_flush_to_interval": {
-                          "description": "NoAlignFlushToInterval disables aligning of flushes to multiples of Interval.\nBy default flushes are aligned to Interval.",
                           "type": "boolean"
                         },
                         "output_relabel_configs": {
-                          "description": "OutputRelabelConfigs is an optional relabeling rules, which are applied\non the aggregated output before being sent to remote storage.",
                           "items": {
-                            "description": "RelabelConfig allows dynamic rewriting of the label set\nMore info: https://docs.victoriametrics.com/victoriametrics/#relabeling",
                             "properties": {
                               "action": {
-                                "description": "Action to perform based on regex matching. Default is 'replace'",
                                 "type": "string"
                               },
                               "if": {
-                                "description": "If represents metricsQL match expression (or list of expressions): '{__name__=~\"foo_.*\"}'",
                                 "x-kubernetes-preserve-unknown-fields": true
                               },
                               "labels": {
                                 "additionalProperties": {
                                   "type": "string"
                                 },
-                                "description": "Labels is used together with Match for `action: graphite`",
                                 "type": "object"
                               },
                               "match": {
-                                "description": "Match is used together with Labels for `action: graphite`",
                                 "type": "string"
                               },
                               "modulus": {
-                                "description": "Modulus to take of the hash of the source label values.",
                                 "format": "int64",
                                 "type": "integer"
                               },
                               "regex": {
-                                "description": "Regular expression against which the extracted value is matched. Default is '(.*)'\nvictoriaMetrics supports multiline regex joined with |\nhttps://docs.victoriametrics.com/victoriametrics/vmagent/#relabeling-enhancements",
                                 "x-kubernetes-preserve-unknown-fields": true
                               },
                               "replacement": {
-                                "description": "Replacement value against which a regex replace is performed if the\nregular expression matches. Regex capture groups are available. Default is '$1'",
                                 "type": "string"
                               },
                               "separator": {
-                                "description": "Separator placed between concatenated source label values. default is ';'.",
                                 "type": "string"
                               },
                               "source_labels": {
-                                "description": "UnderScoreSourceLabels - additional form of source labels source_labels\nfor compatibility with original relabel config.\nif set  both sourceLabels and source_labels, sourceLabels has priority.\nfor details https://github.com/VictoriaMetrics/operator/issues/131",
                                 "items": {
                                   "type": "string"
                                 },
                                 "type": "array"
                               },
                               "sourceLabels": {
-                                "description": "The source labels select values from existing labels. Their content is concatenated\nusing the configured separator and matched against the configured regular expression\nfor the replace, keep, and drop actions.",
                                 "items": {
                                   "type": "string"
                                 },
                                 "type": "array"
                               },
                               "target_label": {
-                                "description": "UnderScoreTargetLabel - additional form of target label - target_label\nfor compatibility with original relabel config.\nif set  both targetLabel and target_label, targetLabel has priority.\nfor details https://github.com/VictoriaMetrics/operator/issues/131",
                                 "type": "string"
                               },
                               "targetLabel": {
-                                "description": "Label to which the resulting value is written in a replace action.\nIt is mandatory for replace actions. Regex capture groups are available.",
                                 "type": "string"
                               }
                             },
@@ -2625,18 +2771,15 @@
                           "type": "array"
                         },
                         "outputs": {
-                          "description": "Outputs is a list of output aggregate functions to produce.\n\nThe following names are allowed:\n\n- total - aggregates input counters\n- increase - counts the increase over input counters\n- count_series - counts the input series\n- count_samples - counts the input samples\n- sum_samples - sums the input samples\n- last - the last biggest sample value\n- min - the minimum sample value\n- max - the maximum sample value\n- avg - the average value across all the samples\n- stddev - standard deviation across all the samples\n- stdvar - standard variance across all the samples\n- histogram_bucket - creates VictoriaMetrics histogram for input samples\n- quantiles(phi1, ..., phiN) - quantiles' estimation for phi in the range [0..1]\n\nThe output time series will have the following names:\n\n  input_name:aggr_<interval>_<output>",
                           "items": {
                             "type": "string"
                           },
                           "type": "array"
                         },
                         "staleness_interval": {
-                          "description": "Staleness interval is interval after which the series state will be reset if no samples have been sent during it.\nThe parameter is only relevant for outputs: total, total_prometheus, increase, increase_prometheus and histogram_bucket.",
                           "type": "string"
                         },
                         "without": {
-                          "description": "Without is an optional list of labels, which must be excluded when grouping input series.\n\nSee also By.\n\nIf neither By nor Without are set, then the Outputs are calculated\nindividually per each input time series.",
                           "items": {
                             "type": "string"
                           },
@@ -2657,25 +2800,19 @@
                 "additionalProperties": false
               },
               "tlsConfig": {
-                "description": "TLSConfig describes tls configuration for remote write target",
                 "properties": {
                   "ca": {
-                    "description": "Struct containing the CA cert to use for the targets.",
                     "properties": {
                       "configMap": {
-                        "description": "ConfigMap containing data to use for the targets.",
                         "properties": {
                           "key": {
-                            "description": "The key to select.",
                             "type": "string"
                           },
                           "name": {
                             "default": "",
-                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                             "type": "string"
                           },
                           "optional": {
-                            "description": "Specify whether the ConfigMap or its key must be defined",
                             "type": "boolean"
                           }
                         },
@@ -2687,19 +2824,15 @@
                         "additionalProperties": false
                       },
                       "secret": {
-                        "description": "Secret containing data to use for the targets.",
                         "properties": {
                           "key": {
-                            "description": "The key of the secret to select from.  Must be a valid secret key.",
                             "type": "string"
                           },
                           "name": {
                             "default": "",
-                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                             "type": "string"
                           },
                           "optional": {
-                            "description": "Specify whether the Secret or its key must be defined",
                             "type": "boolean"
                           }
                         },
@@ -2715,26 +2848,20 @@
                     "additionalProperties": false
                   },
                   "caFile": {
-                    "description": "Path to the CA cert in the container to use for the targets.",
                     "type": "string"
                   },
                   "cert": {
-                    "description": "Struct containing the client cert file for the targets.",
                     "properties": {
                       "configMap": {
-                        "description": "ConfigMap containing data to use for the targets.",
                         "properties": {
                           "key": {
-                            "description": "The key to select.",
                             "type": "string"
                           },
                           "name": {
                             "default": "",
-                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                             "type": "string"
                           },
                           "optional": {
-                            "description": "Specify whether the ConfigMap or its key must be defined",
                             "type": "boolean"
                           }
                         },
@@ -2746,19 +2873,15 @@
                         "additionalProperties": false
                       },
                       "secret": {
-                        "description": "Secret containing data to use for the targets.",
                         "properties": {
                           "key": {
-                            "description": "The key of the secret to select from.  Must be a valid secret key.",
                             "type": "string"
                           },
                           "name": {
                             "default": "",
-                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                             "type": "string"
                           },
                           "optional": {
-                            "description": "Specify whether the Secret or its key must be defined",
                             "type": "boolean"
                           }
                         },
@@ -2774,31 +2897,24 @@
                     "additionalProperties": false
                   },
                   "certFile": {
-                    "description": "Path to the client cert file in the container for the targets.",
                     "type": "string"
                   },
                   "insecureSkipVerify": {
-                    "description": "Disable target certificate validation.",
                     "type": "boolean"
                   },
                   "keyFile": {
-                    "description": "Path to the client key file in the container for the targets.",
                     "type": "string"
                   },
                   "keySecret": {
-                    "description": "Secret containing the client key file for the targets.",
                     "properties": {
                       "key": {
-                        "description": "The key of the secret to select from.  Must be a valid secret key.",
                         "type": "string"
                       },
                       "name": {
                         "default": "",
-                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                         "type": "string"
                       },
                       "optional": {
-                        "description": "Specify whether the Secret or its key must be defined",
                         "type": "boolean"
                       }
                     },
@@ -2810,7 +2926,6 @@
                     "additionalProperties": false
                   },
                   "serverName": {
-                    "description": "Used to verify the hostname for the targets.",
                     "type": "string"
                   }
                 },
@@ -2818,23 +2933,18 @@
                 "additionalProperties": false
               },
               "url": {
-                "description": "URL of the endpoint to send samples to.",
                 "type": "string"
               },
               "urlRelabelConfig": {
-                "description": "ConfigMap with relabeling config which is applied to metrics before sending them to the corresponding -remoteWrite.url",
                 "properties": {
                   "key": {
-                    "description": "The key to select.",
                     "type": "string"
                   },
                   "name": {
                     "default": "",
-                    "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                     "type": "string"
                   },
                   "optional": {
-                    "description": "Specify whether the ConfigMap or its key must be defined",
                     "type": "boolean"
                   }
                 },
@@ -2855,10 +2965,8 @@
           "type": "array"
         },
         "remoteWriteSettings": {
-          "description": "RemoteWriteSettings defines global settings for all remoteWrite urls.",
           "properties": {
             "flushInterval": {
-              "description": "Interval for flushing the data to remote storage. (default 1s)",
               "pattern": "[0-9]+(ms|s|m|h)",
               "type": "string"
             },
@@ -2866,33 +2974,26 @@
               "additionalProperties": {
                 "type": "string"
               },
-              "description": "Labels in the form 'name=value' to add to all the metrics before sending them. This overrides the label if it already exists.",
               "type": "object"
             },
             "maxBlockSize": {
-              "description": "The maximum size in bytes of unpacked request to send to remote storage",
               "format": "int32",
               "type": "integer"
             },
             "maxDiskUsagePerURL": {
-              "description": "The maximum file-based buffer size in bytes at -remoteWrite.tmpDataPath",
               "x-kubernetes-preserve-unknown-fields": true
             },
             "queues": {
-              "description": "The number of concurrent queues",
               "format": "int32",
               "type": "integer"
             },
             "showURL": {
-              "description": "Whether to show -remoteWrite.url in the exported metrics. It is hidden by default, since it can contain sensitive auth info",
               "type": "boolean"
             },
             "tmpDataPath": {
-              "description": "Path to directory where temporary data for remote write component is stored (default vmagent-remotewrite-data)",
               "type": "string"
             },
             "useMultiTenantMode": {
-              "description": "Configures vmagent accepting data via the same multitenant endpoints as vminsert at VictoriaMetrics cluster does,\nsee [here](https://docs.victoriametrics.com/victoriametrics/vmagent/#multitenancy).\nit's global setting and affects all remote storage configurations",
               "type": "boolean"
             }
           },
@@ -2900,24 +3001,18 @@
           "additionalProperties": false
         },
         "replicaCount": {
-          "description": "ReplicaCount is the expected size of the Application.",
           "format": "int32",
           "type": "integer"
         },
         "resources": {
-          "description": "Resources container resource request and limits, https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/\nif not defined default resources from operator config will be used",
           "properties": {
             "claims": {
-              "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis field depends on the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
               "items": {
-                "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
                 "properties": {
                   "name": {
-                    "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
                     "type": "string"
                   },
                   "request": {
-                    "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
                     "type": "string"
                   }
                 },
@@ -2946,7 +3041,6 @@
                 "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                 "x-kubernetes-int-or-string": true
               },
-              "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
               "type": "object"
             },
             "requests": {
@@ -2962,7 +3056,6 @@
                 "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                 "x-kubernetes-int-or-string": true
               },
-              "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
               "type": "object"
             }
           },
@@ -2970,12 +3063,10 @@
           "additionalProperties": false
         },
         "revisionHistoryLimitCount": {
-          "description": "The number of old ReplicaSets to retain to allow rollback in deployment or\nmaximum number of revisions that will be maintained in the Deployment revision history.\nHas no effect at StatefulSets\nDefaults to 10.",
           "format": "int32",
           "type": "integer"
         },
         "rollingUpdate": {
-          "description": "RollingUpdate - overrides deployment update params.",
           "properties": {
             "maxSurge": {
               "anyOf": [
@@ -2986,7 +3077,6 @@
                   "type": "string"
                 }
               ],
-              "description": "The maximum number of pods that can be scheduled above the desired number of\npods.\nValue can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).\nThis can not be 0 if MaxUnavailable is 0.\nAbsolute number is calculated from percentage by rounding up.\nDefaults to 25%.\nExample: when this is set to 30%, the new ReplicaSet can be scaled up immediately when\nthe rolling update starts, such that the total number of old and new pods do not exceed\n130% of desired pods. Once old pods have been killed,\nnew ReplicaSet can be scaled up further, ensuring that total number of pods running\nat any time during the update is at most 130% of desired pods.",
               "x-kubernetes-int-or-string": true
             },
             "maxUnavailable": {
@@ -2998,7 +3088,6 @@
                   "type": "string"
                 }
               ],
-              "description": "The maximum number of pods that can be unavailable during the update.\nValue can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).\nAbsolute number is calculated from percentage by rounding down.\nThis can not be 0 if MaxSurge is 0.\nDefaults to 25%.\nExample: when this is set to 30%, the old ReplicaSet can be scaled down to 70% of desired pods\nimmediately when the rolling update starts. Once new pods are ready, old ReplicaSet\ncan be scaled down further, followed by scaling up the new ReplicaSet, ensuring\nthat the total number of pods available at all times during the update is at\nleast 70% of desired pods.",
               "x-kubernetes-int-or-string": true
             }
           },
@@ -3006,22 +3095,23 @@
           "additionalProperties": false
         },
         "runtimeClassName": {
-          "description": "RuntimeClassName - defines runtime class for kubernetes pod.\nhttps://kubernetes.io/docs/concepts/containers/runtime-class/",
           "type": "string"
         },
+        "sampleLimit": {
+          "type": "integer"
+        },
         "schedulerName": {
-          "description": "SchedulerName - defines kubernetes scheduler name",
           "type": "string"
         },
         "scrapeClasses": {
-          "description": "ScrapeClasses defines the list of scrape classes to expose to scraping objects such as\nPodScrapes, ServiceScrapes, Probes and ScrapeConfigs.",
           "items": {
             "properties": {
               "attachMetadata": {
-                "description": "AttachMetadata defines additional metadata to the discovered targets.\nWhen the scrape object defines its own configuration, it takes\nprecedence over the scrape class configuration.",
                 "properties": {
+                  "namespace": {
+                    "type": "boolean"
+                  },
                   "node": {
-                    "description": "Node instructs vmagent to add node specific metadata from service discovery\nValid for roles: pod, endpoints, endpointslice.",
                     "type": "boolean"
                   }
                 },
@@ -3029,22 +3119,17 @@
                 "additionalProperties": false
               },
               "authorization": {
-                "description": "Authorization with http header Authorization",
                 "properties": {
                   "credentials": {
-                    "description": "Reference to the secret with value for authorization",
                     "properties": {
                       "key": {
-                        "description": "The key of the secret to select from.  Must be a valid secret key.",
                         "type": "string"
                       },
                       "name": {
                         "default": "",
-                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                         "type": "string"
                       },
                       "optional": {
-                        "description": "Specify whether the Secret or its key must be defined",
                         "type": "boolean"
                       }
                     },
@@ -3056,11 +3141,9 @@
                     "additionalProperties": false
                   },
                   "credentialsFile": {
-                    "description": "File with value for authorization",
                     "type": "string"
                   },
                   "type": {
-                    "description": "Type of authorization, default to bearer",
                     "type": "string"
                   }
                 },
@@ -3068,22 +3151,17 @@
                 "additionalProperties": false
               },
               "basicAuth": {
-                "description": "BasicAuth allow an endpoint to authenticate over basic authentication",
                 "properties": {
                   "password": {
-                    "description": "Password defines reference for secret with password value\nThe secret needs to be in the same namespace as scrape object",
                     "properties": {
                       "key": {
-                        "description": "The key of the secret to select from.  Must be a valid secret key.",
                         "type": "string"
                       },
                       "name": {
                         "default": "",
-                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                         "type": "string"
                       },
                       "optional": {
-                        "description": "Specify whether the Secret or its key must be defined",
                         "type": "boolean"
                       }
                     },
@@ -3095,23 +3173,18 @@
                     "additionalProperties": false
                   },
                   "password_file": {
-                    "description": "PasswordFile defines path to password file at disk\nmust be pre-mounted",
                     "type": "string"
                   },
                   "username": {
-                    "description": "Username defines reference for secret with username value\nThe secret needs to be in the same namespace as scrape object",
                     "properties": {
                       "key": {
-                        "description": "The key of the secret to select from.  Must be a valid secret key.",
                         "type": "string"
                       },
                       "name": {
                         "default": "",
-                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                         "type": "string"
                       },
                       "optional": {
-                        "description": "Specify whether the Secret or its key must be defined",
                         "type": "boolean"
                       }
                     },
@@ -3127,24 +3200,19 @@
                 "additionalProperties": false
               },
               "bearerTokenFile": {
-                "description": "File to read bearer token for scraping targets.",
                 "type": "string"
               },
               "bearerTokenSecret": {
-                "description": "Secret to mount to read bearer token for scraping targets. The secret\nneeds to be in the same namespace as the scrape object and accessible by\nthe victoria-metrics operator.",
                 "nullable": true,
                 "properties": {
                   "key": {
-                    "description": "The key of the secret to select from.  Must be a valid secret key.",
                     "type": "string"
                   },
                   "name": {
                     "default": "",
-                    "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                     "type": "string"
                   },
                   "optional": {
-                    "description": "Specify whether the Secret or its key must be defined",
                     "type": "boolean"
                   }
                 },
@@ -3156,70 +3224,55 @@
                 "additionalProperties": false
               },
               "default": {
-                "description": "default defines that the scrape applies to all scrape objects that\ndon't configure an explicit scrape class name.\n\nOnly one scrape class can be set as the default.",
                 "type": "boolean"
               },
               "metricRelabelConfigs": {
-                "description": "MetricRelabelConfigs to apply to samples after scrapping.",
                 "items": {
-                  "description": "RelabelConfig allows dynamic rewriting of the label set\nMore info: https://docs.victoriametrics.com/victoriametrics/#relabeling",
                   "properties": {
                     "action": {
-                      "description": "Action to perform based on regex matching. Default is 'replace'",
                       "type": "string"
                     },
                     "if": {
-                      "description": "If represents metricsQL match expression (or list of expressions): '{__name__=~\"foo_.*\"}'",
                       "x-kubernetes-preserve-unknown-fields": true
                     },
                     "labels": {
                       "additionalProperties": {
                         "type": "string"
                       },
-                      "description": "Labels is used together with Match for `action: graphite`",
                       "type": "object"
                     },
                     "match": {
-                      "description": "Match is used together with Labels for `action: graphite`",
                       "type": "string"
                     },
                     "modulus": {
-                      "description": "Modulus to take of the hash of the source label values.",
                       "format": "int64",
                       "type": "integer"
                     },
                     "regex": {
-                      "description": "Regular expression against which the extracted value is matched. Default is '(.*)'\nvictoriaMetrics supports multiline regex joined with |\nhttps://docs.victoriametrics.com/victoriametrics/vmagent/#relabeling-enhancements",
                       "x-kubernetes-preserve-unknown-fields": true
                     },
                     "replacement": {
-                      "description": "Replacement value against which a regex replace is performed if the\nregular expression matches. Regex capture groups are available. Default is '$1'",
                       "type": "string"
                     },
                     "separator": {
-                      "description": "Separator placed between concatenated source label values. default is ';'.",
                       "type": "string"
                     },
                     "source_labels": {
-                      "description": "UnderScoreSourceLabels - additional form of source labels source_labels\nfor compatibility with original relabel config.\nif set  both sourceLabels and source_labels, sourceLabels has priority.\nfor details https://github.com/VictoriaMetrics/operator/issues/131",
                       "items": {
                         "type": "string"
                       },
                       "type": "array"
                     },
                     "sourceLabels": {
-                      "description": "The source labels select values from existing labels. Their content is concatenated\nusing the configured separator and matched against the configured regular expression\nfor the replace, keep, and drop actions.",
                       "items": {
                         "type": "string"
                       },
                       "type": "array"
                     },
                     "target_label": {
-                      "description": "UnderScoreTargetLabel - additional form of target label - target_label\nfor compatibility with original relabel config.\nif set  both targetLabel and target_label, targetLabel has priority.\nfor details https://github.com/VictoriaMetrics/operator/issues/131",
                       "type": "string"
                     },
                     "targetLabel": {
-                      "description": "Label to which the resulting value is written in a replace action.\nIt is mandatory for replace actions. Regex capture groups are available.",
                       "type": "string"
                     }
                   },
@@ -3229,30 +3282,23 @@
                 "type": "array"
               },
               "name": {
-                "description": "name of the scrape class.",
                 "minLength": 1,
                 "type": "string"
               },
               "oauth2": {
-                "description": "OAuth2 defines auth configuration",
                 "properties": {
                   "client_id": {
-                    "description": "The secret or configmap containing the OAuth2 client id",
                     "properties": {
                       "configMap": {
-                        "description": "ConfigMap containing data to use for the targets.",
                         "properties": {
                           "key": {
-                            "description": "The key to select.",
                             "type": "string"
                           },
                           "name": {
                             "default": "",
-                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                             "type": "string"
                           },
                           "optional": {
-                            "description": "Specify whether the ConfigMap or its key must be defined",
                             "type": "boolean"
                           }
                         },
@@ -3264,19 +3310,15 @@
                         "additionalProperties": false
                       },
                       "secret": {
-                        "description": "Secret containing data to use for the targets.",
                         "properties": {
                           "key": {
-                            "description": "The key of the secret to select from.  Must be a valid secret key.",
                             "type": "string"
                           },
                           "name": {
                             "default": "",
-                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                             "type": "string"
                           },
                           "optional": {
-                            "description": "Specify whether the Secret or its key must be defined",
                             "type": "boolean"
                           }
                         },
@@ -3292,19 +3334,15 @@
                     "additionalProperties": false
                   },
                   "client_secret": {
-                    "description": "The secret containing the OAuth2 client secret",
                     "properties": {
                       "key": {
-                        "description": "The key of the secret to select from.  Must be a valid secret key.",
                         "type": "string"
                       },
                       "name": {
                         "default": "",
-                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                         "type": "string"
                       },
                       "optional": {
-                        "description": "Specify whether the Secret or its key must be defined",
                         "type": "boolean"
                       }
                     },
@@ -3316,33 +3354,27 @@
                     "additionalProperties": false
                   },
                   "client_secret_file": {
-                    "description": "ClientSecretFile defines path for client secret file.",
                     "type": "string"
                   },
                   "endpoint_params": {
                     "additionalProperties": {
                       "type": "string"
                     },
-                    "description": "Parameters to append to the token URL",
                     "type": "object"
                   },
                   "proxy_url": {
-                    "description": "The proxy URL for token_url connection\n( available from v0.55.0).\nIs only supported by Scrape objects family",
                     "type": "string"
                   },
                   "scopes": {
-                    "description": "OAuth2 scopes used for the token request",
                     "items": {
                       "type": "string"
                     },
                     "type": "array"
                   },
                   "tls_config": {
-                    "description": "TLSConfig for token_url connection\n( available from v0.55.0).\nIs only supported by Scrape objects family",
                     "x-kubernetes-preserve-unknown-fields": true
                   },
                   "token_url": {
-                    "description": "The URL to fetch the token from",
                     "minLength": 1,
                     "type": "string"
                   }
@@ -3355,66 +3387,52 @@
                 "additionalProperties": false
               },
               "relabelConfigs": {
-                "description": "RelabelConfigs to apply to samples during service discovery.",
                 "items": {
-                  "description": "RelabelConfig allows dynamic rewriting of the label set\nMore info: https://docs.victoriametrics.com/victoriametrics/#relabeling",
                   "properties": {
                     "action": {
-                      "description": "Action to perform based on regex matching. Default is 'replace'",
                       "type": "string"
                     },
                     "if": {
-                      "description": "If represents metricsQL match expression (or list of expressions): '{__name__=~\"foo_.*\"}'",
                       "x-kubernetes-preserve-unknown-fields": true
                     },
                     "labels": {
                       "additionalProperties": {
                         "type": "string"
                       },
-                      "description": "Labels is used together with Match for `action: graphite`",
                       "type": "object"
                     },
                     "match": {
-                      "description": "Match is used together with Labels for `action: graphite`",
                       "type": "string"
                     },
                     "modulus": {
-                      "description": "Modulus to take of the hash of the source label values.",
                       "format": "int64",
                       "type": "integer"
                     },
                     "regex": {
-                      "description": "Regular expression against which the extracted value is matched. Default is '(.*)'\nvictoriaMetrics supports multiline regex joined with |\nhttps://docs.victoriametrics.com/victoriametrics/vmagent/#relabeling-enhancements",
                       "x-kubernetes-preserve-unknown-fields": true
                     },
                     "replacement": {
-                      "description": "Replacement value against which a regex replace is performed if the\nregular expression matches. Regex capture groups are available. Default is '$1'",
                       "type": "string"
                     },
                     "separator": {
-                      "description": "Separator placed between concatenated source label values. default is ';'.",
                       "type": "string"
                     },
                     "source_labels": {
-                      "description": "UnderScoreSourceLabels - additional form of source labels source_labels\nfor compatibility with original relabel config.\nif set  both sourceLabels and source_labels, sourceLabels has priority.\nfor details https://github.com/VictoriaMetrics/operator/issues/131",
                       "items": {
                         "type": "string"
                       },
                       "type": "array"
                     },
                     "sourceLabels": {
-                      "description": "The source labels select values from existing labels. Their content is concatenated\nusing the configured separator and matched against the configured regular expression\nfor the replace, keep, and drop actions.",
                       "items": {
                         "type": "string"
                       },
                       "type": "array"
                     },
                     "target_label": {
-                      "description": "UnderScoreTargetLabel - additional form of target label - target_label\nfor compatibility with original relabel config.\nif set  both targetLabel and target_label, targetLabel has priority.\nfor details https://github.com/VictoriaMetrics/operator/issues/131",
                       "type": "string"
                     },
                     "targetLabel": {
-                      "description": "Label to which the resulting value is written in a replace action.\nIt is mandatory for replace actions. Regex capture groups are available.",
                       "type": "string"
                     }
                   },
@@ -3424,25 +3442,19 @@
                 "type": "array"
               },
               "tlsConfig": {
-                "description": "TLSConfig configuration to use when scraping the endpoint",
                 "properties": {
                   "ca": {
-                    "description": "Struct containing the CA cert to use for the targets.",
                     "properties": {
                       "configMap": {
-                        "description": "ConfigMap containing data to use for the targets.",
                         "properties": {
                           "key": {
-                            "description": "The key to select.",
                             "type": "string"
                           },
                           "name": {
                             "default": "",
-                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                             "type": "string"
                           },
                           "optional": {
-                            "description": "Specify whether the ConfigMap or its key must be defined",
                             "type": "boolean"
                           }
                         },
@@ -3454,19 +3466,15 @@
                         "additionalProperties": false
                       },
                       "secret": {
-                        "description": "Secret containing data to use for the targets.",
                         "properties": {
                           "key": {
-                            "description": "The key of the secret to select from.  Must be a valid secret key.",
                             "type": "string"
                           },
                           "name": {
                             "default": "",
-                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                             "type": "string"
                           },
                           "optional": {
-                            "description": "Specify whether the Secret or its key must be defined",
                             "type": "boolean"
                           }
                         },
@@ -3482,26 +3490,20 @@
                     "additionalProperties": false
                   },
                   "caFile": {
-                    "description": "Path to the CA cert in the container to use for the targets.",
                     "type": "string"
                   },
                   "cert": {
-                    "description": "Struct containing the client cert file for the targets.",
                     "properties": {
                       "configMap": {
-                        "description": "ConfigMap containing data to use for the targets.",
                         "properties": {
                           "key": {
-                            "description": "The key to select.",
                             "type": "string"
                           },
                           "name": {
                             "default": "",
-                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                             "type": "string"
                           },
                           "optional": {
-                            "description": "Specify whether the ConfigMap or its key must be defined",
                             "type": "boolean"
                           }
                         },
@@ -3513,19 +3515,15 @@
                         "additionalProperties": false
                       },
                       "secret": {
-                        "description": "Secret containing data to use for the targets.",
                         "properties": {
                           "key": {
-                            "description": "The key of the secret to select from.  Must be a valid secret key.",
                             "type": "string"
                           },
                           "name": {
                             "default": "",
-                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                             "type": "string"
                           },
                           "optional": {
-                            "description": "Specify whether the Secret or its key must be defined",
                             "type": "boolean"
                           }
                         },
@@ -3541,31 +3539,24 @@
                     "additionalProperties": false
                   },
                   "certFile": {
-                    "description": "Path to the client cert file in the container for the targets.",
                     "type": "string"
                   },
                   "insecureSkipVerify": {
-                    "description": "Disable target certificate validation.",
                     "type": "boolean"
                   },
                   "keyFile": {
-                    "description": "Path to the client key file in the container for the targets.",
                     "type": "string"
                   },
                   "keySecret": {
-                    "description": "Secret containing the client key file for the targets.",
                     "properties": {
                       "key": {
-                        "description": "The key of the secret to select from.  Must be a valid secret key.",
                         "type": "string"
                       },
                       "name": {
                         "default": "",
-                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                         "type": "string"
                       },
                       "optional": {
-                        "description": "Specify whether the Secret or its key must be defined",
                         "type": "boolean"
                       }
                     },
@@ -3577,7 +3568,6 @@
                     "additionalProperties": false
                   },
                   "serverName": {
-                    "description": "Used to verify the hostname for the targets.",
                     "type": "string"
                   }
                 },
@@ -3598,23 +3588,17 @@
           "x-kubernetes-list-type": "map"
         },
         "scrapeConfigNamespaceSelector": {
-          "description": "ScrapeConfigNamespaceSelector defines Namespaces to be selected for VMScrapeConfig discovery.\nWorks in combination with Selector.\nNamespaceSelector nil - only objects at VMAgent namespace.\nSelector nil - only objects at NamespaceSelector namespaces.\nIf both nil - behaviour controlled by selectAllByDefault",
           "properties": {
             "matchExpressions": {
-              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
               "items": {
-                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
                 "properties": {
                   "key": {
-                    "description": "key is the label key that the selector applies to.",
                     "type": "string"
                   },
                   "operator": {
-                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
                     "type": "string"
                   },
                   "values": {
-                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
                     "items": {
                       "type": "string"
                     },
@@ -3636,7 +3620,6 @@
               "additionalProperties": {
                 "type": "string"
               },
-              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
               "type": "object"
             }
           },
@@ -3645,66 +3628,52 @@
           "additionalProperties": false
         },
         "scrapeConfigRelabelTemplate": {
-          "description": "ScrapeConfigRelabelTemplate defines relabel config, that will be added to each VMScrapeConfig.\nit's useful for adding specific labels to all targets",
           "items": {
-            "description": "RelabelConfig allows dynamic rewriting of the label set\nMore info: https://docs.victoriametrics.com/victoriametrics/#relabeling",
             "properties": {
               "action": {
-                "description": "Action to perform based on regex matching. Default is 'replace'",
                 "type": "string"
               },
               "if": {
-                "description": "If represents metricsQL match expression (or list of expressions): '{__name__=~\"foo_.*\"}'",
                 "x-kubernetes-preserve-unknown-fields": true
               },
               "labels": {
                 "additionalProperties": {
                   "type": "string"
                 },
-                "description": "Labels is used together with Match for `action: graphite`",
                 "type": "object"
               },
               "match": {
-                "description": "Match is used together with Labels for `action: graphite`",
                 "type": "string"
               },
               "modulus": {
-                "description": "Modulus to take of the hash of the source label values.",
                 "format": "int64",
                 "type": "integer"
               },
               "regex": {
-                "description": "Regular expression against which the extracted value is matched. Default is '(.*)'\nvictoriaMetrics supports multiline regex joined with |\nhttps://docs.victoriametrics.com/victoriametrics/vmagent/#relabeling-enhancements",
                 "x-kubernetes-preserve-unknown-fields": true
               },
               "replacement": {
-                "description": "Replacement value against which a regex replace is performed if the\nregular expression matches. Regex capture groups are available. Default is '$1'",
                 "type": "string"
               },
               "separator": {
-                "description": "Separator placed between concatenated source label values. default is ';'.",
                 "type": "string"
               },
               "source_labels": {
-                "description": "UnderScoreSourceLabels - additional form of source labels source_labels\nfor compatibility with original relabel config.\nif set  both sourceLabels and source_labels, sourceLabels has priority.\nfor details https://github.com/VictoriaMetrics/operator/issues/131",
                 "items": {
                   "type": "string"
                 },
                 "type": "array"
               },
               "sourceLabels": {
-                "description": "The source labels select values from existing labels. Their content is concatenated\nusing the configured separator and matched against the configured regular expression\nfor the replace, keep, and drop actions.",
                 "items": {
                   "type": "string"
                 },
                 "type": "array"
               },
               "target_label": {
-                "description": "UnderScoreTargetLabel - additional form of target label - target_label\nfor compatibility with original relabel config.\nif set  both targetLabel and target_label, targetLabel has priority.\nfor details https://github.com/VictoriaMetrics/operator/issues/131",
                 "type": "string"
               },
               "targetLabel": {
-                "description": "Label to which the resulting value is written in a replace action.\nIt is mandatory for replace actions. Regex capture groups are available.",
                 "type": "string"
               }
             },
@@ -3714,23 +3683,17 @@
           "type": "array"
         },
         "scrapeConfigSelector": {
-          "description": "ScrapeConfigSelector defines VMScrapeConfig to be selected for target discovery.\nWorks in combination with NamespaceSelector.",
           "properties": {
             "matchExpressions": {
-              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
               "items": {
-                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
                 "properties": {
                   "key": {
-                    "description": "key is the label key that the selector applies to.",
                     "type": "string"
                   },
                   "operator": {
-                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
                     "type": "string"
                   },
                   "values": {
-                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
                     "items": {
                       "type": "string"
                     },
@@ -3752,7 +3715,6 @@
               "additionalProperties": {
                 "type": "string"
               },
-              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
               "type": "object"
             }
           },
@@ -3761,53 +3723,41 @@
           "additionalProperties": false
         },
         "scrapeInterval": {
-          "description": "ScrapeInterval defines how often scrape targets by default",
           "pattern": "[0-9]+(ms|s|m|h)",
           "type": "string"
         },
         "scrapeTimeout": {
-          "description": "ScrapeTimeout defines global timeout for targets scrape",
           "pattern": "[0-9]+(ms|s|m|h)",
           "type": "string"
         },
         "secrets": {
-          "description": "Secrets is a list of Secrets in the same namespace as the Application\nobject, which shall be mounted into the Application container\nat /etc/vm/secrets/SECRET_NAME folder",
           "items": {
             "type": "string"
           },
           "type": "array"
         },
         "securityContext": {
-          "description": "SecurityContext holds pod-level security attributes and common container settings.\nThis defaults to the default PodSecurityContext.",
           "type": "object",
           "x-kubernetes-preserve-unknown-fields": true
         },
         "selectAllByDefault": {
-          "description": "SelectAllByDefault changes default behavior for empty CRD selectors, such ServiceScrapeSelector.\nwith selectAllByDefault: true and empty serviceScrapeSelector and ServiceScrapeNamespaceSelector\nOperator selects all exist serviceScrapes\nwith selectAllByDefault: false - selects nothing",
           "type": "boolean"
         },
         "serviceAccountName": {
-          "description": "ServiceAccountName is the name of the ServiceAccount to use to run the pods",
           "type": "string"
         },
         "serviceScrapeNamespaceSelector": {
-          "description": "ServiceScrapeNamespaceSelector Namespaces to be selected for VMServiceScrape discovery.\nWorks in combination with Selector.\nNamespaceSelector nil - only objects at VMAgent namespace.\nSelector nil - only objects at NamespaceSelector namespaces.\nIf both nil - behaviour controlled by selectAllByDefault",
           "properties": {
             "matchExpressions": {
-              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
               "items": {
-                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
                 "properties": {
                   "key": {
-                    "description": "key is the label key that the selector applies to.",
                     "type": "string"
                   },
                   "operator": {
-                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
                     "type": "string"
                   },
                   "values": {
-                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
                     "items": {
                       "type": "string"
                     },
@@ -3829,7 +3779,6 @@
               "additionalProperties": {
                 "type": "string"
               },
-              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
               "type": "object"
             }
           },
@@ -3838,66 +3787,52 @@
           "additionalProperties": false
         },
         "serviceScrapeRelabelTemplate": {
-          "description": "ServiceScrapeRelabelTemplate defines relabel config, that will be added to each VMServiceScrape.\nit's useful for adding specific labels to all targets",
           "items": {
-            "description": "RelabelConfig allows dynamic rewriting of the label set\nMore info: https://docs.victoriametrics.com/victoriametrics/#relabeling",
             "properties": {
               "action": {
-                "description": "Action to perform based on regex matching. Default is 'replace'",
                 "type": "string"
               },
               "if": {
-                "description": "If represents metricsQL match expression (or list of expressions): '{__name__=~\"foo_.*\"}'",
                 "x-kubernetes-preserve-unknown-fields": true
               },
               "labels": {
                 "additionalProperties": {
                   "type": "string"
                 },
-                "description": "Labels is used together with Match for `action: graphite`",
                 "type": "object"
               },
               "match": {
-                "description": "Match is used together with Labels for `action: graphite`",
                 "type": "string"
               },
               "modulus": {
-                "description": "Modulus to take of the hash of the source label values.",
                 "format": "int64",
                 "type": "integer"
               },
               "regex": {
-                "description": "Regular expression against which the extracted value is matched. Default is '(.*)'\nvictoriaMetrics supports multiline regex joined with |\nhttps://docs.victoriametrics.com/victoriametrics/vmagent/#relabeling-enhancements",
                 "x-kubernetes-preserve-unknown-fields": true
               },
               "replacement": {
-                "description": "Replacement value against which a regex replace is performed if the\nregular expression matches. Regex capture groups are available. Default is '$1'",
                 "type": "string"
               },
               "separator": {
-                "description": "Separator placed between concatenated source label values. default is ';'.",
                 "type": "string"
               },
               "source_labels": {
-                "description": "UnderScoreSourceLabels - additional form of source labels source_labels\nfor compatibility with original relabel config.\nif set  both sourceLabels and source_labels, sourceLabels has priority.\nfor details https://github.com/VictoriaMetrics/operator/issues/131",
                 "items": {
                   "type": "string"
                 },
                 "type": "array"
               },
               "sourceLabels": {
-                "description": "The source labels select values from existing labels. Their content is concatenated\nusing the configured separator and matched against the configured regular expression\nfor the replace, keep, and drop actions.",
                 "items": {
                   "type": "string"
                 },
                 "type": "array"
               },
               "target_label": {
-                "description": "UnderScoreTargetLabel - additional form of target label - target_label\nfor compatibility with original relabel config.\nif set  both targetLabel and target_label, targetLabel has priority.\nfor details https://github.com/VictoriaMetrics/operator/issues/131",
                 "type": "string"
               },
               "targetLabel": {
-                "description": "Label to which the resulting value is written in a replace action.\nIt is mandatory for replace actions. Regex capture groups are available.",
                 "type": "string"
               }
             },
@@ -3907,23 +3842,17 @@
           "type": "array"
         },
         "serviceScrapeSelector": {
-          "description": "ServiceScrapeSelector defines ServiceScrapes to be selected for target discovery.\nWorks in combination with NamespaceSelector.\nNamespaceSelector nil - only objects at VMAgent namespace.\nSelector nil - only objects at NamespaceSelector namespaces.\nIf both nil - behaviour controlled by selectAllByDefault",
           "properties": {
             "matchExpressions": {
-              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
               "items": {
-                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
                 "properties": {
                   "key": {
-                    "description": "key is the label key that the selector applies to.",
                     "type": "string"
                   },
                   "operator": {
-                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
                     "type": "string"
                   },
                   "values": {
-                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
                     "items": {
                       "type": "string"
                     },
@@ -3945,7 +3874,6 @@
               "additionalProperties": {
                 "type": "string"
               },
-              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
               "type": "object"
             }
           },
@@ -3954,7 +3882,6 @@
           "additionalProperties": false
         },
         "serviceScrapeSpec": {
-          "description": "ServiceScrapeSpec that will be added to vmagent VMServiceScrape spec",
           "required": [
             "endpoints"
           ],
@@ -3962,27 +3889,22 @@
           "x-kubernetes-preserve-unknown-fields": true
         },
         "serviceSpec": {
-          "description": "ServiceSpec that will be added to vmagent service spec",
           "properties": {
             "metadata": {
-              "description": "EmbeddedObjectMetadata defines objectMeta for additional service.",
               "properties": {
                 "annotations": {
                   "additionalProperties": {
                     "type": "string"
                   },
-                  "description": "Annotations is an unstructured key value map stored with a resource that may be\nset by external tools to store and retrieve arbitrary metadata. They are not\nqueryable and should be preserved when modifying objects.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations",
                   "type": "object"
                 },
                 "labels": {
                   "additionalProperties": {
                     "type": "string"
                   },
-                  "description": "Labels Map of string keys and values that can be used to organize and categorize\n(scope and select) objects. May match selectors of replication controllers\nand services.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels",
                   "type": "object"
                 },
                 "name": {
-                  "description": "Name must be unique within a namespace. Is required when creating resources, although\nsome resources may allow a client to request the generation of an appropriate name\nautomatically. Name is primarily intended for creation idempotence and configuration\ndefinition.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names",
                   "type": "string"
                 }
               },
@@ -3990,12 +3912,10 @@
               "additionalProperties": false
             },
             "spec": {
-              "description": "ServiceSpec describes the attributes that a user creates on a service.\nMore info: https://kubernetes.io/docs/concepts/services-networking/service/",
               "type": "object",
               "x-kubernetes-preserve-unknown-fields": true
             },
             "useAsDefault": {
-              "description": "UseAsDefault applies changes from given service definition to the main object Service\nChanging from headless service to clusterIP or loadbalancer may break cross-component communication",
               "type": "boolean"
             }
           },
@@ -4006,34 +3926,41 @@
           "additionalProperties": false
         },
         "shardCount": {
-          "description": "ShardCount - numbers of shards of VMAgent\nin this case operator will use 1 deployment/sts per shard with\nreplicas count according to spec.replicas,\nsee [here](https://docs.victoriametrics.com/victoriametrics/vmagent/#scraping-big-number-of-targets)",
+          "format": "int32",
           "type": "integer"
         },
         "startupProbe": {
-          "description": "StartupProbe that will be added to CRD pod",
           "type": "object",
           "x-kubernetes-preserve-unknown-fields": true
         },
         "statefulMode": {
-          "description": "StatefulMode enables StatefulSet for `VMAgent` instead of Deployment\nit allows using persistent storage for vmagent's persistentQueue",
           "type": "boolean"
         },
         "statefulRollingUpdateStrategy": {
-          "description": "StatefulRollingUpdateStrategy allows configuration for strategyType\nset it to RollingUpdate for disabling operator statefulSet rollingUpdate",
           "type": "string"
         },
-        "statefulStorage": {
-          "description": "StatefulStorage configures storage for StatefulSet",
+        "statefulRollingUpdateStrategyBehavior": {
           "properties": {
-            "disableMountSubPath": {
-              "description": "Deprecated: subPath usage will be disabled by default in a future release, this option will become unnecessary.\nDisableMountSubPath allows to remove any subPath usage in volume mounts.",
-              "type": "boolean"
-            },
+            "maxUnavailable": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "string"
+                }
+              ],
+              "x-kubernetes-int-or-string": true
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "statefulStorage": {
+          "properties": {
             "emptyDir": {
-              "description": "EmptyDirVolumeSource to be used by the Prometheus StatefulSets. If specified, used in place of any volumeClaimTemplate. More\ninfo: https://kubernetes.io/docs/concepts/storage/volumes/#emptydir",
               "properties": {
                 "medium": {
-                  "description": "medium represents what type of storage medium should back this directory.\nThe default is \"\" which means to use the node's default medium.\nMust be an empty string (default) or Memory.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
                   "type": "string"
                 },
                 "sizeLimit": {
@@ -4045,7 +3972,6 @@
                       "type": "string"
                     }
                   ],
-                  "description": "sizeLimit is the total amount of local storage required for this EmptyDir volume.\nThe size limit is also applicable for memory medium.\nThe maximum usage on memory medium EmptyDir would be the minimum value between\nthe SizeLimit specified here and the sum of memory limits of all containers in a pod.\nThe default is nil which means that the limit is undefined.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
                   "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                   "x-kubernetes-int-or-string": true
                 }
@@ -4054,35 +3980,28 @@
               "additionalProperties": false
             },
             "volumeClaimTemplate": {
-              "description": "A PVC spec to be used by the StatefulSets/Deployments.",
               "properties": {
                 "apiVersion": {
-                  "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
                   "type": "string"
                 },
                 "kind": {
-                  "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
                   "type": "string"
                 },
                 "metadata": {
-                  "description": "EmbeddedMetadata contains metadata relevant to an EmbeddedResource.",
                   "properties": {
                     "annotations": {
                       "additionalProperties": {
                         "type": "string"
                       },
-                      "description": "Annotations is an unstructured key value map stored with a resource that may be\nset by external tools to store and retrieve arbitrary metadata. They are not\nqueryable and should be preserved when modifying objects.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations",
                       "type": "object"
                     },
                     "labels": {
                       "additionalProperties": {
                         "type": "string"
                       },
-                      "description": "Labels Map of string keys and values that can be used to organize and categorize\n(scope and select) objects. May match selectors of replication controllers\nand services.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels",
                       "type": "object"
                     },
                     "name": {
-                      "description": "Name must be unique within a namespace. Is required when creating resources, although\nsome resources may allow a client to request the generation of an appropriate name\nautomatically. Name is primarily intended for creation idempotence and configuration\ndefinition.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names",
                       "type": "string"
                     }
                   },
@@ -4090,10 +4009,8 @@
                   "additionalProperties": false
                 },
                 "spec": {
-                  "description": "Spec defines the desired characteristics of a volume requested by a pod author.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
                   "properties": {
                     "accessModes": {
-                      "description": "accessModes contains the desired access modes the volume should have.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1",
                       "items": {
                         "type": "string"
                       },
@@ -4101,18 +4018,14 @@
                       "x-kubernetes-list-type": "atomic"
                     },
                     "dataSource": {
-                      "description": "dataSource field can be used to specify either:\n* An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)\n* An existing PVC (PersistentVolumeClaim)\nIf the provisioner or an external controller can support the specified data source,\nit will create a new volume based on the contents of the specified data source.\nWhen the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,\nand dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.\nIf the namespace is specified, then dataSourceRef will not be copied to dataSource.",
                       "properties": {
                         "apiGroup": {
-                          "description": "APIGroup is the group for the resource being referenced.\nIf APIGroup is not specified, the specified Kind must be in the core API group.\nFor any other third-party types, APIGroup is required.",
                           "type": "string"
                         },
                         "kind": {
-                          "description": "Kind is the type of resource being referenced",
                           "type": "string"
                         },
                         "name": {
-                          "description": "Name is the name of resource being referenced",
                           "type": "string"
                         }
                       },
@@ -4125,22 +4038,17 @@
                       "additionalProperties": false
                     },
                     "dataSourceRef": {
-                      "description": "dataSourceRef specifies the object from which to populate the volume with data, if a non-empty\nvolume is desired. This may be any object from a non-empty API group (non\ncore object) or a PersistentVolumeClaim object.\nWhen this field is specified, volume binding will only succeed if the type of\nthe specified object matches some installed volume populator or dynamic\nprovisioner.\nThis field will replace the functionality of the dataSource field and as such\nif both fields are non-empty, they must have the same value. For backwards\ncompatibility, when namespace isn't specified in dataSourceRef,\nboth fields (dataSource and dataSourceRef) will be set to the same\nvalue automatically if one of them is empty and the other is non-empty.\nWhen namespace is specified in dataSourceRef,\ndataSource isn't set to the same value and must be empty.\nThere are three important differences between dataSource and dataSourceRef:\n* While dataSource only allows two specific types of objects, dataSourceRef\n  allows any non-core object, as well as PersistentVolumeClaim objects.\n* While dataSource ignores disallowed values (dropping them), dataSourceRef\n  preserves all values, and generates an error if a disallowed value is\n  specified.\n* While dataSource only allows local objects, dataSourceRef allows objects\n  in any namespaces.\n(Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.\n(Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.",
                       "properties": {
                         "apiGroup": {
-                          "description": "APIGroup is the group for the resource being referenced.\nIf APIGroup is not specified, the specified Kind must be in the core API group.\nFor any other third-party types, APIGroup is required.",
                           "type": "string"
                         },
                         "kind": {
-                          "description": "Kind is the type of resource being referenced",
                           "type": "string"
                         },
                         "name": {
-                          "description": "Name is the name of resource being referenced",
                           "type": "string"
                         },
                         "namespace": {
-                          "description": "Namespace is the namespace of resource being referenced\nNote that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.\n(Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.",
                           "type": "string"
                         }
                       },
@@ -4152,7 +4060,6 @@
                       "additionalProperties": false
                     },
                     "resources": {
-                      "description": "resources represents the minimum resources the volume should have.\nIf RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements\nthat are lower than previous value but must still be higher than capacity recorded in the\nstatus field of the claim.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources",
                       "properties": {
                         "limits": {
                           "additionalProperties": {
@@ -4167,7 +4074,6 @@
                             "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                             "x-kubernetes-int-or-string": true
                           },
-                          "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
                           "type": "object"
                         },
                         "requests": {
@@ -4183,7 +4089,6 @@
                             "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                             "x-kubernetes-int-or-string": true
                           },
-                          "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
                           "type": "object"
                         }
                       },
@@ -4191,23 +4096,17 @@
                       "additionalProperties": false
                     },
                     "selector": {
-                      "description": "selector is a label query over volumes to consider for binding.",
                       "properties": {
                         "matchExpressions": {
-                          "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
                           "items": {
-                            "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
                             "properties": {
                               "key": {
-                                "description": "key is the label key that the selector applies to.",
                                 "type": "string"
                               },
                               "operator": {
-                                "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
                                 "type": "string"
                               },
                               "values": {
-                                "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
                                 "items": {
                                   "type": "string"
                                 },
@@ -4229,7 +4128,6 @@
                           "additionalProperties": {
                             "type": "string"
                           },
-                          "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                           "type": "object"
                         }
                       },
@@ -4238,19 +4136,15 @@
                       "additionalProperties": false
                     },
                     "storageClassName": {
-                      "description": "storageClassName is the name of the StorageClass required by the claim.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1",
                       "type": "string"
                     },
                     "volumeAttributesClassName": {
-                      "description": "volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.\nIf specified, the CSI driver will create or update the volume with the attributes defined\nin the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,\nit can be changed after the claim is created. An empty string or nil value indicates that no\nVolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,\nthis field can be reset to its previous value (including nil) to cancel the modification.\nIf the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be\nset to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource\nexists.\nMore info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/",
                       "type": "string"
                     },
                     "volumeMode": {
-                      "description": "volumeMode defines what type of volume is required by the claim.\nValue of Filesystem is implied when not included in claim spec.",
                       "type": "string"
                     },
                     "volumeName": {
-                      "description": "volumeName is the binding reference to the PersistentVolume backing this claim.",
                       "type": "string"
                     }
                   },
@@ -4258,10 +4152,8 @@
                   "additionalProperties": false
                 },
                 "status": {
-                  "description": "Status represents the current information/status of a persistent volume claim.\nRead-only.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
                   "properties": {
                     "accessModes": {
-                      "description": "accessModes contains the actual access modes the volume backing the PVC has.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1",
                       "items": {
                         "type": "string"
                       },
@@ -4270,10 +4162,8 @@
                     },
                     "allocatedResourceStatuses": {
                       "additionalProperties": {
-                        "description": "When a controller receives persistentvolume claim update with ClaimResourceStatus for a resource\nthat it does not recognizes, then it should ignore that update and let other controllers\nhandle it.",
                         "type": "string"
                       },
-                      "description": "allocatedResourceStatuses stores status of resource being resized for the given PVC.\nKey names follow standard Kubernetes label syntax. Valid values are either:\n\t* Un-prefixed keys:\n\t\t- storage - the capacity of the volume.\n\t* Custom resources must use implementation-defined prefixed names such as \"example.com/my-custom-resource\"\nApart from above values - keys that are unprefixed or have kubernetes.io prefix are considered\nreserved and hence may not be used.\n\nClaimResourceStatus can be in any of following states:\n\t- ControllerResizeInProgress:\n\t\tState set when resize controller starts resizing the volume in control-plane.\n\t- ControllerResizeFailed:\n\t\tState set when resize has failed in resize controller with a terminal error.\n\t- NodeResizePending:\n\t\tState set when resize controller has finished resizing the volume but further resizing of\n\t\tvolume is needed on the node.\n\t- NodeResizeInProgress:\n\t\tState set when kubelet starts resizing the volume.\n\t- NodeResizeFailed:\n\t\tState set when resizing has failed in kubelet with a terminal error. Transient errors don't set\n\t\tNodeResizeFailed.\nFor example: if expanding a PVC for more capacity - this field can be one of the following states:\n\t- pvc.status.allocatedResourceStatus['storage'] = \"ControllerResizeInProgress\"\n     - pvc.status.allocatedResourceStatus['storage'] = \"ControllerResizeFailed\"\n     - pvc.status.allocatedResourceStatus['storage'] = \"NodeResizePending\"\n     - pvc.status.allocatedResourceStatus['storage'] = \"NodeResizeInProgress\"\n     - pvc.status.allocatedResourceStatus['storage'] = \"NodeResizeFailed\"\nWhen this field is not set, it means that no resize operation is in progress for the given PVC.\n\nA controller that receives PVC update with previously unknown resourceName or ClaimResourceStatus\nshould ignore the update for the purpose it was designed. For example - a controller that\nonly is responsible for resizing capacity of the volume, should ignore PVC updates that change other valid\nresources associated with PVC.\n\nThis is an alpha field and requires enabling RecoverVolumeExpansionFailure feature.",
                       "type": "object",
                       "x-kubernetes-map-type": "granular"
                     },
@@ -4290,7 +4180,6 @@
                         "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                         "x-kubernetes-int-or-string": true
                       },
-                      "description": "allocatedResources tracks the resources allocated to a PVC including its capacity.\nKey names follow standard Kubernetes label syntax. Valid values are either:\n\t* Un-prefixed keys:\n\t\t- storage - the capacity of the volume.\n\t* Custom resources must use implementation-defined prefixed names such as \"example.com/my-custom-resource\"\nApart from above values - keys that are unprefixed or have kubernetes.io prefix are considered\nreserved and hence may not be used.\n\nCapacity reported here may be larger than the actual capacity when a volume expansion operation\nis requested.\nFor storage quota, the larger value from allocatedResources and PVC.spec.resources is used.\nIf allocatedResources is not set, PVC.spec.resources alone is used for quota calculation.\nIf a volume expansion capacity request is lowered, allocatedResources is only\nlowered if there are no expansion operations in progress and if the actual volume capacity\nis equal or lower than the requested capacity.\n\nA controller that receives PVC update with previously unknown resourceName\nshould ignore the update for the purpose it was designed. For example - a controller that\nonly is responsible for resizing capacity of the volume, should ignore PVC updates that change other valid\nresources associated with PVC.\n\nThis is an alpha field and requires enabling RecoverVolumeExpansionFailure feature.",
                       "type": "object"
                     },
                     "capacity": {
@@ -4306,38 +4195,29 @@
                         "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                         "x-kubernetes-int-or-string": true
                       },
-                      "description": "capacity represents the actual resources of the underlying volume.",
                       "type": "object"
                     },
                     "conditions": {
-                      "description": "conditions is the current Condition of persistent volume claim. If underlying persistent volume is being\nresized then the Condition will be set to 'Resizing'.",
                       "items": {
-                        "description": "PersistentVolumeClaimCondition contains details about state of pvc",
                         "properties": {
                           "lastProbeTime": {
-                            "description": "lastProbeTime is the time we probed the condition.",
                             "format": "date-time",
                             "type": "string"
                           },
                           "lastTransitionTime": {
-                            "description": "lastTransitionTime is the time the condition transitioned from one status to another.",
                             "format": "date-time",
                             "type": "string"
                           },
                           "message": {
-                            "description": "message is the human-readable message indicating details about last transition.",
                             "type": "string"
                           },
                           "reason": {
-                            "description": "reason is a unique, this should be a short, machine understandable string that gives the reason\nfor condition's last transition. If it reports \"Resizing\" that means the underlying\npersistent volume is being resized.",
                             "type": "string"
                           },
                           "status": {
-                            "description": "Status is the status of the condition.\nCan be True, False, Unknown.\nMore info: https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-claim-v1/#:~:text=state%20of%20pvc-,conditions.status,-(string)%2C%20required",
                             "type": "string"
                           },
                           "type": {
-                            "description": "Type is the type of the condition.\nMore info: https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-claim-v1/#:~:text=set%20to%20%27ResizeStarted%27.-,PersistentVolumeClaimCondition,-contains%20details%20about",
                             "type": "string"
                           }
                         },
@@ -4355,18 +4235,14 @@
                       "x-kubernetes-list-type": "map"
                     },
                     "currentVolumeAttributesClassName": {
-                      "description": "currentVolumeAttributesClassName is the current name of the VolumeAttributesClass the PVC is using.\nWhen unset, there is no VolumeAttributeClass applied to this PersistentVolumeClaim",
                       "type": "string"
                     },
                     "modifyVolumeStatus": {
-                      "description": "ModifyVolumeStatus represents the status object of ControllerModifyVolume operation.\nWhen this is unset, there is no ModifyVolume operation being attempted.",
                       "properties": {
                         "status": {
-                          "description": "status is the status of the ControllerModifyVolume operation. It can be in any of following states:\n - Pending\n   Pending indicates that the PersistentVolumeClaim cannot be modified due to unmet requirements, such as\n   the specified VolumeAttributesClass not existing.\n - InProgress\n   InProgress indicates that the volume is being modified.\n - Infeasible\n  Infeasible indicates that the request has been rejected as invalid by the CSI driver. To\n\t  resolve the error, a valid VolumeAttributesClass needs to be specified.\nNote: New statuses can be added in the future. Consumers should check for unknown statuses and fail appropriately.",
                           "type": "string"
                         },
                         "targetVolumeAttributesClassName": {
-                          "description": "targetVolumeAttributesClassName is the name of the VolumeAttributesClass the PVC currently being reconciled",
                           "type": "string"
                         }
                       },
@@ -4377,7 +4253,6 @@
                       "additionalProperties": false
                     },
                     "phase": {
-                      "description": "phase represents the current phase of PersistentVolumeClaim.",
                       "type": "string"
                     }
                   },
@@ -4393,23 +4268,17 @@
           "additionalProperties": false
         },
         "staticScrapeNamespaceSelector": {
-          "description": "StaticScrapeNamespaceSelector defines Namespaces to be selected for VMStaticScrape discovery.\nWorks in combination with NamespaceSelector.\nNamespaceSelector nil - only objects at VMAgent namespace.\nSelector nil - only objects at NamespaceSelector namespaces.\nIf both nil - behaviour controlled by selectAllByDefault",
           "properties": {
             "matchExpressions": {
-              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
               "items": {
-                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
                 "properties": {
                   "key": {
-                    "description": "key is the label key that the selector applies to.",
                     "type": "string"
                   },
                   "operator": {
-                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
                     "type": "string"
                   },
                   "values": {
-                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
                     "items": {
                       "type": "string"
                     },
@@ -4431,7 +4300,6 @@
               "additionalProperties": {
                 "type": "string"
               },
-              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
               "type": "object"
             }
           },
@@ -4440,66 +4308,52 @@
           "additionalProperties": false
         },
         "staticScrapeRelabelTemplate": {
-          "description": "StaticScrapeRelabelTemplate defines relabel config, that will be added to each VMStaticScrape.\nit's useful for adding specific labels to all targets",
           "items": {
-            "description": "RelabelConfig allows dynamic rewriting of the label set\nMore info: https://docs.victoriametrics.com/victoriametrics/#relabeling",
             "properties": {
               "action": {
-                "description": "Action to perform based on regex matching. Default is 'replace'",
                 "type": "string"
               },
               "if": {
-                "description": "If represents metricsQL match expression (or list of expressions): '{__name__=~\"foo_.*\"}'",
                 "x-kubernetes-preserve-unknown-fields": true
               },
               "labels": {
                 "additionalProperties": {
                   "type": "string"
                 },
-                "description": "Labels is used together with Match for `action: graphite`",
                 "type": "object"
               },
               "match": {
-                "description": "Match is used together with Labels for `action: graphite`",
                 "type": "string"
               },
               "modulus": {
-                "description": "Modulus to take of the hash of the source label values.",
                 "format": "int64",
                 "type": "integer"
               },
               "regex": {
-                "description": "Regular expression against which the extracted value is matched. Default is '(.*)'\nvictoriaMetrics supports multiline regex joined with |\nhttps://docs.victoriametrics.com/victoriametrics/vmagent/#relabeling-enhancements",
                 "x-kubernetes-preserve-unknown-fields": true
               },
               "replacement": {
-                "description": "Replacement value against which a regex replace is performed if the\nregular expression matches. Regex capture groups are available. Default is '$1'",
                 "type": "string"
               },
               "separator": {
-                "description": "Separator placed between concatenated source label values. default is ';'.",
                 "type": "string"
               },
               "source_labels": {
-                "description": "UnderScoreSourceLabels - additional form of source labels source_labels\nfor compatibility with original relabel config.\nif set  both sourceLabels and source_labels, sourceLabels has priority.\nfor details https://github.com/VictoriaMetrics/operator/issues/131",
                 "items": {
                   "type": "string"
                 },
                 "type": "array"
               },
               "sourceLabels": {
-                "description": "The source labels select values from existing labels. Their content is concatenated\nusing the configured separator and matched against the configured regular expression\nfor the replace, keep, and drop actions.",
                 "items": {
                   "type": "string"
                 },
                 "type": "array"
               },
               "target_label": {
-                "description": "UnderScoreTargetLabel - additional form of target label - target_label\nfor compatibility with original relabel config.\nif set  both targetLabel and target_label, targetLabel has priority.\nfor details https://github.com/VictoriaMetrics/operator/issues/131",
                 "type": "string"
               },
               "targetLabel": {
-                "description": "Label to which the resulting value is written in a replace action.\nIt is mandatory for replace actions. Regex capture groups are available.",
                 "type": "string"
               }
             },
@@ -4509,23 +4363,17 @@
           "type": "array"
         },
         "staticScrapeSelector": {
-          "description": "StaticScrapeSelector defines VMStaticScrape to be selected for target discovery.\nWorks in combination with NamespaceSelector.\nIf both nil - match everything.\nNamespaceSelector nil - only objects at VMAgent namespace.\nSelector nil - only objects at NamespaceSelector namespaces.",
           "properties": {
             "matchExpressions": {
-              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
               "items": {
-                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
                 "properties": {
                   "key": {
-                    "description": "key is the label key that the selector applies to.",
                     "type": "string"
                   },
                   "operator": {
-                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
                     "type": "string"
                   },
                   "values": {
-                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
                     "items": {
                       "type": "string"
                     },
@@ -4547,7 +4395,6 @@
               "additionalProperties": {
                 "type": "string"
               },
-              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
               "type": "object"
             }
           },
@@ -4556,22 +4403,17 @@
           "additionalProperties": false
         },
         "streamAggrConfig": {
-          "description": "StreamAggrConfig defines global stream aggregation configuration for VMAgent",
           "properties": {
             "configmap": {
-              "description": "ConfigMap with stream aggregation rules",
               "properties": {
                 "key": {
-                  "description": "The key to select.",
                   "type": "string"
                 },
                 "name": {
                   "default": "",
-                  "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                   "type": "string"
                 },
                 "optional": {
-                  "description": "Specify whether the ConfigMap or its key must be defined",
                   "type": "boolean"
                 }
               },
@@ -4583,143 +4425,112 @@
               "additionalProperties": false
             },
             "dedupInterval": {
-              "description": "Allows setting different de-duplication intervals per each configured remote storage",
               "type": "string"
             },
             "dropInput": {
-              "description": "Allow drop all the input samples after the aggregation",
               "type": "boolean"
             },
             "dropInputLabels": {
-              "description": "labels to drop from samples for aggregator before stream de-duplication and aggregation",
               "items": {
                 "type": "string"
               },
               "type": "array"
             },
             "enableWindows": {
-              "description": "EnableWindows enables aggregating data in separate windows ( available from v0.54.0).",
               "type": "boolean"
             },
             "ignoreFirstIntervals": {
-              "description": "IgnoreFirstIntervals instructs to ignore first interval",
               "type": "integer"
             },
             "ignoreFirstSampleInterval": {
-              "description": "IgnoreFirstSampleInterval sets interval for total and prometheus_total during which first samples will be ignored",
               "type": "string"
             },
             "ignoreOldSamples": {
-              "description": "IgnoreOldSamples instructs to ignore samples with old timestamps outside the current aggregation interval.",
               "type": "boolean"
             },
             "keepInput": {
-              "description": "Allows writing both raw and aggregate data",
               "type": "boolean"
             },
             "rules": {
-              "description": "Stream aggregation rules",
               "items": {
-                "description": "StreamAggrRule defines the rule in stream aggregation config",
                 "properties": {
                   "by": {
-                    "description": "By is an optional list of labels for grouping input series.\n\nSee also Without.\n\nIf neither By nor Without are set, then the Outputs are calculated\nindividually per each input time series.",
                     "items": {
                       "type": "string"
                     },
                     "type": "array"
                   },
                   "dedup_interval": {
-                    "description": "DedupInterval is an optional interval for deduplication.",
                     "type": "string"
                   },
                   "drop_input_labels": {
-                    "description": "DropInputLabels is an optional list with labels, which must be dropped before further processing of input samples.\n\nLabels are dropped before de-duplication and aggregation.",
                     "items": {
                       "type": "string"
                     },
                     "type": "array"
                   },
                   "enable_windows": {
-                    "description": "EnableWindows enables aggregating data in separate windows",
                     "type": "boolean"
                   },
                   "flush_on_shutdown": {
-                    "description": "FlushOnShutdown defines whether to flush the aggregation state on process termination\nor config reload. Is `false` by default.\nIt is not recommended changing this setting, unless unfinished aggregations states\nare preferred to missing data points.",
                     "type": "boolean"
                   },
                   "ignore_first_intervals": {
                     "type": "integer"
                   },
                   "ignore_old_samples": {
-                    "description": "IgnoreOldSamples instructs to ignore samples with old timestamps outside the current aggregation interval.",
                     "type": "boolean"
                   },
                   "ignoreFirstSampleInterval": {
-                    "description": "IgnoreFirstSampleInterval sets interval for total and prometheus_total during which first samples will be ignored",
                     "type": "string"
                   },
                   "input_relabel_configs": {
-                    "description": "InputRelabelConfigs is an optional relabeling rules, which are applied on the input\nbefore aggregation.",
                     "items": {
-                      "description": "RelabelConfig allows dynamic rewriting of the label set\nMore info: https://docs.victoriametrics.com/victoriametrics/#relabeling",
                       "properties": {
                         "action": {
-                          "description": "Action to perform based on regex matching. Default is 'replace'",
                           "type": "string"
                         },
                         "if": {
-                          "description": "If represents metricsQL match expression (or list of expressions): '{__name__=~\"foo_.*\"}'",
                           "x-kubernetes-preserve-unknown-fields": true
                         },
                         "labels": {
                           "additionalProperties": {
                             "type": "string"
                           },
-                          "description": "Labels is used together with Match for `action: graphite`",
                           "type": "object"
                         },
                         "match": {
-                          "description": "Match is used together with Labels for `action: graphite`",
                           "type": "string"
                         },
                         "modulus": {
-                          "description": "Modulus to take of the hash of the source label values.",
                           "format": "int64",
                           "type": "integer"
                         },
                         "regex": {
-                          "description": "Regular expression against which the extracted value is matched. Default is '(.*)'\nvictoriaMetrics supports multiline regex joined with |\nhttps://docs.victoriametrics.com/victoriametrics/vmagent/#relabeling-enhancements",
                           "x-kubernetes-preserve-unknown-fields": true
                         },
                         "replacement": {
-                          "description": "Replacement value against which a regex replace is performed if the\nregular expression matches. Regex capture groups are available. Default is '$1'",
                           "type": "string"
                         },
                         "separator": {
-                          "description": "Separator placed between concatenated source label values. default is ';'.",
                           "type": "string"
                         },
                         "source_labels": {
-                          "description": "UnderScoreSourceLabels - additional form of source labels source_labels\nfor compatibility with original relabel config.\nif set  both sourceLabels and source_labels, sourceLabels has priority.\nfor details https://github.com/VictoriaMetrics/operator/issues/131",
                           "items": {
                             "type": "string"
                           },
                           "type": "array"
                         },
                         "sourceLabels": {
-                          "description": "The source labels select values from existing labels. Their content is concatenated\nusing the configured separator and matched against the configured regular expression\nfor the replace, keep, and drop actions.",
                           "items": {
                             "type": "string"
                           },
                           "type": "array"
                         },
                         "target_label": {
-                          "description": "UnderScoreTargetLabel - additional form of target label - target_label\nfor compatibility with original relabel config.\nif set  both targetLabel and target_label, targetLabel has priority.\nfor details https://github.com/VictoriaMetrics/operator/issues/131",
                           "type": "string"
                         },
                         "targetLabel": {
-                          "description": "Label to which the resulting value is written in a replace action.\nIt is mandatory for replace actions. Regex capture groups are available.",
                           "type": "string"
                         }
                       },
@@ -4729,82 +4540,64 @@
                     "type": "array"
                   },
                   "interval": {
-                    "description": "Interval is the interval between aggregations.",
                     "type": "string"
                   },
                   "keep_metric_names": {
-                    "description": "KeepMetricNames instructs to leave metric names as is for the output time series without adding any suffix.",
                     "type": "boolean"
                   },
                   "match": {
-                    "description": "Match is a label selector (or list of label selectors) for filtering time series for the given selector.\n\nIf the match isn't set, then all the input time series are processed.",
                     "x-kubernetes-preserve-unknown-fields": true
                   },
                   "no_align_flush_to_interval": {
-                    "description": "NoAlignFlushToInterval disables aligning of flushes to multiples of Interval.\nBy default flushes are aligned to Interval.",
                     "type": "boolean"
                   },
                   "output_relabel_configs": {
-                    "description": "OutputRelabelConfigs is an optional relabeling rules, which are applied\non the aggregated output before being sent to remote storage.",
                     "items": {
-                      "description": "RelabelConfig allows dynamic rewriting of the label set\nMore info: https://docs.victoriametrics.com/victoriametrics/#relabeling",
                       "properties": {
                         "action": {
-                          "description": "Action to perform based on regex matching. Default is 'replace'",
                           "type": "string"
                         },
                         "if": {
-                          "description": "If represents metricsQL match expression (or list of expressions): '{__name__=~\"foo_.*\"}'",
                           "x-kubernetes-preserve-unknown-fields": true
                         },
                         "labels": {
                           "additionalProperties": {
                             "type": "string"
                           },
-                          "description": "Labels is used together with Match for `action: graphite`",
                           "type": "object"
                         },
                         "match": {
-                          "description": "Match is used together with Labels for `action: graphite`",
                           "type": "string"
                         },
                         "modulus": {
-                          "description": "Modulus to take of the hash of the source label values.",
                           "format": "int64",
                           "type": "integer"
                         },
                         "regex": {
-                          "description": "Regular expression against which the extracted value is matched. Default is '(.*)'\nvictoriaMetrics supports multiline regex joined with |\nhttps://docs.victoriametrics.com/victoriametrics/vmagent/#relabeling-enhancements",
                           "x-kubernetes-preserve-unknown-fields": true
                         },
                         "replacement": {
-                          "description": "Replacement value against which a regex replace is performed if the\nregular expression matches. Regex capture groups are available. Default is '$1'",
                           "type": "string"
                         },
                         "separator": {
-                          "description": "Separator placed between concatenated source label values. default is ';'.",
                           "type": "string"
                         },
                         "source_labels": {
-                          "description": "UnderScoreSourceLabels - additional form of source labels source_labels\nfor compatibility with original relabel config.\nif set  both sourceLabels and source_labels, sourceLabels has priority.\nfor details https://github.com/VictoriaMetrics/operator/issues/131",
                           "items": {
                             "type": "string"
                           },
                           "type": "array"
                         },
                         "sourceLabels": {
-                          "description": "The source labels select values from existing labels. Their content is concatenated\nusing the configured separator and matched against the configured regular expression\nfor the replace, keep, and drop actions.",
                           "items": {
                             "type": "string"
                           },
                           "type": "array"
                         },
                         "target_label": {
-                          "description": "UnderScoreTargetLabel - additional form of target label - target_label\nfor compatibility with original relabel config.\nif set  both targetLabel and target_label, targetLabel has priority.\nfor details https://github.com/VictoriaMetrics/operator/issues/131",
                           "type": "string"
                         },
                         "targetLabel": {
-                          "description": "Label to which the resulting value is written in a replace action.\nIt is mandatory for replace actions. Regex capture groups are available.",
                           "type": "string"
                         }
                       },
@@ -4814,18 +4607,15 @@
                     "type": "array"
                   },
                   "outputs": {
-                    "description": "Outputs is a list of output aggregate functions to produce.\n\nThe following names are allowed:\n\n- total - aggregates input counters\n- increase - counts the increase over input counters\n- count_series - counts the input series\n- count_samples - counts the input samples\n- sum_samples - sums the input samples\n- last - the last biggest sample value\n- min - the minimum sample value\n- max - the maximum sample value\n- avg - the average value across all the samples\n- stddev - standard deviation across all the samples\n- stdvar - standard variance across all the samples\n- histogram_bucket - creates VictoriaMetrics histogram for input samples\n- quantiles(phi1, ..., phiN) - quantiles' estimation for phi in the range [0..1]\n\nThe output time series will have the following names:\n\n  input_name:aggr_<interval>_<output>",
                     "items": {
                       "type": "string"
                     },
                     "type": "array"
                   },
                   "staleness_interval": {
-                    "description": "Staleness interval is interval after which the series state will be reset if no samples have been sent during it.\nThe parameter is only relevant for outputs: total, total_prometheus, increase, increase_prometheus and histogram_bucket.",
                     "type": "string"
                   },
                   "without": {
-                    "description": "Without is an optional list of labels, which must be excluded when grouping input series.\n\nSee also By.\n\nIf neither By nor Without are set, then the Outputs are calculated\nindividually per each input time series.",
                     "items": {
                       "type": "string"
                     },
@@ -4846,34 +4636,26 @@
           "additionalProperties": false
         },
         "terminationGracePeriodSeconds": {
-          "description": "TerminationGracePeriodSeconds period for container graceful termination",
           "format": "int64",
           "type": "integer"
         },
         "tolerations": {
-          "description": "Tolerations If specified, the pod's tolerations.",
           "items": {
-            "description": "The pod this Toleration is attached to tolerates any taint that matches\nthe triple <key,value,effect> using the matching operator <operator>.",
             "properties": {
               "effect": {
-                "description": "Effect indicates the taint effect to match. Empty means match all taint effects.\nWhen specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
                 "type": "string"
               },
               "key": {
-                "description": "Key is the taint key that the toleration applies to. Empty means match all taint keys.\nIf the key is empty, operator must be Exists; this combination means to match all values and all keys.",
                 "type": "string"
               },
               "operator": {
-                "description": "Operator represents a key's relationship to the value.\nValid operators are Exists and Equal. Defaults to Equal.\nExists is equivalent to wildcard for value, so that a pod can\ntolerate all taints of a particular category.",
                 "type": "string"
               },
               "tolerationSeconds": {
-                "description": "TolerationSeconds represents the period of time the toleration (which must be\nof effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,\nit is not set, which means tolerate the taint forever (do not evict). Zero and\nnegative values will be treated as 0 (evict immediately) by the system.",
                 "format": "int64",
                 "type": "integer"
               },
               "value": {
-                "description": "Value is the taint value the toleration matches to.\nIf the operator is Exists, the value should be empty, otherwise just a regular string.",
                 "type": "string"
               }
             },
@@ -4883,9 +4665,7 @@
           "type": "array"
         },
         "topologySpreadConstraints": {
-          "description": "TopologySpreadConstraints embedded kubernetes pod configuration option,\ncontrols how pods are spread across your cluster among failure-domains\nsuch as regions, zones, nodes, and other user-defined topology domains\nhttps://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/",
           "items": {
-            "description": "TopologySpreadConstraint specifies how to spread matching pods among the given topology.",
             "required": [
               "maxSkew",
               "topologyKey",
@@ -4897,7 +4677,6 @@
           "type": "array"
         },
         "updateStrategy": {
-          "description": "UpdateStrategy - overrides default update strategy.\nworks only for deployments, statefulset always use OnDelete.",
           "enum": [
             "Recreate",
             "RollingUpdate"
@@ -4905,52 +4684,39 @@
           "type": "string"
         },
         "useDefaultResources": {
-          "description": "UseDefaultResources controls resource settings\nBy default, operator sets built-in resource requirements",
           "type": "boolean"
         },
         "useStrictSecurity": {
-          "description": "UseStrictSecurity enables strict security mode for component\nit restricts disk writes access\nuses non-root user out of the box\ndrops not needed security permissions",
           "type": "boolean"
         },
         "useVMConfigReloader": {
-          "description": "UseVMConfigReloader replaces prometheus-like config-reloader\nwith vm one. It uses secrets watch instead of file watch\nwhich greatly increases speed of config updates",
           "type": "boolean"
         },
         "vmAgentExternalLabelName": {
-          "description": "VMAgentExternalLabelName Name of vmAgent external label used to denote vmAgent instance\nname. Defaults to the value of `prometheus`. External label will\n_not_ be added when value is set to empty string (`\"\"`).",
           "type": "string"
         },
         "volumeMounts": {
-          "description": "VolumeMounts allows configuration of additional VolumeMounts on the output Deployment/StatefulSet definition.\nVolumeMounts specified will be appended to other VolumeMounts in the Application container",
           "items": {
-            "description": "VolumeMount describes a mounting of a Volume within a container.",
             "properties": {
               "mountPath": {
-                "description": "Path within the container at which the volume should be mounted.  Must\nnot contain ':'.",
                 "type": "string"
               },
               "mountPropagation": {
-                "description": "mountPropagation determines how mounts are propagated from the host\nto container and the other way around.\nWhen not set, MountPropagationNone is used.\nThis field is beta in 1.10.\nWhen RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified\n(which defaults to None).",
                 "type": "string"
               },
               "name": {
-                "description": "This must match the Name of a Volume.",
                 "type": "string"
               },
               "readOnly": {
-                "description": "Mounted read-only if true, read-write otherwise (false or unspecified).\nDefaults to false.",
                 "type": "boolean"
               },
               "recursiveReadOnly": {
-                "description": "RecursiveReadOnly specifies whether read-only mounts should be handled\nrecursively.\n\nIf ReadOnly is false, this field has no meaning and must be unspecified.\n\nIf ReadOnly is true, and this field is set to Disabled, the mount is not made\nrecursively read-only.  If this field is set to IfPossible, the mount is made\nrecursively read-only, if it is supported by the container runtime.  If this\nfield is set to Enabled, the mount is made recursively read-only if it is\nsupported by the container runtime, otherwise the pod will not be started and\nan error will be generated to indicate the reason.\n\nIf this field is set to IfPossible or Enabled, MountPropagation must be set to\nNone (or be unspecified, which defaults to None).\n\nIf this field is not specified, it is treated as an equivalent of Disabled.",
                 "type": "string"
               },
               "subPath": {
-                "description": "Path within the volume from which the container's volume should be mounted.\nDefaults to \"\" (volume's root).",
                 "type": "string"
               },
               "subPathExpr": {
-                "description": "Expanded path within the volume from which the container's volume should be mounted.\nBehaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.\nDefaults to \"\" (volume's root).\nSubPathExpr and SubPath are mutually exclusive.",
                 "type": "string"
               }
             },
@@ -4964,9 +4730,7 @@
           "type": "array"
         },
         "volumes": {
-          "description": "Volumes allows configuration of additional volumes on the output Deployment/StatefulSet definition.\nVolumes specified will be appended to other volumes that are generated.\n/ +optional",
           "items": {
-            "description": "Volume represents a named volume in a pod that may be accessed by any container in the pod.",
             "required": [
               "name"
             ],
@@ -4983,42 +4747,33 @@
       "additionalProperties": false
     },
     "status": {
-      "description": "VMAgentStatus defines the observed state of VMAgent",
       "properties": {
         "conditions": {
-          "description": "Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"",
           "items": {
-            "description": "Condition defines status condition of the resource",
             "properties": {
               "lastTransitionTime": {
-                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.",
                 "format": "date-time",
                 "type": "string"
               },
               "lastUpdateTime": {
-                "description": "LastUpdateTime is the last time of given type update.\nThis value is used for status TTL update and removal",
                 "format": "date-time",
                 "type": "string"
               },
               "message": {
-                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
                 "maxLength": 32768,
                 "type": "string"
               },
               "observedGeneration": {
-                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
                 "format": "int64",
                 "minimum": 0,
                 "type": "integer"
               },
               "reason": {
-                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
                 "maxLength": 1024,
                 "minLength": 1,
                 "type": "string"
               },
               "status": {
-                "description": "status of the condition, one of True, False, Unknown.",
                 "enum": [
                   "True",
                   "False",
@@ -5027,7 +4782,6 @@
                 "type": "string"
               },
               "type": {
-                "description": "Type of condition in CamelCase or in name.namespace.resource.victoriametrics.com/CamelCase.",
                 "maxLength": 316,
                 "type": "string"
               }
@@ -5048,31 +4802,28 @@
           ],
           "x-kubernetes-list-type": "map"
         },
+        "lastAppliedSpec": {
+          "x-kubernetes-preserve-unknown-fields": true
+        },
         "observedGeneration": {
-          "description": "ObservedGeneration defines current generation picked by operator for the\nreconcile",
           "format": "int64",
           "type": "integer"
         },
         "reason": {
-          "description": "Reason defines human readable error reason",
           "type": "string"
         },
         "replicas": {
-          "description": "ReplicaCount Total number of pods targeted by this VMAgent",
           "format": "int32",
           "type": "integer"
         },
         "selector": {
-          "description": "Selector string form of label value set for autoscaling",
           "type": "string"
         },
         "shards": {
-          "description": "Shards represents total number of vmagent deployments with uniq scrape targets",
           "format": "int32",
           "type": "integer"
         },
         "updateStatus": {
-          "description": "UpdateStatus defines a status for update rollout",
           "type": "string"
         }
       },

--- a/operator.victoriametrics.com/vmalertmanager_v1beta1.json
+++ b/operator.victoriametrics.com/vmalertmanager_v1beta1.json
@@ -1,55 +1,51 @@
 {
-  "description": "VMAlertmanager represents Victoria-Metrics deployment for Alertmanager.",
   "properties": {
     "apiVersion": {
-      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
       "type": "string"
     },
     "kind": {
-      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
       "type": "string"
     },
     "metadata": {
       "type": "object"
     },
     "spec": {
-      "description": "Specification of the desired behavior of the VMAlertmanager cluster. More info:\nhttps://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
       "properties": {
         "additionalPeers": {
-          "description": "AdditionalPeers allows injecting a set of additional Alertmanagers to peer with to form a highly available cluster.",
           "items": {
             "type": "string"
           },
           "type": "array"
         },
         "affinity": {
-          "description": "Affinity If specified, the pod's scheduling constraints.",
           "type": "object",
           "x-kubernetes-preserve-unknown-fields": true
         },
+        "arbitraryFSAccessThroughSMs": {
+          "properties": {
+            "deny": {
+              "type": "boolean"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
         "claimTemplates": {
-          "description": "ClaimTemplates allows adding additional VolumeClaimTemplates for StatefulSet",
           "items": {
-            "description": "PersistentVolumeClaim is a user's request for and claim to a persistent volume",
             "properties": {
               "apiVersion": {
-                "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
                 "type": "string"
               },
               "kind": {
-                "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
                 "type": "string"
               },
               "metadata": {
-                "description": "Standard object's metadata.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
                 "type": "object",
                 "x-kubernetes-preserve-unknown-fields": true
               },
               "spec": {
-                "description": "spec defines the desired characteristics of a volume requested by a pod author.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
                 "properties": {
                   "accessModes": {
-                    "description": "accessModes contains the desired access modes the volume should have.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1",
                     "items": {
                       "type": "string"
                     },
@@ -57,18 +53,14 @@
                     "x-kubernetes-list-type": "atomic"
                   },
                   "dataSource": {
-                    "description": "dataSource field can be used to specify either:\n* An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)\n* An existing PVC (PersistentVolumeClaim)\nIf the provisioner or an external controller can support the specified data source,\nit will create a new volume based on the contents of the specified data source.\nWhen the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,\nand dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.\nIf the namespace is specified, then dataSourceRef will not be copied to dataSource.",
                     "properties": {
                       "apiGroup": {
-                        "description": "APIGroup is the group for the resource being referenced.\nIf APIGroup is not specified, the specified Kind must be in the core API group.\nFor any other third-party types, APIGroup is required.",
                         "type": "string"
                       },
                       "kind": {
-                        "description": "Kind is the type of resource being referenced",
                         "type": "string"
                       },
                       "name": {
-                        "description": "Name is the name of resource being referenced",
                         "type": "string"
                       }
                     },
@@ -81,22 +73,17 @@
                     "additionalProperties": false
                   },
                   "dataSourceRef": {
-                    "description": "dataSourceRef specifies the object from which to populate the volume with data, if a non-empty\nvolume is desired. This may be any object from a non-empty API group (non\ncore object) or a PersistentVolumeClaim object.\nWhen this field is specified, volume binding will only succeed if the type of\nthe specified object matches some installed volume populator or dynamic\nprovisioner.\nThis field will replace the functionality of the dataSource field and as such\nif both fields are non-empty, they must have the same value. For backwards\ncompatibility, when namespace isn't specified in dataSourceRef,\nboth fields (dataSource and dataSourceRef) will be set to the same\nvalue automatically if one of them is empty and the other is non-empty.\nWhen namespace is specified in dataSourceRef,\ndataSource isn't set to the same value and must be empty.\nThere are three important differences between dataSource and dataSourceRef:\n* While dataSource only allows two specific types of objects, dataSourceRef\n  allows any non-core object, as well as PersistentVolumeClaim objects.\n* While dataSource ignores disallowed values (dropping them), dataSourceRef\n  preserves all values, and generates an error if a disallowed value is\n  specified.\n* While dataSource only allows local objects, dataSourceRef allows objects\n  in any namespaces.\n(Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.\n(Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.",
                     "properties": {
                       "apiGroup": {
-                        "description": "APIGroup is the group for the resource being referenced.\nIf APIGroup is not specified, the specified Kind must be in the core API group.\nFor any other third-party types, APIGroup is required.",
                         "type": "string"
                       },
                       "kind": {
-                        "description": "Kind is the type of resource being referenced",
                         "type": "string"
                       },
                       "name": {
-                        "description": "Name is the name of resource being referenced",
                         "type": "string"
                       },
                       "namespace": {
-                        "description": "Namespace is the namespace of resource being referenced\nNote that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.\n(Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.",
                         "type": "string"
                       }
                     },
@@ -108,7 +95,6 @@
                     "additionalProperties": false
                   },
                   "resources": {
-                    "description": "resources represents the minimum resources the volume should have.\nIf RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements\nthat are lower than previous value but must still be higher than capacity recorded in the\nstatus field of the claim.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources",
                     "properties": {
                       "limits": {
                         "additionalProperties": {
@@ -123,7 +109,6 @@
                           "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                           "x-kubernetes-int-or-string": true
                         },
-                        "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
                         "type": "object"
                       },
                       "requests": {
@@ -139,7 +124,6 @@
                           "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                           "x-kubernetes-int-or-string": true
                         },
-                        "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
                         "type": "object"
                       }
                     },
@@ -147,23 +131,17 @@
                     "additionalProperties": false
                   },
                   "selector": {
-                    "description": "selector is a label query over volumes to consider for binding.",
                     "properties": {
                       "matchExpressions": {
-                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
                         "items": {
-                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
                           "properties": {
                             "key": {
-                              "description": "key is the label key that the selector applies to.",
                               "type": "string"
                             },
                             "operator": {
-                              "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
                               "type": "string"
                             },
                             "values": {
-                              "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
                               "items": {
                                 "type": "string"
                               },
@@ -185,7 +163,6 @@
                         "additionalProperties": {
                           "type": "string"
                         },
-                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                         "type": "object"
                       }
                     },
@@ -194,19 +171,15 @@
                     "additionalProperties": false
                   },
                   "storageClassName": {
-                    "description": "storageClassName is the name of the StorageClass required by the claim.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1",
                     "type": "string"
                   },
                   "volumeAttributesClassName": {
-                    "description": "volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.\nIf specified, the CSI driver will create or update the volume with the attributes defined\nin the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,\nit can be changed after the claim is created. An empty string or nil value indicates that no\nVolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,\nthis field can be reset to its previous value (including nil) to cancel the modification.\nIf the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be\nset to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource\nexists.\nMore info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/",
                     "type": "string"
                   },
                   "volumeMode": {
-                    "description": "volumeMode defines what type of volume is required by the claim.\nValue of Filesystem is implied when not included in claim spec.",
                     "type": "string"
                   },
                   "volumeName": {
-                    "description": "volumeName is the binding reference to the PersistentVolume backing this claim.",
                     "type": "string"
                   }
                 },
@@ -214,10 +187,8 @@
                 "additionalProperties": false
               },
               "status": {
-                "description": "status represents the current information/status of a persistent volume claim.\nRead-only.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
                 "properties": {
                   "accessModes": {
-                    "description": "accessModes contains the actual access modes the volume backing the PVC has.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1",
                     "items": {
                       "type": "string"
                     },
@@ -226,10 +197,8 @@
                   },
                   "allocatedResourceStatuses": {
                     "additionalProperties": {
-                      "description": "When a controller receives persistentvolume claim update with ClaimResourceStatus for a resource\nthat it does not recognizes, then it should ignore that update and let other controllers\nhandle it.",
                       "type": "string"
                     },
-                    "description": "allocatedResourceStatuses stores status of resource being resized for the given PVC.\nKey names follow standard Kubernetes label syntax. Valid values are either:\n\t* Un-prefixed keys:\n\t\t- storage - the capacity of the volume.\n\t* Custom resources must use implementation-defined prefixed names such as \"example.com/my-custom-resource\"\nApart from above values - keys that are unprefixed or have kubernetes.io prefix are considered\nreserved and hence may not be used.\n\nClaimResourceStatus can be in any of following states:\n\t- ControllerResizeInProgress:\n\t\tState set when resize controller starts resizing the volume in control-plane.\n\t- ControllerResizeFailed:\n\t\tState set when resize has failed in resize controller with a terminal error.\n\t- NodeResizePending:\n\t\tState set when resize controller has finished resizing the volume but further resizing of\n\t\tvolume is needed on the node.\n\t- NodeResizeInProgress:\n\t\tState set when kubelet starts resizing the volume.\n\t- NodeResizeFailed:\n\t\tState set when resizing has failed in kubelet with a terminal error. Transient errors don't set\n\t\tNodeResizeFailed.\nFor example: if expanding a PVC for more capacity - this field can be one of the following states:\n\t- pvc.status.allocatedResourceStatus['storage'] = \"ControllerResizeInProgress\"\n     - pvc.status.allocatedResourceStatus['storage'] = \"ControllerResizeFailed\"\n     - pvc.status.allocatedResourceStatus['storage'] = \"NodeResizePending\"\n     - pvc.status.allocatedResourceStatus['storage'] = \"NodeResizeInProgress\"\n     - pvc.status.allocatedResourceStatus['storage'] = \"NodeResizeFailed\"\nWhen this field is not set, it means that no resize operation is in progress for the given PVC.\n\nA controller that receives PVC update with previously unknown resourceName or ClaimResourceStatus\nshould ignore the update for the purpose it was designed. For example - a controller that\nonly is responsible for resizing capacity of the volume, should ignore PVC updates that change other valid\nresources associated with PVC.\n\nThis is an alpha field and requires enabling RecoverVolumeExpansionFailure feature.",
                     "type": "object",
                     "x-kubernetes-map-type": "granular"
                   },
@@ -246,7 +215,6 @@
                       "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                       "x-kubernetes-int-or-string": true
                     },
-                    "description": "allocatedResources tracks the resources allocated to a PVC including its capacity.\nKey names follow standard Kubernetes label syntax. Valid values are either:\n\t* Un-prefixed keys:\n\t\t- storage - the capacity of the volume.\n\t* Custom resources must use implementation-defined prefixed names such as \"example.com/my-custom-resource\"\nApart from above values - keys that are unprefixed or have kubernetes.io prefix are considered\nreserved and hence may not be used.\n\nCapacity reported here may be larger than the actual capacity when a volume expansion operation\nis requested.\nFor storage quota, the larger value from allocatedResources and PVC.spec.resources is used.\nIf allocatedResources is not set, PVC.spec.resources alone is used for quota calculation.\nIf a volume expansion capacity request is lowered, allocatedResources is only\nlowered if there are no expansion operations in progress and if the actual volume capacity\nis equal or lower than the requested capacity.\n\nA controller that receives PVC update with previously unknown resourceName\nshould ignore the update for the purpose it was designed. For example - a controller that\nonly is responsible for resizing capacity of the volume, should ignore PVC updates that change other valid\nresources associated with PVC.\n\nThis is an alpha field and requires enabling RecoverVolumeExpansionFailure feature.",
                     "type": "object"
                   },
                   "capacity": {
@@ -262,38 +230,29 @@
                       "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                       "x-kubernetes-int-or-string": true
                     },
-                    "description": "capacity represents the actual resources of the underlying volume.",
                     "type": "object"
                   },
                   "conditions": {
-                    "description": "conditions is the current Condition of persistent volume claim. If underlying persistent volume is being\nresized then the Condition will be set to 'Resizing'.",
                     "items": {
-                      "description": "PersistentVolumeClaimCondition contains details about state of pvc",
                       "properties": {
                         "lastProbeTime": {
-                          "description": "lastProbeTime is the time we probed the condition.",
                           "format": "date-time",
                           "type": "string"
                         },
                         "lastTransitionTime": {
-                          "description": "lastTransitionTime is the time the condition transitioned from one status to another.",
                           "format": "date-time",
                           "type": "string"
                         },
                         "message": {
-                          "description": "message is the human-readable message indicating details about last transition.",
                           "type": "string"
                         },
                         "reason": {
-                          "description": "reason is a unique, this should be a short, machine understandable string that gives the reason\nfor condition's last transition. If it reports \"Resizing\" that means the underlying\npersistent volume is being resized.",
                           "type": "string"
                         },
                         "status": {
-                          "description": "Status is the status of the condition.\nCan be True, False, Unknown.\nMore info: https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-claim-v1/#:~:text=state%20of%20pvc-,conditions.status,-(string)%2C%20required",
                           "type": "string"
                         },
                         "type": {
-                          "description": "Type is the type of the condition.\nMore info: https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-claim-v1/#:~:text=set%20to%20%27ResizeStarted%27.-,PersistentVolumeClaimCondition,-contains%20details%20about",
                           "type": "string"
                         }
                       },
@@ -311,18 +270,14 @@
                     "x-kubernetes-list-type": "map"
                   },
                   "currentVolumeAttributesClassName": {
-                    "description": "currentVolumeAttributesClassName is the current name of the VolumeAttributesClass the PVC is using.\nWhen unset, there is no VolumeAttributeClass applied to this PersistentVolumeClaim",
                     "type": "string"
                   },
                   "modifyVolumeStatus": {
-                    "description": "ModifyVolumeStatus represents the status object of ControllerModifyVolume operation.\nWhen this is unset, there is no ModifyVolume operation being attempted.",
                     "properties": {
                       "status": {
-                        "description": "status is the status of the ControllerModifyVolume operation. It can be in any of following states:\n - Pending\n   Pending indicates that the PersistentVolumeClaim cannot be modified due to unmet requirements, such as\n   the specified VolumeAttributesClass not existing.\n - InProgress\n   InProgress indicates that the volume is being modified.\n - Infeasible\n  Infeasible indicates that the request has been rejected as invalid by the CSI driver. To\n\t  resolve the error, a valid VolumeAttributesClass needs to be specified.\nNote: New statuses can be added in the future. Consumers should check for unknown statuses and fail appropriately.",
                         "type": "string"
                       },
                       "targetVolumeAttributesClassName": {
-                        "description": "targetVolumeAttributesClassName is the name of the VolumeAttributesClass the PVC currently being reconciled",
                         "type": "string"
                       }
                     },
@@ -333,7 +288,6 @@
                     "additionalProperties": false
                   },
                   "phase": {
-                    "description": "phase represents the current phase of PersistentVolumeClaim.",
                     "type": "string"
                   }
                 },
@@ -347,38 +301,32 @@
           "type": "array"
         },
         "clusterAdvertiseAddress": {
-          "description": "ClusterAdvertiseAddress is the explicit address to advertise in cluster.\nNeeds to be provided for non RFC1918 [1] (public) addresses.\n[1] RFC1918: https://tools.ietf.org/html/rfc1918",
           "type": "string"
         },
         "clusterDomainName": {
-          "description": "ClusterDomainName defines domain name suffix for in-cluster dns addresses\naka .cluster.local\nused to build pod peer addresses for in-cluster communication",
+          "type": "string"
+        },
+        "componentVersion": {
           "type": "string"
         },
         "configMaps": {
-          "description": "ConfigMaps is a list of ConfigMaps in the same namespace as the Application\nobject, which shall be mounted into the Application container\nat /etc/vm/configs/CONFIGMAP_NAME folder",
           "items": {
             "type": "string"
           },
           "type": "array"
         },
         "configNamespaceSelector": {
-          "description": " ConfigNamespaceSelector defines namespace selector for VMAlertmanagerConfig.\nWorks in combination with Selector.\nNamespaceSelector nil - only objects at VMAlertmanager namespace.\nSelector nil - only objects at NamespaceSelector namespaces.\nIf both nil - behaviour controlled by selectAllByDefault",
           "properties": {
             "matchExpressions": {
-              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
               "items": {
-                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
                 "properties": {
                   "key": {
-                    "description": "key is the label key that the selector applies to.",
                     "type": "string"
                   },
                   "operator": {
-                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
                     "type": "string"
                   },
                   "values": {
-                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
                     "items": {
                       "type": "string"
                     },
@@ -400,7 +348,6 @@
               "additionalProperties": {
                 "type": "string"
               },
-              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
               "type": "object"
             }
           },
@@ -409,23 +356,18 @@
           "additionalProperties": false
         },
         "configRawYaml": {
-          "description": "ConfigRawYaml - raw configuration for alertmanager,\nit helps it to start without secret.\npriority -> hardcoded ConfigRaw -> ConfigRaw, provided by user -> ConfigSecret.",
           "type": "string"
         },
         "configReloadAuthKeySecret": {
-          "description": "ConfigReloadAuthKeySecret defines optional secret reference authKey for /-/reload API requests.\nGiven secret reference will be added to the application and vm-config-reloader as volume\navailable since v0.57.0 version",
           "properties": {
             "key": {
-              "description": "The key of the secret to select from.  Must be a valid secret key.",
               "type": "string"
             },
             "name": {
               "default": "",
-              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
               "type": "string"
             },
             "optional": {
-              "description": "Specify whether the Secret or its key must be defined",
               "type": "boolean"
             }
           },
@@ -440,27 +382,23 @@
           "additionalProperties": {
             "type": "string"
           },
-          "description": "ConfigReloaderExtraArgs that will be passed to  VMAuths config-reloader container\nfor example resyncInterval: \"30s\"",
           "type": "object"
         },
+        "configReloaderImage": {
+          "type": "string"
+        },
         "configReloaderImageTag": {
-          "description": "ConfigReloaderImageTag defines image:tag for config-reloader container",
           "type": "string"
         },
         "configReloaderResources": {
-          "description": "ConfigReloaderResources config-reloader container resource request and limits, https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/\nif not defined default resources from operator config will be used",
           "properties": {
             "claims": {
-              "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis field depends on the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
               "items": {
-                "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
                 "properties": {
                   "name": {
-                    "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
                     "type": "string"
                   },
                   "request": {
-                    "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
                     "type": "string"
                   }
                 },
@@ -489,7 +427,6 @@
                 "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                 "x-kubernetes-int-or-string": true
               },
-              "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
               "type": "object"
             },
             "requests": {
@@ -505,7 +442,6 @@
                 "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                 "x-kubernetes-int-or-string": true
               },
-              "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
               "type": "object"
             }
           },
@@ -513,27 +449,20 @@
           "additionalProperties": false
         },
         "configSecret": {
-          "description": "ConfigSecret is the name of a Kubernetes Secret in the same namespace as the\nVMAlertmanager object, which contains configuration for this VMAlertmanager,\nconfiguration must be inside secret key: alertmanager.yaml.\nIt must be created by user.\ninstance. Defaults to 'vmalertmanager-<alertmanager-name>'\nThe secret is mounted into /etc/alertmanager/config.",
           "type": "string"
         },
         "configSelector": {
-          "description": "ConfigSelector defines selector for VMAlertmanagerConfig, result config will be merged with with Raw or Secret config.\nWorks in combination with NamespaceSelector.\nNamespaceSelector nil - only objects at VMAlertmanager namespace.\nSelector nil - only objects at NamespaceSelector namespaces.\nIf both nil - behaviour controlled by selectAllByDefault",
           "properties": {
             "matchExpressions": {
-              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
               "items": {
-                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
                 "properties": {
                   "key": {
-                    "description": "key is the label key that the selector applies to.",
                     "type": "string"
                   },
                   "operator": {
-                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
                     "type": "string"
                   },
                   "values": {
-                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
                     "items": {
                       "type": "string"
                     },
@@ -555,7 +484,6 @@
               "additionalProperties": {
                 "type": "string"
               },
-              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
               "type": "object"
             }
           },
@@ -564,9 +492,7 @@
           "additionalProperties": false
         },
         "containers": {
-          "description": "Containers property allows to inject additions sidecars or to patch existing containers.\nIt can be useful for proxies, backup, etc.",
           "items": {
-            "description": "A single application container that you want to run within a pod.",
             "required": [
               "name"
             ],
@@ -576,29 +502,23 @@
           "type": "array"
         },
         "disableAutomountServiceAccountToken": {
-          "description": "DisableAutomountServiceAccountToken whether to disable serviceAccount auto mount by Kubernetes (available from v0.54.0).\nOperator will conditionally create volumes and volumeMounts for containers if it requires k8s API access.\nFor example, vmagent and vm-config-reloader requires k8s API access.\nOperator creates volumes with name: \"kube-api-access\", which can be used as volumeMount for extraContainers if needed.\nAnd also adds VolumeMounts at /var/run/secrets/kubernetes.io/serviceaccount.",
           "type": "boolean"
         },
         "disableNamespaceMatcher": {
-          "description": "DisableNamespaceMatcher disables adding top route label matcher \"namespace = <VMAlertmanagerConfig.namespace>\" for VMAlertmanagerConfig\nIt may be useful if alert doesn't have namespace label for some reason",
           "type": "boolean"
         },
         "disableRouteContinueEnforce": {
-          "description": "DisableRouteContinueEnforce cancel the behavior for VMAlertmanagerConfig that always enforce first-level route continue to true",
           "type": "boolean"
         },
         "disableSelfServiceScrape": {
-          "description": "DisableSelfServiceScrape controls creation of VMServiceScrape by operator\nfor the application.\nHas priority over `VM_DISABLESELFSERVICESCRAPECREATION` operator env variable",
           "type": "boolean"
         },
         "dnsConfig": {
-          "description": "Specifies the DNS parameters of a pod.\nParameters specified here will be merged to the generated DNS\nconfiguration based on DNSPolicy.",
           "items": {
             "x-kubernetes-preserve-unknown-fields": true
           },
           "properties": {
             "nameservers": {
-              "description": "A list of DNS name server IP addresses.\nThis will be appended to the base nameservers generated from DNSPolicy.\nDuplicated nameservers will be removed.",
               "items": {
                 "type": "string"
               },
@@ -606,16 +526,12 @@
               "x-kubernetes-list-type": "atomic"
             },
             "options": {
-              "description": "A list of DNS resolver options.\nThis will be merged with the base options generated from DNSPolicy.\nDuplicated entries will be removed. Resolution options given in Options\nwill override those that appear in the base DNSPolicy.",
               "items": {
-                "description": "PodDNSConfigOption defines DNS resolver options of a pod.",
                 "properties": {
                   "name": {
-                    "description": "Name is this DNS resolver option's name.\nRequired.",
                     "type": "string"
                   },
                   "value": {
-                    "description": "Value is this DNS resolver option's value.",
                     "type": "string"
                   }
                 },
@@ -626,7 +542,6 @@
               "x-kubernetes-list-type": "atomic"
             },
             "searches": {
-              "description": "A list of DNS search domains for host-name lookup.\nThis will be appended to the base search paths generated from DNSPolicy.\nDuplicated search paths will be removed.",
               "items": {
                 "type": "string"
               },
@@ -638,42 +553,33 @@
           "additionalProperties": false
         },
         "dnsPolicy": {
-          "description": "DNSPolicy sets DNS policy for the pod",
           "type": "string"
         },
         "enforcedNamespaceLabel": {
-          "description": "EnforcedNamespaceLabel defines the namespace label key for top route matcher for VMAlertmanagerConfig\nDefault is \"namespace\"",
           "type": "string"
         },
         "enforcedTopRouteMatchers": {
-          "description": "EnforcedTopRouteMatchers defines label matchers to be added for the top route\nof VMAlertmanagerConfig\nIt allows to make some set of labels required for alerts.\nhttps://prometheus.io/docs/alerting/latest/configuration/#matcher",
           "items": {
             "type": "string"
           },
           "type": "array"
         },
         "externalURL": {
-          "description": "ExternalURL the VMAlertmanager instances will be available under. This is\nnecessary to generate correct URLs. This is necessary if VMAlertmanager is not\nserved from root of a DNS name.",
           "type": "string"
         },
         "extraArgs": {
           "additionalProperties": {
             "type": "string"
           },
-          "description": "ExtraArgs that will be passed to the application container\nfor example remoteWrite.tmpDataPath: /tmp",
           "type": "object"
         },
         "extraEnvs": {
-          "description": "ExtraEnvs that will be passed to the application container",
           "items": {
-            "description": "EnvVar represents an environment variable present in a Container.",
             "properties": {
               "name": {
-                "description": "Name of the environment variable.\nMay consist of any printable ASCII characters except '='.",
                 "type": "string"
               },
               "value": {
-                "description": "Variable references $(VAR_NAME) are expanded\nusing the previously defined environment variables in the container and\nany service environment variables. If a variable cannot be resolved,\nthe reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.\n\"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\".\nEscaped references will never be expanded, regardless of whether the variable\nexists or not.\nDefaults to \"\".",
                 "type": "string"
               }
             },
@@ -687,20 +593,15 @@
           "type": "array"
         },
         "extraEnvsFrom": {
-          "description": "ExtraEnvsFrom defines source of env variables for the application container\ncould either be secret or configmap",
           "items": {
-            "description": "EnvFromSource represents the source of a set of ConfigMaps or Secrets",
             "properties": {
               "configMapRef": {
-                "description": "The ConfigMap to select from",
                 "properties": {
                   "name": {
                     "default": "",
-                    "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                     "type": "string"
                   },
                   "optional": {
-                    "description": "Specify whether the ConfigMap must be defined",
                     "type": "boolean"
                   }
                 },
@@ -709,19 +610,15 @@
                 "additionalProperties": false
               },
               "prefix": {
-                "description": "Optional text to prepend to the name of each environment variable.\nMay consist of any printable ASCII characters except '='.",
                 "type": "string"
               },
               "secretRef": {
-                "description": "The Secret to select from",
                 "properties": {
                   "name": {
                     "default": "",
-                    "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                     "type": "string"
                   },
                   "optional": {
-                    "description": "Specify whether the Secret must be defined",
                     "type": "boolean"
                   }
                 },
@@ -736,29 +633,22 @@
           "type": "array"
         },
         "gossipConfig": {
-          "description": "GossipConfig defines gossip TLS configuration for Alertmanager cluster",
           "properties": {
             "tls_client_config": {
-              "description": "TLSClientConfig defines client TLS configuration for alertmanager",
               "properties": {
                 "ca_file": {
-                  "description": "CAFile defines path to the pre-mounted file with CA\nmutually exclusive with CASecretRef",
                   "type": "string"
                 },
                 "ca_secret_ref": {
-                  "description": "CA defines reference for secret with CA content under given key\nmutually exclusive with CAFile",
                   "properties": {
                     "key": {
-                      "description": "The key of the secret to select from.  Must be a valid secret key.",
                       "type": "string"
                     },
                     "name": {
                       "default": "",
-                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                       "type": "string"
                     },
                     "optional": {
-                      "description": "Specify whether the Secret or its key must be defined",
                       "type": "boolean"
                     }
                   },
@@ -770,23 +660,18 @@
                   "additionalProperties": false
                 },
                 "cert_file": {
-                  "description": "CertFile defines path to the pre-mounted file with certificate\nmutually exclusive with CertSecretRef",
                   "type": "string"
                 },
                 "cert_secret_ref": {
-                  "description": "CertSecretRef defines reference for secret with certificate content under given key\nmutually exclusive with CertFile",
                   "properties": {
                     "key": {
-                      "description": "The key of the secret to select from.  Must be a valid secret key.",
                       "type": "string"
                     },
                     "name": {
                       "default": "",
-                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                       "type": "string"
                     },
                     "optional": {
-                      "description": "Specify whether the Secret or its key must be defined",
                       "type": "boolean"
                     }
                   },
@@ -798,27 +683,21 @@
                   "additionalProperties": false
                 },
                 "insecure_skip_verify": {
-                  "description": "Cert defines reference for secret with CA content under given key\nmutually exclusive with CertFile",
                   "type": "boolean"
                 },
                 "key_file": {
-                  "description": "KeyFile defines path to the pre-mounted file with certificate key\nmutually exclusive with KeySecretRef",
                   "type": "string"
                 },
                 "key_secret_ref": {
-                  "description": "Key defines reference for secret with certificate key content under given key\nmutually exclusive with KeyFile",
                   "properties": {
                     "key": {
-                      "description": "The key of the secret to select from.  Must be a valid secret key.",
                       "type": "string"
                     },
                     "name": {
                       "default": "",
-                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                       "type": "string"
                     },
                     "optional": {
-                      "description": "Specify whether the Secret or its key must be defined",
                       "type": "boolean"
                     }
                   },
@@ -830,7 +709,6 @@
                   "additionalProperties": false
                 },
                 "server_name": {
-                  "description": "ServerName indicates a name of a server",
                   "type": "string"
                 }
               },
@@ -838,26 +716,20 @@
               "additionalProperties": false
             },
             "tls_server_config": {
-              "description": "TLSServerConfig defines server TLS configuration for alertmanager",
               "properties": {
                 "cert_file": {
-                  "description": "CertFile defines path to the pre-mounted file with certificate\nmutually exclusive with CertSecretRef",
                   "type": "string"
                 },
                 "cert_secret_ref": {
-                  "description": "CertSecretRef defines reference for secret with certificate content under given key\nmutually exclusive with CertFile",
                   "properties": {
                     "key": {
-                      "description": "The key of the secret to select from.  Must be a valid secret key.",
                       "type": "string"
                     },
                     "name": {
                       "default": "",
-                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                       "type": "string"
                     },
                     "optional": {
-                      "description": "Specify whether the Secret or its key must be defined",
                       "type": "boolean"
                     }
                   },
@@ -869,14 +741,12 @@
                   "additionalProperties": false
                 },
                 "cipher_suites": {
-                  "description": "CipherSuites defines list of supported cipher suites for TLS versions up to TLS 1.2\nhttps://golang.org/pkg/crypto/tls/#pkg-constants",
                   "items": {
                     "type": "string"
                   },
                   "type": "array"
                 },
                 "client_auth_type": {
-                  "description": "Cert defines reference for secret with CA content under given key\nmutually exclusive with CertFile\nClientAuthType defines server policy for client authentication\nIf you want to enable client authentication (aka mTLS), you need to use RequireAndVerifyClientCert\nNote, mTLS is supported only at enterprise version of VictoriaMetrics components",
                   "enum": [
                     "NoClientCert",
                     "RequireAndVerifyClientCert"
@@ -884,23 +754,18 @@
                   "type": "string"
                 },
                 "client_ca_file": {
-                  "description": "ClientCAFile defines path to the pre-mounted file with CA\nmutually exclusive with ClientCASecretRef",
                   "type": "string"
                 },
                 "client_ca_secret_ref": {
-                  "description": "ClientCASecretRef defines reference for secret with CA content under given key\nmutually exclusive with ClientCAFile",
                   "properties": {
                     "key": {
-                      "description": "The key of the secret to select from.  Must be a valid secret key.",
                       "type": "string"
                     },
                     "name": {
                       "default": "",
-                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                       "type": "string"
                     },
                     "optional": {
-                      "description": "Specify whether the Secret or its key must be defined",
                       "type": "boolean"
                     }
                   },
@@ -912,30 +777,24 @@
                   "additionalProperties": false
                 },
                 "curve_preferences": {
-                  "description": "CurvePreferences defines elliptic curves that will be used in an ECDHE handshake, in preference order.\nhttps://golang.org/pkg/crypto/tls/#CurveID",
                   "items": {
                     "type": "string"
                   },
                   "type": "array"
                 },
                 "key_file": {
-                  "description": "KeyFile defines path to the pre-mounted file with certificate key\nmutually exclusive with KeySecretRef",
                   "type": "string"
                 },
                 "key_secret_ref": {
-                  "description": "Key defines reference for secret with certificate key content under given key\nmutually exclusive with KeyFile",
                   "properties": {
                     "key": {
-                      "description": "The key of the secret to select from.  Must be a valid secret key.",
                       "type": "string"
                     },
                     "name": {
                       "default": "",
-                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                       "type": "string"
                     },
                     "optional": {
-                      "description": "Specify whether the Secret or its key must be defined",
                       "type": "boolean"
                     }
                   },
@@ -947,7 +806,6 @@
                   "additionalProperties": false
                 },
                 "max_version": {
-                  "description": "MaxVersion maximum TLS version that is acceptable.",
                   "enum": [
                     "TLS10",
                     "TLS11",
@@ -957,7 +815,6 @@
                   "type": "string"
                 },
                 "min_version": {
-                  "description": "MinVersion minimum TLS version that is acceptable.",
                   "enum": [
                     "TLS10",
                     "TLS11",
@@ -967,7 +824,6 @@
                   "type": "string"
                 },
                 "prefer_server_cipher_suites": {
-                  "description": "PreferServerCipherSuites controls whether the server selects the\nclient's most preferred ciphersuite",
                   "type": "boolean"
                 }
               },
@@ -979,12 +835,9 @@
           "additionalProperties": false
         },
         "host_aliases": {
-          "description": "HostAliasesUnderScore provides mapping for ip and hostname,\nthat would be propagated to pod,\ncannot be used with HostNetwork.\nHas Priority over hostAliases field",
           "items": {
-            "description": "HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the\npod's hosts file.",
             "properties": {
               "hostnames": {
-                "description": "Hostnames for the above IP address.",
                 "items": {
                   "type": "string"
                 },
@@ -992,7 +845,6 @@
                 "x-kubernetes-list-type": "atomic"
               },
               "ip": {
-                "description": "IP address of the host file entry.",
                 "type": "string"
               }
             },
@@ -1005,12 +857,9 @@
           "type": "array"
         },
         "hostAliases": {
-          "description": "HostAliases provides mapping for ip and hostname,\nthat would be propagated to pod,\ncannot be used with HostNetwork.",
           "items": {
-            "description": "HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the\npod's hosts file.",
             "properties": {
               "hostnames": {
-                "description": "Hostnames for the above IP address.",
                 "items": {
                   "type": "string"
                 },
@@ -1018,7 +867,6 @@
                 "x-kubernetes-list-type": "atomic"
               },
               "ip": {
-                "description": "IP address of the host file entry.",
                 "type": "string"
               }
             },
@@ -1031,22 +879,17 @@
           "type": "array"
         },
         "hostNetwork": {
-          "description": "HostNetwork controls whether the pod may use the node network namespace",
           "type": "boolean"
         },
         "image": {
-          "description": "Image - docker image settings\nif no specified operator uses default version from operator config",
           "properties": {
             "pullPolicy": {
-              "description": "PullPolicy describes how to pull docker image",
               "type": "string"
             },
             "repository": {
-              "description": "Repository contains name of docker image + it's repository if needed",
               "type": "string"
             },
             "tag": {
-              "description": "Tag contains desired docker image version",
               "type": "string"
             }
           },
@@ -1054,13 +897,10 @@
           "additionalProperties": false
         },
         "imagePullSecrets": {
-          "description": "ImagePullSecrets An optional list of references to secrets in the same namespace\nto use for pulling images from registries\nsee https://kubernetes.io/docs/concepts/containers/images/#referring-to-an-imagepullsecrets-on-a-pod",
           "items": {
-            "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
             "properties": {
               "name": {
                 "default": "",
-                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                 "type": "string"
               }
             },
@@ -1071,9 +911,7 @@
           "type": "array"
         },
         "initContainers": {
-          "description": "InitContainers allows adding initContainers to the pod definition.\nAny errors during the execution of an initContainer will lead to a restart of the Pod.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/",
           "items": {
-            "description": "A single application container that you want to run within a pod.",
             "required": [
               "name"
             ],
@@ -1083,16 +921,13 @@
           "type": "array"
         },
         "listenLocal": {
-          "description": "ListenLocal makes the VMAlertmanager server listen on loopback, so that it\ndoes not bind against the Pod IP. Note this is only for the VMAlertmanager\nUI, not the gossip communication.",
           "type": "boolean"
         },
         "livenessProbe": {
-          "description": "LivenessProbe that will be added CRD pod",
           "type": "object",
           "x-kubernetes-preserve-unknown-fields": true
         },
         "logFormat": {
-          "description": "LogFormat for VMAlertmanager to be configured with.",
           "enum": [
             "logfmt",
             "json"
@@ -1100,7 +935,6 @@
           "type": "string"
         },
         "logLevel": {
-          "description": "Log level for VMAlertmanager to be configured with.",
           "enum": [
             "debug",
             "info",
@@ -1114,20 +948,17 @@
           "type": "string"
         },
         "managedMetadata": {
-          "description": "ManagedMetadata defines metadata that will be added to the all objects\ncreated by operator for the given CustomResource",
           "properties": {
             "annotations": {
               "additionalProperties": {
                 "type": "string"
               },
-              "description": "Annotations is an unstructured key value map stored with a resource that may be\nset by external tools to store and retrieve arbitrary metadata. They are not\nqueryable and should be preserved when modifying objects.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations",
               "type": "object"
             },
             "labels": {
               "additionalProperties": {
                 "type": "string"
               },
-              "description": "Labels Map of string keys and values that can be used to organize and categorize\n(scope and select) objects.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels",
               "type": "object"
             }
           },
@@ -1135,7 +966,6 @@
           "additionalProperties": false
         },
         "minReadySeconds": {
-          "description": "MinReadySeconds defines a minimum number of seconds to wait before starting update next pod\nif previous in healthy state\nHas no effect for VLogs and VMSingle",
           "format": "int32",
           "type": "integer"
         },
@@ -1143,22 +973,17 @@
           "additionalProperties": {
             "type": "string"
           },
-          "description": "NodeSelector Define which Nodes the Pods are scheduled on.",
           "type": "object"
         },
         "paused": {
-          "description": "Paused If set to true all actions on the underlying managed objects are not\ngoing to be performed, except for delete actions.",
           "type": "boolean"
         },
         "persistentVolumeClaimRetentionPolicy": {
-          "description": "PersistentVolumeClaimRetentionPolicy allows configuration of PVC retention policy",
           "properties": {
             "whenDeleted": {
-              "description": "WhenDeleted specifies what happens to PVCs created from StatefulSet\nVolumeClaimTemplates when the StatefulSet is deleted. The default policy\nof `Retain` causes PVCs to not be affected by StatefulSet deletion. The\n`Delete` policy causes those PVCs to be deleted.",
               "type": "string"
             },
             "whenScaled": {
-              "description": "WhenScaled specifies what happens to PVCs created from StatefulSet\nVolumeClaimTemplates when the StatefulSet is scaled down. The default\npolicy of `Retain` causes PVCs to not be affected by a scaledown. The\n`Delete` policy causes the associated PVCs for any excess pods above\nthe replica count to be deleted.",
               "type": "string"
             }
           },
@@ -1166,7 +991,6 @@
           "additionalProperties": false
         },
         "podDisruptionBudget": {
-          "description": "PodDisruptionBudget created by operator",
           "properties": {
             "maxUnavailable": {
               "anyOf": [
@@ -1177,7 +1001,6 @@
                   "type": "string"
                 }
               ],
-              "description": "An eviction is allowed if at most \"maxUnavailable\" pods selected by\n\"selector\" are unavailable after the eviction, i.e. even in absence of\nthe evicted pod. For example, one can prevent all voluntary evictions\nby specifying 0. This is a mutually exclusive setting with \"minAvailable\".",
               "x-kubernetes-int-or-string": true
             },
             "minAvailable": {
@@ -1189,18 +1012,15 @@
                   "type": "string"
                 }
               ],
-              "description": "An eviction is allowed if at least \"minAvailable\" pods selected by\n\"selector\" will still be available after the eviction, i.e. even in the\nabsence of the evicted pod.  So for example you can prevent all voluntary\nevictions by specifying \"100%\".",
               "x-kubernetes-int-or-string": true
             },
             "selectorLabels": {
               "additionalProperties": {
                 "type": "string"
               },
-              "description": "replaces default labels selector generated by operator\nit's useful when you need to create custom budget",
               "type": "object"
             },
             "unhealthyPodEvictionPolicy": {
-              "description": "UnhealthyPodEvictionPolicy defines the criteria for when unhealthy pods\n\nValid policies are IfHealthyBudget and AlwaysAllow.\nIf no policy is specified, the default behavior will be used,\nwhich corresponds to the IfHealthyBudget policy.\nAvailable from operator v0.64.0",
               "enum": [
                 "IfHealthyBudget",
                 "AlwaysAllow"
@@ -1212,24 +1032,20 @@
           "additionalProperties": false
         },
         "podMetadata": {
-          "description": "PodMetadata configures Labels and Annotations which are propagated to the alertmanager pods.",
           "properties": {
             "annotations": {
               "additionalProperties": {
                 "type": "string"
               },
-              "description": "Annotations is an unstructured key value map stored with a resource that may be\nset by external tools to store and retrieve arbitrary metadata. They are not\nqueryable and should be preserved when modifying objects.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations",
               "type": "object"
             },
             "labels": {
               "additionalProperties": {
                 "type": "string"
               },
-              "description": "Labels Map of string keys and values that can be used to organize and categorize\n(scope and select) objects. May match selectors of replication controllers\nand services.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels",
               "type": "object"
             },
             "name": {
-              "description": "Name must be unique within a namespace. Is required when creating resources, although\nsome resources may allow a client to request the generation of an appropriate name\nautomatically. Name is primarily intended for creation idempotence and configuration\ndefinition.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names",
               "type": "string"
             }
           },
@@ -1237,24 +1053,18 @@
           "additionalProperties": false
         },
         "port": {
-          "description": "Port listen address",
           "type": "string"
         },
         "portName": {
-          "description": "PortName used for the pods and governing service.\nThis defaults to web",
           "type": "string"
         },
         "priorityClassName": {
-          "description": "PriorityClassName class assigned to the Pods",
           "type": "string"
         },
         "readinessGates": {
-          "description": "ReadinessGates defines pod readiness gates",
           "items": {
-            "description": "PodReadinessGate contains the reference to a pod condition",
             "properties": {
               "conditionType": {
-                "description": "ConditionType refers to a condition in the pod's condition list with matching type.",
                 "type": "string"
               }
             },
@@ -1267,29 +1077,22 @@
           "type": "array"
         },
         "readinessProbe": {
-          "description": "ReadinessProbe that will be added CRD pod",
           "type": "object",
           "x-kubernetes-preserve-unknown-fields": true
         },
         "replicaCount": {
-          "description": "ReplicaCount is the expected size of the Application.",
           "format": "int32",
           "type": "integer"
         },
         "resources": {
-          "description": "Resources container resource request and limits, https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/\nif not defined default resources from operator config will be used",
           "properties": {
             "claims": {
-              "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis field depends on the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
               "items": {
-                "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
                 "properties": {
                   "name": {
-                    "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
                     "type": "string"
                   },
                   "request": {
-                    "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
                     "type": "string"
                   }
                 },
@@ -1318,7 +1121,6 @@
                 "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                 "x-kubernetes-int-or-string": true
               },
-              "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
               "type": "object"
             },
             "requests": {
@@ -1334,7 +1136,6 @@
                 "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                 "x-kubernetes-int-or-string": true
               },
-              "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
               "type": "object"
             }
           },
@@ -1342,53 +1143,42 @@
           "additionalProperties": false
         },
         "retention": {
-          "description": "Retention Time duration VMAlertmanager shall retain data for. Default is '120h',\nand must match the regular expression `[0-9]+(ms|s|m|h)` (milliseconds seconds minutes hours).",
           "pattern": "[0-9]+(ms|s|m|h)",
           "type": "string"
         },
         "revisionHistoryLimitCount": {
-          "description": "The number of old ReplicaSets to retain to allow rollback in deployment or\nmaximum number of revisions that will be maintained in the Deployment revision history.\nHas no effect at StatefulSets\nDefaults to 10.",
           "format": "int32",
           "type": "integer"
         },
         "rollingUpdateStrategy": {
-          "description": "RollingUpdateStrategy defines strategy for application updates\nDefault is OnDelete, in this case operator handles update process\nCan be changed for RollingUpdate",
           "type": "string"
         },
         "routePrefix": {
-          "description": "RoutePrefix VMAlertmanager registers HTTP handlers for. This is useful,\nif using ExternalURL and a proxy is rewriting HTTP routes of a request,\nand the actual ExternalURL is still true, but the server serves requests\nunder a different route prefix. For example for use with `kubectl proxy`.",
           "type": "string"
         },
         "runtimeClassName": {
-          "description": "RuntimeClassName - defines runtime class for kubernetes pod.\nhttps://kubernetes.io/docs/concepts/containers/runtime-class/",
           "type": "string"
         },
         "schedulerName": {
-          "description": "SchedulerName - defines kubernetes scheduler name",
           "type": "string"
         },
         "secrets": {
-          "description": "Secrets is a list of Secrets in the same namespace as the Application\nobject, which shall be mounted into the Application container\nat /etc/vm/secrets/SECRET_NAME folder",
           "items": {
             "type": "string"
           },
           "type": "array"
         },
         "securityContext": {
-          "description": "SecurityContext holds pod-level security attributes and common container settings.\nThis defaults to the default PodSecurityContext.",
           "type": "object",
           "x-kubernetes-preserve-unknown-fields": true
         },
         "selectAllByDefault": {
-          "description": "SelectAllByDefault changes default behavior for empty CRD selectors, such ConfigSelector.\nwith selectAllByDefault: true and undefined ConfigSelector and ConfigNamespaceSelector\nOperator selects all exist alertManagerConfigs\nwith selectAllByDefault: false - selects nothing",
           "type": "boolean"
         },
         "serviceAccountName": {
-          "description": "ServiceAccountName is the name of the ServiceAccount to use to run the pods",
           "type": "string"
         },
         "serviceScrapeSpec": {
-          "description": "ServiceScrapeSpec that will be added to vmalertmanager VMServiceScrape spec",
           "required": [
             "endpoints"
           ],
@@ -1396,27 +1186,22 @@
           "x-kubernetes-preserve-unknown-fields": true
         },
         "serviceSpec": {
-          "description": "ServiceSpec that will be added to vmalertmanager service spec",
           "properties": {
             "metadata": {
-              "description": "EmbeddedObjectMetadata defines objectMeta for additional service.",
               "properties": {
                 "annotations": {
                   "additionalProperties": {
                     "type": "string"
                   },
-                  "description": "Annotations is an unstructured key value map stored with a resource that may be\nset by external tools to store and retrieve arbitrary metadata. They are not\nqueryable and should be preserved when modifying objects.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations",
                   "type": "object"
                 },
                 "labels": {
                   "additionalProperties": {
                     "type": "string"
                   },
-                  "description": "Labels Map of string keys and values that can be used to organize and categorize\n(scope and select) objects. May match selectors of replication controllers\nand services.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels",
                   "type": "object"
                 },
                 "name": {
-                  "description": "Name must be unique within a namespace. Is required when creating resources, although\nsome resources may allow a client to request the generation of an appropriate name\nautomatically. Name is primarily intended for creation idempotence and configuration\ndefinition.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names",
                   "type": "string"
                 }
               },
@@ -1424,12 +1209,10 @@
               "additionalProperties": false
             },
             "spec": {
-              "description": "ServiceSpec describes the attributes that a user creates on a service.\nMore info: https://kubernetes.io/docs/concepts/services-networking/service/",
               "type": "object",
               "x-kubernetes-preserve-unknown-fields": true
             },
             "useAsDefault": {
-              "description": "UseAsDefault applies changes from given service definition to the main object Service\nChanging from headless service to clusterIP or loadbalancer may break cross-component communication",
               "type": "boolean"
             }
           },
@@ -1440,22 +1223,14 @@
           "additionalProperties": false
         },
         "startupProbe": {
-          "description": "StartupProbe that will be added to CRD pod",
           "type": "object",
           "x-kubernetes-preserve-unknown-fields": true
         },
         "storage": {
-          "description": "Storage is the definition of how storage will be used by the VMAlertmanager\ninstances.",
           "properties": {
-            "disableMountSubPath": {
-              "description": "Deprecated: subPath usage will be disabled by default in a future release, this option will become unnecessary.\nDisableMountSubPath allows to remove any subPath usage in volume mounts.",
-              "type": "boolean"
-            },
             "emptyDir": {
-              "description": "EmptyDirVolumeSource to be used by the Prometheus StatefulSets. If specified, used in place of any volumeClaimTemplate. More\ninfo: https://kubernetes.io/docs/concepts/storage/volumes/#emptydir",
               "properties": {
                 "medium": {
-                  "description": "medium represents what type of storage medium should back this directory.\nThe default is \"\" which means to use the node's default medium.\nMust be an empty string (default) or Memory.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
                   "type": "string"
                 },
                 "sizeLimit": {
@@ -1467,7 +1242,6 @@
                       "type": "string"
                     }
                   ],
-                  "description": "sizeLimit is the total amount of local storage required for this EmptyDir volume.\nThe size limit is also applicable for memory medium.\nThe maximum usage on memory medium EmptyDir would be the minimum value between\nthe SizeLimit specified here and the sum of memory limits of all containers in a pod.\nThe default is nil which means that the limit is undefined.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
                   "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                   "x-kubernetes-int-or-string": true
                 }
@@ -1476,35 +1250,28 @@
               "additionalProperties": false
             },
             "volumeClaimTemplate": {
-              "description": "A PVC spec to be used by the StatefulSets/Deployments.",
               "properties": {
                 "apiVersion": {
-                  "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
                   "type": "string"
                 },
                 "kind": {
-                  "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
                   "type": "string"
                 },
                 "metadata": {
-                  "description": "EmbeddedMetadata contains metadata relevant to an EmbeddedResource.",
                   "properties": {
                     "annotations": {
                       "additionalProperties": {
                         "type": "string"
                       },
-                      "description": "Annotations is an unstructured key value map stored with a resource that may be\nset by external tools to store and retrieve arbitrary metadata. They are not\nqueryable and should be preserved when modifying objects.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations",
                       "type": "object"
                     },
                     "labels": {
                       "additionalProperties": {
                         "type": "string"
                       },
-                      "description": "Labels Map of string keys and values that can be used to organize and categorize\n(scope and select) objects. May match selectors of replication controllers\nand services.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels",
                       "type": "object"
                     },
                     "name": {
-                      "description": "Name must be unique within a namespace. Is required when creating resources, although\nsome resources may allow a client to request the generation of an appropriate name\nautomatically. Name is primarily intended for creation idempotence and configuration\ndefinition.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names",
                       "type": "string"
                     }
                   },
@@ -1512,10 +1279,8 @@
                   "additionalProperties": false
                 },
                 "spec": {
-                  "description": "Spec defines the desired characteristics of a volume requested by a pod author.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
                   "properties": {
                     "accessModes": {
-                      "description": "accessModes contains the desired access modes the volume should have.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1",
                       "items": {
                         "type": "string"
                       },
@@ -1523,18 +1288,14 @@
                       "x-kubernetes-list-type": "atomic"
                     },
                     "dataSource": {
-                      "description": "dataSource field can be used to specify either:\n* An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)\n* An existing PVC (PersistentVolumeClaim)\nIf the provisioner or an external controller can support the specified data source,\nit will create a new volume based on the contents of the specified data source.\nWhen the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,\nand dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.\nIf the namespace is specified, then dataSourceRef will not be copied to dataSource.",
                       "properties": {
                         "apiGroup": {
-                          "description": "APIGroup is the group for the resource being referenced.\nIf APIGroup is not specified, the specified Kind must be in the core API group.\nFor any other third-party types, APIGroup is required.",
                           "type": "string"
                         },
                         "kind": {
-                          "description": "Kind is the type of resource being referenced",
                           "type": "string"
                         },
                         "name": {
-                          "description": "Name is the name of resource being referenced",
                           "type": "string"
                         }
                       },
@@ -1547,22 +1308,17 @@
                       "additionalProperties": false
                     },
                     "dataSourceRef": {
-                      "description": "dataSourceRef specifies the object from which to populate the volume with data, if a non-empty\nvolume is desired. This may be any object from a non-empty API group (non\ncore object) or a PersistentVolumeClaim object.\nWhen this field is specified, volume binding will only succeed if the type of\nthe specified object matches some installed volume populator or dynamic\nprovisioner.\nThis field will replace the functionality of the dataSource field and as such\nif both fields are non-empty, they must have the same value. For backwards\ncompatibility, when namespace isn't specified in dataSourceRef,\nboth fields (dataSource and dataSourceRef) will be set to the same\nvalue automatically if one of them is empty and the other is non-empty.\nWhen namespace is specified in dataSourceRef,\ndataSource isn't set to the same value and must be empty.\nThere are three important differences between dataSource and dataSourceRef:\n* While dataSource only allows two specific types of objects, dataSourceRef\n  allows any non-core object, as well as PersistentVolumeClaim objects.\n* While dataSource ignores disallowed values (dropping them), dataSourceRef\n  preserves all values, and generates an error if a disallowed value is\n  specified.\n* While dataSource only allows local objects, dataSourceRef allows objects\n  in any namespaces.\n(Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.\n(Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.",
                       "properties": {
                         "apiGroup": {
-                          "description": "APIGroup is the group for the resource being referenced.\nIf APIGroup is not specified, the specified Kind must be in the core API group.\nFor any other third-party types, APIGroup is required.",
                           "type": "string"
                         },
                         "kind": {
-                          "description": "Kind is the type of resource being referenced",
                           "type": "string"
                         },
                         "name": {
-                          "description": "Name is the name of resource being referenced",
                           "type": "string"
                         },
                         "namespace": {
-                          "description": "Namespace is the namespace of resource being referenced\nNote that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.\n(Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.",
                           "type": "string"
                         }
                       },
@@ -1574,7 +1330,6 @@
                       "additionalProperties": false
                     },
                     "resources": {
-                      "description": "resources represents the minimum resources the volume should have.\nIf RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements\nthat are lower than previous value but must still be higher than capacity recorded in the\nstatus field of the claim.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources",
                       "properties": {
                         "limits": {
                           "additionalProperties": {
@@ -1589,7 +1344,6 @@
                             "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                             "x-kubernetes-int-or-string": true
                           },
-                          "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
                           "type": "object"
                         },
                         "requests": {
@@ -1605,7 +1359,6 @@
                             "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                             "x-kubernetes-int-or-string": true
                           },
-                          "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
                           "type": "object"
                         }
                       },
@@ -1613,23 +1366,17 @@
                       "additionalProperties": false
                     },
                     "selector": {
-                      "description": "selector is a label query over volumes to consider for binding.",
                       "properties": {
                         "matchExpressions": {
-                          "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
                           "items": {
-                            "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
                             "properties": {
                               "key": {
-                                "description": "key is the label key that the selector applies to.",
                                 "type": "string"
                               },
                               "operator": {
-                                "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
                                 "type": "string"
                               },
                               "values": {
-                                "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
                                 "items": {
                                   "type": "string"
                                 },
@@ -1651,7 +1398,6 @@
                           "additionalProperties": {
                             "type": "string"
                           },
-                          "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                           "type": "object"
                         }
                       },
@@ -1660,19 +1406,15 @@
                       "additionalProperties": false
                     },
                     "storageClassName": {
-                      "description": "storageClassName is the name of the StorageClass required by the claim.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1",
                       "type": "string"
                     },
                     "volumeAttributesClassName": {
-                      "description": "volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.\nIf specified, the CSI driver will create or update the volume with the attributes defined\nin the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,\nit can be changed after the claim is created. An empty string or nil value indicates that no\nVolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,\nthis field can be reset to its previous value (including nil) to cancel the modification.\nIf the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be\nset to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource\nexists.\nMore info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/",
                       "type": "string"
                     },
                     "volumeMode": {
-                      "description": "volumeMode defines what type of volume is required by the claim.\nValue of Filesystem is implied when not included in claim spec.",
                       "type": "string"
                     },
                     "volumeName": {
-                      "description": "volumeName is the binding reference to the PersistentVolume backing this claim.",
                       "type": "string"
                     }
                   },
@@ -1680,10 +1422,8 @@
                   "additionalProperties": false
                 },
                 "status": {
-                  "description": "Status represents the current information/status of a persistent volume claim.\nRead-only.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
                   "properties": {
                     "accessModes": {
-                      "description": "accessModes contains the actual access modes the volume backing the PVC has.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1",
                       "items": {
                         "type": "string"
                       },
@@ -1692,10 +1432,8 @@
                     },
                     "allocatedResourceStatuses": {
                       "additionalProperties": {
-                        "description": "When a controller receives persistentvolume claim update with ClaimResourceStatus for a resource\nthat it does not recognizes, then it should ignore that update and let other controllers\nhandle it.",
                         "type": "string"
                       },
-                      "description": "allocatedResourceStatuses stores status of resource being resized for the given PVC.\nKey names follow standard Kubernetes label syntax. Valid values are either:\n\t* Un-prefixed keys:\n\t\t- storage - the capacity of the volume.\n\t* Custom resources must use implementation-defined prefixed names such as \"example.com/my-custom-resource\"\nApart from above values - keys that are unprefixed or have kubernetes.io prefix are considered\nreserved and hence may not be used.\n\nClaimResourceStatus can be in any of following states:\n\t- ControllerResizeInProgress:\n\t\tState set when resize controller starts resizing the volume in control-plane.\n\t- ControllerResizeFailed:\n\t\tState set when resize has failed in resize controller with a terminal error.\n\t- NodeResizePending:\n\t\tState set when resize controller has finished resizing the volume but further resizing of\n\t\tvolume is needed on the node.\n\t- NodeResizeInProgress:\n\t\tState set when kubelet starts resizing the volume.\n\t- NodeResizeFailed:\n\t\tState set when resizing has failed in kubelet with a terminal error. Transient errors don't set\n\t\tNodeResizeFailed.\nFor example: if expanding a PVC for more capacity - this field can be one of the following states:\n\t- pvc.status.allocatedResourceStatus['storage'] = \"ControllerResizeInProgress\"\n     - pvc.status.allocatedResourceStatus['storage'] = \"ControllerResizeFailed\"\n     - pvc.status.allocatedResourceStatus['storage'] = \"NodeResizePending\"\n     - pvc.status.allocatedResourceStatus['storage'] = \"NodeResizeInProgress\"\n     - pvc.status.allocatedResourceStatus['storage'] = \"NodeResizeFailed\"\nWhen this field is not set, it means that no resize operation is in progress for the given PVC.\n\nA controller that receives PVC update with previously unknown resourceName or ClaimResourceStatus\nshould ignore the update for the purpose it was designed. For example - a controller that\nonly is responsible for resizing capacity of the volume, should ignore PVC updates that change other valid\nresources associated with PVC.\n\nThis is an alpha field and requires enabling RecoverVolumeExpansionFailure feature.",
                       "type": "object",
                       "x-kubernetes-map-type": "granular"
                     },
@@ -1712,7 +1450,6 @@
                         "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                         "x-kubernetes-int-or-string": true
                       },
-                      "description": "allocatedResources tracks the resources allocated to a PVC including its capacity.\nKey names follow standard Kubernetes label syntax. Valid values are either:\n\t* Un-prefixed keys:\n\t\t- storage - the capacity of the volume.\n\t* Custom resources must use implementation-defined prefixed names such as \"example.com/my-custom-resource\"\nApart from above values - keys that are unprefixed or have kubernetes.io prefix are considered\nreserved and hence may not be used.\n\nCapacity reported here may be larger than the actual capacity when a volume expansion operation\nis requested.\nFor storage quota, the larger value from allocatedResources and PVC.spec.resources is used.\nIf allocatedResources is not set, PVC.spec.resources alone is used for quota calculation.\nIf a volume expansion capacity request is lowered, allocatedResources is only\nlowered if there are no expansion operations in progress and if the actual volume capacity\nis equal or lower than the requested capacity.\n\nA controller that receives PVC update with previously unknown resourceName\nshould ignore the update for the purpose it was designed. For example - a controller that\nonly is responsible for resizing capacity of the volume, should ignore PVC updates that change other valid\nresources associated with PVC.\n\nThis is an alpha field and requires enabling RecoverVolumeExpansionFailure feature.",
                       "type": "object"
                     },
                     "capacity": {
@@ -1728,38 +1465,29 @@
                         "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                         "x-kubernetes-int-or-string": true
                       },
-                      "description": "capacity represents the actual resources of the underlying volume.",
                       "type": "object"
                     },
                     "conditions": {
-                      "description": "conditions is the current Condition of persistent volume claim. If underlying persistent volume is being\nresized then the Condition will be set to 'Resizing'.",
                       "items": {
-                        "description": "PersistentVolumeClaimCondition contains details about state of pvc",
                         "properties": {
                           "lastProbeTime": {
-                            "description": "lastProbeTime is the time we probed the condition.",
                             "format": "date-time",
                             "type": "string"
                           },
                           "lastTransitionTime": {
-                            "description": "lastTransitionTime is the time the condition transitioned from one status to another.",
                             "format": "date-time",
                             "type": "string"
                           },
                           "message": {
-                            "description": "message is the human-readable message indicating details about last transition.",
                             "type": "string"
                           },
                           "reason": {
-                            "description": "reason is a unique, this should be a short, machine understandable string that gives the reason\nfor condition's last transition. If it reports \"Resizing\" that means the underlying\npersistent volume is being resized.",
                             "type": "string"
                           },
                           "status": {
-                            "description": "Status is the status of the condition.\nCan be True, False, Unknown.\nMore info: https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-claim-v1/#:~:text=state%20of%20pvc-,conditions.status,-(string)%2C%20required",
                             "type": "string"
                           },
                           "type": {
-                            "description": "Type is the type of the condition.\nMore info: https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-claim-v1/#:~:text=set%20to%20%27ResizeStarted%27.-,PersistentVolumeClaimCondition,-contains%20details%20about",
                             "type": "string"
                           }
                         },
@@ -1777,18 +1505,14 @@
                       "x-kubernetes-list-type": "map"
                     },
                     "currentVolumeAttributesClassName": {
-                      "description": "currentVolumeAttributesClassName is the current name of the VolumeAttributesClass the PVC is using.\nWhen unset, there is no VolumeAttributeClass applied to this PersistentVolumeClaim",
                       "type": "string"
                     },
                     "modifyVolumeStatus": {
-                      "description": "ModifyVolumeStatus represents the status object of ControllerModifyVolume operation.\nWhen this is unset, there is no ModifyVolume operation being attempted.",
                       "properties": {
                         "status": {
-                          "description": "status is the status of the ControllerModifyVolume operation. It can be in any of following states:\n - Pending\n   Pending indicates that the PersistentVolumeClaim cannot be modified due to unmet requirements, such as\n   the specified VolumeAttributesClass not existing.\n - InProgress\n   InProgress indicates that the volume is being modified.\n - Infeasible\n  Infeasible indicates that the request has been rejected as invalid by the CSI driver. To\n\t  resolve the error, a valid VolumeAttributesClass needs to be specified.\nNote: New statuses can be added in the future. Consumers should check for unknown statuses and fail appropriately.",
                           "type": "string"
                         },
                         "targetVolumeAttributesClassName": {
-                          "description": "targetVolumeAttributesClassName is the name of the VolumeAttributesClass the PVC currently being reconciled",
                           "type": "string"
                         }
                       },
@@ -1799,7 +1523,6 @@
                       "additionalProperties": false
                     },
                     "phase": {
-                      "description": "phase represents the current phase of PersistentVolumeClaim.",
                       "type": "string"
                     }
                   },
@@ -1815,17 +1538,13 @@
           "additionalProperties": false
         },
         "templates": {
-          "description": "Templates is a list of ConfigMap key references for ConfigMaps in the same namespace as the VMAlertmanager\nobject, which shall be mounted into the VMAlertmanager Pods.\nThe Templates are mounted into /etc/vm/templates/<configmap-name>/<configmap-key>.",
           "items": {
-            "description": "ConfigMapKeyReference refers to a key in a ConfigMap.",
             "properties": {
               "key": {
-                "description": "The ConfigMap key to refer to.",
                 "type": "string"
               },
               "name": {
                 "default": "",
-                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                 "type": "string"
               }
             },
@@ -1839,34 +1558,26 @@
           "type": "array"
         },
         "terminationGracePeriodSeconds": {
-          "description": "TerminationGracePeriodSeconds period for container graceful termination",
           "format": "int64",
           "type": "integer"
         },
         "tolerations": {
-          "description": "Tolerations If specified, the pod's tolerations.",
           "items": {
-            "description": "The pod this Toleration is attached to tolerates any taint that matches\nthe triple <key,value,effect> using the matching operator <operator>.",
             "properties": {
               "effect": {
-                "description": "Effect indicates the taint effect to match. Empty means match all taint effects.\nWhen specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
                 "type": "string"
               },
               "key": {
-                "description": "Key is the taint key that the toleration applies to. Empty means match all taint keys.\nIf the key is empty, operator must be Exists; this combination means to match all values and all keys.",
                 "type": "string"
               },
               "operator": {
-                "description": "Operator represents a key's relationship to the value.\nValid operators are Exists and Equal. Defaults to Equal.\nExists is equivalent to wildcard for value, so that a pod can\ntolerate all taints of a particular category.",
                 "type": "string"
               },
               "tolerationSeconds": {
-                "description": "TolerationSeconds represents the period of time the toleration (which must be\nof effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,\nit is not set, which means tolerate the taint forever (do not evict). Zero and\nnegative values will be treated as 0 (evict immediately) by the system.",
                 "format": "int64",
                 "type": "integer"
               },
               "value": {
-                "description": "Value is the taint value the toleration matches to.\nIf the operator is Exists, the value should be empty, otherwise just a regular string.",
                 "type": "string"
               }
             },
@@ -1876,9 +1587,7 @@
           "type": "array"
         },
         "topologySpreadConstraints": {
-          "description": "TopologySpreadConstraints embedded kubernetes pod configuration option,\ncontrols how pods are spread across your cluster among failure-domains\nsuch as regions, zones, nodes, and other user-defined topology domains\nhttps://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/",
           "items": {
-            "description": "TopologySpreadConstraint specifies how to spread matching pods among the given topology.",
             "required": [
               "maxSkew",
               "topologyKey",
@@ -1889,49 +1598,155 @@
           },
           "type": "array"
         },
+        "tracingConfig": {
+          "properties": {
+            "client_type": {
+              "enum": [
+                "http",
+                "grpc"
+              ],
+              "type": "string"
+            },
+            "compression": {
+              "type": "string"
+            },
+            "endpoint": {
+              "type": "string"
+            },
+            "headers": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "insecure": {
+              "type": "boolean"
+            },
+            "sampling_fraction": {
+              "type": "string"
+            },
+            "timeout": {
+              "type": "string"
+            },
+            "tls_config": {
+              "properties": {
+                "ca_file": {
+                  "type": "string"
+                },
+                "ca_secret_ref": {
+                  "properties": {
+                    "key": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "default": "",
+                      "type": "string"
+                    },
+                    "optional": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "key"
+                  ],
+                  "type": "object",
+                  "x-kubernetes-map-type": "atomic",
+                  "additionalProperties": false
+                },
+                "cert_file": {
+                  "type": "string"
+                },
+                "cert_secret_ref": {
+                  "properties": {
+                    "key": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "default": "",
+                      "type": "string"
+                    },
+                    "optional": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "key"
+                  ],
+                  "type": "object",
+                  "x-kubernetes-map-type": "atomic",
+                  "additionalProperties": false
+                },
+                "insecure_skip_verify": {
+                  "type": "boolean"
+                },
+                "key_file": {
+                  "type": "string"
+                },
+                "key_secret_ref": {
+                  "properties": {
+                    "key": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "default": "",
+                      "type": "string"
+                    },
+                    "optional": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "key"
+                  ],
+                  "type": "object",
+                  "x-kubernetes-map-type": "atomic",
+                  "additionalProperties": false
+                },
+                "server_name": {
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "endpoint"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
         "useDefaultResources": {
-          "description": "UseDefaultResources controls resource settings\nBy default, operator sets built-in resource requirements",
           "type": "boolean"
         },
         "useStrictSecurity": {
-          "description": "UseStrictSecurity enables strict security mode for component\nit restricts disk writes access\nuses non-root user out of the box\ndrops not needed security permissions",
           "type": "boolean"
         },
         "useVMConfigReloader": {
-          "description": "UseVMConfigReloader replaces prometheus-like config-reloader\nwith vm one. It uses secrets watch instead of file watch\nwhich greatly increases speed of config updates",
           "type": "boolean"
         },
         "volumeMounts": {
-          "description": "VolumeMounts allows configuration of additional VolumeMounts on the output Deployment/StatefulSet definition.\nVolumeMounts specified will be appended to other VolumeMounts in the Application container",
           "items": {
-            "description": "VolumeMount describes a mounting of a Volume within a container.",
             "properties": {
               "mountPath": {
-                "description": "Path within the container at which the volume should be mounted.  Must\nnot contain ':'.",
                 "type": "string"
               },
               "mountPropagation": {
-                "description": "mountPropagation determines how mounts are propagated from the host\nto container and the other way around.\nWhen not set, MountPropagationNone is used.\nThis field is beta in 1.10.\nWhen RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified\n(which defaults to None).",
                 "type": "string"
               },
               "name": {
-                "description": "This must match the Name of a Volume.",
                 "type": "string"
               },
               "readOnly": {
-                "description": "Mounted read-only if true, read-write otherwise (false or unspecified).\nDefaults to false.",
                 "type": "boolean"
               },
               "recursiveReadOnly": {
-                "description": "RecursiveReadOnly specifies whether read-only mounts should be handled\nrecursively.\n\nIf ReadOnly is false, this field has no meaning and must be unspecified.\n\nIf ReadOnly is true, and this field is set to Disabled, the mount is not made\nrecursively read-only.  If this field is set to IfPossible, the mount is made\nrecursively read-only, if it is supported by the container runtime.  If this\nfield is set to Enabled, the mount is made recursively read-only if it is\nsupported by the container runtime, otherwise the pod will not be started and\nan error will be generated to indicate the reason.\n\nIf this field is set to IfPossible or Enabled, MountPropagation must be set to\nNone (or be unspecified, which defaults to None).\n\nIf this field is not specified, it is treated as an equivalent of Disabled.",
                 "type": "string"
               },
               "subPath": {
-                "description": "Path within the volume from which the container's volume should be mounted.\nDefaults to \"\" (volume's root).",
                 "type": "string"
               },
               "subPathExpr": {
-                "description": "Expanded path within the volume from which the container's volume should be mounted.\nBehaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.\nDefaults to \"\" (volume's root).\nSubPathExpr and SubPath are mutually exclusive.",
                 "type": "string"
               }
             },
@@ -1945,9 +1760,7 @@
           "type": "array"
         },
         "volumes": {
-          "description": "Volumes allows configuration of additional volumes on the output Deployment/StatefulSet definition.\nVolumes specified will be appended to other volumes that are generated.\n/ +optional",
           "items": {
-            "description": "Volume represents a named volume in a pod that may be accessed by any container in the pod.",
             "required": [
               "name"
             ],
@@ -1957,27 +1770,22 @@
           "type": "array"
         },
         "webConfig": {
-          "description": "WebConfig defines configuration for webserver\nhttps://github.com/prometheus/alertmanager/blob/main/docs/https.md",
           "properties": {
             "basic_auth_users": {
               "additionalProperties": {
                 "type": "string"
               },
-              "description": "BasicAuthUsers Usernames and hashed passwords that have full access to the web server\nPasswords must be hashed with bcrypt",
               "type": "object"
             },
             "http_server_config": {
-              "description": "HTTPServerConfig defines http server configuration for alertmanager web server",
               "properties": {
                 "headers": {
                   "additionalProperties": {
                     "type": "string"
                   },
-                  "description": "Headers defines list of headers that can be added to HTTP responses.",
                   "type": "object"
                 },
                 "http2": {
-                  "description": "HTTP2 enables HTTP/2 support. Note that HTTP/2 is only supported with TLS.\nThis can not be changed on the fly.",
                   "type": "boolean"
                 }
               },
@@ -1985,26 +1793,20 @@
               "additionalProperties": false
             },
             "tls_server_config": {
-              "description": "TLSServerConfig defines server TLS configuration for alertmanager",
               "properties": {
                 "cert_file": {
-                  "description": "CertFile defines path to the pre-mounted file with certificate\nmutually exclusive with CertSecretRef",
                   "type": "string"
                 },
                 "cert_secret_ref": {
-                  "description": "CertSecretRef defines reference for secret with certificate content under given key\nmutually exclusive with CertFile",
                   "properties": {
                     "key": {
-                      "description": "The key of the secret to select from.  Must be a valid secret key.",
                       "type": "string"
                     },
                     "name": {
                       "default": "",
-                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                       "type": "string"
                     },
                     "optional": {
-                      "description": "Specify whether the Secret or its key must be defined",
                       "type": "boolean"
                     }
                   },
@@ -2016,14 +1818,12 @@
                   "additionalProperties": false
                 },
                 "cipher_suites": {
-                  "description": "CipherSuites defines list of supported cipher suites for TLS versions up to TLS 1.2\nhttps://golang.org/pkg/crypto/tls/#pkg-constants",
                   "items": {
                     "type": "string"
                   },
                   "type": "array"
                 },
                 "client_auth_type": {
-                  "description": "Cert defines reference for secret with CA content under given key\nmutually exclusive with CertFile\nClientAuthType defines server policy for client authentication\nIf you want to enable client authentication (aka mTLS), you need to use RequireAndVerifyClientCert\nNote, mTLS is supported only at enterprise version of VictoriaMetrics components",
                   "enum": [
                     "NoClientCert",
                     "RequireAndVerifyClientCert"
@@ -2031,23 +1831,18 @@
                   "type": "string"
                 },
                 "client_ca_file": {
-                  "description": "ClientCAFile defines path to the pre-mounted file with CA\nmutually exclusive with ClientCASecretRef",
                   "type": "string"
                 },
                 "client_ca_secret_ref": {
-                  "description": "ClientCASecretRef defines reference for secret with CA content under given key\nmutually exclusive with ClientCAFile",
                   "properties": {
                     "key": {
-                      "description": "The key of the secret to select from.  Must be a valid secret key.",
                       "type": "string"
                     },
                     "name": {
                       "default": "",
-                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                       "type": "string"
                     },
                     "optional": {
-                      "description": "Specify whether the Secret or its key must be defined",
                       "type": "boolean"
                     }
                   },
@@ -2059,30 +1854,24 @@
                   "additionalProperties": false
                 },
                 "curve_preferences": {
-                  "description": "CurvePreferences defines elliptic curves that will be used in an ECDHE handshake, in preference order.\nhttps://golang.org/pkg/crypto/tls/#CurveID",
                   "items": {
                     "type": "string"
                   },
                   "type": "array"
                 },
                 "key_file": {
-                  "description": "KeyFile defines path to the pre-mounted file with certificate key\nmutually exclusive with KeySecretRef",
                   "type": "string"
                 },
                 "key_secret_ref": {
-                  "description": "Key defines reference for secret with certificate key content under given key\nmutually exclusive with KeyFile",
                   "properties": {
                     "key": {
-                      "description": "The key of the secret to select from.  Must be a valid secret key.",
                       "type": "string"
                     },
                     "name": {
                       "default": "",
-                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                       "type": "string"
                     },
                     "optional": {
-                      "description": "Specify whether the Secret or its key must be defined",
                       "type": "boolean"
                     }
                   },
@@ -2094,7 +1883,6 @@
                   "additionalProperties": false
                 },
                 "max_version": {
-                  "description": "MaxVersion maximum TLS version that is acceptable.",
                   "enum": [
                     "TLS10",
                     "TLS11",
@@ -2104,7 +1892,6 @@
                   "type": "string"
                 },
                 "min_version": {
-                  "description": "MinVersion minimum TLS version that is acceptable.",
                   "enum": [
                     "TLS10",
                     "TLS11",
@@ -2114,7 +1901,6 @@
                   "type": "string"
                 },
                 "prefer_server_cipher_suites": {
-                  "description": "PreferServerCipherSuites controls whether the server selects the\nclient's most preferred ciphersuite",
                   "type": "boolean"
                 }
               },
@@ -2130,42 +1916,33 @@
       "additionalProperties": false
     },
     "status": {
-      "description": "Most recent observed status of the VMAlertmanager cluster.\nOperator API itself. More info:\nhttps://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
       "properties": {
         "conditions": {
-          "description": "Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"",
           "items": {
-            "description": "Condition defines status condition of the resource",
             "properties": {
               "lastTransitionTime": {
-                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.",
                 "format": "date-time",
                 "type": "string"
               },
               "lastUpdateTime": {
-                "description": "LastUpdateTime is the last time of given type update.\nThis value is used for status TTL update and removal",
                 "format": "date-time",
                 "type": "string"
               },
               "message": {
-                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
                 "maxLength": 32768,
                 "type": "string"
               },
               "observedGeneration": {
-                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
                 "format": "int64",
                 "minimum": 0,
                 "type": "integer"
               },
               "reason": {
-                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
                 "maxLength": 1024,
                 "minLength": 1,
                 "type": "string"
               },
               "status": {
-                "description": "status of the condition, one of True, False, Unknown.",
                 "enum": [
                   "True",
                   "False",
@@ -2174,7 +1951,6 @@
                 "type": "string"
               },
               "type": {
-                "description": "Type of condition in CamelCase or in name.namespace.resource.victoriametrics.com/CamelCase.",
                 "maxLength": 316,
                 "type": "string"
               }
@@ -2195,17 +1971,17 @@
           ],
           "x-kubernetes-list-type": "map"
         },
+        "lastAppliedSpec": {
+          "x-kubernetes-preserve-unknown-fields": true
+        },
         "observedGeneration": {
-          "description": "ObservedGeneration defines current generation picked by operator for the\nreconcile",
           "format": "int64",
           "type": "integer"
         },
         "reason": {
-          "description": "Reason defines human readable error reason",
           "type": "string"
         },
         "updateStatus": {
-          "description": "UpdateStatus defines a status for update rollout",
           "type": "string"
         }
       },

--- a/operator.victoriametrics.com/vmauth_v1beta1.json
+++ b/operator.victoriametrics.com/vmauth_v1beta1.json
@@ -1,46 +1,48 @@
 {
-  "description": "VMAuth is the Schema for the vmauths API",
   "properties": {
     "apiVersion": {
-      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
       "type": "string"
     },
     "kind": {
-      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
       "type": "string"
     },
     "metadata": {
       "type": "object"
     },
     "spec": {
-      "description": "VMAuthSpec defines the desired state of VMAuth",
       "properties": {
         "affinity": {
-          "description": "Affinity If specified, the pod's scheduling constraints.",
           "type": "object",
           "x-kubernetes-preserve-unknown-fields": true
         },
+        "arbitraryFSAccessThroughSMs": {
+          "properties": {
+            "deny": {
+              "type": "boolean"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "componentVersion": {
+          "type": "string"
+        },
         "configMaps": {
-          "description": "ConfigMaps is a list of ConfigMaps in the same namespace as the Application\nobject, which shall be mounted into the Application container\nat /etc/vm/configs/CONFIGMAP_NAME folder",
           "items": {
             "type": "string"
           },
           "type": "array"
         },
         "configReloadAuthKeySecret": {
-          "description": "ConfigReloadAuthKeySecret defines optional secret reference authKey for /-/reload API requests.\nGiven secret reference will be added to the application and vm-config-reloader as volume\navailable since v0.57.0 version",
           "properties": {
             "key": {
-              "description": "The key of the secret to select from.  Must be a valid secret key.",
               "type": "string"
             },
             "name": {
               "default": "",
-              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
               "type": "string"
             },
             "optional": {
-              "description": "Specify whether the Secret or its key must be defined",
               "type": "boolean"
             }
           },
@@ -55,27 +57,23 @@
           "additionalProperties": {
             "type": "string"
           },
-          "description": "ConfigReloaderExtraArgs that will be passed to  VMAuths config-reloader container\nfor example resyncInterval: \"30s\"",
           "type": "object"
         },
+        "configReloaderImage": {
+          "type": "string"
+        },
         "configReloaderImageTag": {
-          "description": "ConfigReloaderImageTag defines image:tag for config-reloader container",
           "type": "string"
         },
         "configReloaderResources": {
-          "description": "ConfigReloaderResources config-reloader container resource request and limits, https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/\nif not defined default resources from operator config will be used",
           "properties": {
             "claims": {
-              "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis field depends on the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
               "items": {
-                "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
                 "properties": {
                   "name": {
-                    "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
                     "type": "string"
                   },
                   "request": {
-                    "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
                     "type": "string"
                   }
                 },
@@ -104,7 +102,6 @@
                 "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                 "x-kubernetes-int-or-string": true
               },
-              "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
               "type": "object"
             },
             "requests": {
@@ -120,7 +117,6 @@
                 "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                 "x-kubernetes-int-or-string": true
               },
-              "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
               "type": "object"
             }
           },
@@ -128,13 +124,10 @@
           "additionalProperties": false
         },
         "configSecret": {
-          "description": "ConfigSecret is the name of a Kubernetes Secret in the same namespace as the\nVMAuth object, which contains auth configuration for vmauth,\nconfiguration must be inside secret key: config.yaml.\nIt must be created and managed manually.\nIf it's defined, configuration for vmauth becomes unmanaged and operator'll not create any related secrets/config-reloaders\nDeprecated: use externalConfig.secretRef instead",
           "type": "string"
         },
         "containers": {
-          "description": "Containers property allows to inject additions sidecars or to patch existing containers.\nIt can be useful for proxies, backup, etc.",
           "items": {
-            "description": "A single application container that you want to run within a pod.",
             "required": [
               "name"
             ],
@@ -143,22 +136,235 @@
           },
           "type": "array"
         },
+        "defaultTargetRefs": {
+          "items": {
+            "properties": {
+              "crd": {
+                "properties": {
+                  "kind": {
+                    "enum": [
+                      "VMAgent",
+                      "VMAlert",
+                      "VMSingle",
+                      "VLogs",
+                      "VMAlertManager",
+                      "VMAlertmanager",
+                      "VMCluster/vmselect",
+                      "VMCluster/vmstorage",
+                      "VMCluster/vminsert",
+                      "VLSingle",
+                      "VLCluster/vlinsert",
+                      "VLCluster/vlselect",
+                      "VLCluster/vlstorage",
+                      "VLAgent",
+                      "VTCluster/vtinsert",
+                      "VTCluster/vtselect",
+                      "VTCluster/vtstorage",
+                      "VTSingle",
+                      "VMAnomaly"
+                    ],
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "namespace": {
+                    "type": "string"
+                  },
+                  "objects": {
+                    "items": {
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name",
+                        "namespace"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "kind",
+                  "name",
+                  "namespace"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "discover_backend_ips": {
+                "type": "boolean"
+              },
+              "drop_src_path_prefix_parts": {
+                "type": "integer"
+              },
+              "headers": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "hosts": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "load_balancing_policy": {
+                "enum": [
+                  "least_loaded",
+                  "first_available"
+                ],
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "paths": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "query_args": {
+                "items": {
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "values": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "values"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "response_headers": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "retry_status_codes": {
+                "items": {
+                  "type": "integer"
+                },
+                "type": "array"
+              },
+              "src_headers": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "src_query_args": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "static": {
+                "properties": {
+                  "url": {
+                    "type": "string"
+                  },
+                  "urls": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "target_path_suffix": {
+                "type": "string"
+              },
+              "targetRefBasicAuth": {
+                "properties": {
+                  "password": {
+                    "properties": {
+                      "key": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "default": "",
+                        "type": "string"
+                      },
+                      "optional": {
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "key"
+                    ],
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  },
+                  "username": {
+                    "properties": {
+                      "key": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "default": "",
+                        "type": "string"
+                      },
+                      "optional": {
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "key"
+                    ],
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  }
+                },
+                "required": [
+                  "password",
+                  "username"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
         "disableAutomountServiceAccountToken": {
-          "description": "DisableAutomountServiceAccountToken whether to disable serviceAccount auto mount by Kubernetes (available from v0.54.0).\nOperator will conditionally create volumes and volumeMounts for containers if it requires k8s API access.\nFor example, vmagent and vm-config-reloader requires k8s API access.\nOperator creates volumes with name: \"kube-api-access\", which can be used as volumeMount for extraContainers if needed.\nAnd also adds VolumeMounts at /var/run/secrets/kubernetes.io/serviceaccount.",
           "type": "boolean"
         },
         "disableSelfServiceScrape": {
-          "description": "DisableSelfServiceScrape controls creation of VMServiceScrape by operator\nfor the application.\nHas priority over `VM_DISABLESELFSERVICESCRAPECREATION` operator env variable",
           "type": "boolean"
         },
         "dnsConfig": {
-          "description": "Specifies the DNS parameters of a pod.\nParameters specified here will be merged to the generated DNS\nconfiguration based on DNSPolicy.",
           "items": {
             "x-kubernetes-preserve-unknown-fields": true
           },
           "properties": {
             "nameservers": {
-              "description": "A list of DNS name server IP addresses.\nThis will be appended to the base nameservers generated from DNSPolicy.\nDuplicated nameservers will be removed.",
               "items": {
                 "type": "string"
               },
@@ -166,16 +372,12 @@
               "x-kubernetes-list-type": "atomic"
             },
             "options": {
-              "description": "A list of DNS resolver options.\nThis will be merged with the base options generated from DNSPolicy.\nDuplicated entries will be removed. Resolution options given in Options\nwill override those that appear in the base DNSPolicy.",
               "items": {
-                "description": "PodDNSConfigOption defines DNS resolver options of a pod.",
                 "properties": {
                   "name": {
-                    "description": "Name is this DNS resolver option's name.\nRequired.",
                     "type": "string"
                   },
                   "value": {
-                    "description": "Value is this DNS resolver option's value.",
                     "type": "string"
                   }
                 },
@@ -186,7 +388,6 @@
               "x-kubernetes-list-type": "atomic"
             },
             "searches": {
-              "description": "A list of DNS search domains for host-name lookup.\nThis will be appended to the base search paths generated from DNSPolicy.\nDuplicated search paths will be removed.",
               "items": {
                 "type": "string"
               },
@@ -198,30 +399,23 @@
           "additionalProperties": false
         },
         "dnsPolicy": {
-          "description": "DNSPolicy sets DNS policy for the pod",
           "type": "string"
         },
         "externalConfig": {
-          "description": "ExternalConfig defines a source of external VMAuth configuration.\nIf it's defined, configuration for vmauth becomes unmanaged and operator'll not create any related secrets/config-reloaders",
           "properties": {
             "localPath": {
-              "description": "LocalPath contains static path to a config, which is managed externally for cases\nwhen using secrets is not applicable, e.g.: Vault sidecar.",
               "type": "string"
             },
             "secretRef": {
-              "description": "SecretRef defines selector for externally managed secret which contains configuration",
               "properties": {
                 "key": {
-                  "description": "The key of the secret to select from.  Must be a valid secret key.",
                   "type": "string"
                 },
                 "name": {
                   "default": "",
-                  "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                   "type": "string"
                 },
                 "optional": {
-                  "description": "Specify whether the Secret or its key must be defined",
                   "type": "boolean"
                 }
               },
@@ -240,20 +434,15 @@
           "additionalProperties": {
             "type": "string"
           },
-          "description": "ExtraArgs that will be passed to the application container\nfor example remoteWrite.tmpDataPath: /tmp",
           "type": "object"
         },
         "extraEnvs": {
-          "description": "ExtraEnvs that will be passed to the application container",
           "items": {
-            "description": "EnvVar represents an environment variable present in a Container.",
             "properties": {
               "name": {
-                "description": "Name of the environment variable.\nMay consist of any printable ASCII characters except '='.",
                 "type": "string"
               },
               "value": {
-                "description": "Variable references $(VAR_NAME) are expanded\nusing the previously defined environment variables in the container and\nany service environment variables. If a variable cannot be resolved,\nthe reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.\n\"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\".\nEscaped references will never be expanded, regardless of whether the variable\nexists or not.\nDefaults to \"\".",
                 "type": "string"
               }
             },
@@ -267,20 +456,15 @@
           "type": "array"
         },
         "extraEnvsFrom": {
-          "description": "ExtraEnvsFrom defines source of env variables for the application container\ncould either be secret or configmap",
           "items": {
-            "description": "EnvFromSource represents the source of a set of ConfigMaps or Secrets",
             "properties": {
               "configMapRef": {
-                "description": "The ConfigMap to select from",
                 "properties": {
                   "name": {
                     "default": "",
-                    "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                     "type": "string"
                   },
                   "optional": {
-                    "description": "Specify whether the ConfigMap must be defined",
                     "type": "boolean"
                   }
                 },
@@ -289,19 +473,15 @@
                 "additionalProperties": false
               },
               "prefix": {
-                "description": "Optional text to prepend to the name of each environment variable.\nMay consist of any printable ASCII characters except '='.",
                 "type": "string"
               },
               "secretRef": {
-                "description": "The Secret to select from",
                 "properties": {
                   "name": {
                     "default": "",
-                    "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                     "type": "string"
                   },
                   "optional": {
-                    "description": "Specify whether the Secret must be defined",
                     "type": "boolean"
                   }
                 },
@@ -316,12 +496,9 @@
           "type": "array"
         },
         "host_aliases": {
-          "description": "HostAliasesUnderScore provides mapping for ip and hostname,\nthat would be propagated to pod,\ncannot be used with HostNetwork.\nHas Priority over hostAliases field",
           "items": {
-            "description": "HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the\npod's hosts file.",
             "properties": {
               "hostnames": {
-                "description": "Hostnames for the above IP address.",
                 "items": {
                   "type": "string"
                 },
@@ -329,7 +506,6 @@
                 "x-kubernetes-list-type": "atomic"
               },
               "ip": {
-                "description": "IP address of the host file entry.",
                 "type": "string"
               }
             },
@@ -342,12 +518,9 @@
           "type": "array"
         },
         "hostAliases": {
-          "description": "HostAliases provides mapping for ip and hostname,\nthat would be propagated to pod,\ncannot be used with HostNetwork.",
           "items": {
-            "description": "HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the\npod's hosts file.",
             "properties": {
               "hostnames": {
-                "description": "Hostnames for the above IP address.",
                 "items": {
                   "type": "string"
                 },
@@ -355,7 +528,6 @@
                 "x-kubernetes-list-type": "atomic"
               },
               "ip": {
-                "description": "IP address of the host file entry.",
                 "type": "string"
               }
             },
@@ -368,34 +540,25 @@
           "type": "array"
         },
         "hostNetwork": {
-          "description": "HostNetwork controls whether the pod may use the node network namespace",
           "type": "boolean"
         },
         "hpa": {
-          "description": "Configures horizontal pod autoscaling.",
           "properties": {
             "behaviour": {
-              "description": "HorizontalPodAutoscalerBehavior configures the scaling behavior of the target\nin both Up and Down directions (scaleUp and scaleDown fields respectively).",
               "properties": {
                 "scaleDown": {
-                  "description": "scaleDown is scaling policy for scaling Down.\nIf not set, the default value is to allow to scale down to minReplicas pods, with a\n300 second stabilization window (i.e., the highest recommendation for\nthe last 300sec is used).",
                   "properties": {
                     "policies": {
-                      "description": "policies is a list of potential scaling polices which can be used during scaling.\nIf not set, use the default values:\n- For scale up: allow doubling the number of pods, or an absolute change of 4 pods in a 15s window.\n- For scale down: allow all pods to be removed in a 15s window.",
                       "items": {
-                        "description": "HPAScalingPolicy is a single policy which must hold true for a specified past interval.",
                         "properties": {
                           "periodSeconds": {
-                            "description": "periodSeconds specifies the window of time for which the policy should hold true.\nPeriodSeconds must be greater than zero and less than or equal to 1800 (30 min).",
                             "format": "int32",
                             "type": "integer"
                           },
                           "type": {
-                            "description": "type is used to specify the scaling policy.",
                             "type": "string"
                           },
                           "value": {
-                            "description": "value contains the amount of change which is permitted by the policy.\nIt must be greater than zero",
                             "format": "int32",
                             "type": "integer"
                           }
@@ -412,11 +575,9 @@
                       "x-kubernetes-list-type": "atomic"
                     },
                     "selectPolicy": {
-                      "description": "selectPolicy is used to specify which policy should be used.\nIf not set, the default value Max is used.",
                       "type": "string"
                     },
                     "stabilizationWindowSeconds": {
-                      "description": "stabilizationWindowSeconds is the number of seconds for which past recommendations should be\nconsidered while scaling up or scaling down.\nStabilizationWindowSeconds must be greater than or equal to zero and less than or equal to 3600 (one hour).\nIf not set, use the default values:\n- For scale up: 0 (i.e. no stabilization is done).\n- For scale down: 300 (i.e. the stabilization window is 300 seconds long).",
                       "format": "int32",
                       "type": "integer"
                     },
@@ -429,7 +590,6 @@
                           "type": "string"
                         }
                       ],
-                      "description": "tolerance is the tolerance on the ratio between the current and desired\nmetric value under which no updates are made to the desired number of\nreplicas (e.g. 0.01 for 1%). Must be greater than or equal to zero. If not\nset, the default cluster-wide tolerance is applied (by default 10%).\n\nFor example, if autoscaling is configured with a memory consumption target of 100Mi,\nand scale-down and scale-up tolerances of 5% and 1% respectively, scaling will be\ntriggered when the actual consumption falls below 95Mi or exceeds 101Mi.\n\nThis is an alpha field and requires enabling the HPAConfigurableTolerance\nfeature gate.",
                       "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                       "x-kubernetes-int-or-string": true
                     }
@@ -438,24 +598,18 @@
                   "additionalProperties": false
                 },
                 "scaleUp": {
-                  "description": "scaleUp is scaling policy for scaling Up.\nIf not set, the default value is the higher of:\n  * increase no more than 4 pods per 60 seconds\n  * double the number of pods per 60 seconds\nNo stabilization is used.",
                   "properties": {
                     "policies": {
-                      "description": "policies is a list of potential scaling polices which can be used during scaling.\nIf not set, use the default values:\n- For scale up: allow doubling the number of pods, or an absolute change of 4 pods in a 15s window.\n- For scale down: allow all pods to be removed in a 15s window.",
                       "items": {
-                        "description": "HPAScalingPolicy is a single policy which must hold true for a specified past interval.",
                         "properties": {
                           "periodSeconds": {
-                            "description": "periodSeconds specifies the window of time for which the policy should hold true.\nPeriodSeconds must be greater than zero and less than or equal to 1800 (30 min).",
                             "format": "int32",
                             "type": "integer"
                           },
                           "type": {
-                            "description": "type is used to specify the scaling policy.",
                             "type": "string"
                           },
                           "value": {
-                            "description": "value contains the amount of change which is permitted by the policy.\nIt must be greater than zero",
                             "format": "int32",
                             "type": "integer"
                           }
@@ -472,11 +626,9 @@
                       "x-kubernetes-list-type": "atomic"
                     },
                     "selectPolicy": {
-                      "description": "selectPolicy is used to specify which policy should be used.\nIf not set, the default value Max is used.",
                       "type": "string"
                     },
                     "stabilizationWindowSeconds": {
-                      "description": "stabilizationWindowSeconds is the number of seconds for which past recommendations should be\nconsidered while scaling up or scaling down.\nStabilizationWindowSeconds must be greater than or equal to zero and less than or equal to 3600 (one hour).\nIf not set, use the default values:\n- For scale up: 0 (i.e. no stabilization is done).\n- For scale down: 300 (i.e. the stabilization window is 300 seconds long).",
                       "format": "int32",
                       "type": "integer"
                     },
@@ -489,7 +641,6 @@
                           "type": "string"
                         }
                       ],
-                      "description": "tolerance is the tolerance on the ratio between the current and desired\nmetric value under which no updates are made to the desired number of\nreplicas (e.g. 0.01 for 1%). Must be greater than or equal to zero. If not\nset, the default cluster-wide tolerance is applied (by default 10%).\n\nFor example, if autoscaling is configured with a memory consumption target of 100Mi,\nand scale-down and scale-up tolerances of 5% and 1% respectively, scaling will be\ntriggered when the actual consumption falls below 95Mi or exceeds 101Mi.\n\nThis is an alpha field and requires enabling the HPAConfigurableTolerance\nfeature gate.",
                       "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                       "x-kubernetes-int-or-string": true
                     }
@@ -507,24 +658,18 @@
             },
             "metrics": {
               "items": {
-                "description": "MetricSpec specifies how to scale based on a single metric\n(only `type` and one other matching field should be set at once).",
                 "properties": {
                   "containerResource": {
-                    "description": "containerResource refers to a resource metric (such as those specified in\nrequests and limits) known to Kubernetes describing a single container in\neach pod of the current scale target (e.g. CPU or memory). Such metrics are\nbuilt in to Kubernetes, and have special scaling options on top of those\navailable to normal per-pod metrics using the \"pods\" source.",
                     "properties": {
                       "container": {
-                        "description": "container is the name of the container in the pods of the scaling target",
                         "type": "string"
                       },
                       "name": {
-                        "description": "name is the name of the resource in question.",
                         "type": "string"
                       },
                       "target": {
-                        "description": "target specifies the target value for the given metric",
                         "properties": {
                           "averageUtilization": {
-                            "description": "averageUtilization is the target value of the average of the\nresource metric across all relevant pods, represented as a percentage of\nthe requested value of the resource for the pods.\nCurrently only valid for Resource metric source type",
                             "format": "int32",
                             "type": "integer"
                           },
@@ -537,12 +682,10 @@
                                 "type": "string"
                               }
                             ],
-                            "description": "averageValue is the target value of the average of the\nmetric across all relevant pods (as a quantity)",
                             "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                             "x-kubernetes-int-or-string": true
                           },
                           "type": {
-                            "description": "type represents whether the metric type is Utilization, Value, or AverageValue",
                             "type": "string"
                           },
                           "value": {
@@ -554,7 +697,6 @@
                                 "type": "string"
                               }
                             ],
-                            "description": "value is the target value of the metric (as a quantity).",
                             "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                             "x-kubernetes-int-or-string": true
                           }
@@ -575,33 +717,24 @@
                     "additionalProperties": false
                   },
                   "external": {
-                    "description": "external refers to a global metric that is not associated\nwith any Kubernetes object. It allows autoscaling based on information\ncoming from components running outside of cluster\n(for example length of queue in cloud messaging service, or\nQPS from loadbalancer running outside of cluster).",
                     "properties": {
                       "metric": {
-                        "description": "metric identifies the target metric by name and selector",
                         "properties": {
                           "name": {
-                            "description": "name is the name of the given metric",
                             "type": "string"
                           },
                           "selector": {
-                            "description": "selector is the string-encoded form of a standard kubernetes label selector for the given metric\nWhen set, it is passed as an additional parameter to the metrics server for more specific metrics scoping.\nWhen unset, just the metricName will be used to gather metrics.",
                             "properties": {
                               "matchExpressions": {
-                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
                                 "items": {
-                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
                                   "properties": {
                                     "key": {
-                                      "description": "key is the label key that the selector applies to.",
                                       "type": "string"
                                     },
                                     "operator": {
-                                      "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
                                       "type": "string"
                                     },
                                     "values": {
-                                      "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
                                       "items": {
                                         "type": "string"
                                       },
@@ -623,7 +756,6 @@
                                 "additionalProperties": {
                                   "type": "string"
                                 },
-                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                                 "type": "object"
                               }
                             },
@@ -639,10 +771,8 @@
                         "additionalProperties": false
                       },
                       "target": {
-                        "description": "target specifies the target value for the given metric",
                         "properties": {
                           "averageUtilization": {
-                            "description": "averageUtilization is the target value of the average of the\nresource metric across all relevant pods, represented as a percentage of\nthe requested value of the resource for the pods.\nCurrently only valid for Resource metric source type",
                             "format": "int32",
                             "type": "integer"
                           },
@@ -655,12 +785,10 @@
                                 "type": "string"
                               }
                             ],
-                            "description": "averageValue is the target value of the average of the\nmetric across all relevant pods (as a quantity)",
                             "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                             "x-kubernetes-int-or-string": true
                           },
                           "type": {
-                            "description": "type represents whether the metric type is Utilization, Value, or AverageValue",
                             "type": "string"
                           },
                           "value": {
@@ -672,7 +800,6 @@
                                 "type": "string"
                               }
                             ],
-                            "description": "value is the target value of the metric (as a quantity).",
                             "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                             "x-kubernetes-int-or-string": true
                           }
@@ -692,21 +819,16 @@
                     "additionalProperties": false
                   },
                   "object": {
-                    "description": "object refers to a metric describing a single kubernetes object\n(for example, hits-per-second on an Ingress object).",
                     "properties": {
                       "describedObject": {
-                        "description": "describedObject specifies the descriptions of a object,such as kind,name apiVersion",
                         "properties": {
                           "apiVersion": {
-                            "description": "apiVersion is the API version of the referent",
                             "type": "string"
                           },
                           "kind": {
-                            "description": "kind is the kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
                             "type": "string"
                           },
                           "name": {
-                            "description": "name is the name of the referent; More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                             "type": "string"
                           }
                         },
@@ -718,30 +840,22 @@
                         "additionalProperties": false
                       },
                       "metric": {
-                        "description": "metric identifies the target metric by name and selector",
                         "properties": {
                           "name": {
-                            "description": "name is the name of the given metric",
                             "type": "string"
                           },
                           "selector": {
-                            "description": "selector is the string-encoded form of a standard kubernetes label selector for the given metric\nWhen set, it is passed as an additional parameter to the metrics server for more specific metrics scoping.\nWhen unset, just the metricName will be used to gather metrics.",
                             "properties": {
                               "matchExpressions": {
-                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
                                 "items": {
-                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
                                   "properties": {
                                     "key": {
-                                      "description": "key is the label key that the selector applies to.",
                                       "type": "string"
                                     },
                                     "operator": {
-                                      "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
                                       "type": "string"
                                     },
                                     "values": {
-                                      "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
                                       "items": {
                                         "type": "string"
                                       },
@@ -763,7 +877,6 @@
                                 "additionalProperties": {
                                   "type": "string"
                                 },
-                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                                 "type": "object"
                               }
                             },
@@ -779,10 +892,8 @@
                         "additionalProperties": false
                       },
                       "target": {
-                        "description": "target specifies the target value for the given metric",
                         "properties": {
                           "averageUtilization": {
-                            "description": "averageUtilization is the target value of the average of the\nresource metric across all relevant pods, represented as a percentage of\nthe requested value of the resource for the pods.\nCurrently only valid for Resource metric source type",
                             "format": "int32",
                             "type": "integer"
                           },
@@ -795,12 +906,10 @@
                                 "type": "string"
                               }
                             ],
-                            "description": "averageValue is the target value of the average of the\nmetric across all relevant pods (as a quantity)",
                             "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                             "x-kubernetes-int-or-string": true
                           },
                           "type": {
-                            "description": "type represents whether the metric type is Utilization, Value, or AverageValue",
                             "type": "string"
                           },
                           "value": {
@@ -812,7 +921,6 @@
                                 "type": "string"
                               }
                             ],
-                            "description": "value is the target value of the metric (as a quantity).",
                             "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                             "x-kubernetes-int-or-string": true
                           }
@@ -833,33 +941,24 @@
                     "additionalProperties": false
                   },
                   "pods": {
-                    "description": "pods refers to a metric describing each pod in the current scale target\n(for example, transactions-processed-per-second).  The values will be\naveraged together before being compared to the target value.",
                     "properties": {
                       "metric": {
-                        "description": "metric identifies the target metric by name and selector",
                         "properties": {
                           "name": {
-                            "description": "name is the name of the given metric",
                             "type": "string"
                           },
                           "selector": {
-                            "description": "selector is the string-encoded form of a standard kubernetes label selector for the given metric\nWhen set, it is passed as an additional parameter to the metrics server for more specific metrics scoping.\nWhen unset, just the metricName will be used to gather metrics.",
                             "properties": {
                               "matchExpressions": {
-                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
                                 "items": {
-                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
                                   "properties": {
                                     "key": {
-                                      "description": "key is the label key that the selector applies to.",
                                       "type": "string"
                                     },
                                     "operator": {
-                                      "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
                                       "type": "string"
                                     },
                                     "values": {
-                                      "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
                                       "items": {
                                         "type": "string"
                                       },
@@ -881,7 +980,6 @@
                                 "additionalProperties": {
                                   "type": "string"
                                 },
-                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                                 "type": "object"
                               }
                             },
@@ -897,10 +995,8 @@
                         "additionalProperties": false
                       },
                       "target": {
-                        "description": "target specifies the target value for the given metric",
                         "properties": {
                           "averageUtilization": {
-                            "description": "averageUtilization is the target value of the average of the\nresource metric across all relevant pods, represented as a percentage of\nthe requested value of the resource for the pods.\nCurrently only valid for Resource metric source type",
                             "format": "int32",
                             "type": "integer"
                           },
@@ -913,12 +1009,10 @@
                                 "type": "string"
                               }
                             ],
-                            "description": "averageValue is the target value of the average of the\nmetric across all relevant pods (as a quantity)",
                             "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                             "x-kubernetes-int-or-string": true
                           },
                           "type": {
-                            "description": "type represents whether the metric type is Utilization, Value, or AverageValue",
                             "type": "string"
                           },
                           "value": {
@@ -930,7 +1024,6 @@
                                 "type": "string"
                               }
                             ],
-                            "description": "value is the target value of the metric (as a quantity).",
                             "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                             "x-kubernetes-int-or-string": true
                           }
@@ -950,17 +1043,13 @@
                     "additionalProperties": false
                   },
                   "resource": {
-                    "description": "resource refers to a resource metric (such as those specified in\nrequests and limits) known to Kubernetes describing each pod in the\ncurrent scale target (e.g. CPU or memory). Such metrics are built in to\nKubernetes, and have special scaling options on top of those available\nto normal per-pod metrics using the \"pods\" source.",
                     "properties": {
                       "name": {
-                        "description": "name is the name of the resource in question.",
                         "type": "string"
                       },
                       "target": {
-                        "description": "target specifies the target value for the given metric",
                         "properties": {
                           "averageUtilization": {
-                            "description": "averageUtilization is the target value of the average of the\nresource metric across all relevant pods, represented as a percentage of\nthe requested value of the resource for the pods.\nCurrently only valid for Resource metric source type",
                             "format": "int32",
                             "type": "integer"
                           },
@@ -973,12 +1062,10 @@
                                 "type": "string"
                               }
                             ],
-                            "description": "averageValue is the target value of the average of the\nmetric across all relevant pods (as a quantity)",
                             "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                             "x-kubernetes-int-or-string": true
                           },
                           "type": {
-                            "description": "type represents whether the metric type is Utilization, Value, or AverageValue",
                             "type": "string"
                           },
                           "value": {
@@ -990,7 +1077,6 @@
                                 "type": "string"
                               }
                             ],
-                            "description": "value is the target value of the metric (as a quantity).",
                             "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                             "x-kubernetes-int-or-string": true
                           }
@@ -1010,7 +1096,6 @@
                     "additionalProperties": false
                   },
                   "type": {
-                    "description": "type is the type of metric source.  It should be one of \"ContainerResource\", \"External\",\n\"Object\", \"Pods\" or \"Resource\", each mapping to a matching field in the object.",
                     "type": "string"
                   }
                 },
@@ -1031,17 +1116,14 @@
           "additionalProperties": false
         },
         "httpRoute": {
-          "description": "HTTPRoute enables httproute configuration for VMAuth.",
           "properties": {
             "annotations": {
               "additionalProperties": {
                 "type": "string"
               },
-              "description": "Annotations is an unstructured key value map stored with a resource that may be\nset by external tools to store and retrieve arbitrary metadata. They are not\nqueryable and should be preserved when modifying objects.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations",
               "type": "object"
             },
             "extraRules": {
-              "description": "ExtraRules defines custom HTTPRouteRule in raw form, bypassing Gateway API CEL validations.",
               "items": {
                 "type": "object",
                 "x-kubernetes-preserve-unknown-fields": true
@@ -1050,9 +1132,7 @@
               "x-kubernetes-preserve-unknown-fields": true
             },
             "hostnames": {
-              "description": "Hostnames defines a set of hostnames that should match against the HTTP Host\nheader to select a HTTPRoute used to process the request.",
               "items": {
-                "description": "Hostname is the fully qualified domain name of a network host. This matches\nthe RFC 1123 definition of a hostname with 2 notable exceptions:\n\n 1. IPs are not allowed.\n 2. A hostname may be prefixed with a wildcard label (`*.`). The wildcard\n    label must appear by itself as the first label.\n\nHostname can be \"precise\" which is a domain name without the terminating\ndot of a network host (e.g. \"foo.example.com\") or \"wildcard\", which is a\ndomain name prefixed with a single wildcard label (e.g. `*.example.com`).\n\nNote that as per RFC1035 and RFC1123, a *label* must consist of lower case\nalphanumeric characters or '-', and must start and end with an alphanumeric\ncharacter. No other punctuation is allowed.",
                 "maxLength": 253,
                 "minLength": 1,
                 "pattern": "^(\\*\\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
@@ -1064,55 +1144,45 @@
               "additionalProperties": {
                 "type": "string"
               },
-              "description": "Labels Map of string keys and values that can be used to organize and categorize\n(scope and select) objects. May match selectors of replication controllers\nand services.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels",
               "type": "object"
             },
             "name": {
-              "description": "Name must be unique within a namespace. Is required when creating resources, although\nsome resources may allow a client to request the generation of an appropriate name\nautomatically. Name is primarily intended for creation idempotence and configuration\ndefinition.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names",
               "type": "string"
             },
             "parentRefs": {
-              "description": "ParentRefs references the resources (usually Gateways) that a Route wants to be attached to.",
               "items": {
-                "description": "ParentReference identifies an API object (usually a Gateway) that can be considered\na parent of this resource (usually a route). There are two kinds of parent resources\nwith \"Core\" support:\n\n* Gateway (Gateway conformance profile)\n* Service (Mesh conformance profile, ClusterIP Services only)\n\nThis API may be extended in the future to support additional kinds of parent\nresources.\n\nThe API object must be valid in the cluster; the Group and Kind must\nbe registered in the cluster for this reference to be valid.",
                 "properties": {
                   "group": {
                     "default": "gateway.networking.k8s.io",
-                    "description": "Group is the group of the referent.\nWhen unspecified, \"gateway.networking.k8s.io\" is inferred.\nTo set the core API group (such as for a \"Service\" kind referent),\nGroup must be explicitly set to \"\" (empty string).\n\nSupport: Core",
                     "maxLength": 253,
                     "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
                     "type": "string"
                   },
                   "kind": {
                     "default": "Gateway",
-                    "description": "Kind is kind of the referent.\n\nThere are two kinds of parent resources with \"Core\" support:\n\n* Gateway (Gateway conformance profile)\n* Service (Mesh conformance profile, ClusterIP Services only)\n\nSupport for other resources is Implementation-Specific.",
                     "maxLength": 63,
                     "minLength": 1,
                     "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
                     "type": "string"
                   },
                   "name": {
-                    "description": "Name is the name of the referent.\n\nSupport: Core",
                     "maxLength": 253,
                     "minLength": 1,
                     "type": "string"
                   },
                   "namespace": {
-                    "description": "Namespace is the namespace of the referent. When unspecified, this refers\nto the local namespace of the Route.\n\nNote that there are specific rules for ParentRefs which cross namespace\nboundaries. Cross-namespace references are only valid if they are explicitly\nallowed by something in the namespace they are referring to. For example:\nGateway has the AllowedRoutes field, and ReferenceGrant provides a\ngeneric way to enable any other kind of cross-namespace reference.\n\n<gateway:experimental:description>\nParentRefs from a Route to a Service in the same namespace are \"producer\"\nroutes, which apply default routing rules to inbound connections from\nany namespace to the Service.\n\nParentRefs from a Route to a Service in a different namespace are\n\"consumer\" routes, and these routing rules are only applied to outbound\nconnections originating from the same namespace as the Route, for which\nthe intended destination of the connections are a Service targeted as a\nParentRef of the Route.\n</gateway:experimental:description>\n\nSupport: Core",
                     "maxLength": 63,
                     "minLength": 1,
                     "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                     "type": "string"
                   },
                   "port": {
-                    "description": "Port is the network port this Route targets. It can be interpreted\ndifferently based on the type of parent resource.\n\nWhen the parent resource is a Gateway, this targets all listeners\nlistening on the specified port that also support this kind of Route(and\nselect this Route). It's not recommended to set `Port` unless the\nnetworking behaviors specified in a Route must apply to a specific port\nas opposed to a listener(s) whose port(s) may be changed. When both Port\nand SectionName are specified, the name and port of the selected listener\nmust match both specified values.\n\n<gateway:experimental:description>\nWhen the parent resource is a Service, this targets a specific port in the\nService spec. When both Port (experimental) and SectionName are specified,\nthe name and port of the selected port must match both specified values.\n</gateway:experimental:description>\n\nImplementations MAY choose to support other parent resources.\nImplementations supporting other types of parent resources MUST clearly\ndocument how/if Port is interpreted.\n\nFor the purpose of status, an attachment is considered successful as\nlong as the parent resource accepts it partially. For example, Gateway\nlisteners can restrict which Routes can attach to them by Route kind,\nnamespace, or hostname. If 1 of 2 Gateway listeners accept attachment\nfrom the referencing Route, the Route MUST be considered successfully\nattached. If no Gateway listeners accept attachment from this Route,\nthe Route MUST be considered detached from the Gateway.\n\nSupport: Extended",
                     "format": "int32",
                     "maximum": 65535,
                     "minimum": 1,
                     "type": "integer"
                   },
                   "sectionName": {
-                    "description": "SectionName is the name of a section within the target resource. In the\nfollowing resources, SectionName is interpreted as the following:\n\n* Gateway: Listener name. When both Port (experimental) and SectionName\nare specified, the name and port of the selected listener must match\nboth specified values.\n* Service: Port name. When both Port (experimental) and SectionName\nare specified, the name and port of the selected listener must match\nboth specified values.\n\nImplementations MAY choose to support attaching Routes to other resources.\nIf that is the case, they MUST clearly document how SectionName is\ninterpreted.\n\nWhen unspecified (empty string), this will reference the entire resource.\nFor the purpose of status, an attachment is considered successful if at\nleast one section in the parent resource accepts it. For example, Gateway\nlisteners can restrict which Routes can attach to them by Route kind,\nnamespace, or hostname. If 1 of 2 Gateway listeners accept attachment from\nthe referencing Route, the Route MUST be considered successfully\nattached. If no Gateway listeners accept attachment from this Route, the\nRoute MUST be considered detached from the Gateway.\n\nSupport: Core",
                     "maxLength": 253,
                     "minLength": 1,
                     "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
@@ -1132,18 +1202,14 @@
           "additionalProperties": false
         },
         "image": {
-          "description": "Image - docker image settings\nif no specified operator uses default version from operator config",
           "properties": {
             "pullPolicy": {
-              "description": "PullPolicy describes how to pull docker image",
               "type": "string"
             },
             "repository": {
-              "description": "Repository contains name of docker image + it's repository if needed",
               "type": "string"
             },
             "tag": {
-              "description": "Tag contains desired docker image version",
               "type": "string"
             }
           },
@@ -1151,13 +1217,10 @@
           "additionalProperties": false
         },
         "imagePullSecrets": {
-          "description": "ImagePullSecrets An optional list of references to secrets in the same namespace\nto use for pulling images from registries\nsee https://kubernetes.io/docs/concepts/containers/images/#referring-to-an-imagepullsecrets-on-a-pod",
           "items": {
-            "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
             "properties": {
               "name": {
                 "default": "",
-                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                 "type": "string"
               }
             },
@@ -1168,52 +1231,38 @@
           "type": "array"
         },
         "ingress": {
-          "description": "Ingress enables ingress configuration for VMAuth.",
           "properties": {
             "annotations": {
               "additionalProperties": {
                 "type": "string"
               },
-              "description": "Annotations is an unstructured key value map stored with a resource that may be\nset by external tools to store and retrieve arbitrary metadata. They are not\nqueryable and should be preserved when modifying objects.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations",
               "type": "object"
             },
             "class_name": {
-              "description": "ClassName defines ingress class name for VMAuth",
               "type": "string"
             },
             "extraRules": {
-              "description": "ExtraRules - additional rules for ingress,\nmust be checked for correctness by user.",
               "items": {
-                "description": "IngressRule represents the rules mapping the paths under a specified host to\nthe related backend services. Incoming requests are first evaluated for a host\nmatch, then routed to the backend associated with the matching IngressRuleValue.",
                 "properties": {
                   "host": {
-                    "description": "host is the fully qualified domain name of a network host, as defined by RFC 3986.\nNote the following deviations from the \"host\" part of the\nURI as defined in RFC 3986:\n1. IPs are not allowed. Currently an IngressRuleValue can only apply to\n   the IP in the Spec of the parent Ingress.\n2. The `:` delimiter is not respected because ports are not allowed.\n\t  Currently the port of an Ingress is implicitly :80 for http and\n\t  :443 for https.\nBoth these may change in the future.\nIncoming requests are matched against the host before the\nIngressRuleValue. If the host is unspecified, the Ingress routes all\ntraffic based on the specified IngressRuleValue.\n\nhost can be \"precise\" which is a domain name without the terminating dot of\na network host (e.g. \"foo.bar.com\") or \"wildcard\", which is a domain name\nprefixed with a single wildcard label (e.g. \"*.foo.com\").\nThe wildcard character '*' must appear by itself as the first DNS label and\nmatches only a single label. You cannot have a wildcard label by itself (e.g. Host == \"*\").\nRequests will be matched against the Host field in the following way:\n1. If host is precise, the request matches this rule if the http host header is equal to Host.\n2. If host is a wildcard, then the request matches this rule if the http host header\nis to equal to the suffix (removing the first label) of the wildcard rule.",
                     "type": "string"
                   },
                   "http": {
-                    "description": "HTTPIngressRuleValue is a list of http selectors pointing to backends.\nIn the example: http://<host>/<path>?<searchpart> -> backend where\nwhere parts of the url correspond to RFC 3986, this resource will be used\nto match against everything after the last '/' and before the first '?'\nor '#'.",
                     "properties": {
                       "paths": {
-                        "description": "paths is a collection of paths that map requests to backends.",
                         "items": {
-                          "description": "HTTPIngressPath associates a path with a backend. Incoming urls matching the\npath are forwarded to the backend.",
                           "properties": {
                             "backend": {
-                              "description": "backend defines the referenced service endpoint to which the traffic\nwill be forwarded to.",
                               "properties": {
                                 "resource": {
-                                  "description": "resource is an ObjectRef to another Kubernetes resource in the namespace\nof the Ingress object. If resource is specified, a service.Name and\nservice.Port must not be specified.\nThis is a mutually exclusive setting with \"Service\".",
                                   "properties": {
                                     "apiGroup": {
-                                      "description": "APIGroup is the group for the resource being referenced.\nIf APIGroup is not specified, the specified Kind must be in the core API group.\nFor any other third-party types, APIGroup is required.",
                                       "type": "string"
                                     },
                                     "kind": {
-                                      "description": "Kind is the type of resource being referenced",
                                       "type": "string"
                                     },
                                     "name": {
-                                      "description": "Name is the name of resource being referenced",
                                       "type": "string"
                                     }
                                   },
@@ -1226,21 +1275,16 @@
                                   "additionalProperties": false
                                 },
                                 "service": {
-                                  "description": "service references a service as a backend.\nThis is a mutually exclusive setting with \"Resource\".",
                                   "properties": {
                                     "name": {
-                                      "description": "name is the referenced service. The service must exist in\nthe same namespace as the Ingress object.",
                                       "type": "string"
                                     },
                                     "port": {
-                                      "description": "port of the referenced service. A port name or port number\nis required for a IngressServiceBackend.",
                                       "properties": {
                                         "name": {
-                                          "description": "name is the name of the port on the Service.\nThis is a mutually exclusive setting with \"Number\".",
                                           "type": "string"
                                         },
                                         "number": {
-                                          "description": "number is the numerical port number (e.g. 80) on the Service.\nThis is a mutually exclusive setting with \"Name\".",
                                           "format": "int32",
                                           "type": "integer"
                                         }
@@ -1261,11 +1305,9 @@
                               "additionalProperties": false
                             },
                             "path": {
-                              "description": "path is matched against the path of an incoming request. Currently it can\ncontain characters disallowed from the conventional \"path\" part of a URL\nas defined by RFC 3986. Paths must begin with a '/' and must be present\nwhen using PathType with value \"Exact\" or \"Prefix\".",
                               "type": "string"
                             },
                             "pathType": {
-                              "description": "pathType determines the interpretation of the path matching. PathType can\nbe one of the following values:\n* Exact: Matches the URL path exactly.\n* Prefix: Matches based on a URL path prefix split by '/'. Matching is\n  done on a path element by element basis. A path element refers is the\n  list of labels in the path split by the '/' separator. A request is a\n  match for path p if every p is an element-wise prefix of p of the\n  request path. Note that if the last element of the path is a substring\n  of the last element in request path, it is not a match (e.g. /foo/bar\n  matches /foo/bar/baz, but does not match /foo/barbaz).\n* ImplementationSpecific: Interpretation of the Path matching is up to\n  the IngressClass. Implementations can treat this as a separate PathType\n  or treat it identically to Prefix or Exact path types.\nImplementations are required to support all path types.",
                               "type": "string"
                             }
                           },
@@ -1293,12 +1335,9 @@
               "type": "array"
             },
             "extraTls": {
-              "description": "ExtraTLS - additional TLS configuration for ingress\nmust be checked for correctness by user.",
               "items": {
-                "description": "IngressTLS describes the transport layer security associated with an ingress.",
                 "properties": {
                   "hosts": {
-                    "description": "hosts is a list of hosts included in the TLS certificate. The values in\nthis list must match the name/s used in the tlsSecret. Defaults to the\nwildcard host setting for the loadbalancer controller fulfilling this\nIngress, if left unspecified.",
                     "items": {
                       "type": "string"
                     },
@@ -1306,7 +1345,6 @@
                     "x-kubernetes-list-type": "atomic"
                   },
                   "secretName": {
-                    "description": "secretName is the name of the secret used to terminate TLS traffic on\nport 443. Field is left optional to allow TLS routing based on SNI\nhostname alone. If the SNI host in a listener conflicts with the \"Host\"\nheader field used by an IngressRule, the SNI host is used for termination\nand value of the \"Host\" header is used for routing.",
                     "type": "string"
                   }
                 },
@@ -1316,36 +1354,30 @@
               "type": "array"
             },
             "host": {
-              "description": "Host defines ingress host parameter for default rule\nIt will be used, only if TlsHosts is empty",
               "type": "string"
             },
             "labels": {
               "additionalProperties": {
                 "type": "string"
               },
-              "description": "Labels Map of string keys and values that can be used to organize and categorize\n(scope and select) objects. May match selectors of replication controllers\nand services.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels",
               "type": "object"
             },
             "name": {
-              "description": "Name must be unique within a namespace. Is required when creating resources, although\nsome resources may allow a client to request the generation of an appropriate name\nautomatically. Name is primarily intended for creation idempotence and configuration\ndefinition.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names",
               "type": "string"
             },
             "paths": {
-              "description": "Paths defines ingress paths parameter for default rule",
               "items": {
                 "type": "string"
               },
               "type": "array"
             },
             "tlsHosts": {
-              "description": "TlsHosts configures TLS access for ingress, tlsSecretName must be defined for it.",
               "items": {
                 "type": "string"
               },
               "type": "array"
             },
             "tlsSecretName": {
-              "description": "TlsSecretName defines secretname at the VMAuth namespace with cert and key\nhttps://kubernetes.io/docs/concepts/services-networking/ingress/#tls",
               "type": "string"
             }
           },
@@ -1353,9 +1385,7 @@
           "additionalProperties": false
         },
         "initContainers": {
-          "description": "InitContainers allows adding initContainers to the pod definition.\nAny errors during the execution of an initContainer will lead to a restart of the Pod.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/",
           "items": {
-            "description": "A single application container that you want to run within a pod.",
             "required": [
               "name"
             ],
@@ -1365,34 +1395,26 @@
           "type": "array"
         },
         "internalListenPort": {
-          "description": "InternalListenPort instructs vmauth to serve internal routes at given port\navailable from v0.56.0 operator\nand v1.111.0 vmauth version\nrelated doc https://docs.victoriametrics.com/victoriametrics/vmauth/#security",
           "type": "string"
         },
         "license": {
-          "description": "License allows to configure license key to be used for enterprise features.\nUsing license key is supported starting from VictoriaMetrics v1.94.0.\nSee [here](https://docs.victoriametrics.com/victoriametrics/enterprise/)",
           "properties": {
             "forceOffline": {
-              "description": "Enforce offline verification of the license key.",
               "type": "boolean"
             },
             "key": {
-              "description": "Enterprise license key. This flag is available only in [VictoriaMetrics enterprise](https://docs.victoriametrics.com/victoriametrics/enterprise/).\nTo request a trial license, [go to](https://victoriametrics.com/products/enterprise/trial)",
               "type": "string"
             },
             "keyRef": {
-              "description": "KeyRef is reference to secret with license key for enterprise features.",
               "properties": {
                 "key": {
-                  "description": "The key of the secret to select from.  Must be a valid secret key.",
                   "type": "string"
                 },
                 "name": {
                   "default": "",
-                  "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                   "type": "string"
                 },
                 "optional": {
-                  "description": "Specify whether the Secret or its key must be defined",
                   "type": "boolean"
                 }
               },
@@ -1404,7 +1426,6 @@
               "additionalProperties": false
             },
             "reloadInterval": {
-              "description": "Interval to be used for checking for license key changes. Note that this is only applicable when using KeyRef.",
               "type": "string"
             }
           },
@@ -1412,12 +1433,10 @@
           "additionalProperties": false
         },
         "livenessProbe": {
-          "description": "LivenessProbe that will be added CRD pod",
           "type": "object",
           "x-kubernetes-preserve-unknown-fields": true
         },
         "logFormat": {
-          "description": "LogFormat for VMAuth to be configured with.",
           "enum": [
             "default",
             "json"
@@ -1425,7 +1444,6 @@
           "type": "string"
         },
         "logLevel": {
-          "description": "LogLevel for victoria metrics single to be configured with.",
           "enum": [
             "INFO",
             "WARN",
@@ -1436,20 +1454,17 @@
           "type": "string"
         },
         "managedMetadata": {
-          "description": "ManagedMetadata defines metadata that will be added to the all objects\ncreated by operator for the given CustomResource",
           "properties": {
             "annotations": {
               "additionalProperties": {
                 "type": "string"
               },
-              "description": "Annotations is an unstructured key value map stored with a resource that may be\nset by external tools to store and retrieve arbitrary metadata. They are not\nqueryable and should be preserved when modifying objects.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations",
               "type": "object"
             },
             "labels": {
               "additionalProperties": {
                 "type": "string"
               },
-              "description": "Labels Map of string keys and values that can be used to organize and categorize\n(scope and select) objects.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels",
               "type": "object"
             }
           },
@@ -1457,7 +1472,6 @@
           "additionalProperties": false
         },
         "minReadySeconds": {
-          "description": "MinReadySeconds defines a minimum number of seconds to wait before starting update next pod\nif previous in healthy state\nHas no effect for VLogs and VMSingle",
           "format": "int32",
           "type": "integer"
         },
@@ -1465,15 +1479,12 @@
           "additionalProperties": {
             "type": "string"
           },
-          "description": "NodeSelector Define which Nodes the Pods are scheduled on.",
           "type": "object"
         },
         "paused": {
-          "description": "Paused If set to true all actions on the underlying managed objects are not\ngoing to be performed, except for delete actions.",
           "type": "boolean"
         },
         "podDisruptionBudget": {
-          "description": "PodDisruptionBudget created by operator",
           "properties": {
             "maxUnavailable": {
               "anyOf": [
@@ -1484,7 +1495,6 @@
                   "type": "string"
                 }
               ],
-              "description": "An eviction is allowed if at most \"maxUnavailable\" pods selected by\n\"selector\" are unavailable after the eviction, i.e. even in absence of\nthe evicted pod. For example, one can prevent all voluntary evictions\nby specifying 0. This is a mutually exclusive setting with \"minAvailable\".",
               "x-kubernetes-int-or-string": true
             },
             "minAvailable": {
@@ -1496,18 +1506,15 @@
                   "type": "string"
                 }
               ],
-              "description": "An eviction is allowed if at least \"minAvailable\" pods selected by\n\"selector\" will still be available after the eviction, i.e. even in the\nabsence of the evicted pod.  So for example you can prevent all voluntary\nevictions by specifying \"100%\".",
               "x-kubernetes-int-or-string": true
             },
             "selectorLabels": {
               "additionalProperties": {
                 "type": "string"
               },
-              "description": "replaces default labels selector generated by operator\nit's useful when you need to create custom budget",
               "type": "object"
             },
             "unhealthyPodEvictionPolicy": {
-              "description": "UnhealthyPodEvictionPolicy defines the criteria for when unhealthy pods\n\nValid policies are IfHealthyBudget and AlwaysAllow.\nIf no policy is specified, the default behavior will be used,\nwhich corresponds to the IfHealthyBudget policy.\nAvailable from operator v0.64.0",
               "enum": [
                 "IfHealthyBudget",
                 "AlwaysAllow"
@@ -1519,24 +1526,20 @@
           "additionalProperties": false
         },
         "podMetadata": {
-          "description": "PodMetadata configures Labels and Annotations which are propagated to the VMAuth pods.",
           "properties": {
             "annotations": {
               "additionalProperties": {
                 "type": "string"
               },
-              "description": "Annotations is an unstructured key value map stored with a resource that may be\nset by external tools to store and retrieve arbitrary metadata. They are not\nqueryable and should be preserved when modifying objects.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations",
               "type": "object"
             },
             "labels": {
               "additionalProperties": {
                 "type": "string"
               },
-              "description": "Labels Map of string keys and values that can be used to organize and categorize\n(scope and select) objects. May match selectors of replication controllers\nand services.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels",
               "type": "object"
             },
             "name": {
-              "description": "Name must be unique within a namespace. Is required when creating resources, although\nsome resources may allow a client to request the generation of an appropriate name\nautomatically. Name is primarily intended for creation idempotence and configuration\ndefinition.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names",
               "type": "string"
             }
           },
@@ -1544,20 +1547,15 @@
           "additionalProperties": false
         },
         "port": {
-          "description": "Port listen address",
           "type": "string"
         },
         "priorityClassName": {
-          "description": "PriorityClassName class assigned to the Pods",
           "type": "string"
         },
         "readinessGates": {
-          "description": "ReadinessGates defines pod readiness gates",
           "items": {
-            "description": "PodReadinessGate contains the reference to a pod condition",
             "properties": {
               "conditionType": {
-                "description": "ConditionType refers to a condition in the pod's condition list with matching type.",
                 "type": "string"
               }
             },
@@ -1570,29 +1568,22 @@
           "type": "array"
         },
         "readinessProbe": {
-          "description": "ReadinessProbe that will be added CRD pod",
           "type": "object",
           "x-kubernetes-preserve-unknown-fields": true
         },
         "replicaCount": {
-          "description": "ReplicaCount is the expected size of the Application.",
           "format": "int32",
           "type": "integer"
         },
         "resources": {
-          "description": "Resources container resource request and limits, https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/\nif not defined default resources from operator config will be used",
           "properties": {
             "claims": {
-              "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis field depends on the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
               "items": {
-                "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
                 "properties": {
                   "name": {
-                    "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
                     "type": "string"
                   },
                   "request": {
-                    "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
                     "type": "string"
                   }
                 },
@@ -1621,7 +1612,6 @@
                 "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                 "x-kubernetes-int-or-string": true
               },
-              "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
               "type": "object"
             },
             "requests": {
@@ -1637,7 +1627,6 @@
                 "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                 "x-kubernetes-int-or-string": true
               },
-              "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
               "type": "object"
             }
           },
@@ -1645,12 +1634,10 @@
           "additionalProperties": false
         },
         "revisionHistoryLimitCount": {
-          "description": "The number of old ReplicaSets to retain to allow rollback in deployment or\nmaximum number of revisions that will be maintained in the Deployment revision history.\nHas no effect at StatefulSets\nDefaults to 10.",
           "format": "int32",
           "type": "integer"
         },
         "rollingUpdate": {
-          "description": "RollingUpdate - overrides deployment update params.\nAvailable from operator v0.64.0",
           "properties": {
             "maxSurge": {
               "anyOf": [
@@ -1661,7 +1648,6 @@
                   "type": "string"
                 }
               ],
-              "description": "The maximum number of pods that can be scheduled above the desired number of\npods.\nValue can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).\nThis can not be 0 if MaxUnavailable is 0.\nAbsolute number is calculated from percentage by rounding up.\nDefaults to 25%.\nExample: when this is set to 30%, the new ReplicaSet can be scaled up immediately when\nthe rolling update starts, such that the total number of old and new pods do not exceed\n130% of desired pods. Once old pods have been killed,\nnew ReplicaSet can be scaled up further, ensuring that total number of pods running\nat any time during the update is at most 130% of desired pods.",
               "x-kubernetes-int-or-string": true
             },
             "maxUnavailable": {
@@ -1673,7 +1659,6 @@
                   "type": "string"
                 }
               ],
-              "description": "The maximum number of pods that can be unavailable during the update.\nValue can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).\nAbsolute number is calculated from percentage by rounding down.\nThis can not be 0 if MaxSurge is 0.\nDefaults to 25%.\nExample: when this is set to 30%, the old ReplicaSet can be scaled down to 70% of desired pods\nimmediately when the rolling update starts. Once new pods are ready, old ReplicaSet\ncan be scaled down further, followed by scaling up the new ReplicaSet, ensuring\nthat the total number of pods available at all times during the update is at\nleast 70% of desired pods.",
               "x-kubernetes-int-or-string": true
             }
           },
@@ -1681,35 +1666,28 @@
           "additionalProperties": false
         },
         "runtimeClassName": {
-          "description": "RuntimeClassName - defines runtime class for kubernetes pod.\nhttps://kubernetes.io/docs/concepts/containers/runtime-class/",
           "type": "string"
         },
         "schedulerName": {
-          "description": "SchedulerName - defines kubernetes scheduler name",
           "type": "string"
         },
         "secrets": {
-          "description": "Secrets is a list of Secrets in the same namespace as the Application\nobject, which shall be mounted into the Application container\nat /etc/vm/secrets/SECRET_NAME folder",
           "items": {
             "type": "string"
           },
           "type": "array"
         },
         "securityContext": {
-          "description": "SecurityContext holds pod-level security attributes and common container settings.\nThis defaults to the default PodSecurityContext.",
           "type": "object",
           "x-kubernetes-preserve-unknown-fields": true
         },
         "selectAllByDefault": {
-          "description": "SelectAllByDefault changes default behavior for empty CRD selectors, such userSelector.\nwith selectAllByDefault: true and empty userSelector and userNamespaceSelector\nOperator selects all exist users\nwith selectAllByDefault: false - selects nothing",
           "type": "boolean"
         },
         "serviceAccountName": {
-          "description": "ServiceAccountName is the name of the ServiceAccount to use to run the pods",
           "type": "string"
         },
         "serviceScrapeSpec": {
-          "description": "ServiceScrapeSpec that will be added to vmauth VMServiceScrape spec",
           "required": [
             "endpoints"
           ],
@@ -1717,27 +1695,22 @@
           "x-kubernetes-preserve-unknown-fields": true
         },
         "serviceSpec": {
-          "description": "ServiceSpec that will be added to vmsingle service spec",
           "properties": {
             "metadata": {
-              "description": "EmbeddedObjectMetadata defines objectMeta for additional service.",
               "properties": {
                 "annotations": {
                   "additionalProperties": {
                     "type": "string"
                   },
-                  "description": "Annotations is an unstructured key value map stored with a resource that may be\nset by external tools to store and retrieve arbitrary metadata. They are not\nqueryable and should be preserved when modifying objects.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations",
                   "type": "object"
                 },
                 "labels": {
                   "additionalProperties": {
                     "type": "string"
                   },
-                  "description": "Labels Map of string keys and values that can be used to organize and categorize\n(scope and select) objects. May match selectors of replication controllers\nand services.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels",
                   "type": "object"
                 },
                 "name": {
-                  "description": "Name must be unique within a namespace. Is required when creating resources, although\nsome resources may allow a client to request the generation of an appropriate name\nautomatically. Name is primarily intended for creation idempotence and configuration\ndefinition.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names",
                   "type": "string"
                 }
               },
@@ -1745,12 +1718,10 @@
               "additionalProperties": false
             },
             "spec": {
-              "description": "ServiceSpec describes the attributes that a user creates on a service.\nMore info: https://kubernetes.io/docs/concepts/services-networking/service/",
               "type": "object",
               "x-kubernetes-preserve-unknown-fields": true
             },
             "useAsDefault": {
-              "description": "UseAsDefault applies changes from given service definition to the main object Service\nChanging from headless service to clusterIP or loadbalancer may break cross-component communication",
               "type": "boolean"
             }
           },
@@ -1761,39 +1732,30 @@
           "additionalProperties": false
         },
         "startupProbe": {
-          "description": "StartupProbe that will be added to CRD pod",
           "type": "object",
           "x-kubernetes-preserve-unknown-fields": true
         },
         "terminationGracePeriodSeconds": {
-          "description": "TerminationGracePeriodSeconds period for container graceful termination",
           "format": "int64",
           "type": "integer"
         },
         "tolerations": {
-          "description": "Tolerations If specified, the pod's tolerations.",
           "items": {
-            "description": "The pod this Toleration is attached to tolerates any taint that matches\nthe triple <key,value,effect> using the matching operator <operator>.",
             "properties": {
               "effect": {
-                "description": "Effect indicates the taint effect to match. Empty means match all taint effects.\nWhen specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
                 "type": "string"
               },
               "key": {
-                "description": "Key is the taint key that the toleration applies to. Empty means match all taint keys.\nIf the key is empty, operator must be Exists; this combination means to match all values and all keys.",
                 "type": "string"
               },
               "operator": {
-                "description": "Operator represents a key's relationship to the value.\nValid operators are Exists and Equal. Defaults to Equal.\nExists is equivalent to wildcard for value, so that a pod can\ntolerate all taints of a particular category.",
                 "type": "string"
               },
               "tolerationSeconds": {
-                "description": "TolerationSeconds represents the period of time the toleration (which must be\nof effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,\nit is not set, which means tolerate the taint forever (do not evict). Zero and\nnegative values will be treated as 0 (evict immediately) by the system.",
                 "format": "int64",
                 "type": "integer"
               },
               "value": {
-                "description": "Value is the taint value the toleration matches to.\nIf the operator is Exists, the value should be empty, otherwise just a regular string.",
                 "type": "string"
               }
             },
@@ -1803,9 +1765,7 @@
           "type": "array"
         },
         "topologySpreadConstraints": {
-          "description": "TopologySpreadConstraints embedded kubernetes pod configuration option,\ncontrols how pods are spread across your cluster among failure-domains\nsuch as regions, zones, nodes, and other user-defined topology domains\nhttps://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/",
           "items": {
-            "description": "TopologySpreadConstraint specifies how to spread matching pods among the given topology.",
             "required": [
               "maxSkew",
               "topologyKey",
@@ -1817,40 +1777,32 @@
           "type": "array"
         },
         "unauthorizedAccessConfig": {
-          "description": "UnauthorizedAccessConfig configures access for un authorized users\n\nDeprecated: use unauthorizedUserAccessSpec instead\nwill be removed at v1.0 release",
           "x-kubernetes-preserve-unknown-fields": true
         },
         "unauthorizedUserAccessSpec": {
-          "description": "UnauthorizedUserAccessSpec defines unauthorized_user config section of vmauth config",
           "properties": {
             "default_url": {
-              "description": "DefaultURLs backend url for non-matching paths filter\nusually used for default backend with error message",
               "items": {
                 "type": "string"
               },
               "type": "array"
             },
             "discover_backend_ips": {
-              "description": "DiscoverBackendIPs instructs discovering URLPrefix backend IPs via DNS.",
               "type": "boolean"
             },
             "drop_src_path_prefix_parts": {
-              "description": "DropSrcPathPrefixParts is the number of `/`-delimited request path prefix parts to drop before proxying the request to backend.\nSee [here](https://docs.victoriametrics.com/victoriametrics/vmauth/#dropping-request-path-prefix) for more details.",
               "type": "integer"
             },
             "dump_request_on_errors": {
-              "description": "DumpRequestOnErrors instructs vmauth to return detailed request params to the client\nif routing rules don't allow to forward request to the backends.\nUseful for debugging `src_hosts` and `src_headers` based routing rules\n\navailable since v1.107.0 vmauth version",
               "type": "boolean"
             },
             "headers": {
-              "description": "Headers represent additional http headers, that vmauth uses\nin form of [\"header_key: header_value\"]\nmultiple values for header key:\n[\"header_key: value1,value2\"]\nit's available since 1.68.0 version of vmauth",
               "items": {
                 "type": "string"
               },
               "type": "array"
             },
             "ip_filters": {
-              "description": "IPFilters defines per target src ip filters\nsupported only with enterprise version of [vmauth](https://docs.victoriametrics.com/victoriametrics/vmauth/#ip-filters)",
               "properties": {
                 "allow_list": {
                   "items": {
@@ -1869,7 +1821,6 @@
               "additionalProperties": false
             },
             "load_balancing_policy": {
-              "description": "LoadBalancingPolicy defines load balancing policy to use for backend urls.\nSupported policies: least_loaded, first_available.\nSee [here](https://docs.victoriametrics.com/victoriametrics/vmauth/#load-balancing) for more details (default \"least_loaded\")",
               "enum": [
                 "least_loaded",
                 "first_available"
@@ -1877,50 +1828,257 @@
               "type": "string"
             },
             "max_concurrent_requests": {
-              "description": "MaxConcurrentRequests defines max concurrent requests per user\n300 is default value for vmauth",
               "type": "integer"
             },
             "metric_labels": {
               "additionalProperties": {
                 "type": "string"
               },
-              "description": "MetricLabels - additional labels for metrics exported by vmauth for given user.",
               "type": "object"
             },
             "response_headers": {
-              "description": "ResponseHeaders represent additional http headers, that vmauth adds for request response\nin form of [\"header_key: header_value\"]\nmultiple values for header key:\n[\"header_key: value1,value2\"]\nit's available since 1.93.0 version of vmauth",
               "items": {
                 "type": "string"
               },
               "type": "array"
             },
             "retry_status_codes": {
-              "description": "RetryStatusCodes defines http status codes in numeric format for request retries\ne.g. [429,503]",
               "items": {
                 "type": "integer"
               },
               "type": "array"
             },
+            "targetRefs": {
+              "items": {
+                "properties": {
+                  "crd": {
+                    "properties": {
+                      "kind": {
+                        "enum": [
+                          "VMAgent",
+                          "VMAlert",
+                          "VMSingle",
+                          "VLogs",
+                          "VMAlertManager",
+                          "VMAlertmanager",
+                          "VMCluster/vmselect",
+                          "VMCluster/vmstorage",
+                          "VMCluster/vminsert",
+                          "VLSingle",
+                          "VLCluster/vlinsert",
+                          "VLCluster/vlselect",
+                          "VLCluster/vlstorage",
+                          "VLAgent",
+                          "VTCluster/vtinsert",
+                          "VTCluster/vtselect",
+                          "VTCluster/vtstorage",
+                          "VTSingle",
+                          "VMAnomaly"
+                        ],
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "namespace": {
+                        "type": "string"
+                      },
+                      "objects": {
+                        "items": {
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "namespace": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name",
+                            "namespace"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "required": [
+                      "kind",
+                      "name",
+                      "namespace"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "discover_backend_ips": {
+                    "type": "boolean"
+                  },
+                  "drop_src_path_prefix_parts": {
+                    "type": "integer"
+                  },
+                  "headers": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "hosts": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "load_balancing_policy": {
+                    "enum": [
+                      "least_loaded",
+                      "first_available"
+                    ],
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "paths": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "query_args": {
+                    "items": {
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        },
+                        "values": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "required": [
+                        "name",
+                        "values"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
+                  "response_headers": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "retry_status_codes": {
+                    "items": {
+                      "type": "integer"
+                    },
+                    "type": "array"
+                  },
+                  "src_headers": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "src_query_args": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "static": {
+                    "properties": {
+                      "url": {
+                        "type": "string"
+                      },
+                      "urls": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "target_path_suffix": {
+                    "type": "string"
+                  },
+                  "targetRefBasicAuth": {
+                    "properties": {
+                      "password": {
+                        "properties": {
+                          "key": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "default": "",
+                            "type": "string"
+                          },
+                          "optional": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "key"
+                        ],
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "username": {
+                        "properties": {
+                          "key": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "default": "",
+                            "type": "string"
+                          },
+                          "optional": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "key"
+                        ],
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "password",
+                      "username"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
             "tlsConfig": {
-              "description": "TLSConfig defines tls configuration for the backend connection",
               "properties": {
                 "ca": {
-                  "description": "Struct containing the CA cert to use for the targets.",
                   "properties": {
                     "configMap": {
-                      "description": "ConfigMap containing data to use for the targets.",
                       "properties": {
                         "key": {
-                          "description": "The key to select.",
                           "type": "string"
                         },
                         "name": {
                           "default": "",
-                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                           "type": "string"
                         },
                         "optional": {
-                          "description": "Specify whether the ConfigMap or its key must be defined",
                           "type": "boolean"
                         }
                       },
@@ -1932,19 +2090,15 @@
                       "additionalProperties": false
                     },
                     "secret": {
-                      "description": "Secret containing data to use for the targets.",
                       "properties": {
                         "key": {
-                          "description": "The key of the secret to select from.  Must be a valid secret key.",
                           "type": "string"
                         },
                         "name": {
                           "default": "",
-                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                           "type": "string"
                         },
                         "optional": {
-                          "description": "Specify whether the Secret or its key must be defined",
                           "type": "boolean"
                         }
                       },
@@ -1960,26 +2114,20 @@
                   "additionalProperties": false
                 },
                 "caFile": {
-                  "description": "Path to the CA cert in the container to use for the targets.",
                   "type": "string"
                 },
                 "cert": {
-                  "description": "Struct containing the client cert file for the targets.",
                   "properties": {
                     "configMap": {
-                      "description": "ConfigMap containing data to use for the targets.",
                       "properties": {
                         "key": {
-                          "description": "The key to select.",
                           "type": "string"
                         },
                         "name": {
                           "default": "",
-                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                           "type": "string"
                         },
                         "optional": {
-                          "description": "Specify whether the ConfigMap or its key must be defined",
                           "type": "boolean"
                         }
                       },
@@ -1991,19 +2139,15 @@
                       "additionalProperties": false
                     },
                     "secret": {
-                      "description": "Secret containing data to use for the targets.",
                       "properties": {
                         "key": {
-                          "description": "The key of the secret to select from.  Must be a valid secret key.",
                           "type": "string"
                         },
                         "name": {
                           "default": "",
-                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                           "type": "string"
                         },
                         "optional": {
-                          "description": "Specify whether the Secret or its key must be defined",
                           "type": "boolean"
                         }
                       },
@@ -2019,31 +2163,24 @@
                   "additionalProperties": false
                 },
                 "certFile": {
-                  "description": "Path to the client cert file in the container for the targets.",
                   "type": "string"
                 },
                 "insecureSkipVerify": {
-                  "description": "Disable target certificate validation.",
                   "type": "boolean"
                 },
                 "keyFile": {
-                  "description": "Path to the client key file in the container for the targets.",
                   "type": "string"
                 },
                 "keySecret": {
-                  "description": "Secret containing the client key file for the targets.",
                   "properties": {
                     "key": {
-                      "description": "The key of the secret to select from.  Must be a valid secret key.",
                       "type": "string"
                     },
                     "name": {
                       "default": "",
-                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                       "type": "string"
                     },
                     "optional": {
-                      "description": "Specify whether the Secret or its key must be defined",
                       "type": "boolean"
                     }
                   },
@@ -2055,7 +2192,6 @@
                   "additionalProperties": false
                 },
                 "serverName": {
-                  "description": "Used to verify the hostname for the targets.",
                   "type": "string"
                 }
               },
@@ -2064,25 +2200,20 @@
             },
             "url_map": {
               "items": {
-                "description": "UnauthorizedAccessConfigURLMap defines element of url_map routing configuration\nFor UnauthorizedAccessConfig and VMAuthUnauthorizedUserAccessSpec.URLMap",
                 "properties": {
                   "discover_backend_ips": {
-                    "description": "DiscoverBackendIPs instructs discovering URLPrefix backend IPs via DNS.",
                     "type": "boolean"
                   },
                   "drop_src_path_prefix_parts": {
-                    "description": "DropSrcPathPrefixParts is the number of `/`-delimited request path prefix parts to drop before proxying the request to backend.\nSee [here](https://docs.victoriametrics.com/victoriametrics/vmauth/#dropping-request-path-prefix) for more details.",
                     "type": "integer"
                   },
                   "headers": {
-                    "description": "RequestHeaders represent additional http headers, that vmauth uses\nin form of [\"header_key: header_value\"]\nmultiple values for header key:\n[\"header_key: value1,value2\"]\nit's available since 1.68.0 version of vmauth",
                     "items": {
                       "type": "string"
                     },
                     "type": "array"
                   },
                   "load_balancing_policy": {
-                    "description": "LoadBalancingPolicy defines load balancing policy to use for backend urls.\nSupported policies: least_loaded, first_available.\nSee [here](https://docs.victoriametrics.com/victoriametrics/vmauth/#load-balancing) for more details (default \"least_loaded\")",
                     "enum": [
                       "least_loaded",
                       "first_available"
@@ -2090,49 +2221,42 @@
                     "type": "string"
                   },
                   "response_headers": {
-                    "description": "ResponseHeaders represent additional http headers, that vmauth adds for request response\nin form of [\"header_key: header_value\"]\nmultiple values for header key:\n[\"header_key: value1,value2\"]\nit's available since 1.93.0 version of vmauth",
                     "items": {
                       "type": "string"
                     },
                     "type": "array"
                   },
                   "retry_status_codes": {
-                    "description": "RetryStatusCodes defines http status codes in numeric format for request retries\nCan be defined per target or at VMUser.spec level\ne.g. [429,503]",
                     "items": {
                       "type": "integer"
                     },
                     "type": "array"
                   },
                   "src_headers": {
-                    "description": "SrcHeaders is an optional list of headers, which must match request headers.",
                     "items": {
                       "type": "string"
                     },
                     "type": "array"
                   },
                   "src_hosts": {
-                    "description": "SrcHosts is an optional list of regular expressions, which must match the request hostname.",
                     "items": {
                       "type": "string"
                     },
                     "type": "array"
                   },
                   "src_paths": {
-                    "description": "SrcPaths is an optional list of regular expressions, which must match the request path.",
                     "items": {
                       "type": "string"
                     },
                     "type": "array"
                   },
                   "src_query_args": {
-                    "description": "SrcQueryArgs is an optional list of query args, which must match request URL query args.",
                     "items": {
                       "type": "string"
                     },
                     "type": "array"
                   },
                   "url_prefix": {
-                    "description": "UrlPrefix contains backend url prefixes for the proxied request url.\nURLPrefix defines prefix prefix for destination",
                     "x-kubernetes-preserve-unknown-fields": true
                   }
                 },
@@ -2142,7 +2266,6 @@
               "type": "array"
             },
             "url_prefix": {
-              "description": "URLPrefix defines prefix prefix for destination",
               "x-kubernetes-preserve-unknown-fields": true
             }
           },
@@ -2150,7 +2273,6 @@
           "additionalProperties": false
         },
         "updateStrategy": {
-          "description": "UpdateStrategy - overrides default update strategy.\nAvailable from operator v0.64.0",
           "enum": [
             "Recreate",
             "RollingUpdate"
@@ -2158,39 +2280,29 @@
           "type": "string"
         },
         "useDefaultResources": {
-          "description": "UseDefaultResources controls resource settings\nBy default, operator sets built-in resource requirements",
           "type": "boolean"
         },
         "useProxyProtocol": {
-          "description": "UseProxyProtocol enables proxy protocol for vmauth\nhttps://www.haproxy.org/download/2.3/doc/proxy-protocol.txt",
           "type": "boolean"
         },
         "useStrictSecurity": {
-          "description": "UseStrictSecurity enables strict security mode for component\nit restricts disk writes access\nuses non-root user out of the box\ndrops not needed security permissions",
           "type": "boolean"
         },
         "useVMConfigReloader": {
-          "description": "UseVMConfigReloader replaces prometheus-like config-reloader\nwith vm one. It uses secrets watch instead of file watch\nwhich greatly increases speed of config updates",
           "type": "boolean"
         },
         "userNamespaceSelector": {
-          "description": "UserNamespaceSelector Namespaces to be selected for  VMAuth discovery.\nWorks in combination with Selector.\nNamespaceSelector nil - only objects at VMAuth namespace.\nSelector nil - only objects at NamespaceSelector namespaces.\nIf both nil - behaviour controlled by selectAllByDefault",
           "properties": {
             "matchExpressions": {
-              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
               "items": {
-                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
                 "properties": {
                   "key": {
-                    "description": "key is the label key that the selector applies to.",
                     "type": "string"
                   },
                   "operator": {
-                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
                     "type": "string"
                   },
                   "values": {
-                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
                     "items": {
                       "type": "string"
                     },
@@ -2212,7 +2324,6 @@
               "additionalProperties": {
                 "type": "string"
               },
-              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
               "type": "object"
             }
           },
@@ -2221,23 +2332,17 @@
           "additionalProperties": false
         },
         "userSelector": {
-          "description": "UserSelector defines VMUser to be selected for config file generation.\nWorks in combination with NamespaceSelector.\nNamespaceSelector nil - only objects at VMAuth namespace.\nIf both nil - behaviour controlled by selectAllByDefault",
           "properties": {
             "matchExpressions": {
-              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
               "items": {
-                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
                 "properties": {
                   "key": {
-                    "description": "key is the label key that the selector applies to.",
                     "type": "string"
                   },
                   "operator": {
-                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
                     "type": "string"
                   },
                   "values": {
-                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
                     "items": {
                       "type": "string"
                     },
@@ -2259,7 +2364,6 @@
               "additionalProperties": {
                 "type": "string"
               },
-              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
               "type": "object"
             }
           },
@@ -2268,36 +2372,27 @@
           "additionalProperties": false
         },
         "volumeMounts": {
-          "description": "VolumeMounts allows configuration of additional VolumeMounts on the output Deployment/StatefulSet definition.\nVolumeMounts specified will be appended to other VolumeMounts in the Application container",
           "items": {
-            "description": "VolumeMount describes a mounting of a Volume within a container.",
             "properties": {
               "mountPath": {
-                "description": "Path within the container at which the volume should be mounted.  Must\nnot contain ':'.",
                 "type": "string"
               },
               "mountPropagation": {
-                "description": "mountPropagation determines how mounts are propagated from the host\nto container and the other way around.\nWhen not set, MountPropagationNone is used.\nThis field is beta in 1.10.\nWhen RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified\n(which defaults to None).",
                 "type": "string"
               },
               "name": {
-                "description": "This must match the Name of a Volume.",
                 "type": "string"
               },
               "readOnly": {
-                "description": "Mounted read-only if true, read-write otherwise (false or unspecified).\nDefaults to false.",
                 "type": "boolean"
               },
               "recursiveReadOnly": {
-                "description": "RecursiveReadOnly specifies whether read-only mounts should be handled\nrecursively.\n\nIf ReadOnly is false, this field has no meaning and must be unspecified.\n\nIf ReadOnly is true, and this field is set to Disabled, the mount is not made\nrecursively read-only.  If this field is set to IfPossible, the mount is made\nrecursively read-only, if it is supported by the container runtime.  If this\nfield is set to Enabled, the mount is made recursively read-only if it is\nsupported by the container runtime, otherwise the pod will not be started and\nan error will be generated to indicate the reason.\n\nIf this field is set to IfPossible or Enabled, MountPropagation must be set to\nNone (or be unspecified, which defaults to None).\n\nIf this field is not specified, it is treated as an equivalent of Disabled.",
                 "type": "string"
               },
               "subPath": {
-                "description": "Path within the volume from which the container's volume should be mounted.\nDefaults to \"\" (volume's root).",
                 "type": "string"
               },
               "subPathExpr": {
-                "description": "Expanded path within the volume from which the container's volume should be mounted.\nBehaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.\nDefaults to \"\" (volume's root).\nSubPathExpr and SubPath are mutually exclusive.",
                 "type": "string"
               }
             },
@@ -2311,9 +2406,7 @@
           "type": "array"
         },
         "volumes": {
-          "description": "Volumes allows configuration of additional volumes on the output Deployment/StatefulSet definition.\nVolumes specified will be appended to other volumes that are generated.\n/ +optional",
           "items": {
-            "description": "Volume represents a named volume in a pod that may be accessed by any container in the pod.",
             "required": [
               "name"
             ],
@@ -2321,6 +2414,165 @@
             "x-kubernetes-preserve-unknown-fields": true
           },
           "type": "array"
+        },
+        "vpa": {
+          "properties": {
+            "recommenders": {
+              "items": {
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "resourcePolicy": {
+              "properties": {
+                "containerPolicies": {
+                  "items": {
+                    "properties": {
+                      "containerName": {
+                        "type": "string"
+                      },
+                      "controlledResources": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "controlledValues": {
+                        "enum": [
+                          "RequestsAndLimits",
+                          "RequestsOnly"
+                        ],
+                        "type": "string"
+                      },
+                      "maxAllowed": {
+                        "additionalProperties": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                          "x-kubernetes-int-or-string": true
+                        },
+                        "type": "object"
+                      },
+                      "minAllowed": {
+                        "additionalProperties": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                          "x-kubernetes-int-or-string": true
+                        },
+                        "type": "object"
+                      },
+                      "mode": {
+                        "enum": [
+                          "Auto",
+                          "Off"
+                        ],
+                        "type": "string"
+                      },
+                      "oomBumpUpRatio": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "oomMinBumpUp": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                        "x-kubernetes-int-or-string": true
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "updatePolicy": {
+              "properties": {
+                "evictionRequirements": {
+                  "items": {
+                    "properties": {
+                      "changeRequirement": {
+                        "enum": [
+                          "TargetHigherThanRequests",
+                          "TargetLowerThanRequests"
+                        ],
+                        "type": "string"
+                      },
+                      "resources": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "required": [
+                      "changeRequirement",
+                      "resources"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "minReplicas": {
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "updateMode": {
+                  "enum": [
+                    "Off",
+                    "Initial",
+                    "Recreate",
+                    "InPlaceOrRecreate",
+                    "Auto"
+                  ],
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
         }
       },
       "type": "object",
@@ -2328,42 +2580,33 @@
       "additionalProperties": false
     },
     "status": {
-      "description": "VMAuthStatus defines the observed state of VMAuth",
       "properties": {
         "conditions": {
-          "description": "Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"",
           "items": {
-            "description": "Condition defines status condition of the resource",
             "properties": {
               "lastTransitionTime": {
-                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.",
                 "format": "date-time",
                 "type": "string"
               },
               "lastUpdateTime": {
-                "description": "LastUpdateTime is the last time of given type update.\nThis value is used for status TTL update and removal",
                 "format": "date-time",
                 "type": "string"
               },
               "message": {
-                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
                 "maxLength": 32768,
                 "type": "string"
               },
               "observedGeneration": {
-                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
                 "format": "int64",
                 "minimum": 0,
                 "type": "integer"
               },
               "reason": {
-                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
                 "maxLength": 1024,
                 "minLength": 1,
                 "type": "string"
               },
               "status": {
-                "description": "status of the condition, one of True, False, Unknown.",
                 "enum": [
                   "True",
                   "False",
@@ -2372,7 +2615,6 @@
                 "type": "string"
               },
               "type": {
-                "description": "Type of condition in CamelCase or in name.namespace.resource.victoriametrics.com/CamelCase.",
                 "maxLength": 316,
                 "type": "string"
               }
@@ -2393,17 +2635,17 @@
           ],
           "x-kubernetes-list-type": "map"
         },
+        "lastAppliedSpec": {
+          "x-kubernetes-preserve-unknown-fields": true
+        },
         "observedGeneration": {
-          "description": "ObservedGeneration defines current generation picked by operator for the\nreconcile",
           "format": "int64",
           "type": "integer"
         },
         "reason": {
-          "description": "Reason defines human readable error reason",
           "type": "string"
         },
         "updateStatus": {
-          "description": "UpdateStatus defines a status for update rollout",
           "type": "string"
         }
       },

--- a/operator.victoriametrics.com/vmcluster_v1beta1.json
+++ b/operator.victoriametrics.com/vmcluster_v1beta1.json
@@ -1,36 +1,27 @@
 {
-  "description": "VMCluster is fast, cost-effective and scalable time-series database.\nCluster version with",
   "properties": {
     "apiVersion": {
-      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
       "type": "string"
     },
     "kind": {
-      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
       "type": "string"
     },
     "metadata": {
       "type": "object"
     },
     "spec": {
-      "description": "VMClusterSpec defines the desired state of VMCluster",
       "properties": {
         "clusterDomainName": {
-          "description": "ClusterDomainName defines domain name suffix for in-cluster dns addresses\naka .cluster.local\nused by vminsert and vmselect to build vmstorage address",
           "type": "string"
         },
         "clusterVersion": {
-          "description": "ClusterVersion defines default images tag for all components.\nit can be overwritten with component specific image.tag value.",
           "type": "string"
         },
         "imagePullSecrets": {
-          "description": "ImagePullSecrets An optional list of references to secrets in the same namespace\nto use for pulling images from registries\nsee https://kubernetes.io/docs/concepts/containers/images/#referring-to-an-imagepullsecrets-on-a-pod",
           "items": {
-            "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
             "properties": {
               "name": {
                 "default": "",
-                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                 "type": "string"
               }
             },
@@ -41,30 +32,23 @@
           "type": "array"
         },
         "license": {
-          "description": "License allows to configure license key to be used for enterprise features.\nUsing license key is supported starting from VictoriaMetrics v1.94.0.\nSee [here](https://docs.victoriametrics.com/victoriametrics/enterprise/)",
           "properties": {
             "forceOffline": {
-              "description": "Enforce offline verification of the license key.",
               "type": "boolean"
             },
             "key": {
-              "description": "Enterprise license key. This flag is available only in [VictoriaMetrics enterprise](https://docs.victoriametrics.com/victoriametrics/enterprise/).\nTo request a trial license, [go to](https://victoriametrics.com/products/enterprise/trial)",
               "type": "string"
             },
             "keyRef": {
-              "description": "KeyRef is reference to secret with license key for enterprise features.",
               "properties": {
                 "key": {
-                  "description": "The key of the secret to select from.  Must be a valid secret key.",
                   "type": "string"
                 },
                 "name": {
                   "default": "",
-                  "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                   "type": "string"
                 },
                 "optional": {
-                  "description": "Specify whether the Secret or its key must be defined",
                   "type": "boolean"
                 }
               },
@@ -76,7 +60,6 @@
               "additionalProperties": false
             },
             "reloadInterval": {
-              "description": "Interval to be used for checking for license key changes. Note that this is only applicable when using KeyRef.",
               "type": "string"
             }
           },
@@ -84,20 +67,17 @@
           "additionalProperties": false
         },
         "managedMetadata": {
-          "description": "ManagedMetadata defines metadata that will be added to the all objects\ncreated by operator for the given CustomResource",
           "properties": {
             "annotations": {
               "additionalProperties": {
                 "type": "string"
               },
-              "description": "Annotations is an unstructured key value map stored with a resource that may be\nset by external tools to store and retrieve arbitrary metadata. They are not\nqueryable and should be preserved when modifying objects.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations",
               "type": "object"
             },
             "labels": {
               "additionalProperties": {
                 "type": "string"
               },
-              "description": "Labels Map of string keys and values that can be used to organize and categorize\n(scope and select) objects.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels",
               "type": "object"
             }
           },
@@ -105,16 +85,13 @@
           "additionalProperties": false
         },
         "paused": {
-          "description": "Paused If set to true all actions on the underlying managed objects are not\ngoing to be performed, except for delete actions.",
           "type": "boolean"
         },
         "replicationFactor": {
-          "description": "ReplicationFactor defines how many copies of data make among\ndistinct storage nodes",
           "format": "int32",
           "type": "integer"
         },
         "requestsLoadBalancer": {
-          "description": "RequestsLoadBalancer configures load-balancing for vminsert and vmselect requests.\nIt helps to evenly spread load across pods.\nUsually it's not possible with Kubernetes TCP-based services.\nSee more [here](https://docs.victoriametrics.com/operator/resources/vmcluster/#requests-load-balancing)",
           "properties": {
             "disableInsertBalancing": {
               "type": "boolean"
@@ -126,7 +103,6 @@
               "type": "boolean"
             },
             "spec": {
-              "description": "VMAuthLoadBalancerSpec defines configuration spec for VMAuth used as load-balancer\nfor VMCluster component",
               "type": "object",
               "x-kubernetes-preserve-unknown-fields": true
             }
@@ -135,40 +111,35 @@
           "additionalProperties": false
         },
         "retentionPeriod": {
-          "description": "RetentionPeriod defines how long to retain stored metrics, specified as a duration (e.g., \"1d\", \"1w\", \"1m\").\nData with timestamps outside the RetentionPeriod is automatically deleted. The minimum allowed value is 1d, or 24h.\nThe default value is 1 (one month).\nSee [retention](https://docs.victoriametrics.com/victoriametrics/single-server-victoriametrics/#retention) docs for details.",
           "pattern": "^[0-9]+(h|d|w|y)?$",
           "type": "string"
         },
         "serviceAccountName": {
-          "description": "ServiceAccountName is the name of the ServiceAccount to use to run the\nVMSelect, VMStorage and VMInsert Pods.",
           "type": "string"
         },
         "useStrictSecurity": {
-          "description": "UseStrictSecurity enables strict security mode for component\nit restricts disk writes access\nuses non-root user out of the box\ndrops not needed security permissions",
           "type": "boolean"
         },
         "vminsert": {
           "properties": {
             "affinity": {
-              "description": "Affinity If specified, the pod's scheduling constraints.",
               "type": "object",
               "x-kubernetes-preserve-unknown-fields": true
             },
             "clusterNativeListenPort": {
-              "description": "ClusterNativePort for multi-level cluster setup.\nMore [details](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/#multi-level-cluster-setup)",
+              "type": "string"
+            },
+            "componentVersion": {
               "type": "string"
             },
             "configMaps": {
-              "description": "ConfigMaps is a list of ConfigMaps in the same namespace as the Application\nobject, which shall be mounted into the Application container\nat /etc/vm/configs/CONFIGMAP_NAME folder",
               "items": {
                 "type": "string"
               },
               "type": "array"
             },
             "containers": {
-              "description": "Containers property allows to inject additions sidecars or to patch existing containers.\nIt can be useful for proxies, backup, etc.",
               "items": {
-                "description": "A single application container that you want to run within a pod.",
                 "required": [
                   "name"
                 ],
@@ -178,21 +149,17 @@
               "type": "array"
             },
             "disableAutomountServiceAccountToken": {
-              "description": "DisableAutomountServiceAccountToken whether to disable serviceAccount auto mount by Kubernetes (available from v0.54.0).\nOperator will conditionally create volumes and volumeMounts for containers if it requires k8s API access.\nFor example, vmagent and vm-config-reloader requires k8s API access.\nOperator creates volumes with name: \"kube-api-access\", which can be used as volumeMount for extraContainers if needed.\nAnd also adds VolumeMounts at /var/run/secrets/kubernetes.io/serviceaccount.",
               "type": "boolean"
             },
             "disableSelfServiceScrape": {
-              "description": "DisableSelfServiceScrape controls creation of VMServiceScrape by operator\nfor the application.\nHas priority over `VM_DISABLESELFSERVICESCRAPECREATION` operator env variable",
               "type": "boolean"
             },
             "dnsConfig": {
-              "description": "Specifies the DNS parameters of a pod.\nParameters specified here will be merged to the generated DNS\nconfiguration based on DNSPolicy.",
               "items": {
                 "x-kubernetes-preserve-unknown-fields": true
               },
               "properties": {
                 "nameservers": {
-                  "description": "A list of DNS name server IP addresses.\nThis will be appended to the base nameservers generated from DNSPolicy.\nDuplicated nameservers will be removed.",
                   "items": {
                     "type": "string"
                   },
@@ -200,16 +167,12 @@
                   "x-kubernetes-list-type": "atomic"
                 },
                 "options": {
-                  "description": "A list of DNS resolver options.\nThis will be merged with the base options generated from DNSPolicy.\nDuplicated entries will be removed. Resolution options given in Options\nwill override those that appear in the base DNSPolicy.",
                   "items": {
-                    "description": "PodDNSConfigOption defines DNS resolver options of a pod.",
                     "properties": {
                       "name": {
-                        "description": "Name is this DNS resolver option's name.\nRequired.",
                         "type": "string"
                       },
                       "value": {
-                        "description": "Value is this DNS resolver option's value.",
                         "type": "string"
                       }
                     },
@@ -220,7 +183,6 @@
                   "x-kubernetes-list-type": "atomic"
                 },
                 "searches": {
-                  "description": "A list of DNS search domains for host-name lookup.\nThis will be appended to the base search paths generated from DNSPolicy.\nDuplicated search paths will be removed.",
                   "items": {
                     "type": "string"
                   },
@@ -232,27 +194,21 @@
               "additionalProperties": false
             },
             "dnsPolicy": {
-              "description": "DNSPolicy sets DNS policy for the pod",
               "type": "string"
             },
             "extraArgs": {
               "additionalProperties": {
                 "type": "string"
               },
-              "description": "ExtraArgs that will be passed to the application container\nfor example remoteWrite.tmpDataPath: /tmp",
               "type": "object"
             },
             "extraEnvs": {
-              "description": "ExtraEnvs that will be passed to the application container",
               "items": {
-                "description": "EnvVar represents an environment variable present in a Container.",
                 "properties": {
                   "name": {
-                    "description": "Name of the environment variable.\nMay consist of any printable ASCII characters except '='.",
                     "type": "string"
                   },
                   "value": {
-                    "description": "Variable references $(VAR_NAME) are expanded\nusing the previously defined environment variables in the container and\nany service environment variables. If a variable cannot be resolved,\nthe reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.\n\"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\".\nEscaped references will never be expanded, regardless of whether the variable\nexists or not.\nDefaults to \"\".",
                     "type": "string"
                   }
                 },
@@ -266,20 +222,15 @@
               "type": "array"
             },
             "extraEnvsFrom": {
-              "description": "ExtraEnvsFrom defines source of env variables for the application container\ncould either be secret or configmap",
               "items": {
-                "description": "EnvFromSource represents the source of a set of ConfigMaps or Secrets",
                 "properties": {
                   "configMapRef": {
-                    "description": "The ConfigMap to select from",
                     "properties": {
                       "name": {
                         "default": "",
-                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                         "type": "string"
                       },
                       "optional": {
-                        "description": "Specify whether the ConfigMap must be defined",
                         "type": "boolean"
                       }
                     },
@@ -288,19 +239,15 @@
                     "additionalProperties": false
                   },
                   "prefix": {
-                    "description": "Optional text to prepend to the name of each environment variable.\nMay consist of any printable ASCII characters except '='.",
                     "type": "string"
                   },
                   "secretRef": {
-                    "description": "The Secret to select from",
                     "properties": {
                       "name": {
                         "default": "",
-                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                         "type": "string"
                       },
                       "optional": {
-                        "description": "Specify whether the Secret must be defined",
                         "type": "boolean"
                       }
                     },
@@ -315,12 +262,9 @@
               "type": "array"
             },
             "host_aliases": {
-              "description": "HostAliasesUnderScore provides mapping for ip and hostname,\nthat would be propagated to pod,\ncannot be used with HostNetwork.\nHas Priority over hostAliases field",
               "items": {
-                "description": "HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the\npod's hosts file.",
                 "properties": {
                   "hostnames": {
-                    "description": "Hostnames for the above IP address.",
                     "items": {
                       "type": "string"
                     },
@@ -328,7 +272,6 @@
                     "x-kubernetes-list-type": "atomic"
                   },
                   "ip": {
-                    "description": "IP address of the host file entry.",
                     "type": "string"
                   }
                 },
@@ -341,12 +284,9 @@
               "type": "array"
             },
             "hostAliases": {
-              "description": "HostAliases provides mapping for ip and hostname,\nthat would be propagated to pod,\ncannot be used with HostNetwork.",
               "items": {
-                "description": "HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the\npod's hosts file.",
                 "properties": {
                   "hostnames": {
-                    "description": "Hostnames for the above IP address.",
                     "items": {
                       "type": "string"
                     },
@@ -354,7 +294,6 @@
                     "x-kubernetes-list-type": "atomic"
                   },
                   "ip": {
-                    "description": "IP address of the host file entry.",
                     "type": "string"
                   }
                 },
@@ -367,27 +306,21 @@
               "type": "array"
             },
             "hostNetwork": {
-              "description": "HostNetwork controls whether the pod may use the node network namespace",
               "type": "boolean"
             },
             "hpa": {
-              "description": "HPA defines kubernetes PodAutoScaling configuration version 2.",
               "type": "object",
               "x-kubernetes-preserve-unknown-fields": true
             },
             "image": {
-              "description": "Image - docker image settings\nif no specified operator uses default version from operator config",
               "properties": {
                 "pullPolicy": {
-                  "description": "PullPolicy describes how to pull docker image",
                   "type": "string"
                 },
                 "repository": {
-                  "description": "Repository contains name of docker image + it's repository if needed",
                   "type": "string"
                 },
                 "tag": {
-                  "description": "Tag contains desired docker image version",
                   "type": "string"
                 }
               },
@@ -395,13 +328,10 @@
               "additionalProperties": false
             },
             "imagePullSecrets": {
-              "description": "ImagePullSecrets An optional list of references to secrets in the same namespace\nto use for pulling images from registries\nsee https://kubernetes.io/docs/concepts/containers/images/#referring-to-an-imagepullsecrets-on-a-pod",
               "items": {
-                "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
                 "properties": {
                   "name": {
                     "default": "",
-                    "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                     "type": "string"
                   }
                 },
@@ -412,9 +342,7 @@
               "type": "array"
             },
             "initContainers": {
-              "description": "InitContainers allows adding initContainers to the pod definition.\nAny errors during the execution of an initContainer will lead to a restart of the Pod.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/",
               "items": {
-                "description": "A single application container that you want to run within a pod.",
                 "required": [
                   "name"
                 ],
@@ -424,22 +352,17 @@
               "type": "array"
             },
             "insertPorts": {
-              "description": "InsertPorts - additional listen ports for data ingestion.",
               "properties": {
                 "graphitePort": {
-                  "description": "GraphitePort listen port",
                   "type": "string"
                 },
                 "influxPort": {
-                  "description": "InfluxPort listen port",
                   "type": "string"
                 },
                 "openTSDBHTTPPort": {
-                  "description": "OpenTSDBHTTPPort for http connections.",
                   "type": "string"
                 },
                 "openTSDBPort": {
-                  "description": "OpenTSDBPort for tcp and udp listen",
                   "type": "string"
                 }
               },
@@ -447,12 +370,10 @@
               "additionalProperties": false
             },
             "livenessProbe": {
-              "description": "LivenessProbe that will be added CRD pod",
               "type": "object",
               "x-kubernetes-preserve-unknown-fields": true
             },
             "logFormat": {
-              "description": "LogFormat for VMInsert to be configured with.\ndefault or json",
               "enum": [
                 "default",
                 "json"
@@ -460,7 +381,6 @@
               "type": "string"
             },
             "logLevel": {
-              "description": "LogLevel for VMInsert to be configured with.",
               "enum": [
                 "INFO",
                 "WARN",
@@ -471,7 +391,6 @@
               "type": "string"
             },
             "minReadySeconds": {
-              "description": "MinReadySeconds defines a minimum number of seconds to wait before starting update next pod\nif previous in healthy state\nHas no effect for VLogs and VMSingle",
               "format": "int32",
               "type": "integer"
             },
@@ -479,15 +398,12 @@
               "additionalProperties": {
                 "type": "string"
               },
-              "description": "NodeSelector Define which Nodes the Pods are scheduled on.",
               "type": "object"
             },
             "paused": {
-              "description": "Paused If set to true all actions on the underlying managed objects are not\ngoing to be performed, except for delete actions.",
               "type": "boolean"
             },
             "podDisruptionBudget": {
-              "description": "PodDisruptionBudget created by operator",
               "properties": {
                 "maxUnavailable": {
                   "anyOf": [
@@ -498,7 +414,6 @@
                       "type": "string"
                     }
                   ],
-                  "description": "An eviction is allowed if at most \"maxUnavailable\" pods selected by\n\"selector\" are unavailable after the eviction, i.e. even in absence of\nthe evicted pod. For example, one can prevent all voluntary evictions\nby specifying 0. This is a mutually exclusive setting with \"minAvailable\".",
                   "x-kubernetes-int-or-string": true
                 },
                 "minAvailable": {
@@ -510,18 +425,15 @@
                       "type": "string"
                     }
                   ],
-                  "description": "An eviction is allowed if at least \"minAvailable\" pods selected by\n\"selector\" will still be available after the eviction, i.e. even in the\nabsence of the evicted pod.  So for example you can prevent all voluntary\nevictions by specifying \"100%\".",
                   "x-kubernetes-int-or-string": true
                 },
                 "selectorLabels": {
                   "additionalProperties": {
                     "type": "string"
                   },
-                  "description": "replaces default labels selector generated by operator\nit's useful when you need to create custom budget",
                   "type": "object"
                 },
                 "unhealthyPodEvictionPolicy": {
-                  "description": "UnhealthyPodEvictionPolicy defines the criteria for when unhealthy pods\n\nValid policies are IfHealthyBudget and AlwaysAllow.\nIf no policy is specified, the default behavior will be used,\nwhich corresponds to the IfHealthyBudget policy.\nAvailable from operator v0.64.0",
                   "enum": [
                     "IfHealthyBudget",
                     "AlwaysAllow"
@@ -533,24 +445,20 @@
               "additionalProperties": false
             },
             "podMetadata": {
-              "description": "PodMetadata configures Labels and Annotations which are propagated to the VMInsert pods.",
               "properties": {
                 "annotations": {
                   "additionalProperties": {
                     "type": "string"
                   },
-                  "description": "Annotations is an unstructured key value map stored with a resource that may be\nset by external tools to store and retrieve arbitrary metadata. They are not\nqueryable and should be preserved when modifying objects.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations",
                   "type": "object"
                 },
                 "labels": {
                   "additionalProperties": {
                     "type": "string"
                   },
-                  "description": "Labels Map of string keys and values that can be used to organize and categorize\n(scope and select) objects. May match selectors of replication controllers\nand services.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels",
                   "type": "object"
                 },
                 "name": {
-                  "description": "Name must be unique within a namespace. Is required when creating resources, although\nsome resources may allow a client to request the generation of an appropriate name\nautomatically. Name is primarily intended for creation idempotence and configuration\ndefinition.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names",
                   "type": "string"
                 }
               },
@@ -558,20 +466,15 @@
               "additionalProperties": false
             },
             "port": {
-              "description": "Port listen address",
               "type": "string"
             },
             "priorityClassName": {
-              "description": "PriorityClassName class assigned to the Pods",
               "type": "string"
             },
             "readinessGates": {
-              "description": "ReadinessGates defines pod readiness gates",
               "items": {
-                "description": "PodReadinessGate contains the reference to a pod condition",
                 "properties": {
                   "conditionType": {
-                    "description": "ConditionType refers to a condition in the pod's condition list with matching type.",
                     "type": "string"
                   }
                 },
@@ -584,29 +487,22 @@
               "type": "array"
             },
             "readinessProbe": {
-              "description": "ReadinessProbe that will be added CRD pod",
               "type": "object",
               "x-kubernetes-preserve-unknown-fields": true
             },
             "replicaCount": {
-              "description": "ReplicaCount is the expected size of the Application.",
               "format": "int32",
               "type": "integer"
             },
             "resources": {
-              "description": "Resources container resource request and limits, https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/\nif not defined default resources from operator config will be used",
               "properties": {
                 "claims": {
-                  "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis field depends on the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
                   "items": {
-                    "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
                     "properties": {
                       "name": {
-                        "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
                         "type": "string"
                       },
                       "request": {
-                        "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
                         "type": "string"
                       }
                     },
@@ -635,7 +531,6 @@
                     "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                     "x-kubernetes-int-or-string": true
                   },
-                  "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
                   "type": "object"
                 },
                 "requests": {
@@ -651,7 +546,6 @@
                     "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                     "x-kubernetes-int-or-string": true
                   },
-                  "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
                   "type": "object"
                 }
               },
@@ -659,12 +553,10 @@
               "additionalProperties": false
             },
             "revisionHistoryLimitCount": {
-              "description": "The number of old ReplicaSets to retain to allow rollback in deployment or\nmaximum number of revisions that will be maintained in the Deployment revision history.\nHas no effect at StatefulSets\nDefaults to 10.",
               "format": "int32",
               "type": "integer"
             },
             "rollingUpdate": {
-              "description": "RollingUpdate - overrides deployment update params.",
               "properties": {
                 "maxSurge": {
                   "anyOf": [
@@ -675,7 +567,6 @@
                       "type": "string"
                     }
                   ],
-                  "description": "The maximum number of pods that can be scheduled above the desired number of\npods.\nValue can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).\nThis can not be 0 if MaxUnavailable is 0.\nAbsolute number is calculated from percentage by rounding up.\nDefaults to 25%.\nExample: when this is set to 30%, the new ReplicaSet can be scaled up immediately when\nthe rolling update starts, such that the total number of old and new pods do not exceed\n130% of desired pods. Once old pods have been killed,\nnew ReplicaSet can be scaled up further, ensuring that total number of pods running\nat any time during the update is at most 130% of desired pods.",
                   "x-kubernetes-int-or-string": true
                 },
                 "maxUnavailable": {
@@ -687,7 +578,6 @@
                       "type": "string"
                     }
                   ],
-                  "description": "The maximum number of pods that can be unavailable during the update.\nValue can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).\nAbsolute number is calculated from percentage by rounding down.\nThis can not be 0 if MaxSurge is 0.\nDefaults to 25%.\nExample: when this is set to 30%, the old ReplicaSet can be scaled down to 70% of desired pods\nimmediately when the rolling update starts. Once new pods are ready, old ReplicaSet\ncan be scaled down further, followed by scaling up the new ReplicaSet, ensuring\nthat the total number of pods available at all times during the update is at\nleast 70% of desired pods.",
                   "x-kubernetes-int-or-string": true
                 }
               },
@@ -695,27 +585,22 @@
               "additionalProperties": false
             },
             "runtimeClassName": {
-              "description": "RuntimeClassName - defines runtime class for kubernetes pod.\nhttps://kubernetes.io/docs/concepts/containers/runtime-class/",
               "type": "string"
             },
             "schedulerName": {
-              "description": "SchedulerName - defines kubernetes scheduler name",
               "type": "string"
             },
             "secrets": {
-              "description": "Secrets is a list of Secrets in the same namespace as the Application\nobject, which shall be mounted into the Application container\nat /etc/vm/secrets/SECRET_NAME folder",
               "items": {
                 "type": "string"
               },
               "type": "array"
             },
             "securityContext": {
-              "description": "SecurityContext holds pod-level security attributes and common container settings.\nThis defaults to the default PodSecurityContext.",
               "type": "object",
               "x-kubernetes-preserve-unknown-fields": true
             },
             "serviceScrapeSpec": {
-              "description": "ServiceScrapeSpec that will be added to vminsert VMServiceScrape spec",
               "required": [
                 "endpoints"
               ],
@@ -723,27 +608,22 @@
               "x-kubernetes-preserve-unknown-fields": true
             },
             "serviceSpec": {
-              "description": "ServiceSpec that will be added to vminsert service spec",
               "properties": {
                 "metadata": {
-                  "description": "EmbeddedObjectMetadata defines objectMeta for additional service.",
                   "properties": {
                     "annotations": {
                       "additionalProperties": {
                         "type": "string"
                       },
-                      "description": "Annotations is an unstructured key value map stored with a resource that may be\nset by external tools to store and retrieve arbitrary metadata. They are not\nqueryable and should be preserved when modifying objects.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations",
                       "type": "object"
                     },
                     "labels": {
                       "additionalProperties": {
                         "type": "string"
                       },
-                      "description": "Labels Map of string keys and values that can be used to organize and categorize\n(scope and select) objects. May match selectors of replication controllers\nand services.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels",
                       "type": "object"
                     },
                     "name": {
-                      "description": "Name must be unique within a namespace. Is required when creating resources, although\nsome resources may allow a client to request the generation of an appropriate name\nautomatically. Name is primarily intended for creation idempotence and configuration\ndefinition.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names",
                       "type": "string"
                     }
                   },
@@ -751,12 +631,10 @@
                   "additionalProperties": false
                 },
                 "spec": {
-                  "description": "ServiceSpec describes the attributes that a user creates on a service.\nMore info: https://kubernetes.io/docs/concepts/services-networking/service/",
                   "type": "object",
                   "x-kubernetes-preserve-unknown-fields": true
                 },
                 "useAsDefault": {
-                  "description": "UseAsDefault applies changes from given service definition to the main object Service\nChanging from headless service to clusterIP or loadbalancer may break cross-component communication",
                   "type": "boolean"
                 }
               },
@@ -767,39 +645,30 @@
               "additionalProperties": false
             },
             "startupProbe": {
-              "description": "StartupProbe that will be added to CRD pod",
               "type": "object",
               "x-kubernetes-preserve-unknown-fields": true
             },
             "terminationGracePeriodSeconds": {
-              "description": "TerminationGracePeriodSeconds period for container graceful termination",
               "format": "int64",
               "type": "integer"
             },
             "tolerations": {
-              "description": "Tolerations If specified, the pod's tolerations.",
               "items": {
-                "description": "The pod this Toleration is attached to tolerates any taint that matches\nthe triple <key,value,effect> using the matching operator <operator>.",
                 "properties": {
                   "effect": {
-                    "description": "Effect indicates the taint effect to match. Empty means match all taint effects.\nWhen specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
                     "type": "string"
                   },
                   "key": {
-                    "description": "Key is the taint key that the toleration applies to. Empty means match all taint keys.\nIf the key is empty, operator must be Exists; this combination means to match all values and all keys.",
                     "type": "string"
                   },
                   "operator": {
-                    "description": "Operator represents a key's relationship to the value.\nValid operators are Exists and Equal. Defaults to Equal.\nExists is equivalent to wildcard for value, so that a pod can\ntolerate all taints of a particular category.",
                     "type": "string"
                   },
                   "tolerationSeconds": {
-                    "description": "TolerationSeconds represents the period of time the toleration (which must be\nof effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,\nit is not set, which means tolerate the taint forever (do not evict). Zero and\nnegative values will be treated as 0 (evict immediately) by the system.",
                     "format": "int64",
                     "type": "integer"
                   },
                   "value": {
-                    "description": "Value is the taint value the toleration matches to.\nIf the operator is Exists, the value should be empty, otherwise just a regular string.",
                     "type": "string"
                   }
                 },
@@ -809,9 +678,7 @@
               "type": "array"
             },
             "topologySpreadConstraints": {
-              "description": "TopologySpreadConstraints embedded kubernetes pod configuration option,\ncontrols how pods are spread across your cluster among failure-domains\nsuch as regions, zones, nodes, and other user-defined topology domains\nhttps://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/",
               "items": {
-                "description": "TopologySpreadConstraint specifies how to spread matching pods among the given topology.",
                 "required": [
                   "maxSkew",
                   "topologyKey",
@@ -823,7 +690,6 @@
               "type": "array"
             },
             "updateStrategy": {
-              "description": "UpdateStrategy - overrides default update strategy.",
               "enum": [
                 "Recreate",
                 "RollingUpdate"
@@ -831,44 +697,33 @@
               "type": "string"
             },
             "useDefaultResources": {
-              "description": "UseDefaultResources controls resource settings\nBy default, operator sets built-in resource requirements",
               "type": "boolean"
             },
             "useStrictSecurity": {
-              "description": "UseStrictSecurity enables strict security mode for component\nit restricts disk writes access\nuses non-root user out of the box\ndrops not needed security permissions",
               "type": "boolean"
             },
             "volumeMounts": {
-              "description": "VolumeMounts allows configuration of additional VolumeMounts on the output Deployment/StatefulSet definition.\nVolumeMounts specified will be appended to other VolumeMounts in the Application container",
               "items": {
-                "description": "VolumeMount describes a mounting of a Volume within a container.",
                 "properties": {
                   "mountPath": {
-                    "description": "Path within the container at which the volume should be mounted.  Must\nnot contain ':'.",
                     "type": "string"
                   },
                   "mountPropagation": {
-                    "description": "mountPropagation determines how mounts are propagated from the host\nto container and the other way around.\nWhen not set, MountPropagationNone is used.\nThis field is beta in 1.10.\nWhen RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified\n(which defaults to None).",
                     "type": "string"
                   },
                   "name": {
-                    "description": "This must match the Name of a Volume.",
                     "type": "string"
                   },
                   "readOnly": {
-                    "description": "Mounted read-only if true, read-write otherwise (false or unspecified).\nDefaults to false.",
                     "type": "boolean"
                   },
                   "recursiveReadOnly": {
-                    "description": "RecursiveReadOnly specifies whether read-only mounts should be handled\nrecursively.\n\nIf ReadOnly is false, this field has no meaning and must be unspecified.\n\nIf ReadOnly is true, and this field is set to Disabled, the mount is not made\nrecursively read-only.  If this field is set to IfPossible, the mount is made\nrecursively read-only, if it is supported by the container runtime.  If this\nfield is set to Enabled, the mount is made recursively read-only if it is\nsupported by the container runtime, otherwise the pod will not be started and\nan error will be generated to indicate the reason.\n\nIf this field is set to IfPossible or Enabled, MountPropagation must be set to\nNone (or be unspecified, which defaults to None).\n\nIf this field is not specified, it is treated as an equivalent of Disabled.",
                     "type": "string"
                   },
                   "subPath": {
-                    "description": "Path within the volume from which the container's volume should be mounted.\nDefaults to \"\" (volume's root).",
                     "type": "string"
                   },
                   "subPathExpr": {
-                    "description": "Expanded path within the volume from which the container's volume should be mounted.\nBehaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.\nDefaults to \"\" (volume's root).\nSubPathExpr and SubPath are mutually exclusive.",
                     "type": "string"
                   }
                 },
@@ -882,9 +737,7 @@
               "type": "array"
             },
             "volumes": {
-              "description": "Volumes allows configuration of additional volumes on the output Deployment/StatefulSet definition.\nVolumes specified will be appended to other volumes that are generated.\n/ +optional",
               "items": {
-                "description": "Volume represents a named volume in a pod that may be accessed by any container in the pod.",
                 "required": [
                   "name"
                 ],
@@ -892,46 +745,199 @@
                 "x-kubernetes-preserve-unknown-fields": true
               },
               "type": "array"
+            },
+            "vpa": {
+              "properties": {
+                "recommenders": {
+                  "items": {
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "resourcePolicy": {
+                  "properties": {
+                    "containerPolicies": {
+                      "items": {
+                        "properties": {
+                          "containerName": {
+                            "type": "string"
+                          },
+                          "controlledResources": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "controlledValues": {
+                            "enum": [
+                              "RequestsAndLimits",
+                              "RequestsOnly"
+                            ],
+                            "type": "string"
+                          },
+                          "maxAllowed": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          },
+                          "minAllowed": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          },
+                          "mode": {
+                            "enum": [
+                              "Auto",
+                              "Off"
+                            ],
+                            "type": "string"
+                          },
+                          "oomBumpUpRatio": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "oomMinBumpUp": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                            "x-kubernetes-int-or-string": true
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "updatePolicy": {
+                  "properties": {
+                    "evictionRequirements": {
+                      "items": {
+                        "properties": {
+                          "changeRequirement": {
+                            "enum": [
+                              "TargetHigherThanRequests",
+                              "TargetLowerThanRequests"
+                            ],
+                            "type": "string"
+                          },
+                          "resources": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "changeRequirement",
+                          "resources"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "minReplicas": {
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "updateMode": {
+                      "enum": [
+                        "Off",
+                        "Initial",
+                        "Recreate",
+                        "InPlaceOrRecreate",
+                        "Auto"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
             }
           },
           "type": "object",
           "additionalProperties": false
         },
         "vmselect": {
-          "description": "VMSelect defines configuration section for vmselect components of the victoria-metrics cluster",
           "properties": {
             "affinity": {
-              "description": "Affinity If specified, the pod's scheduling constraints.",
               "type": "object",
               "x-kubernetes-preserve-unknown-fields": true
             },
             "cacheMountPath": {
-              "description": "CacheMountPath allows to add cache persistent for VMSelect,\nwill use \"/cache\" as default if not specified.",
               "type": "string"
             },
             "claimTemplates": {
-              "description": "ClaimTemplates allows adding additional VolumeClaimTemplates for StatefulSet",
               "items": {
-                "description": "PersistentVolumeClaim is a user's request for and claim to a persistent volume",
                 "type": "object"
               },
               "type": "array"
             },
             "clusterNativeListenPort": {
-              "description": "ClusterNativePort for multi-level cluster setup.\nMore [details](https://docs.victoriametrics.com/victoriametrics/cluster-victoriametrics/#multi-level-cluster-setup)",
+              "type": "string"
+            },
+            "componentVersion": {
               "type": "string"
             },
             "configMaps": {
-              "description": "ConfigMaps is a list of ConfigMaps in the same namespace as the Application\nobject, which shall be mounted into the Application container\nat /etc/vm/configs/CONFIGMAP_NAME folder",
               "items": {
                 "type": "string"
               },
               "type": "array"
             },
             "containers": {
-              "description": "Containers property allows to inject additions sidecars or to patch existing containers.\nIt can be useful for proxies, backup, etc.",
               "items": {
-                "description": "A single application container that you want to run within a pod.",
                 "required": [
                   "name"
                 ],
@@ -941,21 +947,17 @@
               "type": "array"
             },
             "disableAutomountServiceAccountToken": {
-              "description": "DisableAutomountServiceAccountToken whether to disable serviceAccount auto mount by Kubernetes (available from v0.54.0).\nOperator will conditionally create volumes and volumeMounts for containers if it requires k8s API access.\nFor example, vmagent and vm-config-reloader requires k8s API access.\nOperator creates volumes with name: \"kube-api-access\", which can be used as volumeMount for extraContainers if needed.\nAnd also adds VolumeMounts at /var/run/secrets/kubernetes.io/serviceaccount.",
               "type": "boolean"
             },
             "disableSelfServiceScrape": {
-              "description": "DisableSelfServiceScrape controls creation of VMServiceScrape by operator\nfor the application.\nHas priority over `VM_DISABLESELFSERVICESCRAPECREATION` operator env variable",
               "type": "boolean"
             },
             "dnsConfig": {
-              "description": "Specifies the DNS parameters of a pod.\nParameters specified here will be merged to the generated DNS\nconfiguration based on DNSPolicy.",
               "items": {
                 "x-kubernetes-preserve-unknown-fields": true
               },
               "properties": {
                 "nameservers": {
-                  "description": "A list of DNS name server IP addresses.\nThis will be appended to the base nameservers generated from DNSPolicy.\nDuplicated nameservers will be removed.",
                   "items": {
                     "type": "string"
                   },
@@ -963,16 +965,12 @@
                   "x-kubernetes-list-type": "atomic"
                 },
                 "options": {
-                  "description": "A list of DNS resolver options.\nThis will be merged with the base options generated from DNSPolicy.\nDuplicated entries will be removed. Resolution options given in Options\nwill override those that appear in the base DNSPolicy.",
                   "items": {
-                    "description": "PodDNSConfigOption defines DNS resolver options of a pod.",
                     "properties": {
                       "name": {
-                        "description": "Name is this DNS resolver option's name.\nRequired.",
                         "type": "string"
                       },
                       "value": {
-                        "description": "Value is this DNS resolver option's value.",
                         "type": "string"
                       }
                     },
@@ -983,7 +981,6 @@
                   "x-kubernetes-list-type": "atomic"
                 },
                 "searches": {
-                  "description": "A list of DNS search domains for host-name lookup.\nThis will be appended to the base search paths generated from DNSPolicy.\nDuplicated search paths will be removed.",
                   "items": {
                     "type": "string"
                   },
@@ -995,27 +992,21 @@
               "additionalProperties": false
             },
             "dnsPolicy": {
-              "description": "DNSPolicy sets DNS policy for the pod",
               "type": "string"
             },
             "extraArgs": {
               "additionalProperties": {
                 "type": "string"
               },
-              "description": "ExtraArgs that will be passed to the application container\nfor example remoteWrite.tmpDataPath: /tmp",
               "type": "object"
             },
             "extraEnvs": {
-              "description": "ExtraEnvs that will be passed to the application container",
               "items": {
-                "description": "EnvVar represents an environment variable present in a Container.",
                 "properties": {
                   "name": {
-                    "description": "Name of the environment variable.\nMay consist of any printable ASCII characters except '='.",
                     "type": "string"
                   },
                   "value": {
-                    "description": "Variable references $(VAR_NAME) are expanded\nusing the previously defined environment variables in the container and\nany service environment variables. If a variable cannot be resolved,\nthe reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.\n\"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\".\nEscaped references will never be expanded, regardless of whether the variable\nexists or not.\nDefaults to \"\".",
                     "type": "string"
                   }
                 },
@@ -1029,20 +1020,15 @@
               "type": "array"
             },
             "extraEnvsFrom": {
-              "description": "ExtraEnvsFrom defines source of env variables for the application container\ncould either be secret or configmap",
               "items": {
-                "description": "EnvFromSource represents the source of a set of ConfigMaps or Secrets",
                 "properties": {
                   "configMapRef": {
-                    "description": "The ConfigMap to select from",
                     "properties": {
                       "name": {
                         "default": "",
-                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                         "type": "string"
                       },
                       "optional": {
-                        "description": "Specify whether the ConfigMap must be defined",
                         "type": "boolean"
                       }
                     },
@@ -1051,19 +1037,15 @@
                     "additionalProperties": false
                   },
                   "prefix": {
-                    "description": "Optional text to prepend to the name of each environment variable.\nMay consist of any printable ASCII characters except '='.",
                     "type": "string"
                   },
                   "secretRef": {
-                    "description": "The Secret to select from",
                     "properties": {
                       "name": {
                         "default": "",
-                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                         "type": "string"
                       },
                       "optional": {
-                        "description": "Specify whether the Secret must be defined",
                         "type": "boolean"
                       }
                     },
@@ -1078,12 +1060,9 @@
               "type": "array"
             },
             "host_aliases": {
-              "description": "HostAliasesUnderScore provides mapping for ip and hostname,\nthat would be propagated to pod,\ncannot be used with HostNetwork.\nHas Priority over hostAliases field",
               "items": {
-                "description": "HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the\npod's hosts file.",
                 "properties": {
                   "hostnames": {
-                    "description": "Hostnames for the above IP address.",
                     "items": {
                       "type": "string"
                     },
@@ -1091,7 +1070,6 @@
                     "x-kubernetes-list-type": "atomic"
                   },
                   "ip": {
-                    "description": "IP address of the host file entry.",
                     "type": "string"
                   }
                 },
@@ -1104,12 +1082,9 @@
               "type": "array"
             },
             "hostAliases": {
-              "description": "HostAliases provides mapping for ip and hostname,\nthat would be propagated to pod,\ncannot be used with HostNetwork.",
               "items": {
-                "description": "HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the\npod's hosts file.",
                 "properties": {
                   "hostnames": {
-                    "description": "Hostnames for the above IP address.",
                     "items": {
                       "type": "string"
                     },
@@ -1117,7 +1092,6 @@
                     "x-kubernetes-list-type": "atomic"
                   },
                   "ip": {
-                    "description": "IP address of the host file entry.",
                     "type": "string"
                   }
                 },
@@ -1130,27 +1104,21 @@
               "type": "array"
             },
             "hostNetwork": {
-              "description": "HostNetwork controls whether the pod may use the node network namespace",
               "type": "boolean"
             },
             "hpa": {
-              "description": "Configures horizontal pod autoscaling.\nNote, enabling this option disables vmselect to vmselect communication. In most cases it's not an issue.",
               "type": "object",
               "x-kubernetes-preserve-unknown-fields": true
             },
             "image": {
-              "description": "Image - docker image settings\nif no specified operator uses default version from operator config",
               "properties": {
                 "pullPolicy": {
-                  "description": "PullPolicy describes how to pull docker image",
                   "type": "string"
                 },
                 "repository": {
-                  "description": "Repository contains name of docker image + it's repository if needed",
                   "type": "string"
                 },
                 "tag": {
-                  "description": "Tag contains desired docker image version",
                   "type": "string"
                 }
               },
@@ -1158,13 +1126,10 @@
               "additionalProperties": false
             },
             "imagePullSecrets": {
-              "description": "ImagePullSecrets An optional list of references to secrets in the same namespace\nto use for pulling images from registries\nsee https://kubernetes.io/docs/concepts/containers/images/#referring-to-an-imagepullsecrets-on-a-pod",
               "items": {
-                "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
                 "properties": {
                   "name": {
                     "default": "",
-                    "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                     "type": "string"
                   }
                 },
@@ -1175,9 +1140,7 @@
               "type": "array"
             },
             "initContainers": {
-              "description": "InitContainers allows adding initContainers to the pod definition.\nAny errors during the execution of an initContainer will lead to a restart of the Pod.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/",
               "items": {
-                "description": "A single application container that you want to run within a pod.",
                 "required": [
                   "name"
                 ],
@@ -1187,12 +1150,10 @@
               "type": "array"
             },
             "livenessProbe": {
-              "description": "LivenessProbe that will be added CRD pod",
               "type": "object",
               "x-kubernetes-preserve-unknown-fields": true
             },
             "logFormat": {
-              "description": "LogFormat for VMSelect to be configured with.\ndefault or json",
               "enum": [
                 "default",
                 "json"
@@ -1200,7 +1161,6 @@
               "type": "string"
             },
             "logLevel": {
-              "description": "LogLevel for VMSelect to be configured with.",
               "enum": [
                 "INFO",
                 "WARN",
@@ -1211,7 +1171,6 @@
               "type": "string"
             },
             "minReadySeconds": {
-              "description": "MinReadySeconds defines a minimum number of seconds to wait before starting update next pod\nif previous in healthy state\nHas no effect for VLogs and VMSingle",
               "format": "int32",
               "type": "integer"
             },
@@ -1219,62 +1178,17 @@
               "additionalProperties": {
                 "type": "string"
               },
-              "description": "NodeSelector Define which Nodes the Pods are scheduled on.",
               "type": "object"
             },
             "paused": {
-              "description": "Paused If set to true all actions on the underlying managed objects are not\ngoing to be performed, except for delete actions.",
               "type": "boolean"
             },
-            "persistentVolume": {
-              "description": "PersistentVolume - add persistent volume for cacheMountPath\nits useful for persistent cache\nuse storage instead of persistentVolume.",
-              "properties": {
-                "disableMountSubPath": {
-                  "description": "Deprecated: subPath usage will be disabled by default in a future release, this option will become unnecessary.\nDisableMountSubPath allows to remove any subPath usage in volume mounts.",
-                  "type": "boolean"
-                },
-                "emptyDir": {
-                  "description": "EmptyDirVolumeSource to be used by the Prometheus StatefulSets. If specified, used in place of any volumeClaimTemplate. More\ninfo: https://kubernetes.io/docs/concepts/storage/volumes/#emptydir",
-                  "properties": {
-                    "medium": {
-                      "description": "medium represents what type of storage medium should back this directory.\nThe default is \"\" which means to use the node's default medium.\nMust be an empty string (default) or Memory.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
-                      "type": "string"
-                    },
-                    "sizeLimit": {
-                      "anyOf": [
-                        {
-                          "type": "integer"
-                        },
-                        {
-                          "type": "string"
-                        }
-                      ],
-                      "description": "sizeLimit is the total amount of local storage required for this EmptyDir volume.\nThe size limit is also applicable for memory medium.\nThe maximum usage on memory medium EmptyDir would be the minimum value between\nthe SizeLimit specified here and the sum of memory limits of all containers in a pod.\nThe default is nil which means that the limit is undefined.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
-                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
-                      "x-kubernetes-int-or-string": true
-                    }
-                  },
-                  "type": "object",
-                  "additionalProperties": false
-                },
-                "volumeClaimTemplate": {
-                  "description": "A PVC spec to be used by the StatefulSets/Deployments.",
-                  "type": "object",
-                  "x-kubernetes-preserve-unknown-fields": true
-                }
-              },
-              "type": "object",
-              "additionalProperties": false
-            },
             "persistentVolumeClaimRetentionPolicy": {
-              "description": "PersistentVolumeClaimRetentionPolicy allows configuration of PVC retention policy",
               "properties": {
                 "whenDeleted": {
-                  "description": "WhenDeleted specifies what happens to PVCs created from StatefulSet\nVolumeClaimTemplates when the StatefulSet is deleted. The default policy\nof `Retain` causes PVCs to not be affected by StatefulSet deletion. The\n`Delete` policy causes those PVCs to be deleted.",
                   "type": "string"
                 },
                 "whenScaled": {
-                  "description": "WhenScaled specifies what happens to PVCs created from StatefulSet\nVolumeClaimTemplates when the StatefulSet is scaled down. The default\npolicy of `Retain` causes PVCs to not be affected by a scaledown. The\n`Delete` policy causes the associated PVCs for any excess pods above\nthe replica count to be deleted.",
                   "type": "string"
                 }
               },
@@ -1282,7 +1196,6 @@
               "additionalProperties": false
             },
             "podDisruptionBudget": {
-              "description": "PodDisruptionBudget created by operator",
               "properties": {
                 "maxUnavailable": {
                   "anyOf": [
@@ -1293,7 +1206,6 @@
                       "type": "string"
                     }
                   ],
-                  "description": "An eviction is allowed if at most \"maxUnavailable\" pods selected by\n\"selector\" are unavailable after the eviction, i.e. even in absence of\nthe evicted pod. For example, one can prevent all voluntary evictions\nby specifying 0. This is a mutually exclusive setting with \"minAvailable\".",
                   "x-kubernetes-int-or-string": true
                 },
                 "minAvailable": {
@@ -1305,18 +1217,15 @@
                       "type": "string"
                     }
                   ],
-                  "description": "An eviction is allowed if at least \"minAvailable\" pods selected by\n\"selector\" will still be available after the eviction, i.e. even in the\nabsence of the evicted pod.  So for example you can prevent all voluntary\nevictions by specifying \"100%\".",
                   "x-kubernetes-int-or-string": true
                 },
                 "selectorLabels": {
                   "additionalProperties": {
                     "type": "string"
                   },
-                  "description": "replaces default labels selector generated by operator\nit's useful when you need to create custom budget",
                   "type": "object"
                 },
                 "unhealthyPodEvictionPolicy": {
-                  "description": "UnhealthyPodEvictionPolicy defines the criteria for when unhealthy pods\n\nValid policies are IfHealthyBudget and AlwaysAllow.\nIf no policy is specified, the default behavior will be used,\nwhich corresponds to the IfHealthyBudget policy.\nAvailable from operator v0.64.0",
                   "enum": [
                     "IfHealthyBudget",
                     "AlwaysAllow"
@@ -1328,24 +1237,20 @@
               "additionalProperties": false
             },
             "podMetadata": {
-              "description": "PodMetadata configures Labels and Annotations which are propagated to the VMSelect pods.",
               "properties": {
                 "annotations": {
                   "additionalProperties": {
                     "type": "string"
                   },
-                  "description": "Annotations is an unstructured key value map stored with a resource that may be\nset by external tools to store and retrieve arbitrary metadata. They are not\nqueryable and should be preserved when modifying objects.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations",
                   "type": "object"
                 },
                 "labels": {
                   "additionalProperties": {
                     "type": "string"
                   },
-                  "description": "Labels Map of string keys and values that can be used to organize and categorize\n(scope and select) objects. May match selectors of replication controllers\nand services.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels",
                   "type": "object"
                 },
                 "name": {
-                  "description": "Name must be unique within a namespace. Is required when creating resources, although\nsome resources may allow a client to request the generation of an appropriate name\nautomatically. Name is primarily intended for creation idempotence and configuration\ndefinition.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names",
                   "type": "string"
                 }
               },
@@ -1353,20 +1258,15 @@
               "additionalProperties": false
             },
             "port": {
-              "description": "Port listen address",
               "type": "string"
             },
             "priorityClassName": {
-              "description": "PriorityClassName class assigned to the Pods",
               "type": "string"
             },
             "readinessGates": {
-              "description": "ReadinessGates defines pod readiness gates",
               "items": {
-                "description": "PodReadinessGate contains the reference to a pod condition",
                 "properties": {
                   "conditionType": {
-                    "description": "ConditionType refers to a condition in the pod's condition list with matching type.",
                     "type": "string"
                   }
                 },
@@ -1379,29 +1279,22 @@
               "type": "array"
             },
             "readinessProbe": {
-              "description": "ReadinessProbe that will be added CRD pod",
               "type": "object",
               "x-kubernetes-preserve-unknown-fields": true
             },
             "replicaCount": {
-              "description": "ReplicaCount is the expected size of the Application.",
               "format": "int32",
               "type": "integer"
             },
             "resources": {
-              "description": "Resources container resource request and limits, https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/\nif not defined default resources from operator config will be used",
               "properties": {
                 "claims": {
-                  "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis field depends on the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
                   "items": {
-                    "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
                     "properties": {
                       "name": {
-                        "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
                         "type": "string"
                       },
                       "request": {
-                        "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
                         "type": "string"
                       }
                     },
@@ -1430,7 +1323,6 @@
                     "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                     "x-kubernetes-int-or-string": true
                   },
-                  "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
                   "type": "object"
                 },
                 "requests": {
@@ -1446,7 +1338,6 @@
                     "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                     "x-kubernetes-int-or-string": true
                   },
-                  "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
                   "type": "object"
                 }
               },
@@ -1454,16 +1345,13 @@
               "additionalProperties": false
             },
             "revisionHistoryLimitCount": {
-              "description": "The number of old ReplicaSets to retain to allow rollback in deployment or\nmaximum number of revisions that will be maintained in the Deployment revision history.\nHas no effect at StatefulSets\nDefaults to 10.",
               "format": "int32",
               "type": "integer"
             },
             "rollingUpdateStrategy": {
-              "description": "RollingUpdateStrategy defines strategy for application updates\nDefault is OnDelete, in this case operator handles update process\nCan be changed for RollingUpdate",
               "type": "string"
             },
             "rollingUpdateStrategyBehavior": {
-              "description": "RollingUpdateStrategyBehavior defines customized behavior for rolling updates.\nIt applies if the RollingUpdateStrategy is set to OnDelete, which is the default.",
               "properties": {
                 "maxUnavailable": {
                   "anyOf": [
@@ -1474,7 +1362,6 @@
                       "type": "string"
                     }
                   ],
-                  "description": "MaxUnavailable defines the maximum number of pods that can be unavailable during the update.\nIt can be specified as an absolute number (e.g. 2) or a percentage of the total pods (e.g. \"50%\").\nFor example, if set to 100%, all pods will be upgraded at once, minimizing downtime when needed.",
                   "x-kubernetes-int-or-string": true
                 }
               },
@@ -1482,27 +1369,22 @@
               "additionalProperties": false
             },
             "runtimeClassName": {
-              "description": "RuntimeClassName - defines runtime class for kubernetes pod.\nhttps://kubernetes.io/docs/concepts/containers/runtime-class/",
               "type": "string"
             },
             "schedulerName": {
-              "description": "SchedulerName - defines kubernetes scheduler name",
               "type": "string"
             },
             "secrets": {
-              "description": "Secrets is a list of Secrets in the same namespace as the Application\nobject, which shall be mounted into the Application container\nat /etc/vm/secrets/SECRET_NAME folder",
               "items": {
                 "type": "string"
               },
               "type": "array"
             },
             "securityContext": {
-              "description": "SecurityContext holds pod-level security attributes and common container settings.\nThis defaults to the default PodSecurityContext.",
               "type": "object",
               "x-kubernetes-preserve-unknown-fields": true
             },
             "serviceScrapeSpec": {
-              "description": "ServiceScrapeSpec that will be added to vmselect VMServiceScrape spec",
               "required": [
                 "endpoints"
               ],
@@ -1510,27 +1392,22 @@
               "x-kubernetes-preserve-unknown-fields": true
             },
             "serviceSpec": {
-              "description": "ServiceSpec that will be added to vmselect service spec",
               "properties": {
                 "metadata": {
-                  "description": "EmbeddedObjectMetadata defines objectMeta for additional service.",
                   "properties": {
                     "annotations": {
                       "additionalProperties": {
                         "type": "string"
                       },
-                      "description": "Annotations is an unstructured key value map stored with a resource that may be\nset by external tools to store and retrieve arbitrary metadata. They are not\nqueryable and should be preserved when modifying objects.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations",
                       "type": "object"
                     },
                     "labels": {
                       "additionalProperties": {
                         "type": "string"
                       },
-                      "description": "Labels Map of string keys and values that can be used to organize and categorize\n(scope and select) objects. May match selectors of replication controllers\nand services.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels",
                       "type": "object"
                     },
                     "name": {
-                      "description": "Name must be unique within a namespace. Is required when creating resources, although\nsome resources may allow a client to request the generation of an appropriate name\nautomatically. Name is primarily intended for creation idempotence and configuration\ndefinition.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names",
                       "type": "string"
                     }
                   },
@@ -1538,12 +1415,10 @@
                   "additionalProperties": false
                 },
                 "spec": {
-                  "description": "ServiceSpec describes the attributes that a user creates on a service.\nMore info: https://kubernetes.io/docs/concepts/services-networking/service/",
                   "type": "object",
                   "x-kubernetes-preserve-unknown-fields": true
                 },
                 "useAsDefault": {
-                  "description": "UseAsDefault applies changes from given service definition to the main object Service\nChanging from headless service to clusterIP or loadbalancer may break cross-component communication",
                   "type": "boolean"
                 }
               },
@@ -1554,22 +1429,14 @@
               "additionalProperties": false
             },
             "startupProbe": {
-              "description": "StartupProbe that will be added to CRD pod",
               "type": "object",
               "x-kubernetes-preserve-unknown-fields": true
             },
             "storage": {
-              "description": "StorageSpec - add persistent volume claim for cacheMountPath\nits needed for persistent cache",
               "properties": {
-                "disableMountSubPath": {
-                  "description": "Deprecated: subPath usage will be disabled by default in a future release, this option will become unnecessary.\nDisableMountSubPath allows to remove any subPath usage in volume mounts.",
-                  "type": "boolean"
-                },
                 "emptyDir": {
-                  "description": "EmptyDirVolumeSource to be used by the Prometheus StatefulSets. If specified, used in place of any volumeClaimTemplate. More\ninfo: https://kubernetes.io/docs/concepts/storage/volumes/#emptydir",
                   "properties": {
                     "medium": {
-                      "description": "medium represents what type of storage medium should back this directory.\nThe default is \"\" which means to use the node's default medium.\nMust be an empty string (default) or Memory.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
                       "type": "string"
                     },
                     "sizeLimit": {
@@ -1581,7 +1448,6 @@
                           "type": "string"
                         }
                       ],
-                      "description": "sizeLimit is the total amount of local storage required for this EmptyDir volume.\nThe size limit is also applicable for memory medium.\nThe maximum usage on memory medium EmptyDir would be the minimum value between\nthe SizeLimit specified here and the sum of memory limits of all containers in a pod.\nThe default is nil which means that the limit is undefined.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
                       "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                       "x-kubernetes-int-or-string": true
                     }
@@ -1590,35 +1456,28 @@
                   "additionalProperties": false
                 },
                 "volumeClaimTemplate": {
-                  "description": "A PVC spec to be used by the StatefulSets/Deployments.",
                   "properties": {
                     "apiVersion": {
-                      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
                       "type": "string"
                     },
                     "kind": {
-                      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
                       "type": "string"
                     },
                     "metadata": {
-                      "description": "EmbeddedMetadata contains metadata relevant to an EmbeddedResource.",
                       "properties": {
                         "annotations": {
                           "additionalProperties": {
                             "type": "string"
                           },
-                          "description": "Annotations is an unstructured key value map stored with a resource that may be\nset by external tools to store and retrieve arbitrary metadata. They are not\nqueryable and should be preserved when modifying objects.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations",
                           "type": "object"
                         },
                         "labels": {
                           "additionalProperties": {
                             "type": "string"
                           },
-                          "description": "Labels Map of string keys and values that can be used to organize and categorize\n(scope and select) objects. May match selectors of replication controllers\nand services.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels",
                           "type": "object"
                         },
                         "name": {
-                          "description": "Name must be unique within a namespace. Is required when creating resources, although\nsome resources may allow a client to request the generation of an appropriate name\nautomatically. Name is primarily intended for creation idempotence and configuration\ndefinition.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names",
                           "type": "string"
                         }
                       },
@@ -1626,10 +1485,8 @@
                       "additionalProperties": false
                     },
                     "spec": {
-                      "description": "Spec defines the desired characteristics of a volume requested by a pod author.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
                       "properties": {
                         "accessModes": {
-                          "description": "accessModes contains the desired access modes the volume should have.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1",
                           "items": {
                             "type": "string"
                           },
@@ -1637,18 +1494,14 @@
                           "x-kubernetes-list-type": "atomic"
                         },
                         "dataSource": {
-                          "description": "dataSource field can be used to specify either:\n* An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)\n* An existing PVC (PersistentVolumeClaim)\nIf the provisioner or an external controller can support the specified data source,\nit will create a new volume based on the contents of the specified data source.\nWhen the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,\nand dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.\nIf the namespace is specified, then dataSourceRef will not be copied to dataSource.",
                           "properties": {
                             "apiGroup": {
-                              "description": "APIGroup is the group for the resource being referenced.\nIf APIGroup is not specified, the specified Kind must be in the core API group.\nFor any other third-party types, APIGroup is required.",
                               "type": "string"
                             },
                             "kind": {
-                              "description": "Kind is the type of resource being referenced",
                               "type": "string"
                             },
                             "name": {
-                              "description": "Name is the name of resource being referenced",
                               "type": "string"
                             }
                           },
@@ -1661,22 +1514,17 @@
                           "additionalProperties": false
                         },
                         "dataSourceRef": {
-                          "description": "dataSourceRef specifies the object from which to populate the volume with data, if a non-empty\nvolume is desired. This may be any object from a non-empty API group (non\ncore object) or a PersistentVolumeClaim object.\nWhen this field is specified, volume binding will only succeed if the type of\nthe specified object matches some installed volume populator or dynamic\nprovisioner.\nThis field will replace the functionality of the dataSource field and as such\nif both fields are non-empty, they must have the same value. For backwards\ncompatibility, when namespace isn't specified in dataSourceRef,\nboth fields (dataSource and dataSourceRef) will be set to the same\nvalue automatically if one of them is empty and the other is non-empty.\nWhen namespace is specified in dataSourceRef,\ndataSource isn't set to the same value and must be empty.\nThere are three important differences between dataSource and dataSourceRef:\n* While dataSource only allows two specific types of objects, dataSourceRef\n  allows any non-core object, as well as PersistentVolumeClaim objects.\n* While dataSource ignores disallowed values (dropping them), dataSourceRef\n  preserves all values, and generates an error if a disallowed value is\n  specified.\n* While dataSource only allows local objects, dataSourceRef allows objects\n  in any namespaces.\n(Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.\n(Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.",
                           "properties": {
                             "apiGroup": {
-                              "description": "APIGroup is the group for the resource being referenced.\nIf APIGroup is not specified, the specified Kind must be in the core API group.\nFor any other third-party types, APIGroup is required.",
                               "type": "string"
                             },
                             "kind": {
-                              "description": "Kind is the type of resource being referenced",
                               "type": "string"
                             },
                             "name": {
-                              "description": "Name is the name of resource being referenced",
                               "type": "string"
                             },
                             "namespace": {
-                              "description": "Namespace is the namespace of resource being referenced\nNote that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.\n(Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.",
                               "type": "string"
                             }
                           },
@@ -1688,7 +1536,6 @@
                           "additionalProperties": false
                         },
                         "resources": {
-                          "description": "resources represents the minimum resources the volume should have.\nIf RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements\nthat are lower than previous value but must still be higher than capacity recorded in the\nstatus field of the claim.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources",
                           "properties": {
                             "limits": {
                               "additionalProperties": {
@@ -1703,7 +1550,6 @@
                                 "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                                 "x-kubernetes-int-or-string": true
                               },
-                              "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
                               "type": "object"
                             },
                             "requests": {
@@ -1719,7 +1565,6 @@
                                 "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                                 "x-kubernetes-int-or-string": true
                               },
-                              "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
                               "type": "object"
                             }
                           },
@@ -1727,23 +1572,17 @@
                           "additionalProperties": false
                         },
                         "selector": {
-                          "description": "selector is a label query over volumes to consider for binding.",
                           "properties": {
                             "matchExpressions": {
-                              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
                               "items": {
-                                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
                                 "properties": {
                                   "key": {
-                                    "description": "key is the label key that the selector applies to.",
                                     "type": "string"
                                   },
                                   "operator": {
-                                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
                                     "type": "string"
                                   },
                                   "values": {
-                                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
                                     "items": {
                                       "type": "string"
                                     },
@@ -1765,7 +1604,6 @@
                               "additionalProperties": {
                                 "type": "string"
                               },
-                              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                               "type": "object"
                             }
                           },
@@ -1774,19 +1612,15 @@
                           "additionalProperties": false
                         },
                         "storageClassName": {
-                          "description": "storageClassName is the name of the StorageClass required by the claim.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1",
                           "type": "string"
                         },
                         "volumeAttributesClassName": {
-                          "description": "volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.\nIf specified, the CSI driver will create or update the volume with the attributes defined\nin the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,\nit can be changed after the claim is created. An empty string or nil value indicates that no\nVolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,\nthis field can be reset to its previous value (including nil) to cancel the modification.\nIf the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be\nset to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource\nexists.\nMore info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/",
                           "type": "string"
                         },
                         "volumeMode": {
-                          "description": "volumeMode defines what type of volume is required by the claim.\nValue of Filesystem is implied when not included in claim spec.",
                           "type": "string"
                         },
                         "volumeName": {
-                          "description": "volumeName is the binding reference to the PersistentVolume backing this claim.",
                           "type": "string"
                         }
                       },
@@ -1794,10 +1628,8 @@
                       "additionalProperties": false
                     },
                     "status": {
-                      "description": "Status represents the current information/status of a persistent volume claim.\nRead-only.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
                       "properties": {
                         "accessModes": {
-                          "description": "accessModes contains the actual access modes the volume backing the PVC has.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1",
                           "items": {
                             "type": "string"
                           },
@@ -1806,10 +1638,8 @@
                         },
                         "allocatedResourceStatuses": {
                           "additionalProperties": {
-                            "description": "When a controller receives persistentvolume claim update with ClaimResourceStatus for a resource\nthat it does not recognizes, then it should ignore that update and let other controllers\nhandle it.",
                             "type": "string"
                           },
-                          "description": "allocatedResourceStatuses stores status of resource being resized for the given PVC.\nKey names follow standard Kubernetes label syntax. Valid values are either:\n\t* Un-prefixed keys:\n\t\t- storage - the capacity of the volume.\n\t* Custom resources must use implementation-defined prefixed names such as \"example.com/my-custom-resource\"\nApart from above values - keys that are unprefixed or have kubernetes.io prefix are considered\nreserved and hence may not be used.\n\nClaimResourceStatus can be in any of following states:\n\t- ControllerResizeInProgress:\n\t\tState set when resize controller starts resizing the volume in control-plane.\n\t- ControllerResizeFailed:\n\t\tState set when resize has failed in resize controller with a terminal error.\n\t- NodeResizePending:\n\t\tState set when resize controller has finished resizing the volume but further resizing of\n\t\tvolume is needed on the node.\n\t- NodeResizeInProgress:\n\t\tState set when kubelet starts resizing the volume.\n\t- NodeResizeFailed:\n\t\tState set when resizing has failed in kubelet with a terminal error. Transient errors don't set\n\t\tNodeResizeFailed.\nFor example: if expanding a PVC for more capacity - this field can be one of the following states:\n\t- pvc.status.allocatedResourceStatus['storage'] = \"ControllerResizeInProgress\"\n     - pvc.status.allocatedResourceStatus['storage'] = \"ControllerResizeFailed\"\n     - pvc.status.allocatedResourceStatus['storage'] = \"NodeResizePending\"\n     - pvc.status.allocatedResourceStatus['storage'] = \"NodeResizeInProgress\"\n     - pvc.status.allocatedResourceStatus['storage'] = \"NodeResizeFailed\"\nWhen this field is not set, it means that no resize operation is in progress for the given PVC.\n\nA controller that receives PVC update with previously unknown resourceName or ClaimResourceStatus\nshould ignore the update for the purpose it was designed. For example - a controller that\nonly is responsible for resizing capacity of the volume, should ignore PVC updates that change other valid\nresources associated with PVC.\n\nThis is an alpha field and requires enabling RecoverVolumeExpansionFailure feature.",
                           "type": "object",
                           "x-kubernetes-map-type": "granular"
                         },
@@ -1826,7 +1656,6 @@
                             "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                             "x-kubernetes-int-or-string": true
                           },
-                          "description": "allocatedResources tracks the resources allocated to a PVC including its capacity.\nKey names follow standard Kubernetes label syntax. Valid values are either:\n\t* Un-prefixed keys:\n\t\t- storage - the capacity of the volume.\n\t* Custom resources must use implementation-defined prefixed names such as \"example.com/my-custom-resource\"\nApart from above values - keys that are unprefixed or have kubernetes.io prefix are considered\nreserved and hence may not be used.\n\nCapacity reported here may be larger than the actual capacity when a volume expansion operation\nis requested.\nFor storage quota, the larger value from allocatedResources and PVC.spec.resources is used.\nIf allocatedResources is not set, PVC.spec.resources alone is used for quota calculation.\nIf a volume expansion capacity request is lowered, allocatedResources is only\nlowered if there are no expansion operations in progress and if the actual volume capacity\nis equal or lower than the requested capacity.\n\nA controller that receives PVC update with previously unknown resourceName\nshould ignore the update for the purpose it was designed. For example - a controller that\nonly is responsible for resizing capacity of the volume, should ignore PVC updates that change other valid\nresources associated with PVC.\n\nThis is an alpha field and requires enabling RecoverVolumeExpansionFailure feature.",
                           "type": "object"
                         },
                         "capacity": {
@@ -1842,38 +1671,29 @@
                             "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                             "x-kubernetes-int-or-string": true
                           },
-                          "description": "capacity represents the actual resources of the underlying volume.",
                           "type": "object"
                         },
                         "conditions": {
-                          "description": "conditions is the current Condition of persistent volume claim. If underlying persistent volume is being\nresized then the Condition will be set to 'Resizing'.",
                           "items": {
-                            "description": "PersistentVolumeClaimCondition contains details about state of pvc",
                             "properties": {
                               "lastProbeTime": {
-                                "description": "lastProbeTime is the time we probed the condition.",
                                 "format": "date-time",
                                 "type": "string"
                               },
                               "lastTransitionTime": {
-                                "description": "lastTransitionTime is the time the condition transitioned from one status to another.",
                                 "format": "date-time",
                                 "type": "string"
                               },
                               "message": {
-                                "description": "message is the human-readable message indicating details about last transition.",
                                 "type": "string"
                               },
                               "reason": {
-                                "description": "reason is a unique, this should be a short, machine understandable string that gives the reason\nfor condition's last transition. If it reports \"Resizing\" that means the underlying\npersistent volume is being resized.",
                                 "type": "string"
                               },
                               "status": {
-                                "description": "Status is the status of the condition.\nCan be True, False, Unknown.\nMore info: https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-claim-v1/#:~:text=state%20of%20pvc-,conditions.status,-(string)%2C%20required",
                                 "type": "string"
                               },
                               "type": {
-                                "description": "Type is the type of the condition.\nMore info: https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-claim-v1/#:~:text=set%20to%20%27ResizeStarted%27.-,PersistentVolumeClaimCondition,-contains%20details%20about",
                                 "type": "string"
                               }
                             },
@@ -1891,18 +1711,14 @@
                           "x-kubernetes-list-type": "map"
                         },
                         "currentVolumeAttributesClassName": {
-                          "description": "currentVolumeAttributesClassName is the current name of the VolumeAttributesClass the PVC is using.\nWhen unset, there is no VolumeAttributeClass applied to this PersistentVolumeClaim",
                           "type": "string"
                         },
                         "modifyVolumeStatus": {
-                          "description": "ModifyVolumeStatus represents the status object of ControllerModifyVolume operation.\nWhen this is unset, there is no ModifyVolume operation being attempted.",
                           "properties": {
                             "status": {
-                              "description": "status is the status of the ControllerModifyVolume operation. It can be in any of following states:\n - Pending\n   Pending indicates that the PersistentVolumeClaim cannot be modified due to unmet requirements, such as\n   the specified VolumeAttributesClass not existing.\n - InProgress\n   InProgress indicates that the volume is being modified.\n - Infeasible\n  Infeasible indicates that the request has been rejected as invalid by the CSI driver. To\n\t  resolve the error, a valid VolumeAttributesClass needs to be specified.\nNote: New statuses can be added in the future. Consumers should check for unknown statuses and fail appropriately.",
                               "type": "string"
                             },
                             "targetVolumeAttributesClassName": {
-                              "description": "targetVolumeAttributesClassName is the name of the VolumeAttributesClass the PVC currently being reconciled",
                               "type": "string"
                             }
                           },
@@ -1913,7 +1729,6 @@
                           "additionalProperties": false
                         },
                         "phase": {
-                          "description": "phase represents the current phase of PersistentVolumeClaim.",
                           "type": "string"
                         }
                       },
@@ -1929,34 +1744,26 @@
               "additionalProperties": false
             },
             "terminationGracePeriodSeconds": {
-              "description": "TerminationGracePeriodSeconds period for container graceful termination",
               "format": "int64",
               "type": "integer"
             },
             "tolerations": {
-              "description": "Tolerations If specified, the pod's tolerations.",
               "items": {
-                "description": "The pod this Toleration is attached to tolerates any taint that matches\nthe triple <key,value,effect> using the matching operator <operator>.",
                 "properties": {
                   "effect": {
-                    "description": "Effect indicates the taint effect to match. Empty means match all taint effects.\nWhen specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
                     "type": "string"
                   },
                   "key": {
-                    "description": "Key is the taint key that the toleration applies to. Empty means match all taint keys.\nIf the key is empty, operator must be Exists; this combination means to match all values and all keys.",
                     "type": "string"
                   },
                   "operator": {
-                    "description": "Operator represents a key's relationship to the value.\nValid operators are Exists and Equal. Defaults to Equal.\nExists is equivalent to wildcard for value, so that a pod can\ntolerate all taints of a particular category.",
                     "type": "string"
                   },
                   "tolerationSeconds": {
-                    "description": "TolerationSeconds represents the period of time the toleration (which must be\nof effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,\nit is not set, which means tolerate the taint forever (do not evict). Zero and\nnegative values will be treated as 0 (evict immediately) by the system.",
                     "format": "int64",
                     "type": "integer"
                   },
                   "value": {
-                    "description": "Value is the taint value the toleration matches to.\nIf the operator is Exists, the value should be empty, otherwise just a regular string.",
                     "type": "string"
                   }
                 },
@@ -1966,9 +1773,7 @@
               "type": "array"
             },
             "topologySpreadConstraints": {
-              "description": "TopologySpreadConstraints embedded kubernetes pod configuration option,\ncontrols how pods are spread across your cluster among failure-domains\nsuch as regions, zones, nodes, and other user-defined topology domains\nhttps://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/",
               "items": {
-                "description": "TopologySpreadConstraint specifies how to spread matching pods among the given topology.",
                 "required": [
                   "maxSkew",
                   "topologyKey",
@@ -1980,44 +1785,33 @@
               "type": "array"
             },
             "useDefaultResources": {
-              "description": "UseDefaultResources controls resource settings\nBy default, operator sets built-in resource requirements",
               "type": "boolean"
             },
             "useStrictSecurity": {
-              "description": "UseStrictSecurity enables strict security mode for component\nit restricts disk writes access\nuses non-root user out of the box\ndrops not needed security permissions",
               "type": "boolean"
             },
             "volumeMounts": {
-              "description": "VolumeMounts allows configuration of additional VolumeMounts on the output Deployment/StatefulSet definition.\nVolumeMounts specified will be appended to other VolumeMounts in the Application container",
               "items": {
-                "description": "VolumeMount describes a mounting of a Volume within a container.",
                 "properties": {
                   "mountPath": {
-                    "description": "Path within the container at which the volume should be mounted.  Must\nnot contain ':'.",
                     "type": "string"
                   },
                   "mountPropagation": {
-                    "description": "mountPropagation determines how mounts are propagated from the host\nto container and the other way around.\nWhen not set, MountPropagationNone is used.\nThis field is beta in 1.10.\nWhen RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified\n(which defaults to None).",
                     "type": "string"
                   },
                   "name": {
-                    "description": "This must match the Name of a Volume.",
                     "type": "string"
                   },
                   "readOnly": {
-                    "description": "Mounted read-only if true, read-write otherwise (false or unspecified).\nDefaults to false.",
                     "type": "boolean"
                   },
                   "recursiveReadOnly": {
-                    "description": "RecursiveReadOnly specifies whether read-only mounts should be handled\nrecursively.\n\nIf ReadOnly is false, this field has no meaning and must be unspecified.\n\nIf ReadOnly is true, and this field is set to Disabled, the mount is not made\nrecursively read-only.  If this field is set to IfPossible, the mount is made\nrecursively read-only, if it is supported by the container runtime.  If this\nfield is set to Enabled, the mount is made recursively read-only if it is\nsupported by the container runtime, otherwise the pod will not be started and\nan error will be generated to indicate the reason.\n\nIf this field is set to IfPossible or Enabled, MountPropagation must be set to\nNone (or be unspecified, which defaults to None).\n\nIf this field is not specified, it is treated as an equivalent of Disabled.",
                     "type": "string"
                   },
                   "subPath": {
-                    "description": "Path within the volume from which the container's volume should be mounted.\nDefaults to \"\" (volume's root).",
                     "type": "string"
                   },
                   "subPathExpr": {
-                    "description": "Expanded path within the volume from which the container's volume should be mounted.\nBehaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.\nDefaults to \"\" (volume's root).\nSubPathExpr and SubPath are mutually exclusive.",
                     "type": "string"
                   }
                 },
@@ -2031,9 +1825,7 @@
               "type": "array"
             },
             "volumes": {
-              "description": "Volumes allows configuration of additional volumes on the output Deployment/StatefulSet definition.\nVolumes specified will be appended to other volumes that are generated.\n/ +optional",
               "items": {
-                "description": "Volume represents a named volume in a pod that may be accessed by any container in the pod.",
                 "required": [
                   "name"
                 ],
@@ -2041,6 +1833,165 @@
                 "x-kubernetes-preserve-unknown-fields": true
               },
               "type": "array"
+            },
+            "vpa": {
+              "properties": {
+                "recommenders": {
+                  "items": {
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "resourcePolicy": {
+                  "properties": {
+                    "containerPolicies": {
+                      "items": {
+                        "properties": {
+                          "containerName": {
+                            "type": "string"
+                          },
+                          "controlledResources": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "controlledValues": {
+                            "enum": [
+                              "RequestsAndLimits",
+                              "RequestsOnly"
+                            ],
+                            "type": "string"
+                          },
+                          "maxAllowed": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          },
+                          "minAllowed": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          },
+                          "mode": {
+                            "enum": [
+                              "Auto",
+                              "Off"
+                            ],
+                            "type": "string"
+                          },
+                          "oomBumpUpRatio": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "oomMinBumpUp": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                            "x-kubernetes-int-or-string": true
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "updatePolicy": {
+                  "properties": {
+                    "evictionRequirements": {
+                      "items": {
+                        "properties": {
+                          "changeRequirement": {
+                            "enum": [
+                              "TargetHigherThanRequests",
+                              "TargetLowerThanRequests"
+                            ],
+                            "type": "string"
+                          },
+                          "resources": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "changeRequirement",
+                          "resources"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "minReplicas": {
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "updateMode": {
+                      "enum": [
+                        "Off",
+                        "Initial",
+                        "Recreate",
+                        "InPlaceOrRecreate",
+                        "Auto"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
             }
           },
           "type": "object",
@@ -2049,30 +2000,27 @@
         "vmstorage": {
           "properties": {
             "affinity": {
-              "description": "Affinity If specified, the pod's scheduling constraints.",
               "type": "object",
               "x-kubernetes-preserve-unknown-fields": true
             },
             "claimTemplates": {
-              "description": "ClaimTemplates allows adding additional VolumeClaimTemplates for StatefulSet",
               "items": {
-                "description": "PersistentVolumeClaim is a user's request for and claim to a persistent volume",
                 "type": "object",
                 "x-kubernetes-preserve-unknown-fields": true
               },
               "type": "array"
             },
+            "componentVersion": {
+              "type": "string"
+            },
             "configMaps": {
-              "description": "ConfigMaps is a list of ConfigMaps in the same namespace as the Application\nobject, which shall be mounted into the Application container\nat /etc/vm/configs/CONFIGMAP_NAME folder",
               "items": {
                 "type": "string"
               },
               "type": "array"
             },
             "containers": {
-              "description": "Containers property allows to inject additions sidecars or to patch existing containers.\nIt can be useful for proxies, backup, etc.",
               "items": {
-                "description": "A single application container that you want to run within a pod.",
                 "required": [
                   "name"
                 ],
@@ -2082,21 +2030,17 @@
               "type": "array"
             },
             "disableAutomountServiceAccountToken": {
-              "description": "DisableAutomountServiceAccountToken whether to disable serviceAccount auto mount by Kubernetes (available from v0.54.0).\nOperator will conditionally create volumes and volumeMounts for containers if it requires k8s API access.\nFor example, vmagent and vm-config-reloader requires k8s API access.\nOperator creates volumes with name: \"kube-api-access\", which can be used as volumeMount for extraContainers if needed.\nAnd also adds VolumeMounts at /var/run/secrets/kubernetes.io/serviceaccount.",
               "type": "boolean"
             },
             "disableSelfServiceScrape": {
-              "description": "DisableSelfServiceScrape controls creation of VMServiceScrape by operator\nfor the application.\nHas priority over `VM_DISABLESELFSERVICESCRAPECREATION` operator env variable",
               "type": "boolean"
             },
             "dnsConfig": {
-              "description": "Specifies the DNS parameters of a pod.\nParameters specified here will be merged to the generated DNS\nconfiguration based on DNSPolicy.",
               "items": {
                 "x-kubernetes-preserve-unknown-fields": true
               },
               "properties": {
                 "nameservers": {
-                  "description": "A list of DNS name server IP addresses.\nThis will be appended to the base nameservers generated from DNSPolicy.\nDuplicated nameservers will be removed.",
                   "items": {
                     "type": "string"
                   },
@@ -2104,16 +2048,12 @@
                   "x-kubernetes-list-type": "atomic"
                 },
                 "options": {
-                  "description": "A list of DNS resolver options.\nThis will be merged with the base options generated from DNSPolicy.\nDuplicated entries will be removed. Resolution options given in Options\nwill override those that appear in the base DNSPolicy.",
                   "items": {
-                    "description": "PodDNSConfigOption defines DNS resolver options of a pod.",
                     "properties": {
                       "name": {
-                        "description": "Name is this DNS resolver option's name.\nRequired.",
                         "type": "string"
                       },
                       "value": {
-                        "description": "Value is this DNS resolver option's value.",
                         "type": "string"
                       }
                     },
@@ -2124,7 +2064,6 @@
                   "x-kubernetes-list-type": "atomic"
                 },
                 "searches": {
-                  "description": "A list of DNS search domains for host-name lookup.\nThis will be appended to the base search paths generated from DNSPolicy.\nDuplicated search paths will be removed.",
                   "items": {
                     "type": "string"
                   },
@@ -2136,27 +2075,21 @@
               "additionalProperties": false
             },
             "dnsPolicy": {
-              "description": "DNSPolicy sets DNS policy for the pod",
               "type": "string"
             },
             "extraArgs": {
               "additionalProperties": {
                 "type": "string"
               },
-              "description": "ExtraArgs that will be passed to the application container\nfor example remoteWrite.tmpDataPath: /tmp",
               "type": "object"
             },
             "extraEnvs": {
-              "description": "ExtraEnvs that will be passed to the application container",
               "items": {
-                "description": "EnvVar represents an environment variable present in a Container.",
                 "properties": {
                   "name": {
-                    "description": "Name of the environment variable.\nMay consist of any printable ASCII characters except '='.",
                     "type": "string"
                   },
                   "value": {
-                    "description": "Variable references $(VAR_NAME) are expanded\nusing the previously defined environment variables in the container and\nany service environment variables. If a variable cannot be resolved,\nthe reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.\n\"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\".\nEscaped references will never be expanded, regardless of whether the variable\nexists or not.\nDefaults to \"\".",
                     "type": "string"
                   }
                 },
@@ -2170,20 +2103,15 @@
               "type": "array"
             },
             "extraEnvsFrom": {
-              "description": "ExtraEnvsFrom defines source of env variables for the application container\ncould either be secret or configmap",
               "items": {
-                "description": "EnvFromSource represents the source of a set of ConfigMaps or Secrets",
                 "properties": {
                   "configMapRef": {
-                    "description": "The ConfigMap to select from",
                     "properties": {
                       "name": {
                         "default": "",
-                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                         "type": "string"
                       },
                       "optional": {
-                        "description": "Specify whether the ConfigMap must be defined",
                         "type": "boolean"
                       }
                     },
@@ -2192,19 +2120,15 @@
                     "additionalProperties": false
                   },
                   "prefix": {
-                    "description": "Optional text to prepend to the name of each environment variable.\nMay consist of any printable ASCII characters except '='.",
                     "type": "string"
                   },
                   "secretRef": {
-                    "description": "The Secret to select from",
                     "properties": {
                       "name": {
                         "default": "",
-                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                         "type": "string"
                       },
                       "optional": {
-                        "description": "Specify whether the Secret must be defined",
                         "type": "boolean"
                       }
                     },
@@ -2219,12 +2143,9 @@
               "type": "array"
             },
             "host_aliases": {
-              "description": "HostAliasesUnderScore provides mapping for ip and hostname,\nthat would be propagated to pod,\ncannot be used with HostNetwork.\nHas Priority over hostAliases field",
               "items": {
-                "description": "HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the\npod's hosts file.",
                 "properties": {
                   "hostnames": {
-                    "description": "Hostnames for the above IP address.",
                     "items": {
                       "type": "string"
                     },
@@ -2232,7 +2153,6 @@
                     "x-kubernetes-list-type": "atomic"
                   },
                   "ip": {
-                    "description": "IP address of the host file entry.",
                     "type": "string"
                   }
                 },
@@ -2245,12 +2165,9 @@
               "type": "array"
             },
             "hostAliases": {
-              "description": "HostAliases provides mapping for ip and hostname,\nthat would be propagated to pod,\ncannot be used with HostNetwork.",
               "items": {
-                "description": "HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the\npod's hosts file.",
                 "properties": {
                   "hostnames": {
-                    "description": "Hostnames for the above IP address.",
                     "items": {
                       "type": "string"
                     },
@@ -2258,7 +2175,6 @@
                     "x-kubernetes-list-type": "atomic"
                   },
                   "ip": {
-                    "description": "IP address of the host file entry.",
                     "type": "string"
                   }
                 },
@@ -2271,22 +2187,590 @@
               "type": "array"
             },
             "hostNetwork": {
-              "description": "HostNetwork controls whether the pod may use the node network namespace",
               "type": "boolean"
             },
+            "hpa": {
+              "properties": {
+                "behaviour": {
+                  "properties": {
+                    "scaleDown": {
+                      "properties": {
+                        "policies": {
+                          "items": {
+                            "properties": {
+                              "periodSeconds": {
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "type": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "format": "int32",
+                                "type": "integer"
+                              }
+                            },
+                            "required": [
+                              "periodSeconds",
+                              "type",
+                              "value"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array",
+                          "x-kubernetes-list-type": "atomic"
+                        },
+                        "selectPolicy": {
+                          "type": "string"
+                        },
+                        "stabilizationWindowSeconds": {
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "tolerance": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                          "x-kubernetes-int-or-string": true
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "scaleUp": {
+                      "properties": {
+                        "policies": {
+                          "items": {
+                            "properties": {
+                              "periodSeconds": {
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "type": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "format": "int32",
+                                "type": "integer"
+                              }
+                            },
+                            "required": [
+                              "periodSeconds",
+                              "type",
+                              "value"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array",
+                          "x-kubernetes-list-type": "atomic"
+                        },
+                        "selectPolicy": {
+                          "type": "string"
+                        },
+                        "stabilizationWindowSeconds": {
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "tolerance": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                          "x-kubernetes-int-or-string": true
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "maxReplicas": {
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "metrics": {
+                  "items": {
+                    "properties": {
+                      "containerResource": {
+                        "properties": {
+                          "container": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "target": {
+                            "properties": {
+                              "averageUtilization": {
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "averageValue": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "type": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "required": [
+                              "type"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "container",
+                          "name",
+                          "target"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "external": {
+                        "properties": {
+                          "metric": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "selector": {
+                                "properties": {
+                                  "matchExpressions": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              }
+                            },
+                            "required": [
+                              "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "target": {
+                            "properties": {
+                              "averageUtilization": {
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "averageValue": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "type": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "required": [
+                              "type"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "metric",
+                          "target"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "object": {
+                        "properties": {
+                          "describedObject": {
+                            "properties": {
+                              "apiVersion": {
+                                "type": "string"
+                              },
+                              "kind": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "kind",
+                              "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "metric": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "selector": {
+                                "properties": {
+                                  "matchExpressions": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              }
+                            },
+                            "required": [
+                              "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "target": {
+                            "properties": {
+                              "averageUtilization": {
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "averageValue": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "type": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "required": [
+                              "type"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "describedObject",
+                          "metric",
+                          "target"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "pods": {
+                        "properties": {
+                          "metric": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "selector": {
+                                "properties": {
+                                  "matchExpressions": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array",
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              }
+                            },
+                            "required": [
+                              "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "target": {
+                            "properties": {
+                              "averageUtilization": {
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "averageValue": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "type": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "required": [
+                              "type"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "metric",
+                          "target"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "resource": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "target": {
+                            "properties": {
+                              "averageUtilization": {
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "averageValue": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "type": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "required": [
+                              "type"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "target"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "type"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "minReplicas": {
+                  "format": "int32",
+                  "type": "integer"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
             "image": {
-              "description": "Image - docker image settings\nif no specified operator uses default version from operator config",
               "properties": {
                 "pullPolicy": {
-                  "description": "PullPolicy describes how to pull docker image",
                   "type": "string"
                 },
                 "repository": {
-                  "description": "Repository contains name of docker image + it's repository if needed",
                   "type": "string"
                 },
                 "tag": {
-                  "description": "Tag contains desired docker image version",
                   "type": "string"
                 }
               },
@@ -2294,13 +2778,10 @@
               "additionalProperties": false
             },
             "imagePullSecrets": {
-              "description": "ImagePullSecrets An optional list of references to secrets in the same namespace\nto use for pulling images from registries\nsee https://kubernetes.io/docs/concepts/containers/images/#referring-to-an-imagepullsecrets-on-a-pod",
               "items": {
-                "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
                 "properties": {
                   "name": {
                     "default": "",
-                    "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                     "type": "string"
                   }
                 },
@@ -2311,9 +2792,7 @@
               "type": "array"
             },
             "initContainers": {
-              "description": "InitContainers allows adding initContainers to the pod definition.\nAny errors during the execution of an initContainer will lead to a restart of the Pod.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/",
               "items": {
-                "description": "A single application container that you want to run within a pod.",
                 "required": [
                   "name"
                 ],
@@ -2323,12 +2802,10 @@
               "type": "array"
             },
             "livenessProbe": {
-              "description": "LivenessProbe that will be added CRD pod",
               "type": "object",
               "x-kubernetes-preserve-unknown-fields": true
             },
             "logFormat": {
-              "description": "LogFormat for VMStorage to be configured with.\ndefault or json",
               "enum": [
                 "default",
                 "json"
@@ -2336,7 +2813,6 @@
               "type": "string"
             },
             "logLevel": {
-              "description": "LogLevel for VMStorage to be configured with.",
               "enum": [
                 "INFO",
                 "WARN",
@@ -2347,7 +2823,6 @@
               "type": "string"
             },
             "maintenanceInsertNodeIDs": {
-              "description": "MaintenanceInsertNodeIDs - excludes given node ids from insert requests routing, must contain pod suffixes - for pod-0, id will be 0 and etc.\nlets say, you have pod-0, pod-1, pod-2, pod-3. to exclude pod-0 and pod-3 from insert routing, define nodeIDs: [0,3].\nUseful at storage expanding, when you want to rebalance some data at cluster.",
               "items": {
                 "format": "int32",
                 "type": "integer"
@@ -2355,7 +2830,6 @@
               "type": "array"
             },
             "maintenanceSelectNodeIDs": {
-              "description": "MaintenanceInsertNodeIDs - excludes given node ids from select requests routing, must contain pod suffixes - for pod-0, id will be 0 and etc.",
               "items": {
                 "format": "int32",
                 "type": "integer"
@@ -2363,7 +2837,6 @@
               "type": "array"
             },
             "minReadySeconds": {
-              "description": "MinReadySeconds defines a minimum number of seconds to wait before starting update next pod\nif previous in healthy state\nHas no effect for VLogs and VMSingle",
               "format": "int32",
               "type": "integer"
             },
@@ -2371,22 +2844,17 @@
               "additionalProperties": {
                 "type": "string"
               },
-              "description": "NodeSelector Define which Nodes the Pods are scheduled on.",
               "type": "object"
             },
             "paused": {
-              "description": "Paused If set to true all actions on the underlying managed objects are not\ngoing to be performed, except for delete actions.",
               "type": "boolean"
             },
             "persistentVolumeClaimRetentionPolicy": {
-              "description": "PersistentVolumeClaimRetentionPolicy allows configuration of PVC retention policy",
               "properties": {
                 "whenDeleted": {
-                  "description": "WhenDeleted specifies what happens to PVCs created from StatefulSet\nVolumeClaimTemplates when the StatefulSet is deleted. The default policy\nof `Retain` causes PVCs to not be affected by StatefulSet deletion. The\n`Delete` policy causes those PVCs to be deleted.",
                   "type": "string"
                 },
                 "whenScaled": {
-                  "description": "WhenScaled specifies what happens to PVCs created from StatefulSet\nVolumeClaimTemplates when the StatefulSet is scaled down. The default\npolicy of `Retain` causes PVCs to not be affected by a scaledown. The\n`Delete` policy causes the associated PVCs for any excess pods above\nthe replica count to be deleted.",
                   "type": "string"
                 }
               },
@@ -2394,7 +2862,6 @@
               "additionalProperties": false
             },
             "podDisruptionBudget": {
-              "description": "PodDisruptionBudget created by operator",
               "properties": {
                 "maxUnavailable": {
                   "anyOf": [
@@ -2405,7 +2872,6 @@
                       "type": "string"
                     }
                   ],
-                  "description": "An eviction is allowed if at most \"maxUnavailable\" pods selected by\n\"selector\" are unavailable after the eviction, i.e. even in absence of\nthe evicted pod. For example, one can prevent all voluntary evictions\nby specifying 0. This is a mutually exclusive setting with \"minAvailable\".",
                   "x-kubernetes-int-or-string": true
                 },
                 "minAvailable": {
@@ -2417,18 +2883,15 @@
                       "type": "string"
                     }
                   ],
-                  "description": "An eviction is allowed if at least \"minAvailable\" pods selected by\n\"selector\" will still be available after the eviction, i.e. even in the\nabsence of the evicted pod.  So for example you can prevent all voluntary\nevictions by specifying \"100%\".",
                   "x-kubernetes-int-or-string": true
                 },
                 "selectorLabels": {
                   "additionalProperties": {
                     "type": "string"
                   },
-                  "description": "replaces default labels selector generated by operator\nit's useful when you need to create custom budget",
                   "type": "object"
                 },
                 "unhealthyPodEvictionPolicy": {
-                  "description": "UnhealthyPodEvictionPolicy defines the criteria for when unhealthy pods\n\nValid policies are IfHealthyBudget and AlwaysAllow.\nIf no policy is specified, the default behavior will be used,\nwhich corresponds to the IfHealthyBudget policy.\nAvailable from operator v0.64.0",
                   "enum": [
                     "IfHealthyBudget",
                     "AlwaysAllow"
@@ -2440,24 +2903,20 @@
               "additionalProperties": false
             },
             "podMetadata": {
-              "description": "PodMetadata configures Labels and Annotations which are propagated to the VMStorage pods.",
               "properties": {
                 "annotations": {
                   "additionalProperties": {
                     "type": "string"
                   },
-                  "description": "Annotations is an unstructured key value map stored with a resource that may be\nset by external tools to store and retrieve arbitrary metadata. They are not\nqueryable and should be preserved when modifying objects.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations",
                   "type": "object"
                 },
                 "labels": {
                   "additionalProperties": {
                     "type": "string"
                   },
-                  "description": "Labels Map of string keys and values that can be used to organize and categorize\n(scope and select) objects. May match selectors of replication controllers\nand services.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels",
                   "type": "object"
                 },
                 "name": {
-                  "description": "Name must be unique within a namespace. Is required when creating resources, although\nsome resources may allow a client to request the generation of an appropriate name\nautomatically. Name is primarily intended for creation idempotence and configuration\ndefinition.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names",
                   "type": "string"
                 }
               },
@@ -2465,20 +2924,15 @@
               "additionalProperties": false
             },
             "port": {
-              "description": "Port listen address",
               "type": "string"
             },
             "priorityClassName": {
-              "description": "PriorityClassName class assigned to the Pods",
               "type": "string"
             },
             "readinessGates": {
-              "description": "ReadinessGates defines pod readiness gates",
               "items": {
-                "description": "PodReadinessGate contains the reference to a pod condition",
                 "properties": {
                   "conditionType": {
-                    "description": "ConditionType refers to a condition in the pod's condition list with matching type.",
                     "type": "string"
                   }
                 },
@@ -2491,29 +2945,22 @@
               "type": "array"
             },
             "readinessProbe": {
-              "description": "ReadinessProbe that will be added CRD pod",
               "type": "object",
               "x-kubernetes-preserve-unknown-fields": true
             },
             "replicaCount": {
-              "description": "ReplicaCount is the expected size of the Application.",
               "format": "int32",
               "type": "integer"
             },
             "resources": {
-              "description": "Resources container resource request and limits, https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/\nif not defined default resources from operator config will be used",
               "properties": {
                 "claims": {
-                  "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis field depends on the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
                   "items": {
-                    "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
                     "properties": {
                       "name": {
-                        "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
                         "type": "string"
                       },
                       "request": {
-                        "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
                         "type": "string"
                       }
                     },
@@ -2542,7 +2989,6 @@
                     "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                     "x-kubernetes-int-or-string": true
                   },
-                  "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
                   "type": "object"
                 },
                 "requests": {
@@ -2558,7 +3004,6 @@
                     "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                     "x-kubernetes-int-or-string": true
                   },
-                  "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
                   "type": "object"
                 }
               },
@@ -2566,16 +3011,13 @@
               "additionalProperties": false
             },
             "revisionHistoryLimitCount": {
-              "description": "The number of old ReplicaSets to retain to allow rollback in deployment or\nmaximum number of revisions that will be maintained in the Deployment revision history.\nHas no effect at StatefulSets\nDefaults to 10.",
               "format": "int32",
               "type": "integer"
             },
             "rollingUpdateStrategy": {
-              "description": "RollingUpdateStrategy defines strategy for application updates\nDefault is OnDelete, in this case operator handles update process\nCan be changed for RollingUpdate",
               "type": "string"
             },
             "rollingUpdateStrategyBehavior": {
-              "description": "RollingUpdateStrategyBehavior defines customized behavior for rolling updates.\nIt applies if the RollingUpdateStrategy is set to OnDelete, which is the default.",
               "properties": {
                 "maxUnavailable": {
                   "anyOf": [
@@ -2586,7 +3028,6 @@
                       "type": "string"
                     }
                   ],
-                  "description": "MaxUnavailable defines the maximum number of pods that can be unavailable during the update.\nIt can be specified as an absolute number (e.g. 2) or a percentage of the total pods (e.g. \"50%\").\nFor example, if set to 100%, all pods will be upgraded at once, minimizing downtime when needed.",
                   "x-kubernetes-int-or-string": true
                 }
               },
@@ -2594,27 +3035,22 @@
               "additionalProperties": false
             },
             "runtimeClassName": {
-              "description": "RuntimeClassName - defines runtime class for kubernetes pod.\nhttps://kubernetes.io/docs/concepts/containers/runtime-class/",
               "type": "string"
             },
             "schedulerName": {
-              "description": "SchedulerName - defines kubernetes scheduler name",
               "type": "string"
             },
             "secrets": {
-              "description": "Secrets is a list of Secrets in the same namespace as the Application\nobject, which shall be mounted into the Application container\nat /etc/vm/secrets/SECRET_NAME folder",
               "items": {
                 "type": "string"
               },
               "type": "array"
             },
             "securityContext": {
-              "description": "SecurityContext holds pod-level security attributes and common container settings.\nThis defaults to the default PodSecurityContext.",
               "type": "object",
               "x-kubernetes-preserve-unknown-fields": true
             },
             "serviceScrapeSpec": {
-              "description": "ServiceScrapeSpec that will be added to vmstorage VMServiceScrape spec",
               "required": [
                 "endpoints"
               ],
@@ -2622,27 +3058,22 @@
               "x-kubernetes-preserve-unknown-fields": true
             },
             "serviceSpec": {
-              "description": "ServiceSpec that will be create additional service for vmstorage",
               "properties": {
                 "metadata": {
-                  "description": "EmbeddedObjectMetadata defines objectMeta for additional service.",
                   "properties": {
                     "annotations": {
                       "additionalProperties": {
                         "type": "string"
                       },
-                      "description": "Annotations is an unstructured key value map stored with a resource that may be\nset by external tools to store and retrieve arbitrary metadata. They are not\nqueryable and should be preserved when modifying objects.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations",
                       "type": "object"
                     },
                     "labels": {
                       "additionalProperties": {
                         "type": "string"
                       },
-                      "description": "Labels Map of string keys and values that can be used to organize and categorize\n(scope and select) objects. May match selectors of replication controllers\nand services.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels",
                       "type": "object"
                     },
                     "name": {
-                      "description": "Name must be unique within a namespace. Is required when creating resources, although\nsome resources may allow a client to request the generation of an appropriate name\nautomatically. Name is primarily intended for creation idempotence and configuration\ndefinition.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names",
                       "type": "string"
                     }
                   },
@@ -2650,12 +3081,10 @@
                   "additionalProperties": false
                 },
                 "spec": {
-                  "description": "ServiceSpec describes the attributes that a user creates on a service.\nMore info: https://kubernetes.io/docs/concepts/services-networking/service/",
                   "type": "object",
                   "x-kubernetes-preserve-unknown-fields": true
                 },
                 "useAsDefault": {
-                  "description": "UseAsDefault applies changes from given service definition to the main object Service\nChanging from headless service to clusterIP or loadbalancer may break cross-component communication",
                   "type": "boolean"
                 }
               },
@@ -2666,22 +3095,14 @@
               "additionalProperties": false
             },
             "startupProbe": {
-              "description": "StartupProbe that will be added to CRD pod",
               "type": "object",
               "x-kubernetes-preserve-unknown-fields": true
             },
             "storage": {
-              "description": "Storage - add persistent volume for StorageDataPath\nits useful for persistent cache",
               "properties": {
-                "disableMountSubPath": {
-                  "description": "Deprecated: subPath usage will be disabled by default in a future release, this option will become unnecessary.\nDisableMountSubPath allows to remove any subPath usage in volume mounts.",
-                  "type": "boolean"
-                },
                 "emptyDir": {
-                  "description": "EmptyDirVolumeSource to be used by the Prometheus StatefulSets. If specified, used in place of any volumeClaimTemplate. More\ninfo: https://kubernetes.io/docs/concepts/storage/volumes/#emptydir",
                   "properties": {
                     "medium": {
-                      "description": "medium represents what type of storage medium should back this directory.\nThe default is \"\" which means to use the node's default medium.\nMust be an empty string (default) or Memory.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
                       "type": "string"
                     },
                     "sizeLimit": {
@@ -2693,7 +3114,6 @@
                           "type": "string"
                         }
                       ],
-                      "description": "sizeLimit is the total amount of local storage required for this EmptyDir volume.\nThe size limit is also applicable for memory medium.\nThe maximum usage on memory medium EmptyDir would be the minimum value between\nthe SizeLimit specified here and the sum of memory limits of all containers in a pod.\nThe default is nil which means that the limit is undefined.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
                       "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                       "x-kubernetes-int-or-string": true
                     }
@@ -2702,7 +3122,6 @@
                   "additionalProperties": false
                 },
                 "volumeClaimTemplate": {
-                  "description": "A PVC spec to be used by the StatefulSets/Deployments.",
                   "type": "object",
                   "x-kubernetes-preserve-unknown-fields": true
                 }
@@ -2711,38 +3130,29 @@
               "additionalProperties": false
             },
             "storageDataPath": {
-              "description": "StorageDataPath - path to storage data",
               "type": "string"
             },
             "terminationGracePeriodSeconds": {
-              "description": "TerminationGracePeriodSeconds period for container graceful termination",
               "format": "int64",
               "type": "integer"
             },
             "tolerations": {
-              "description": "Tolerations If specified, the pod's tolerations.",
               "items": {
-                "description": "The pod this Toleration is attached to tolerates any taint that matches\nthe triple <key,value,effect> using the matching operator <operator>.",
                 "properties": {
                   "effect": {
-                    "description": "Effect indicates the taint effect to match. Empty means match all taint effects.\nWhen specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
                     "type": "string"
                   },
                   "key": {
-                    "description": "Key is the taint key that the toleration applies to. Empty means match all taint keys.\nIf the key is empty, operator must be Exists; this combination means to match all values and all keys.",
                     "type": "string"
                   },
                   "operator": {
-                    "description": "Operator represents a key's relationship to the value.\nValid operators are Exists and Equal. Defaults to Equal.\nExists is equivalent to wildcard for value, so that a pod can\ntolerate all taints of a particular category.",
                     "type": "string"
                   },
                   "tolerationSeconds": {
-                    "description": "TolerationSeconds represents the period of time the toleration (which must be\nof effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,\nit is not set, which means tolerate the taint forever (do not evict). Zero and\nnegative values will be treated as 0 (evict immediately) by the system.",
                     "format": "int64",
                     "type": "integer"
                   },
                   "value": {
-                    "description": "Value is the taint value the toleration matches to.\nIf the operator is Exists, the value should be empty, otherwise just a regular string.",
                     "type": "string"
                   }
                 },
@@ -2752,9 +3162,7 @@
               "type": "array"
             },
             "topologySpreadConstraints": {
-              "description": "TopologySpreadConstraints embedded kubernetes pod configuration option,\ncontrols how pods are spread across your cluster among failure-domains\nsuch as regions, zones, nodes, and other user-defined topology domains\nhttps://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/",
               "items": {
-                "description": "TopologySpreadConstraint specifies how to spread matching pods among the given topology.",
                 "required": [
                   "maxSkew",
                   "topologyKey",
@@ -2766,39 +3174,30 @@
               "type": "array"
             },
             "useDefaultResources": {
-              "description": "UseDefaultResources controls resource settings\nBy default, operator sets built-in resource requirements",
               "type": "boolean"
             },
             "useStrictSecurity": {
-              "description": "UseStrictSecurity enables strict security mode for component\nit restricts disk writes access\nuses non-root user out of the box\ndrops not needed security permissions",
               "type": "boolean"
             },
             "vmBackup": {
-              "description": "VMBackup configuration for backup",
               "properties": {
                 "acceptEULA": {
-                  "description": "AcceptEULA accepts enterprise feature usage, must be set to true.\notherwise backupmanager cannot be added to single/cluster version.\nhttps://victoriametrics.com/legal/esa/\nDeprecated: use license.key or license.keyRef instead",
                   "type": "boolean"
                 },
                 "concurrency": {
-                  "description": "Defines number of concurrent workers. Higher concurrency may reduce backup duration (default 10)",
                   "format": "int32",
                   "type": "integer"
                 },
                 "credentialsSecret": {
-                  "description": "CredentialsSecret is secret in the same namespace for access to remote storage\nThe secret is mounted into /etc/vm/creds.",
                   "properties": {
                     "key": {
-                      "description": "The key of the secret to select from.  Must be a valid secret key.",
                       "type": "string"
                     },
                     "name": {
                       "default": "",
-                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                       "type": "string"
                     },
                     "optional": {
-                      "description": "Specify whether the Secret or its key must be defined",
                       "type": "boolean"
                     }
                   },
@@ -2810,69 +3209,53 @@
                   "additionalProperties": false
                 },
                 "customS3Endpoint": {
-                  "description": "Custom S3 endpoint for use with S3-compatible storages (e.g. MinIO). S3 is used if not set",
                   "type": "string"
                 },
                 "destination": {
-                  "description": "Defines destination for backup",
                   "type": "string"
                 },
                 "destinationDisableSuffixAdd": {
-                  "description": "DestinationDisableSuffixAdd - disables suffix adding for cluster version backups\neach vmstorage backup must have unique backup folder\nso operator adds POD_NAME as suffix for backup destination folder.",
                   "type": "boolean"
                 },
                 "disableDaily": {
-                  "description": "Defines if daily backups disabled (default false)",
                   "type": "boolean"
                 },
                 "disableHourly": {
-                  "description": "Defines if hourly backups disabled (default false)",
                   "type": "boolean"
                 },
                 "disableMonthly": {
-                  "description": "Defines if monthly backups disabled (default false)",
                   "type": "boolean"
                 },
                 "disableWeekly": {
-                  "description": "Defines if weekly backups disabled (default false)",
                   "type": "boolean"
                 },
                 "extraArgs": {
                   "additionalProperties": {
                     "type": "string"
                   },
-                  "description": "extra args like maxBytesPerSecond default 0",
                   "type": "object"
                 },
                 "extraEnvs": {
                   "items": {
-                    "description": "EnvVar represents an environment variable present in a Container.",
                     "properties": {
                       "name": {
-                        "description": "Name of the environment variable.\nMay consist of any printable ASCII characters except '='.",
                         "type": "string"
                       },
                       "value": {
-                        "description": "Variable references $(VAR_NAME) are expanded\nusing the previously defined environment variables in the container and\nany service environment variables. If a variable cannot be resolved,\nthe reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.\n\"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\".\nEscaped references will never be expanded, regardless of whether the variable\nexists or not.\nDefaults to \"\".",
                         "type": "string"
                       },
                       "valueFrom": {
-                        "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
                         "properties": {
                           "configMapKeyRef": {
-                            "description": "Selects a key of a ConfigMap.",
                             "properties": {
                               "key": {
-                                "description": "The key to select.",
                                 "type": "string"
                               },
                               "name": {
                                 "default": "",
-                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                 "type": "string"
                               },
                               "optional": {
-                                "description": "Specify whether the ConfigMap or its key must be defined",
                                 "type": "boolean"
                               }
                             },
@@ -2884,14 +3267,11 @@
                             "additionalProperties": false
                           },
                           "fieldRef": {
-                            "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,\nspec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
                             "properties": {
                               "apiVersion": {
-                                "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
                                 "type": "string"
                               },
                               "fieldPath": {
-                                "description": "Path of the field to select in the specified API version.",
                                 "type": "string"
                               }
                             },
@@ -2903,23 +3283,18 @@
                             "additionalProperties": false
                           },
                           "fileKeyRef": {
-                            "description": "FileKeyRef selects a key of the env file.\nRequires the EnvFiles feature gate to be enabled.",
                             "properties": {
                               "key": {
-                                "description": "The key within the env file. An invalid key will prevent the pod from starting.\nThe keys defined within a source may consist of any printable ASCII characters except '='.\nDuring Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.",
                                 "type": "string"
                               },
                               "optional": {
                                 "default": false,
-                                "description": "Specify whether the file or its key must be defined. If the file or key\ndoes not exist, then the env var is not published.\nIf optional is set to true and the specified key does not exist,\nthe environment variable will not be set in the Pod's containers.\n\nIf optional is set to false and the specified key does not exist,\nan error will be returned during Pod creation.",
                                 "type": "boolean"
                               },
                               "path": {
-                                "description": "The path within the volume from which to select the file.\nMust be relative and may not contain the '..' path or start with '..'.",
                                 "type": "string"
                               },
                               "volumeName": {
-                                "description": "The name of the volume mount containing the env file.",
                                 "type": "string"
                               }
                             },
@@ -2933,10 +3308,8 @@
                             "additionalProperties": false
                           },
                           "resourceFieldRef": {
-                            "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
                             "properties": {
                               "containerName": {
-                                "description": "Container name: required for volumes, optional for env vars",
                                 "type": "string"
                               },
                               "divisor": {
@@ -2948,12 +3321,10 @@
                                     "type": "string"
                                   }
                                 ],
-                                "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
                                 "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                                 "x-kubernetes-int-or-string": true
                               },
                               "resource": {
-                                "description": "Required: resource to select",
                                 "type": "string"
                               }
                             },
@@ -2965,19 +3336,15 @@
                             "additionalProperties": false
                           },
                           "secretKeyRef": {
-                            "description": "Selects a key of a secret in the pod's namespace",
                             "properties": {
                               "key": {
-                                "description": "The key of the secret to select from.  Must be a valid secret key.",
                                 "type": "string"
                               },
                               "name": {
                                 "default": "",
-                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                 "type": "string"
                               },
                               "optional": {
-                                "description": "Specify whether the Secret or its key must be defined",
                                 "type": "boolean"
                               }
                             },
@@ -3002,20 +3369,15 @@
                   "type": "array"
                 },
                 "extraEnvsFrom": {
-                  "description": "ExtraEnvsFrom defines source of env variables for the application container\ncould either be secret or configmap",
                   "items": {
-                    "description": "EnvFromSource represents the source of a set of ConfigMaps or Secrets",
                     "properties": {
                       "configMapRef": {
-                        "description": "The ConfigMap to select from",
                         "properties": {
                           "name": {
                             "default": "",
-                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                             "type": "string"
                           },
                           "optional": {
-                            "description": "Specify whether the ConfigMap must be defined",
                             "type": "boolean"
                           }
                         },
@@ -3024,19 +3386,15 @@
                         "additionalProperties": false
                       },
                       "prefix": {
-                        "description": "Optional text to prepend to the name of each environment variable.\nMay consist of any printable ASCII characters except '='.",
                         "type": "string"
                       },
                       "secretRef": {
-                        "description": "The Secret to select from",
                         "properties": {
                           "name": {
                             "default": "",
-                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                             "type": "string"
                           },
                           "optional": {
-                            "description": "Specify whether the Secret must be defined",
                             "type": "boolean"
                           }
                         },
@@ -3051,18 +3409,14 @@
                   "type": "array"
                 },
                 "image": {
-                  "description": "Image - docker image settings for VMBackuper",
                   "properties": {
                     "pullPolicy": {
-                      "description": "PullPolicy describes how to pull docker image",
                       "type": "string"
                     },
                     "repository": {
-                      "description": "Repository contains name of docker image + it's repository if needed",
                       "type": "string"
                     },
                     "tag": {
-                      "description": "Tag contains desired docker image version",
                       "type": "string"
                     }
                   },
@@ -3070,7 +3424,6 @@
                   "additionalProperties": false
                 },
                 "logFormat": {
-                  "description": "LogFormat for VMBackup to be configured with.\ndefault or json",
                   "enum": [
                     "default",
                     "json"
@@ -3078,7 +3431,6 @@
                   "type": "string"
                 },
                 "logLevel": {
-                  "description": "LogLevel for VMBackup to be configured with.",
                   "enum": [
                     "INFO",
                     "WARN",
@@ -3089,23 +3441,17 @@
                   "type": "string"
                 },
                 "port": {
-                  "description": "Port for health check connections",
                   "type": "string"
                 },
                 "resources": {
-                  "description": "Resources container resource request and limits, https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/\nif not defined default resources from operator config will be used",
                   "properties": {
                     "claims": {
-                      "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis field depends on the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
                       "items": {
-                        "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
                         "properties": {
                           "name": {
-                            "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
                             "type": "string"
                           },
                           "request": {
-                            "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
                             "type": "string"
                           }
                         },
@@ -3134,7 +3480,6 @@
                         "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                         "x-kubernetes-int-or-string": true
                       },
-                      "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
                       "type": "object"
                     },
                     "requests": {
@@ -3150,7 +3495,6 @@
                         "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                         "x-kubernetes-int-or-string": true
                       },
-                      "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
                       "type": "object"
                     }
                   },
@@ -3158,13 +3502,10 @@
                   "additionalProperties": false
                 },
                 "restore": {
-                  "description": "Restore Allows to enable restore options for pod\nRead [more](https://docs.victoriametrics.com/victoriametrics/vmbackupmanager/#restore-commands)",
                   "properties": {
                     "onStart": {
-                      "description": "OnStart defines configuration for restore on pod start",
                       "properties": {
                         "enabled": {
-                          "description": "Enabled defines if restore on start enabled",
                           "type": "boolean"
                         }
                       },
@@ -3176,44 +3517,33 @@
                   "additionalProperties": false
                 },
                 "snapshotCreateURL": {
-                  "description": "SnapshotCreateURL overwrites url for snapshot create",
                   "type": "string"
                 },
                 "snapshotDeleteURL": {
-                  "description": "SnapShotDeleteURL overwrites url for snapshot delete",
                   "type": "string"
                 },
                 "volumeMounts": {
-                  "description": "VolumeMounts allows configuration of additional VolumeMounts on the output Deployment definition.\nVolumeMounts specified will be appended to other VolumeMounts in the vmbackupmanager container,\nthat are generated as a result of StorageSpec objects.",
                   "items": {
-                    "description": "VolumeMount describes a mounting of a Volume within a container.",
                     "properties": {
                       "mountPath": {
-                        "description": "Path within the container at which the volume should be mounted.  Must\nnot contain ':'.",
                         "type": "string"
                       },
                       "mountPropagation": {
-                        "description": "mountPropagation determines how mounts are propagated from the host\nto container and the other way around.\nWhen not set, MountPropagationNone is used.\nThis field is beta in 1.10.\nWhen RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified\n(which defaults to None).",
                         "type": "string"
                       },
                       "name": {
-                        "description": "This must match the Name of a Volume.",
                         "type": "string"
                       },
                       "readOnly": {
-                        "description": "Mounted read-only if true, read-write otherwise (false or unspecified).\nDefaults to false.",
                         "type": "boolean"
                       },
                       "recursiveReadOnly": {
-                        "description": "RecursiveReadOnly specifies whether read-only mounts should be handled\nrecursively.\n\nIf ReadOnly is false, this field has no meaning and must be unspecified.\n\nIf ReadOnly is true, and this field is set to Disabled, the mount is not made\nrecursively read-only.  If this field is set to IfPossible, the mount is made\nrecursively read-only, if it is supported by the container runtime.  If this\nfield is set to Enabled, the mount is made recursively read-only if it is\nsupported by the container runtime, otherwise the pod will not be started and\nan error will be generated to indicate the reason.\n\nIf this field is set to IfPossible or Enabled, MountPropagation must be set to\nNone (or be unspecified, which defaults to None).\n\nIf this field is not specified, it is treated as an equivalent of Disabled.",
                         "type": "string"
                       },
                       "subPath": {
-                        "description": "Path within the volume from which the container's volume should be mounted.\nDefaults to \"\" (volume's root).",
                         "type": "string"
                       },
                       "subPathExpr": {
-                        "description": "Expanded path within the volume from which the container's volume should be mounted.\nBehaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.\nDefaults to \"\" (volume's root).\nSubPathExpr and SubPath are mutually exclusive.",
                         "type": "string"
                       }
                     },
@@ -3231,44 +3561,33 @@
               "additionalProperties": false
             },
             "vmInsertPort": {
-              "description": "VMInsertPort for VMInsert connections",
               "type": "string"
             },
             "vmSelectPort": {
-              "description": "VMSelectPort for VMSelect connections",
               "type": "string"
             },
             "volumeMounts": {
-              "description": "VolumeMounts allows configuration of additional VolumeMounts on the output Deployment/StatefulSet definition.\nVolumeMounts specified will be appended to other VolumeMounts in the Application container",
               "items": {
-                "description": "VolumeMount describes a mounting of a Volume within a container.",
                 "properties": {
                   "mountPath": {
-                    "description": "Path within the container at which the volume should be mounted.  Must\nnot contain ':'.",
                     "type": "string"
                   },
                   "mountPropagation": {
-                    "description": "mountPropagation determines how mounts are propagated from the host\nto container and the other way around.\nWhen not set, MountPropagationNone is used.\nThis field is beta in 1.10.\nWhen RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified\n(which defaults to None).",
                     "type": "string"
                   },
                   "name": {
-                    "description": "This must match the Name of a Volume.",
                     "type": "string"
                   },
                   "readOnly": {
-                    "description": "Mounted read-only if true, read-write otherwise (false or unspecified).\nDefaults to false.",
                     "type": "boolean"
                   },
                   "recursiveReadOnly": {
-                    "description": "RecursiveReadOnly specifies whether read-only mounts should be handled\nrecursively.\n\nIf ReadOnly is false, this field has no meaning and must be unspecified.\n\nIf ReadOnly is true, and this field is set to Disabled, the mount is not made\nrecursively read-only.  If this field is set to IfPossible, the mount is made\nrecursively read-only, if it is supported by the container runtime.  If this\nfield is set to Enabled, the mount is made recursively read-only if it is\nsupported by the container runtime, otherwise the pod will not be started and\nan error will be generated to indicate the reason.\n\nIf this field is set to IfPossible or Enabled, MountPropagation must be set to\nNone (or be unspecified, which defaults to None).\n\nIf this field is not specified, it is treated as an equivalent of Disabled.",
                     "type": "string"
                   },
                   "subPath": {
-                    "description": "Path within the volume from which the container's volume should be mounted.\nDefaults to \"\" (volume's root).",
                     "type": "string"
                   },
                   "subPathExpr": {
-                    "description": "Expanded path within the volume from which the container's volume should be mounted.\nBehaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.\nDefaults to \"\" (volume's root).\nSubPathExpr and SubPath are mutually exclusive.",
                     "type": "string"
                   }
                 },
@@ -3282,9 +3601,7 @@
               "type": "array"
             },
             "volumes": {
-              "description": "Volumes allows configuration of additional volumes on the output Deployment/StatefulSet definition.\nVolumes specified will be appended to other volumes that are generated.\n/ +optional",
               "items": {
-                "description": "Volume represents a named volume in a pod that may be accessed by any container in the pod.",
                 "required": [
                   "name"
                 ],
@@ -3292,6 +3609,165 @@
                 "x-kubernetes-preserve-unknown-fields": true
               },
               "type": "array"
+            },
+            "vpa": {
+              "properties": {
+                "recommenders": {
+                  "items": {
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "resourcePolicy": {
+                  "properties": {
+                    "containerPolicies": {
+                      "items": {
+                        "properties": {
+                          "containerName": {
+                            "type": "string"
+                          },
+                          "controlledResources": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "controlledValues": {
+                            "enum": [
+                              "RequestsAndLimits",
+                              "RequestsOnly"
+                            ],
+                            "type": "string"
+                          },
+                          "maxAllowed": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          },
+                          "minAllowed": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          },
+                          "mode": {
+                            "enum": [
+                              "Auto",
+                              "Off"
+                            ],
+                            "type": "string"
+                          },
+                          "oomBumpUpRatio": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "oomMinBumpUp": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                            "x-kubernetes-int-or-string": true
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "updatePolicy": {
+                  "properties": {
+                    "evictionRequirements": {
+                      "items": {
+                        "properties": {
+                          "changeRequirement": {
+                            "enum": [
+                              "TargetHigherThanRequests",
+                              "TargetLowerThanRequests"
+                            ],
+                            "type": "string"
+                          },
+                          "resources": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "changeRequirement",
+                          "resources"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "minReplicas": {
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "updateMode": {
+                      "enum": [
+                        "Off",
+                        "Initial",
+                        "Recreate",
+                        "InPlaceOrRecreate",
+                        "Auto"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
             }
           },
           "type": "object",
@@ -3302,42 +3778,33 @@
       "additionalProperties": false
     },
     "status": {
-      "description": "VMClusterStatus defines the observed state of VMCluster",
       "properties": {
         "conditions": {
-          "description": "Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"",
           "items": {
-            "description": "Condition defines status condition of the resource",
             "properties": {
               "lastTransitionTime": {
-                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.",
                 "format": "date-time",
                 "type": "string"
               },
               "lastUpdateTime": {
-                "description": "LastUpdateTime is the last time of given type update.\nThis value is used for status TTL update and removal",
                 "format": "date-time",
                 "type": "string"
               },
               "message": {
-                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
                 "maxLength": 32768,
                 "type": "string"
               },
               "observedGeneration": {
-                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
                 "format": "int64",
                 "minimum": 0,
                 "type": "integer"
               },
               "reason": {
-                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
                 "maxLength": 1024,
                 "minLength": 1,
                 "type": "string"
               },
               "status": {
-                "description": "status of the condition, one of True, False, Unknown.",
                 "enum": [
                   "True",
                   "False",
@@ -3346,7 +3813,6 @@
                 "type": "string"
               },
               "type": {
-                "description": "Type of condition in CamelCase or in name.namespace.resource.victoriametrics.com/CamelCase.",
                 "maxLength": 316,
                 "type": "string"
               }
@@ -3367,17 +3833,17 @@
           ],
           "x-kubernetes-list-type": "map"
         },
+        "lastAppliedSpec": {
+          "x-kubernetes-preserve-unknown-fields": true
+        },
         "observedGeneration": {
-          "description": "ObservedGeneration defines current generation picked by operator for the\nreconcile",
           "format": "int64",
           "type": "integer"
         },
         "reason": {
-          "description": "Reason defines human readable error reason",
           "type": "string"
         },
         "updateStatus": {
-          "description": "UpdateStatus defines a status for update rollout",
           "type": "string"
         }
       },

--- a/operator.victoriametrics.com/vmpodscrape_v1beta1.json
+++ b/operator.victoriametrics.com/vmpodscrape_v1beta1.json
@@ -1,25 +1,22 @@
 {
-  "description": "VMPodScrape is scrape configuration for pods,\nit generates vmagent's config for scraping pod targets\nbased on selectors.",
   "properties": {
     "apiVersion": {
-      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
       "type": "string"
     },
     "kind": {
-      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
       "type": "string"
     },
     "metadata": {
       "type": "object"
     },
     "spec": {
-      "description": "VMPodScrapeSpec defines the desired state of VMPodScrape",
       "properties": {
         "attach_metadata": {
-          "description": "AttachMetadata configures metadata attaching from service discovery",
           "properties": {
+            "namespace": {
+              "type": "boolean"
+            },
             "node": {
-              "description": "Node instructs vmagent to add node specific metadata from service discovery\nValid for roles: pod, endpoints, endpointslice.",
               "type": "boolean"
             }
           },
@@ -27,18 +24,14 @@
           "additionalProperties": false
         },
         "jobLabel": {
-          "description": "The label to use to retrieve the job name from.",
           "type": "string"
         },
         "namespaceSelector": {
-          "description": "Selector to select which namespaces the Endpoints objects are discovered from.",
           "properties": {
             "any": {
-              "description": "Boolean describing whether all namespaces are selected in contrast to a\nlist restricting them.",
               "type": "boolean"
             },
             "matchNames": {
-              "description": "List of namespace names.",
               "items": {
                 "type": "string"
               },
@@ -49,15 +42,14 @@
           "additionalProperties": false
         },
         "podMetricsEndpoints": {
-          "description": "A list of endpoints allowed as part of this PodMonitor.",
           "items": {
-            "description": "PodMetricsEndpoint defines a scrapeable endpoint of a Kubernetes Pod serving metrics.",
             "properties": {
               "attach_metadata": {
-                "description": "AttachMetadata configures metadata attaching from service discovery",
                 "properties": {
+                  "namespace": {
+                    "type": "boolean"
+                  },
                   "node": {
-                    "description": "Node instructs vmagent to add node specific metadata from service discovery\nValid for roles: pod, endpoints, endpointslice.",
                     "type": "boolean"
                   }
                 },
@@ -65,22 +57,17 @@
                 "additionalProperties": false
               },
               "authorization": {
-                "description": "Authorization with http header Authorization",
                 "properties": {
                   "credentials": {
-                    "description": "Reference to the secret with value for authorization",
                     "properties": {
                       "key": {
-                        "description": "The key of the secret to select from.  Must be a valid secret key.",
                         "type": "string"
                       },
                       "name": {
                         "default": "",
-                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                         "type": "string"
                       },
                       "optional": {
-                        "description": "Specify whether the Secret or its key must be defined",
                         "type": "boolean"
                       }
                     },
@@ -92,11 +79,9 @@
                     "additionalProperties": false
                   },
                   "credentialsFile": {
-                    "description": "File with value for authorization",
                     "type": "string"
                   },
                   "type": {
-                    "description": "Type of authorization, default to bearer",
                     "type": "string"
                   }
                 },
@@ -104,22 +89,17 @@
                 "additionalProperties": false
               },
               "basicAuth": {
-                "description": "BasicAuth allow an endpoint to authenticate over basic authentication",
                 "properties": {
                   "password": {
-                    "description": "Password defines reference for secret with password value\nThe secret needs to be in the same namespace as scrape object",
                     "properties": {
                       "key": {
-                        "description": "The key of the secret to select from.  Must be a valid secret key.",
                         "type": "string"
                       },
                       "name": {
                         "default": "",
-                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                         "type": "string"
                       },
                       "optional": {
-                        "description": "Specify whether the Secret or its key must be defined",
                         "type": "boolean"
                       }
                     },
@@ -131,23 +111,18 @@
                     "additionalProperties": false
                   },
                   "password_file": {
-                    "description": "PasswordFile defines path to password file at disk\nmust be pre-mounted",
                     "type": "string"
                   },
                   "username": {
-                    "description": "Username defines reference for secret with username value\nThe secret needs to be in the same namespace as scrape object",
                     "properties": {
                       "key": {
-                        "description": "The key of the secret to select from.  Must be a valid secret key.",
                         "type": "string"
                       },
                       "name": {
                         "default": "",
-                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                         "type": "string"
                       },
                       "optional": {
-                        "description": "Specify whether the Secret or its key must be defined",
                         "type": "boolean"
                       }
                     },
@@ -163,24 +138,19 @@
                 "additionalProperties": false
               },
               "bearerTokenFile": {
-                "description": "File to read bearer token for scraping targets.",
                 "type": "string"
               },
               "bearerTokenSecret": {
-                "description": "Secret to mount to read bearer token for scraping targets. The secret\nneeds to be in the same namespace as the scrape object and accessible by\nthe victoria-metrics operator.",
                 "nullable": true,
                 "properties": {
                   "key": {
-                    "description": "The key of the secret to select from.  Must be a valid secret key.",
                     "type": "string"
                   },
                   "name": {
                     "default": "",
-                    "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                     "type": "string"
                   },
                   "optional": {
-                    "description": "Specify whether the Secret or its key must be defined",
                     "type": "boolean"
                   }
                 },
@@ -192,90 +162,70 @@
                 "additionalProperties": false
               },
               "filterRunning": {
-                "description": "FilterRunning applies filter with pod status == running\nit prevents from scrapping metrics at failed or succeed state pods.\nenabled by default",
                 "type": "boolean"
               },
               "follow_redirects": {
-                "description": "FollowRedirects controls redirects for scraping.",
                 "type": "boolean"
               },
               "honorLabels": {
-                "description": "HonorLabels chooses the metric's labels on collisions with target labels.",
                 "type": "boolean"
               },
               "honorTimestamps": {
-                "description": "HonorTimestamps controls whether vmagent respects the timestamps present in scraped data.",
                 "type": "boolean"
               },
               "interval": {
-                "description": "Interval at which metrics should be scraped",
                 "type": "string"
               },
               "max_scrape_size": {
-                "description": "MaxScrapeSize defines a maximum size of scraped data for a job",
                 "type": "string"
               },
               "metricRelabelConfigs": {
-                "description": "MetricRelabelConfigs to apply to samples after scrapping.",
                 "items": {
-                  "description": "RelabelConfig allows dynamic rewriting of the label set\nMore info: https://docs.victoriametrics.com/victoriametrics/#relabeling",
                   "properties": {
                     "action": {
-                      "description": "Action to perform based on regex matching. Default is 'replace'",
                       "type": "string"
                     },
                     "if": {
-                      "description": "If represents metricsQL match expression (or list of expressions): '{__name__=~\"foo_.*\"}'",
                       "x-kubernetes-preserve-unknown-fields": true
                     },
                     "labels": {
                       "additionalProperties": {
                         "type": "string"
                       },
-                      "description": "Labels is used together with Match for `action: graphite`",
                       "type": "object"
                     },
                     "match": {
-                      "description": "Match is used together with Labels for `action: graphite`",
                       "type": "string"
                     },
                     "modulus": {
-                      "description": "Modulus to take of the hash of the source label values.",
                       "format": "int64",
                       "type": "integer"
                     },
                     "regex": {
-                      "description": "Regular expression against which the extracted value is matched. Default is '(.*)'\nvictoriaMetrics supports multiline regex joined with |\nhttps://docs.victoriametrics.com/victoriametrics/vmagent/#relabeling-enhancements",
                       "x-kubernetes-preserve-unknown-fields": true
                     },
                     "replacement": {
-                      "description": "Replacement value against which a regex replace is performed if the\nregular expression matches. Regex capture groups are available. Default is '$1'",
                       "type": "string"
                     },
                     "separator": {
-                      "description": "Separator placed between concatenated source label values. default is ';'.",
                       "type": "string"
                     },
                     "source_labels": {
-                      "description": "UnderScoreSourceLabels - additional form of source labels source_labels\nfor compatibility with original relabel config.\nif set  both sourceLabels and source_labels, sourceLabels has priority.\nfor details https://github.com/VictoriaMetrics/operator/issues/131",
                       "items": {
                         "type": "string"
                       },
                       "type": "array"
                     },
                     "sourceLabels": {
-                      "description": "The source labels select values from existing labels. Their content is concatenated\nusing the configured separator and matched against the configured regular expression\nfor the replace, keep, and drop actions.",
                       "items": {
                         "type": "string"
                       },
                       "type": "array"
                     },
                     "target_label": {
-                      "description": "UnderScoreTargetLabel - additional form of target label - target_label\nfor compatibility with original relabel config.\nif set  both targetLabel and target_label, targetLabel has priority.\nfor details https://github.com/VictoriaMetrics/operator/issues/131",
                       "type": "string"
                     },
                     "targetLabel": {
-                      "description": "Label to which the resulting value is written in a replace action.\nIt is mandatory for replace actions. Regex capture groups are available.",
                       "type": "string"
                     }
                   },
@@ -285,25 +235,19 @@
                 "type": "array"
               },
               "oauth2": {
-                "description": "OAuth2 defines auth configuration",
                 "properties": {
                   "client_id": {
-                    "description": "The secret or configmap containing the OAuth2 client id",
                     "properties": {
                       "configMap": {
-                        "description": "ConfigMap containing data to use for the targets.",
                         "properties": {
                           "key": {
-                            "description": "The key to select.",
                             "type": "string"
                           },
                           "name": {
                             "default": "",
-                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                             "type": "string"
                           },
                           "optional": {
-                            "description": "Specify whether the ConfigMap or its key must be defined",
                             "type": "boolean"
                           }
                         },
@@ -315,19 +259,15 @@
                         "additionalProperties": false
                       },
                       "secret": {
-                        "description": "Secret containing data to use for the targets.",
                         "properties": {
                           "key": {
-                            "description": "The key of the secret to select from.  Must be a valid secret key.",
                             "type": "string"
                           },
                           "name": {
                             "default": "",
-                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                             "type": "string"
                           },
                           "optional": {
-                            "description": "Specify whether the Secret or its key must be defined",
                             "type": "boolean"
                           }
                         },
@@ -343,19 +283,15 @@
                     "additionalProperties": false
                   },
                   "client_secret": {
-                    "description": "The secret containing the OAuth2 client secret",
                     "properties": {
                       "key": {
-                        "description": "The key of the secret to select from.  Must be a valid secret key.",
                         "type": "string"
                       },
                       "name": {
                         "default": "",
-                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                         "type": "string"
                       },
                       "optional": {
-                        "description": "Specify whether the Secret or its key must be defined",
                         "type": "boolean"
                       }
                     },
@@ -367,33 +303,27 @@
                     "additionalProperties": false
                   },
                   "client_secret_file": {
-                    "description": "ClientSecretFile defines path for client secret file.",
                     "type": "string"
                   },
                   "endpoint_params": {
                     "additionalProperties": {
                       "type": "string"
                     },
-                    "description": "Parameters to append to the token URL",
                     "type": "object"
                   },
                   "proxy_url": {
-                    "description": "The proxy URL for token_url connection\n( available from v0.55.0).\nIs only supported by Scrape objects family",
                     "type": "string"
                   },
                   "scopes": {
-                    "description": "OAuth2 scopes used for the token request",
                     "items": {
                       "type": "string"
                     },
                     "type": "array"
                   },
                   "tls_config": {
-                    "description": "TLSConfig for token_url connection\n( available from v0.55.0).\nIs only supported by Scrape objects family",
                     "x-kubernetes-preserve-unknown-fields": true
                   },
                   "token_url": {
-                    "description": "The URL to fetch the token from",
                     "minLength": 1,
                     "type": "string"
                   }
@@ -412,89 +342,70 @@
                   },
                   "type": "array"
                 },
-                "description": "Optional HTTP URL parameters",
                 "type": "object"
               },
               "path": {
-                "description": "HTTP path to scrape for metrics.",
                 "type": "string"
               },
               "port": {
-                "description": "Name of the port exposed at Pod.",
                 "type": "string"
               },
               "portNumber": {
-                "description": "PortNumber defines the `Pod` port number which exposes the endpoint.",
                 "format": "int32",
                 "maximum": 65535,
                 "minimum": 1,
                 "type": "integer"
               },
               "proxyURL": {
-                "description": "ProxyURL eg http://proxyserver:2195 Directs scrapes to proxy through this endpoint.",
                 "type": "string"
               },
               "relabelConfigs": {
-                "description": "RelabelConfigs to apply to samples during service discovery.",
                 "items": {
-                  "description": "RelabelConfig allows dynamic rewriting of the label set\nMore info: https://docs.victoriametrics.com/victoriametrics/#relabeling",
                   "properties": {
                     "action": {
-                      "description": "Action to perform based on regex matching. Default is 'replace'",
                       "type": "string"
                     },
                     "if": {
-                      "description": "If represents metricsQL match expression (or list of expressions): '{__name__=~\"foo_.*\"}'",
                       "x-kubernetes-preserve-unknown-fields": true
                     },
                     "labels": {
                       "additionalProperties": {
                         "type": "string"
                       },
-                      "description": "Labels is used together with Match for `action: graphite`",
                       "type": "object"
                     },
                     "match": {
-                      "description": "Match is used together with Labels for `action: graphite`",
                       "type": "string"
                     },
                     "modulus": {
-                      "description": "Modulus to take of the hash of the source label values.",
                       "format": "int64",
                       "type": "integer"
                     },
                     "regex": {
-                      "description": "Regular expression against which the extracted value is matched. Default is '(.*)'\nvictoriaMetrics supports multiline regex joined with |\nhttps://docs.victoriametrics.com/victoriametrics/vmagent/#relabeling-enhancements",
                       "x-kubernetes-preserve-unknown-fields": true
                     },
                     "replacement": {
-                      "description": "Replacement value against which a regex replace is performed if the\nregular expression matches. Regex capture groups are available. Default is '$1'",
                       "type": "string"
                     },
                     "separator": {
-                      "description": "Separator placed between concatenated source label values. default is ';'.",
                       "type": "string"
                     },
                     "source_labels": {
-                      "description": "UnderScoreSourceLabels - additional form of source labels source_labels\nfor compatibility with original relabel config.\nif set  both sourceLabels and source_labels, sourceLabels has priority.\nfor details https://github.com/VictoriaMetrics/operator/issues/131",
                       "items": {
                         "type": "string"
                       },
                       "type": "array"
                     },
                     "sourceLabels": {
-                      "description": "The source labels select values from existing labels. Their content is concatenated\nusing the configured separator and matched against the configured regular expression\nfor the replace, keep, and drop actions.",
                       "items": {
                         "type": "string"
                       },
                       "type": "array"
                     },
                     "target_label": {
-                      "description": "UnderScoreTargetLabel - additional form of target label - target_label\nfor compatibility with original relabel config.\nif set  both targetLabel and target_label, targetLabel has priority.\nfor details https://github.com/VictoriaMetrics/operator/issues/131",
                       "type": "string"
                     },
                     "targetLabel": {
-                      "description": "Label to which the resulting value is written in a replace action.\nIt is mandatory for replace actions. Regex capture groups are available.",
                       "type": "string"
                     }
                   },
@@ -504,11 +415,9 @@
                 "type": "array"
               },
               "sampleLimit": {
-                "description": "SampleLimit defines per-scrape limit on number of scraped samples that will be accepted.",
                 "type": "integer"
               },
               "scheme": {
-                "description": "HTTP scheme to use for scraping.",
                 "enum": [
                   "http",
                   "https",
@@ -518,15 +427,12 @@
                 "type": "string"
               },
               "scrape_interval": {
-                "description": "ScrapeInterval is the same as Interval and has priority over it.\none of scrape_interval or interval can be used",
                 "type": "string"
               },
               "scrapeTimeout": {
-                "description": "Timeout after which the scrape is ended",
                 "type": "string"
               },
               "seriesLimit": {
-                "description": "SeriesLimit defines per-scrape limit on number of unique time series\na single target can expose during all the scrapes on the time window of 24h.",
                 "type": "integer"
               },
               "targetPort": {
@@ -538,29 +444,22 @@
                     "type": "string"
                   }
                 ],
-                "description": "TargetPort defines name or number of the pod port this endpoint refers to.\nMutually exclusive with Port and PortNumber.",
                 "x-kubernetes-int-or-string": true
               },
               "tlsConfig": {
-                "description": "TLSConfig configuration to use when scraping the endpoint",
                 "properties": {
                   "ca": {
-                    "description": "Struct containing the CA cert to use for the targets.",
                     "properties": {
                       "configMap": {
-                        "description": "ConfigMap containing data to use for the targets.",
                         "properties": {
                           "key": {
-                            "description": "The key to select.",
                             "type": "string"
                           },
                           "name": {
                             "default": "",
-                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                             "type": "string"
                           },
                           "optional": {
-                            "description": "Specify whether the ConfigMap or its key must be defined",
                             "type": "boolean"
                           }
                         },
@@ -572,19 +471,15 @@
                         "additionalProperties": false
                       },
                       "secret": {
-                        "description": "Secret containing data to use for the targets.",
                         "properties": {
                           "key": {
-                            "description": "The key of the secret to select from.  Must be a valid secret key.",
                             "type": "string"
                           },
                           "name": {
                             "default": "",
-                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                             "type": "string"
                           },
                           "optional": {
-                            "description": "Specify whether the Secret or its key must be defined",
                             "type": "boolean"
                           }
                         },
@@ -600,26 +495,20 @@
                     "additionalProperties": false
                   },
                   "caFile": {
-                    "description": "Path to the CA cert in the container to use for the targets.",
                     "type": "string"
                   },
                   "cert": {
-                    "description": "Struct containing the client cert file for the targets.",
                     "properties": {
                       "configMap": {
-                        "description": "ConfigMap containing data to use for the targets.",
                         "properties": {
                           "key": {
-                            "description": "The key to select.",
                             "type": "string"
                           },
                           "name": {
                             "default": "",
-                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                             "type": "string"
                           },
                           "optional": {
-                            "description": "Specify whether the ConfigMap or its key must be defined",
                             "type": "boolean"
                           }
                         },
@@ -631,19 +520,15 @@
                         "additionalProperties": false
                       },
                       "secret": {
-                        "description": "Secret containing data to use for the targets.",
                         "properties": {
                           "key": {
-                            "description": "The key of the secret to select from.  Must be a valid secret key.",
                             "type": "string"
                           },
                           "name": {
                             "default": "",
-                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                             "type": "string"
                           },
                           "optional": {
-                            "description": "Specify whether the Secret or its key must be defined",
                             "type": "boolean"
                           }
                         },
@@ -659,31 +544,24 @@
                     "additionalProperties": false
                   },
                   "certFile": {
-                    "description": "Path to the client cert file in the container for the targets.",
                     "type": "string"
                   },
                   "insecureSkipVerify": {
-                    "description": "Disable target certificate validation.",
                     "type": "boolean"
                   },
                   "keyFile": {
-                    "description": "Path to the client key file in the container for the targets.",
                     "type": "string"
                   },
                   "keySecret": {
-                    "description": "Secret containing the client key file for the targets.",
                     "properties": {
                       "key": {
-                        "description": "The key of the secret to select from.  Must be a valid secret key.",
                         "type": "string"
                       },
                       "name": {
                         "default": "",
-                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                         "type": "string"
                       },
                       "optional": {
-                        "description": "Specify whether the Secret or its key must be defined",
                         "type": "boolean"
                       }
                     },
@@ -695,7 +573,6 @@
                     "additionalProperties": false
                   },
                   "serverName": {
-                    "description": "Used to verify the hostname for the targets.",
                     "type": "string"
                   }
                 },
@@ -703,18 +580,14 @@
                 "additionalProperties": false
               },
               "vm_scrape_params": {
-                "description": "VMScrapeParams defines VictoriaMetrics specific scrape parameters",
                 "properties": {
                   "disable_compression": {
-                    "description": "DisableCompression",
                     "type": "boolean"
                   },
                   "disable_keep_alive": {
-                    "description": "disable_keepalive allows disabling HTTP keep-alive when scraping targets.\nBy default, HTTP keep-alive is enabled, so TCP connections to scrape targets\ncould be reused.\nSee https://docs.victoriametrics.com/victoriametrics/vmagent/#scrape_config-enhancements",
                     "type": "boolean"
                   },
                   "headers": {
-                    "description": "Headers allows sending custom headers to scrape targets\nmust be in of semicolon separated header with it's value\neg:\nheaderName: headerValue\nvmagent supports since 1.79.0 version",
                     "items": {
                       "type": "string"
                     },
@@ -724,25 +597,51 @@
                     "type": "boolean"
                   },
                   "proxy_client_config": {
-                    "description": "ProxyClientConfig configures proxy auth settings for scraping\nSee feature description https://docs.victoriametrics.com/victoriametrics/vmagent/#scraping-targets-via-a-proxy",
                     "properties": {
-                      "basic_auth": {
-                        "description": "BasicAuth allow an endpoint to authenticate over basic authentication",
+                      "authorization": {
                         "properties": {
-                          "password": {
-                            "description": "Password defines reference for secret with password value\nThe secret needs to be in the same namespace as scrape object",
+                          "credentials": {
                             "properties": {
                               "key": {
-                                "description": "The key of the secret to select from.  Must be a valid secret key.",
                                 "type": "string"
                               },
                               "name": {
                                 "default": "",
-                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                 "type": "string"
                               },
                               "optional": {
-                                "description": "Specify whether the Secret or its key must be defined",
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "credentialsFile": {
+                            "type": "string"
+                          },
+                          "type": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "basic_auth": {
+                        "properties": {
+                          "password": {
+                            "properties": {
+                              "key": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "default": "",
+                                "type": "string"
+                              },
+                              "optional": {
                                 "type": "boolean"
                               }
                             },
@@ -754,23 +653,18 @@
                             "additionalProperties": false
                           },
                           "password_file": {
-                            "description": "PasswordFile defines path to password file at disk\nmust be pre-mounted",
                             "type": "string"
                           },
                           "username": {
-                            "description": "Username defines reference for secret with username value\nThe secret needs to be in the same namespace as scrape object",
                             "properties": {
                               "key": {
-                                "description": "The key of the secret to select from.  Must be a valid secret key.",
                                 "type": "string"
                               },
                               "name": {
                                 "default": "",
-                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                 "type": "string"
                               },
                               "optional": {
-                                "description": "Specify whether the Secret or its key must be defined",
                                 "type": "boolean"
                               }
                             },
@@ -786,19 +680,16 @@
                         "additionalProperties": false
                       },
                       "bearer_token": {
-                        "description": "SecretKeySelector selects a key of a Secret.",
+                        "nullable": true,
                         "properties": {
                           "key": {
-                            "description": "The key of the secret to select from.  Must be a valid secret key.",
                             "type": "string"
                           },
                           "name": {
                             "default": "",
-                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                             "type": "string"
                           },
                           "optional": {
-                            "description": "Specify whether the Secret or its key must be defined",
                             "type": "boolean"
                           }
                         },
@@ -811,6 +702,107 @@
                       },
                       "bearer_token_file": {
                         "type": "string"
+                      },
+                      "oauth2": {
+                        "properties": {
+                          "client_id": {
+                            "properties": {
+                              "configMap": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "default": "",
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "secret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "default": "",
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "client_secret": {
+                            "properties": {
+                              "key": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "default": "",
+                                "type": "string"
+                              },
+                              "optional": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "client_secret_file": {
+                            "type": "string"
+                          },
+                          "endpoint_params": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          },
+                          "proxy_url": {
+                            "type": "string"
+                          },
+                          "scopes": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "tls_config": {
+                            "x-kubernetes-preserve-unknown-fields": true
+                          },
+                          "token_url": {
+                            "minLength": 1,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "client_id",
+                          "token_url"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "tls_config": {
                         "x-kubernetes-preserve-unknown-fields": true
@@ -839,38 +831,29 @@
           "type": "array"
         },
         "podTargetLabels": {
-          "description": "PodTargetLabels transfers labels on the Kubernetes Pod onto the target.",
           "items": {
             "type": "string"
           },
           "type": "array"
         },
         "sampleLimit": {
-          "description": "SampleLimit defines per-scrape limit on number of scraped samples that will be accepted.",
           "type": "integer"
         },
         "scrapeClass": {
-          "description": "ScrapeClass defined scrape class to apply",
           "type": "string"
         },
         "selector": {
-          "description": "Selector to select Pod objects.",
           "properties": {
             "matchExpressions": {
-              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
               "items": {
-                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
                 "properties": {
                   "key": {
-                    "description": "key is the label key that the selector applies to.",
                     "type": "string"
                   },
                   "operator": {
-                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
                     "type": "string"
                   },
                   "values": {
-                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
                     "items": {
                       "type": "string"
                     },
@@ -892,7 +875,6 @@
               "additionalProperties": {
                 "type": "string"
               },
-              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
               "type": "object"
             }
           },
@@ -901,7 +883,6 @@
           "additionalProperties": false
         },
         "seriesLimit": {
-          "description": "SeriesLimit defines per-scrape limit on number of unique time series\na single target can expose during all the scrapes on the time window of 24h.",
           "type": "integer"
         }
       },
@@ -912,42 +893,33 @@
       "additionalProperties": false
     },
     "status": {
-      "description": "ScrapeObjectStatus defines the observed state of ScrapeObjects",
       "properties": {
         "conditions": {
-          "description": "Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"",
           "items": {
-            "description": "Condition defines status condition of the resource",
             "properties": {
               "lastTransitionTime": {
-                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.",
                 "format": "date-time",
                 "type": "string"
               },
               "lastUpdateTime": {
-                "description": "LastUpdateTime is the last time of given type update.\nThis value is used for status TTL update and removal",
                 "format": "date-time",
                 "type": "string"
               },
               "message": {
-                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
                 "maxLength": 32768,
                 "type": "string"
               },
               "observedGeneration": {
-                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
                 "format": "int64",
                 "minimum": 0,
                 "type": "integer"
               },
               "reason": {
-                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
                 "maxLength": 1024,
                 "minLength": 1,
                 "type": "string"
               },
               "status": {
-                "description": "status of the condition, one of True, False, Unknown.",
                 "enum": [
                   "True",
                   "False",
@@ -956,7 +928,6 @@
                 "type": "string"
               },
               "type": {
-                "description": "Type of condition in CamelCase or in name.namespace.resource.victoriametrics.com/CamelCase.",
                 "maxLength": 316,
                 "type": "string"
               }
@@ -978,16 +949,13 @@
           "x-kubernetes-list-type": "map"
         },
         "observedGeneration": {
-          "description": "ObservedGeneration defines current generation picked by operator for the\nreconcile",
           "format": "int64",
           "type": "integer"
         },
         "reason": {
-          "description": "Reason defines human readable error reason",
           "type": "string"
         },
         "updateStatus": {
-          "description": "UpdateStatus defines a status for update rollout",
           "type": "string"
         }
       },

--- a/operator.victoriametrics.com/vmrule_v1beta1.json
+++ b/operator.victoriametrics.com/vmrule_v1beta1.json
@@ -1,76 +1,53 @@
 {
-  "description": "VMRule defines rule records for vmalert application",
   "properties": {
     "apiVersion": {
-      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
       "type": "string"
     },
     "kind": {
-      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
       "type": "string"
     },
     "metadata": {
       "type": "object"
     },
     "spec": {
-      "description": "VMRuleSpec defines the desired state of VMRule",
       "properties": {
         "groups": {
-          "description": "Groups list of group rules",
           "items": {
-            "description": "RuleGroup is a list of sequentially evaluated recording and alerting rules.",
             "properties": {
               "concurrency": {
-                "description": "Concurrency defines how many rules execute at once.",
                 "type": "integer"
               },
               "eval_alignment": {
-                "description": "Optional\nThe evaluation timestamp will be aligned with group's interval,\ninstead of using the actual timestamp that evaluation happens at.\nIt is enabled by default to get more predictable results\nand to visually align with graphs plotted via Grafana or vmui.",
                 "type": "boolean"
               },
               "eval_delay": {
-                "description": "Optional\nAdjust the `time` parameter of group evaluation requests to compensate intentional query delay from the datasource.",
                 "type": "string"
               },
               "eval_offset": {
-                "description": "Optional\nGroup will be evaluated at the exact offset in the range of [0...interval].",
                 "type": "string"
               },
-              "extra_filter_labels": {
-                "additionalProperties": {
-                  "type": "string"
-                },
-                "description": "ExtraFilterLabels optional list of label filters applied to every rule's\nrequest within a group. Is compatible only with VM datasource.\nSee more details [here](https://docs.victoriametrics.com/victoriametrics/#prometheus-querying-api-enhancements)\nDeprecated: use params instead",
-                "type": "object"
-              },
               "headers": {
-                "description": "Headers contains optional HTTP headers added to each rule request\nMust be in form `header-name: value`\nFor example:\n headers:\n   - \"CustomHeader: foo\"\n   - \"CustomHeader2: bar\"",
                 "items": {
                   "type": "string"
                 },
                 "type": "array"
               },
               "interval": {
-                "description": "evaluation interval for group",
                 "type": "string"
               },
               "labels": {
                 "additionalProperties": {
                   "type": "string"
                 },
-                "description": "Labels optional list of labels added to every rule within a group.\nIt has priority over the external labels.\nLabels are commonly used for adding environment\nor tenant-specific tag.",
                 "type": "object"
               },
               "limit": {
-                "description": "Limit the number of alerts an alerting rule and series a recording\nrule can produce",
                 "type": "integer"
               },
               "name": {
-                "description": "Name of group",
                 "type": "string"
               },
               "notifier_headers": {
-                "description": "NotifierHeaders contains optional HTTP headers added to each alert request which will send to notifier\nMust be in form `header-name: value`\nFor example:\n headers:\n   - \"CustomHeader: foo\"\n   - \"CustomHeader2: bar\"",
                 "items": {
                   "type": "string"
                 },
@@ -83,54 +60,42 @@
                   },
                   "type": "array"
                 },
-                "description": "Params optional HTTP URL parameters added to each rule request",
                 "type": "object"
               },
               "rules": {
-                "description": "Rules list of alert rules",
                 "items": {
-                  "description": "Rule describes an alerting or recording rule.",
                   "properties": {
                     "alert": {
-                      "description": "Alert is a name for alert",
                       "type": "string"
                     },
                     "annotations": {
                       "additionalProperties": {
                         "type": "string"
                       },
-                      "description": "Annotations will be added to rule configuration",
                       "type": "object"
                     },
                     "debug": {
-                      "description": "Debug enables logging for rule\nit useful for tracking",
                       "type": "boolean"
                     },
                     "expr": {
-                      "description": "Expr is query, that will be evaluated at dataSource",
                       "type": "string"
                     },
                     "for": {
-                      "description": "For evaluation interval in time.Duration format\n30s, 1m, 1h  or nanoseconds",
                       "type": "string"
                     },
                     "keep_firing_for": {
-                      "description": "KeepFiringFor will make alert continue firing for this long\neven when the alerting expression no longer has results.\nUse time.Duration format, 30s, 1m, 1h  or nanoseconds",
                       "type": "string"
                     },
                     "labels": {
                       "additionalProperties": {
                         "type": "string"
                       },
-                      "description": "Labels will be added to rule configuration",
                       "type": "object"
                     },
                     "record": {
-                      "description": "Record represents a query, that will be recorded to dataSource",
                       "type": "string"
                     },
                     "update_entries_limit": {
-                      "description": "UpdateEntriesLimit defines max number of rule's state updates stored in memory.\nOverrides `-rule.updateEntriesLimit` in vmalert.",
                       "type": "integer"
                     }
                   },
@@ -140,11 +105,9 @@
                 "type": "array"
               },
               "tenant": {
-                "description": "Tenant id for group, can be used only with enterprise version of vmalert.\nSee more details [here](https://docs.victoriametrics.com/victoriametrics/vmalert/#multitenancy).",
                 "type": "string"
               },
               "type": {
-                "description": "Type defines datasource type for enterprise version of vmalert\npossible values - prometheus,graphite,vlogs",
                 "type": "string"
               }
             },
@@ -155,7 +118,11 @@
             "type": "object",
             "additionalProperties": false
           },
-          "type": "array"
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "name"
+          ],
+          "x-kubernetes-list-type": "map"
         }
       },
       "required": [
@@ -165,42 +132,33 @@
       "additionalProperties": false
     },
     "status": {
-      "description": "VMRuleStatus defines the observed state of VMRule",
       "properties": {
         "conditions": {
-          "description": "Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"",
           "items": {
-            "description": "Condition defines status condition of the resource",
             "properties": {
               "lastTransitionTime": {
-                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.",
                 "format": "date-time",
                 "type": "string"
               },
               "lastUpdateTime": {
-                "description": "LastUpdateTime is the last time of given type update.\nThis value is used for status TTL update and removal",
                 "format": "date-time",
                 "type": "string"
               },
               "message": {
-                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
                 "maxLength": 32768,
                 "type": "string"
               },
               "observedGeneration": {
-                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
                 "format": "int64",
                 "minimum": 0,
                 "type": "integer"
               },
               "reason": {
-                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
                 "maxLength": 1024,
                 "minLength": 1,
                 "type": "string"
               },
               "status": {
-                "description": "status of the condition, one of True, False, Unknown.",
                 "enum": [
                   "True",
                   "False",
@@ -209,7 +167,6 @@
                 "type": "string"
               },
               "type": {
-                "description": "Type of condition in CamelCase or in name.namespace.resource.victoriametrics.com/CamelCase.",
                 "maxLength": 316,
                 "type": "string"
               }
@@ -231,16 +188,13 @@
           "x-kubernetes-list-type": "map"
         },
         "observedGeneration": {
-          "description": "ObservedGeneration defines current generation picked by operator for the\nreconcile",
           "format": "int64",
           "type": "integer"
         },
         "reason": {
-          "description": "Reason defines human readable error reason",
           "type": "string"
         },
         "updateStatus": {
-          "description": "UpdateStatus defines a status for update rollout",
           "type": "string"
         }
       },

--- a/operator.victoriametrics.com/vmservicescrape_v1beta1.json
+++ b/operator.victoriametrics.com/vmservicescrape_v1beta1.json
@@ -1,25 +1,22 @@
 {
-  "description": "VMServiceScrape is scrape configuration for endpoints associated with\nkubernetes service,\nit generates scrape configuration for vmagent based on selectors.\nresult config will scrape service endpoints",
   "properties": {
     "apiVersion": {
-      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
       "type": "string"
     },
     "kind": {
-      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
       "type": "string"
     },
     "metadata": {
       "type": "object"
     },
     "spec": {
-      "description": "VMServiceScrapeSpec defines the desired state of VMServiceScrape",
       "properties": {
         "attach_metadata": {
-          "description": "AttachMetadata configures metadata attaching from service discovery",
           "properties": {
+            "namespace": {
+              "type": "boolean"
+            },
             "node": {
-              "description": "Node instructs vmagent to add node specific metadata from service discovery\nValid for roles: pod, endpoints, endpointslice.",
               "type": "boolean"
             }
           },
@@ -27,24 +24,23 @@
           "additionalProperties": false
         },
         "discoveryRole": {
-          "description": "DiscoveryRole - defines kubernetes_sd role for objects discovery.\nby default, its endpoints.\ncan be changed to service or endpointslices.\nnote, that with service setting, you have to use port: \"name\"\nand cannot use targetPort for endpoints.",
           "enum": [
             "endpoints",
             "service",
-            "endpointslices"
+            "endpointslices",
+            "endpointslice"
           ],
           "type": "string"
         },
         "endpoints": {
-          "description": "A list of endpoints allowed as part of this ServiceScrape.",
           "items": {
-            "description": "Endpoint defines a scrapeable endpoint serving metrics.",
             "properties": {
               "attach_metadata": {
-                "description": "AttachMetadata configures metadata attaching from service discovery",
                 "properties": {
+                  "namespace": {
+                    "type": "boolean"
+                  },
                   "node": {
-                    "description": "Node instructs vmagent to add node specific metadata from service discovery\nValid for roles: pod, endpoints, endpointslice.",
                     "type": "boolean"
                   }
                 },
@@ -52,22 +48,17 @@
                 "additionalProperties": false
               },
               "authorization": {
-                "description": "Authorization with http header Authorization",
                 "properties": {
                   "credentials": {
-                    "description": "Reference to the secret with value for authorization",
                     "properties": {
                       "key": {
-                        "description": "The key of the secret to select from.  Must be a valid secret key.",
                         "type": "string"
                       },
                       "name": {
                         "default": "",
-                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                         "type": "string"
                       },
                       "optional": {
-                        "description": "Specify whether the Secret or its key must be defined",
                         "type": "boolean"
                       }
                     },
@@ -79,11 +70,9 @@
                     "additionalProperties": false
                   },
                   "credentialsFile": {
-                    "description": "File with value for authorization",
                     "type": "string"
                   },
                   "type": {
-                    "description": "Type of authorization, default to bearer",
                     "type": "string"
                   }
                 },
@@ -91,22 +80,17 @@
                 "additionalProperties": false
               },
               "basicAuth": {
-                "description": "BasicAuth allow an endpoint to authenticate over basic authentication",
                 "properties": {
                   "password": {
-                    "description": "Password defines reference for secret with password value\nThe secret needs to be in the same namespace as scrape object",
                     "properties": {
                       "key": {
-                        "description": "The key of the secret to select from.  Must be a valid secret key.",
                         "type": "string"
                       },
                       "name": {
                         "default": "",
-                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                         "type": "string"
                       },
                       "optional": {
-                        "description": "Specify whether the Secret or its key must be defined",
                         "type": "boolean"
                       }
                     },
@@ -118,23 +102,18 @@
                     "additionalProperties": false
                   },
                   "password_file": {
-                    "description": "PasswordFile defines path to password file at disk\nmust be pre-mounted",
                     "type": "string"
                   },
                   "username": {
-                    "description": "Username defines reference for secret with username value\nThe secret needs to be in the same namespace as scrape object",
                     "properties": {
                       "key": {
-                        "description": "The key of the secret to select from.  Must be a valid secret key.",
                         "type": "string"
                       },
                       "name": {
                         "default": "",
-                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                         "type": "string"
                       },
                       "optional": {
-                        "description": "Specify whether the Secret or its key must be defined",
                         "type": "boolean"
                       }
                     },
@@ -150,24 +129,19 @@
                 "additionalProperties": false
               },
               "bearerTokenFile": {
-                "description": "File to read bearer token for scraping targets.",
                 "type": "string"
               },
               "bearerTokenSecret": {
-                "description": "Secret to mount to read bearer token for scraping targets. The secret\nneeds to be in the same namespace as the scrape object and accessible by\nthe victoria-metrics operator.",
                 "nullable": true,
                 "properties": {
                   "key": {
-                    "description": "The key of the secret to select from.  Must be a valid secret key.",
                     "type": "string"
                   },
                   "name": {
                     "default": "",
-                    "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                     "type": "string"
                   },
                   "optional": {
-                    "description": "Specify whether the Secret or its key must be defined",
                     "type": "boolean"
                   }
                 },
@@ -179,86 +153,67 @@
                 "additionalProperties": false
               },
               "follow_redirects": {
-                "description": "FollowRedirects controls redirects for scraping.",
                 "type": "boolean"
               },
               "honorLabels": {
-                "description": "HonorLabels chooses the metric's labels on collisions with target labels.",
                 "type": "boolean"
               },
               "honorTimestamps": {
-                "description": "HonorTimestamps controls whether vmagent respects the timestamps present in scraped data.",
                 "type": "boolean"
               },
               "interval": {
-                "description": "Interval at which metrics should be scraped",
                 "type": "string"
               },
               "max_scrape_size": {
-                "description": "MaxScrapeSize defines a maximum size of scraped data for a job",
                 "type": "string"
               },
               "metricRelabelConfigs": {
-                "description": "MetricRelabelConfigs to apply to samples after scrapping.",
                 "items": {
-                  "description": "RelabelConfig allows dynamic rewriting of the label set\nMore info: https://docs.victoriametrics.com/victoriametrics/#relabeling",
                   "properties": {
                     "action": {
-                      "description": "Action to perform based on regex matching. Default is 'replace'",
                       "type": "string"
                     },
                     "if": {
-                      "description": "If represents metricsQL match expression (or list of expressions): '{__name__=~\"foo_.*\"}'",
                       "x-kubernetes-preserve-unknown-fields": true
                     },
                     "labels": {
                       "additionalProperties": {
                         "type": "string"
                       },
-                      "description": "Labels is used together with Match for `action: graphite`",
                       "type": "object"
                     },
                     "match": {
-                      "description": "Match is used together with Labels for `action: graphite`",
                       "type": "string"
                     },
                     "modulus": {
-                      "description": "Modulus to take of the hash of the source label values.",
                       "format": "int64",
                       "type": "integer"
                     },
                     "regex": {
-                      "description": "Regular expression against which the extracted value is matched. Default is '(.*)'\nvictoriaMetrics supports multiline regex joined with |\nhttps://docs.victoriametrics.com/victoriametrics/vmagent/#relabeling-enhancements",
                       "x-kubernetes-preserve-unknown-fields": true
                     },
                     "replacement": {
-                      "description": "Replacement value against which a regex replace is performed if the\nregular expression matches. Regex capture groups are available. Default is '$1'",
                       "type": "string"
                     },
                     "separator": {
-                      "description": "Separator placed between concatenated source label values. default is ';'.",
                       "type": "string"
                     },
                     "source_labels": {
-                      "description": "UnderScoreSourceLabels - additional form of source labels source_labels\nfor compatibility with original relabel config.\nif set  both sourceLabels and source_labels, sourceLabels has priority.\nfor details https://github.com/VictoriaMetrics/operator/issues/131",
                       "items": {
                         "type": "string"
                       },
                       "type": "array"
                     },
                     "sourceLabels": {
-                      "description": "The source labels select values from existing labels. Their content is concatenated\nusing the configured separator and matched against the configured regular expression\nfor the replace, keep, and drop actions.",
                       "items": {
                         "type": "string"
                       },
                       "type": "array"
                     },
                     "target_label": {
-                      "description": "UnderScoreTargetLabel - additional form of target label - target_label\nfor compatibility with original relabel config.\nif set  both targetLabel and target_label, targetLabel has priority.\nfor details https://github.com/VictoriaMetrics/operator/issues/131",
                       "type": "string"
                     },
                     "targetLabel": {
-                      "description": "Label to which the resulting value is written in a replace action.\nIt is mandatory for replace actions. Regex capture groups are available.",
                       "type": "string"
                     }
                   },
@@ -268,25 +223,19 @@
                 "type": "array"
               },
               "oauth2": {
-                "description": "OAuth2 defines auth configuration",
                 "properties": {
                   "client_id": {
-                    "description": "The secret or configmap containing the OAuth2 client id",
                     "properties": {
                       "configMap": {
-                        "description": "ConfigMap containing data to use for the targets.",
                         "properties": {
                           "key": {
-                            "description": "The key to select.",
                             "type": "string"
                           },
                           "name": {
                             "default": "",
-                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                             "type": "string"
                           },
                           "optional": {
-                            "description": "Specify whether the ConfigMap or its key must be defined",
                             "type": "boolean"
                           }
                         },
@@ -298,19 +247,15 @@
                         "additionalProperties": false
                       },
                       "secret": {
-                        "description": "Secret containing data to use for the targets.",
                         "properties": {
                           "key": {
-                            "description": "The key of the secret to select from.  Must be a valid secret key.",
                             "type": "string"
                           },
                           "name": {
                             "default": "",
-                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                             "type": "string"
                           },
                           "optional": {
-                            "description": "Specify whether the Secret or its key must be defined",
                             "type": "boolean"
                           }
                         },
@@ -326,19 +271,15 @@
                     "additionalProperties": false
                   },
                   "client_secret": {
-                    "description": "The secret containing the OAuth2 client secret",
                     "properties": {
                       "key": {
-                        "description": "The key of the secret to select from.  Must be a valid secret key.",
                         "type": "string"
                       },
                       "name": {
                         "default": "",
-                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                         "type": "string"
                       },
                       "optional": {
-                        "description": "Specify whether the Secret or its key must be defined",
                         "type": "boolean"
                       }
                     },
@@ -350,33 +291,27 @@
                     "additionalProperties": false
                   },
                   "client_secret_file": {
-                    "description": "ClientSecretFile defines path for client secret file.",
                     "type": "string"
                   },
                   "endpoint_params": {
                     "additionalProperties": {
                       "type": "string"
                     },
-                    "description": "Parameters to append to the token URL",
                     "type": "object"
                   },
                   "proxy_url": {
-                    "description": "The proxy URL for token_url connection\n( available from v0.55.0).\nIs only supported by Scrape objects family",
                     "type": "string"
                   },
                   "scopes": {
-                    "description": "OAuth2 scopes used for the token request",
                     "items": {
                       "type": "string"
                     },
                     "type": "array"
                   },
                   "tls_config": {
-                    "description": "TLSConfig for token_url connection\n( available from v0.55.0).\nIs only supported by Scrape objects family",
                     "x-kubernetes-preserve-unknown-fields": true
                   },
                   "token_url": {
-                    "description": "The URL to fetch the token from",
                     "minLength": 1,
                     "type": "string"
                   }
@@ -395,82 +330,64 @@
                   },
                   "type": "array"
                 },
-                "description": "Optional HTTP URL parameters",
                 "type": "object"
               },
               "path": {
-                "description": "HTTP path to scrape for metrics.",
                 "type": "string"
               },
               "port": {
-                "description": "Name of the port exposed at Service.",
                 "type": "string"
               },
               "proxyURL": {
-                "description": "ProxyURL eg http://proxyserver:2195 Directs scrapes to proxy through this endpoint.",
                 "type": "string"
               },
               "relabelConfigs": {
-                "description": "RelabelConfigs to apply to samples during service discovery.",
                 "items": {
-                  "description": "RelabelConfig allows dynamic rewriting of the label set\nMore info: https://docs.victoriametrics.com/victoriametrics/#relabeling",
                   "properties": {
                     "action": {
-                      "description": "Action to perform based on regex matching. Default is 'replace'",
                       "type": "string"
                     },
                     "if": {
-                      "description": "If represents metricsQL match expression (or list of expressions): '{__name__=~\"foo_.*\"}'",
                       "x-kubernetes-preserve-unknown-fields": true
                     },
                     "labels": {
                       "additionalProperties": {
                         "type": "string"
                       },
-                      "description": "Labels is used together with Match for `action: graphite`",
                       "type": "object"
                     },
                     "match": {
-                      "description": "Match is used together with Labels for `action: graphite`",
                       "type": "string"
                     },
                     "modulus": {
-                      "description": "Modulus to take of the hash of the source label values.",
                       "format": "int64",
                       "type": "integer"
                     },
                     "regex": {
-                      "description": "Regular expression against which the extracted value is matched. Default is '(.*)'\nvictoriaMetrics supports multiline regex joined with |\nhttps://docs.victoriametrics.com/victoriametrics/vmagent/#relabeling-enhancements",
                       "x-kubernetes-preserve-unknown-fields": true
                     },
                     "replacement": {
-                      "description": "Replacement value against which a regex replace is performed if the\nregular expression matches. Regex capture groups are available. Default is '$1'",
                       "type": "string"
                     },
                     "separator": {
-                      "description": "Separator placed between concatenated source label values. default is ';'.",
                       "type": "string"
                     },
                     "source_labels": {
-                      "description": "UnderScoreSourceLabels - additional form of source labels source_labels\nfor compatibility with original relabel config.\nif set  both sourceLabels and source_labels, sourceLabels has priority.\nfor details https://github.com/VictoriaMetrics/operator/issues/131",
                       "items": {
                         "type": "string"
                       },
                       "type": "array"
                     },
                     "sourceLabels": {
-                      "description": "The source labels select values from existing labels. Their content is concatenated\nusing the configured separator and matched against the configured regular expression\nfor the replace, keep, and drop actions.",
                       "items": {
                         "type": "string"
                       },
                       "type": "array"
                     },
                     "target_label": {
-                      "description": "UnderScoreTargetLabel - additional form of target label - target_label\nfor compatibility with original relabel config.\nif set  both targetLabel and target_label, targetLabel has priority.\nfor details https://github.com/VictoriaMetrics/operator/issues/131",
                       "type": "string"
                     },
                     "targetLabel": {
-                      "description": "Label to which the resulting value is written in a replace action.\nIt is mandatory for replace actions. Regex capture groups are available.",
                       "type": "string"
                     }
                   },
@@ -480,11 +397,9 @@
                 "type": "array"
               },
               "sampleLimit": {
-                "description": "SampleLimit defines per-scrape limit on number of scraped samples that will be accepted.",
                 "type": "integer"
               },
               "scheme": {
-                "description": "HTTP scheme to use for scraping.",
                 "enum": [
                   "http",
                   "https",
@@ -494,15 +409,12 @@
                 "type": "string"
               },
               "scrape_interval": {
-                "description": "ScrapeInterval is the same as Interval and has priority over it.\none of scrape_interval or interval can be used",
                 "type": "string"
               },
               "scrapeTimeout": {
-                "description": "Timeout after which the scrape is ended",
                 "type": "string"
               },
               "seriesLimit": {
-                "description": "SeriesLimit defines per-scrape limit on number of unique time series\na single target can expose during all the scrapes on the time window of 24h.",
                 "type": "integer"
               },
               "targetPort": {
@@ -514,29 +426,22 @@
                     "type": "string"
                   }
                 ],
-                "description": "TargetPort\nName or number of the pod port this endpoint refers to. Mutually exclusive with port.",
                 "x-kubernetes-int-or-string": true
               },
               "tlsConfig": {
-                "description": "TLSConfig configuration to use when scraping the endpoint",
                 "properties": {
                   "ca": {
-                    "description": "Struct containing the CA cert to use for the targets.",
                     "properties": {
                       "configMap": {
-                        "description": "ConfigMap containing data to use for the targets.",
                         "properties": {
                           "key": {
-                            "description": "The key to select.",
                             "type": "string"
                           },
                           "name": {
                             "default": "",
-                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                             "type": "string"
                           },
                           "optional": {
-                            "description": "Specify whether the ConfigMap or its key must be defined",
                             "type": "boolean"
                           }
                         },
@@ -548,19 +453,15 @@
                         "additionalProperties": false
                       },
                       "secret": {
-                        "description": "Secret containing data to use for the targets.",
                         "properties": {
                           "key": {
-                            "description": "The key of the secret to select from.  Must be a valid secret key.",
                             "type": "string"
                           },
                           "name": {
                             "default": "",
-                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                             "type": "string"
                           },
                           "optional": {
-                            "description": "Specify whether the Secret or its key must be defined",
                             "type": "boolean"
                           }
                         },
@@ -576,26 +477,20 @@
                     "additionalProperties": false
                   },
                   "caFile": {
-                    "description": "Path to the CA cert in the container to use for the targets.",
                     "type": "string"
                   },
                   "cert": {
-                    "description": "Struct containing the client cert file for the targets.",
                     "properties": {
                       "configMap": {
-                        "description": "ConfigMap containing data to use for the targets.",
                         "properties": {
                           "key": {
-                            "description": "The key to select.",
                             "type": "string"
                           },
                           "name": {
                             "default": "",
-                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                             "type": "string"
                           },
                           "optional": {
-                            "description": "Specify whether the ConfigMap or its key must be defined",
                             "type": "boolean"
                           }
                         },
@@ -607,19 +502,15 @@
                         "additionalProperties": false
                       },
                       "secret": {
-                        "description": "Secret containing data to use for the targets.",
                         "properties": {
                           "key": {
-                            "description": "The key of the secret to select from.  Must be a valid secret key.",
                             "type": "string"
                           },
                           "name": {
                             "default": "",
-                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                             "type": "string"
                           },
                           "optional": {
-                            "description": "Specify whether the Secret or its key must be defined",
                             "type": "boolean"
                           }
                         },
@@ -635,31 +526,24 @@
                     "additionalProperties": false
                   },
                   "certFile": {
-                    "description": "Path to the client cert file in the container for the targets.",
                     "type": "string"
                   },
                   "insecureSkipVerify": {
-                    "description": "Disable target certificate validation.",
                     "type": "boolean"
                   },
                   "keyFile": {
-                    "description": "Path to the client key file in the container for the targets.",
                     "type": "string"
                   },
                   "keySecret": {
-                    "description": "Secret containing the client key file for the targets.",
                     "properties": {
                       "key": {
-                        "description": "The key of the secret to select from.  Must be a valid secret key.",
                         "type": "string"
                       },
                       "name": {
                         "default": "",
-                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                         "type": "string"
                       },
                       "optional": {
-                        "description": "Specify whether the Secret or its key must be defined",
                         "type": "boolean"
                       }
                     },
@@ -671,7 +555,6 @@
                     "additionalProperties": false
                   },
                   "serverName": {
-                    "description": "Used to verify the hostname for the targets.",
                     "type": "string"
                   }
                 },
@@ -679,18 +562,14 @@
                 "additionalProperties": false
               },
               "vm_scrape_params": {
-                "description": "VMScrapeParams defines VictoriaMetrics specific scrape parameters",
                 "properties": {
                   "disable_compression": {
-                    "description": "DisableCompression",
                     "type": "boolean"
                   },
                   "disable_keep_alive": {
-                    "description": "disable_keepalive allows disabling HTTP keep-alive when scraping targets.\nBy default, HTTP keep-alive is enabled, so TCP connections to scrape targets\ncould be reused.\nSee https://docs.victoriametrics.com/victoriametrics/vmagent/#scrape_config-enhancements",
                     "type": "boolean"
                   },
                   "headers": {
-                    "description": "Headers allows sending custom headers to scrape targets\nmust be in of semicolon separated header with it's value\neg:\nheaderName: headerValue\nvmagent supports since 1.79.0 version",
                     "items": {
                       "type": "string"
                     },
@@ -700,25 +579,51 @@
                     "type": "boolean"
                   },
                   "proxy_client_config": {
-                    "description": "ProxyClientConfig configures proxy auth settings for scraping\nSee feature description https://docs.victoriametrics.com/victoriametrics/vmagent/#scraping-targets-via-a-proxy",
                     "properties": {
-                      "basic_auth": {
-                        "description": "BasicAuth allow an endpoint to authenticate over basic authentication",
+                      "authorization": {
                         "properties": {
-                          "password": {
-                            "description": "Password defines reference for secret with password value\nThe secret needs to be in the same namespace as scrape object",
+                          "credentials": {
                             "properties": {
                               "key": {
-                                "description": "The key of the secret to select from.  Must be a valid secret key.",
                                 "type": "string"
                               },
                               "name": {
                                 "default": "",
-                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                 "type": "string"
                               },
                               "optional": {
-                                "description": "Specify whether the Secret or its key must be defined",
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "credentialsFile": {
+                            "type": "string"
+                          },
+                          "type": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "basic_auth": {
+                        "properties": {
+                          "password": {
+                            "properties": {
+                              "key": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "default": "",
+                                "type": "string"
+                              },
+                              "optional": {
                                 "type": "boolean"
                               }
                             },
@@ -730,23 +635,18 @@
                             "additionalProperties": false
                           },
                           "password_file": {
-                            "description": "PasswordFile defines path to password file at disk\nmust be pre-mounted",
                             "type": "string"
                           },
                           "username": {
-                            "description": "Username defines reference for secret with username value\nThe secret needs to be in the same namespace as scrape object",
                             "properties": {
                               "key": {
-                                "description": "The key of the secret to select from.  Must be a valid secret key.",
                                 "type": "string"
                               },
                               "name": {
                                 "default": "",
-                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                 "type": "string"
                               },
                               "optional": {
-                                "description": "Specify whether the Secret or its key must be defined",
                                 "type": "boolean"
                               }
                             },
@@ -762,19 +662,16 @@
                         "additionalProperties": false
                       },
                       "bearer_token": {
-                        "description": "SecretKeySelector selects a key of a Secret.",
+                        "nullable": true,
                         "properties": {
                           "key": {
-                            "description": "The key of the secret to select from.  Must be a valid secret key.",
                             "type": "string"
                           },
                           "name": {
                             "default": "",
-                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                             "type": "string"
                           },
                           "optional": {
-                            "description": "Specify whether the Secret or its key must be defined",
                             "type": "boolean"
                           }
                         },
@@ -787,6 +684,107 @@
                       },
                       "bearer_token_file": {
                         "type": "string"
+                      },
+                      "oauth2": {
+                        "properties": {
+                          "client_id": {
+                            "properties": {
+                              "configMap": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "default": "",
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "secret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "default": "",
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "client_secret": {
+                            "properties": {
+                              "key": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "default": "",
+                                "type": "string"
+                              },
+                              "optional": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "client_secret_file": {
+                            "type": "string"
+                          },
+                          "endpoint_params": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          },
+                          "proxy_url": {
+                            "type": "string"
+                          },
+                          "scopes": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "tls_config": {
+                            "x-kubernetes-preserve-unknown-fields": true
+                          },
+                          "token_url": {
+                            "minLength": 1,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "client_id",
+                          "token_url"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "tls_config": {
                         "x-kubernetes-preserve-unknown-fields": true
@@ -815,18 +813,14 @@
           "type": "array"
         },
         "jobLabel": {
-          "description": "The label to use to retrieve the job name from.",
           "type": "string"
         },
         "namespaceSelector": {
-          "description": "Selector to select which namespaces the Endpoints objects are discovered from.",
           "properties": {
             "any": {
-              "description": "Boolean describing whether all namespaces are selected in contrast to a\nlist restricting them.",
               "type": "boolean"
             },
             "matchNames": {
-              "description": "List of namespace names.",
               "items": {
                 "type": "string"
               },
@@ -837,38 +831,29 @@
           "additionalProperties": false
         },
         "podTargetLabels": {
-          "description": "PodTargetLabels transfers labels on the Kubernetes Pod onto the target.",
           "items": {
             "type": "string"
           },
           "type": "array"
         },
         "sampleLimit": {
-          "description": "SampleLimit defines per-scrape limit on number of scraped samples that will be accepted.",
           "type": "integer"
         },
         "scrapeClass": {
-          "description": "ScrapeClass defined scrape class to apply",
           "type": "string"
         },
         "selector": {
-          "description": "Selector to select Endpoints objects by corresponding Service labels.",
           "properties": {
             "matchExpressions": {
-              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
               "items": {
-                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
                 "properties": {
                   "key": {
-                    "description": "key is the label key that the selector applies to.",
                     "type": "string"
                   },
                   "operator": {
-                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
                     "type": "string"
                   },
                   "values": {
-                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
                     "items": {
                       "type": "string"
                     },
@@ -890,7 +875,6 @@
               "additionalProperties": {
                 "type": "string"
               },
-              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
               "type": "object"
             }
           },
@@ -899,11 +883,9 @@
           "additionalProperties": false
         },
         "seriesLimit": {
-          "description": "SeriesLimit defines per-scrape limit on number of unique time series\na single target can expose during all the scrapes on the time window of 24h.",
           "type": "integer"
         },
         "targetLabels": {
-          "description": "TargetLabels transfers labels on the Kubernetes Service onto the target.",
           "items": {
             "type": "string"
           },
@@ -917,42 +899,33 @@
       "additionalProperties": false
     },
     "status": {
-      "description": "ScrapeObjectStatus defines the observed state of ScrapeObjects",
       "properties": {
         "conditions": {
-          "description": "Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"",
           "items": {
-            "description": "Condition defines status condition of the resource",
             "properties": {
               "lastTransitionTime": {
-                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.",
                 "format": "date-time",
                 "type": "string"
               },
               "lastUpdateTime": {
-                "description": "LastUpdateTime is the last time of given type update.\nThis value is used for status TTL update and removal",
                 "format": "date-time",
                 "type": "string"
               },
               "message": {
-                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
                 "maxLength": 32768,
                 "type": "string"
               },
               "observedGeneration": {
-                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
                 "format": "int64",
                 "minimum": 0,
                 "type": "integer"
               },
               "reason": {
-                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
                 "maxLength": 1024,
                 "minLength": 1,
                 "type": "string"
               },
               "status": {
-                "description": "status of the condition, one of True, False, Unknown.",
                 "enum": [
                   "True",
                   "False",
@@ -961,7 +934,6 @@
                 "type": "string"
               },
               "type": {
-                "description": "Type of condition in CamelCase or in name.namespace.resource.victoriametrics.com/CamelCase.",
                 "maxLength": 316,
                 "type": "string"
               }
@@ -983,16 +955,13 @@
           "x-kubernetes-list-type": "map"
         },
         "observedGeneration": {
-          "description": "ObservedGeneration defines current generation picked by operator for the\nreconcile",
           "format": "int64",
           "type": "integer"
         },
         "reason": {
-          "description": "Reason defines human readable error reason",
           "type": "string"
         },
         "updateStatus": {
-          "description": "UpdateStatus defines a status for update rollout",
           "type": "string"
         }
       },

--- a/operator.victoriametrics.com/vmstaticscrape_v1beta1.json
+++ b/operator.victoriametrics.com/vmstaticscrape_v1beta1.json
@@ -1,58 +1,43 @@
 {
-  "description": "VMStaticScrape  defines static targets configuration for scraping.",
   "properties": {
     "apiVersion": {
-      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
       "type": "string"
     },
     "kind": {
-      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
       "type": "string"
     },
     "metadata": {
       "type": "object"
     },
     "spec": {
-      "description": "VMStaticScrapeSpec defines the desired state of VMStaticScrape.",
       "properties": {
         "jobName": {
-          "description": "JobName name of job.",
           "type": "string"
         },
         "sampleLimit": {
-          "description": "SampleLimit defines per-scrape limit on number of scraped samples that will be accepted.",
           "type": "integer"
         },
         "scrapeClass": {
-          "description": "ScrapeClass defined scrape class to apply",
           "type": "string"
         },
         "seriesLimit": {
-          "description": "SeriesLimit defines per-scrape limit on number of unique time series\na single target can expose during all the scrapes on the time window of 24h.",
           "type": "integer"
         },
         "targetEndpoints": {
-          "description": "A list of target endpoints to scrape metrics from.",
           "items": {
-            "description": "TargetEndpoint defines single static target endpoint.",
             "properties": {
               "authorization": {
-                "description": "Authorization with http header Authorization",
                 "properties": {
                   "credentials": {
-                    "description": "Reference to the secret with value for authorization",
                     "properties": {
                       "key": {
-                        "description": "The key of the secret to select from.  Must be a valid secret key.",
                         "type": "string"
                       },
                       "name": {
                         "default": "",
-                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                         "type": "string"
                       },
                       "optional": {
-                        "description": "Specify whether the Secret or its key must be defined",
                         "type": "boolean"
                       }
                     },
@@ -64,11 +49,9 @@
                     "additionalProperties": false
                   },
                   "credentialsFile": {
-                    "description": "File with value for authorization",
                     "type": "string"
                   },
                   "type": {
-                    "description": "Type of authorization, default to bearer",
                     "type": "string"
                   }
                 },
@@ -76,22 +59,17 @@
                 "additionalProperties": false
               },
               "basicAuth": {
-                "description": "BasicAuth allow an endpoint to authenticate over basic authentication",
                 "properties": {
                   "password": {
-                    "description": "Password defines reference for secret with password value\nThe secret needs to be in the same namespace as scrape object",
                     "properties": {
                       "key": {
-                        "description": "The key of the secret to select from.  Must be a valid secret key.",
                         "type": "string"
                       },
                       "name": {
                         "default": "",
-                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                         "type": "string"
                       },
                       "optional": {
-                        "description": "Specify whether the Secret or its key must be defined",
                         "type": "boolean"
                       }
                     },
@@ -103,23 +81,18 @@
                     "additionalProperties": false
                   },
                   "password_file": {
-                    "description": "PasswordFile defines path to password file at disk\nmust be pre-mounted",
                     "type": "string"
                   },
                   "username": {
-                    "description": "Username defines reference for secret with username value\nThe secret needs to be in the same namespace as scrape object",
                     "properties": {
                       "key": {
-                        "description": "The key of the secret to select from.  Must be a valid secret key.",
                         "type": "string"
                       },
                       "name": {
                         "default": "",
-                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                         "type": "string"
                       },
                       "optional": {
-                        "description": "Specify whether the Secret or its key must be defined",
                         "type": "boolean"
                       }
                     },
@@ -135,24 +108,19 @@
                 "additionalProperties": false
               },
               "bearerTokenFile": {
-                "description": "File to read bearer token for scraping targets.",
                 "type": "string"
               },
               "bearerTokenSecret": {
-                "description": "Secret to mount to read bearer token for scraping targets. The secret\nneeds to be in the same namespace as the scrape object and accessible by\nthe victoria-metrics operator.",
                 "nullable": true,
                 "properties": {
                   "key": {
-                    "description": "The key of the secret to select from.  Must be a valid secret key.",
                     "type": "string"
                   },
                   "name": {
                     "default": "",
-                    "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                     "type": "string"
                   },
                   "optional": {
-                    "description": "Specify whether the Secret or its key must be defined",
                     "type": "boolean"
                   }
                 },
@@ -164,93 +132,73 @@
                 "additionalProperties": false
               },
               "follow_redirects": {
-                "description": "FollowRedirects controls redirects for scraping.",
                 "type": "boolean"
               },
               "honorLabels": {
-                "description": "HonorLabels chooses the metric's labels on collisions with target labels.",
                 "type": "boolean"
               },
               "honorTimestamps": {
-                "description": "HonorTimestamps controls whether vmagent respects the timestamps present in scraped data.",
                 "type": "boolean"
               },
               "interval": {
-                "description": "Interval at which metrics should be scraped",
                 "type": "string"
               },
               "labels": {
                 "additionalProperties": {
                   "type": "string"
                 },
-                "description": "Labels static labels for targets.",
                 "type": "object"
               },
               "max_scrape_size": {
-                "description": "MaxScrapeSize defines a maximum size of scraped data for a job",
                 "type": "string"
               },
               "metricRelabelConfigs": {
-                "description": "MetricRelabelConfigs to apply to samples after scrapping.",
                 "items": {
-                  "description": "RelabelConfig allows dynamic rewriting of the label set\nMore info: https://docs.victoriametrics.com/victoriametrics/#relabeling",
                   "properties": {
                     "action": {
-                      "description": "Action to perform based on regex matching. Default is 'replace'",
                       "type": "string"
                     },
                     "if": {
-                      "description": "If represents metricsQL match expression (or list of expressions): '{__name__=~\"foo_.*\"}'",
                       "x-kubernetes-preserve-unknown-fields": true
                     },
                     "labels": {
                       "additionalProperties": {
                         "type": "string"
                       },
-                      "description": "Labels is used together with Match for `action: graphite`",
                       "type": "object"
                     },
                     "match": {
-                      "description": "Match is used together with Labels for `action: graphite`",
                       "type": "string"
                     },
                     "modulus": {
-                      "description": "Modulus to take of the hash of the source label values.",
                       "format": "int64",
                       "type": "integer"
                     },
                     "regex": {
-                      "description": "Regular expression against which the extracted value is matched. Default is '(.*)'\nvictoriaMetrics supports multiline regex joined with |\nhttps://docs.victoriametrics.com/victoriametrics/vmagent/#relabeling-enhancements",
                       "x-kubernetes-preserve-unknown-fields": true
                     },
                     "replacement": {
-                      "description": "Replacement value against which a regex replace is performed if the\nregular expression matches. Regex capture groups are available. Default is '$1'",
                       "type": "string"
                     },
                     "separator": {
-                      "description": "Separator placed between concatenated source label values. default is ';'.",
                       "type": "string"
                     },
                     "source_labels": {
-                      "description": "UnderScoreSourceLabels - additional form of source labels source_labels\nfor compatibility with original relabel config.\nif set  both sourceLabels and source_labels, sourceLabels has priority.\nfor details https://github.com/VictoriaMetrics/operator/issues/131",
                       "items": {
                         "type": "string"
                       },
                       "type": "array"
                     },
                     "sourceLabels": {
-                      "description": "The source labels select values from existing labels. Their content is concatenated\nusing the configured separator and matched against the configured regular expression\nfor the replace, keep, and drop actions.",
                       "items": {
                         "type": "string"
                       },
                       "type": "array"
                     },
                     "target_label": {
-                      "description": "UnderScoreTargetLabel - additional form of target label - target_label\nfor compatibility with original relabel config.\nif set  both targetLabel and target_label, targetLabel has priority.\nfor details https://github.com/VictoriaMetrics/operator/issues/131",
                       "type": "string"
                     },
                     "targetLabel": {
-                      "description": "Label to which the resulting value is written in a replace action.\nIt is mandatory for replace actions. Regex capture groups are available.",
                       "type": "string"
                     }
                   },
@@ -260,25 +208,19 @@
                 "type": "array"
               },
               "oauth2": {
-                "description": "OAuth2 defines auth configuration",
                 "properties": {
                   "client_id": {
-                    "description": "The secret or configmap containing the OAuth2 client id",
                     "properties": {
                       "configMap": {
-                        "description": "ConfigMap containing data to use for the targets.",
                         "properties": {
                           "key": {
-                            "description": "The key to select.",
                             "type": "string"
                           },
                           "name": {
                             "default": "",
-                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                             "type": "string"
                           },
                           "optional": {
-                            "description": "Specify whether the ConfigMap or its key must be defined",
                             "type": "boolean"
                           }
                         },
@@ -290,19 +232,15 @@
                         "additionalProperties": false
                       },
                       "secret": {
-                        "description": "Secret containing data to use for the targets.",
                         "properties": {
                           "key": {
-                            "description": "The key of the secret to select from.  Must be a valid secret key.",
                             "type": "string"
                           },
                           "name": {
                             "default": "",
-                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                             "type": "string"
                           },
                           "optional": {
-                            "description": "Specify whether the Secret or its key must be defined",
                             "type": "boolean"
                           }
                         },
@@ -318,19 +256,15 @@
                     "additionalProperties": false
                   },
                   "client_secret": {
-                    "description": "The secret containing the OAuth2 client secret",
                     "properties": {
                       "key": {
-                        "description": "The key of the secret to select from.  Must be a valid secret key.",
                         "type": "string"
                       },
                       "name": {
                         "default": "",
-                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                         "type": "string"
                       },
                       "optional": {
-                        "description": "Specify whether the Secret or its key must be defined",
                         "type": "boolean"
                       }
                     },
@@ -342,33 +276,27 @@
                     "additionalProperties": false
                   },
                   "client_secret_file": {
-                    "description": "ClientSecretFile defines path for client secret file.",
                     "type": "string"
                   },
                   "endpoint_params": {
                     "additionalProperties": {
                       "type": "string"
                     },
-                    "description": "Parameters to append to the token URL",
                     "type": "object"
                   },
                   "proxy_url": {
-                    "description": "The proxy URL for token_url connection\n( available from v0.55.0).\nIs only supported by Scrape objects family",
                     "type": "string"
                   },
                   "scopes": {
-                    "description": "OAuth2 scopes used for the token request",
                     "items": {
                       "type": "string"
                     },
                     "type": "array"
                   },
                   "tls_config": {
-                    "description": "TLSConfig for token_url connection\n( available from v0.55.0).\nIs only supported by Scrape objects family",
                     "x-kubernetes-preserve-unknown-fields": true
                   },
                   "token_url": {
-                    "description": "The URL to fetch the token from",
                     "minLength": 1,
                     "type": "string"
                   }
@@ -387,78 +315,61 @@
                   },
                   "type": "array"
                 },
-                "description": "Optional HTTP URL parameters",
                 "type": "object"
               },
               "path": {
-                "description": "HTTP path to scrape for metrics.",
                 "type": "string"
               },
               "proxyURL": {
-                "description": "ProxyURL eg http://proxyserver:2195 Directs scrapes to proxy through this endpoint.",
                 "type": "string"
               },
               "relabelConfigs": {
-                "description": "RelabelConfigs to apply to samples during service discovery.",
                 "items": {
-                  "description": "RelabelConfig allows dynamic rewriting of the label set\nMore info: https://docs.victoriametrics.com/victoriametrics/#relabeling",
                   "properties": {
                     "action": {
-                      "description": "Action to perform based on regex matching. Default is 'replace'",
                       "type": "string"
                     },
                     "if": {
-                      "description": "If represents metricsQL match expression (or list of expressions): '{__name__=~\"foo_.*\"}'",
                       "x-kubernetes-preserve-unknown-fields": true
                     },
                     "labels": {
                       "additionalProperties": {
                         "type": "string"
                       },
-                      "description": "Labels is used together with Match for `action: graphite`",
                       "type": "object"
                     },
                     "match": {
-                      "description": "Match is used together with Labels for `action: graphite`",
                       "type": "string"
                     },
                     "modulus": {
-                      "description": "Modulus to take of the hash of the source label values.",
                       "format": "int64",
                       "type": "integer"
                     },
                     "regex": {
-                      "description": "Regular expression against which the extracted value is matched. Default is '(.*)'\nvictoriaMetrics supports multiline regex joined with |\nhttps://docs.victoriametrics.com/victoriametrics/vmagent/#relabeling-enhancements",
                       "x-kubernetes-preserve-unknown-fields": true
                     },
                     "replacement": {
-                      "description": "Replacement value against which a regex replace is performed if the\nregular expression matches. Regex capture groups are available. Default is '$1'",
                       "type": "string"
                     },
                     "separator": {
-                      "description": "Separator placed between concatenated source label values. default is ';'.",
                       "type": "string"
                     },
                     "source_labels": {
-                      "description": "UnderScoreSourceLabels - additional form of source labels source_labels\nfor compatibility with original relabel config.\nif set  both sourceLabels and source_labels, sourceLabels has priority.\nfor details https://github.com/VictoriaMetrics/operator/issues/131",
                       "items": {
                         "type": "string"
                       },
                       "type": "array"
                     },
                     "sourceLabels": {
-                      "description": "The source labels select values from existing labels. Their content is concatenated\nusing the configured separator and matched against the configured regular expression\nfor the replace, keep, and drop actions.",
                       "items": {
                         "type": "string"
                       },
                       "type": "array"
                     },
                     "target_label": {
-                      "description": "UnderScoreTargetLabel - additional form of target label - target_label\nfor compatibility with original relabel config.\nif set  both targetLabel and target_label, targetLabel has priority.\nfor details https://github.com/VictoriaMetrics/operator/issues/131",
                       "type": "string"
                     },
                     "targetLabel": {
-                      "description": "Label to which the resulting value is written in a replace action.\nIt is mandatory for replace actions. Regex capture groups are available.",
                       "type": "string"
                     }
                   },
@@ -468,11 +379,9 @@
                 "type": "array"
               },
               "sampleLimit": {
-                "description": "SampleLimit defines per-scrape limit on number of scraped samples that will be accepted.",
                 "type": "integer"
               },
               "scheme": {
-                "description": "HTTP scheme to use for scraping.",
                 "enum": [
                   "http",
                   "https",
@@ -482,19 +391,15 @@
                 "type": "string"
               },
               "scrape_interval": {
-                "description": "ScrapeInterval is the same as Interval and has priority over it.\none of scrape_interval or interval can be used",
                 "type": "string"
               },
               "scrapeTimeout": {
-                "description": "Timeout after which the scrape is ended",
                 "type": "string"
               },
               "seriesLimit": {
-                "description": "SeriesLimit defines per-scrape limit on number of unique time series\na single target can expose during all the scrapes on the time window of 24h.",
                 "type": "integer"
               },
               "targets": {
-                "description": "Targets static targets addresses in form of [\"192.122.55.55:9100\",\"some-name:9100\"].",
                 "items": {
                   "type": "string"
                 },
@@ -502,25 +407,19 @@
                 "type": "array"
               },
               "tlsConfig": {
-                "description": "TLSConfig configuration to use when scraping the endpoint",
                 "properties": {
                   "ca": {
-                    "description": "Struct containing the CA cert to use for the targets.",
                     "properties": {
                       "configMap": {
-                        "description": "ConfigMap containing data to use for the targets.",
                         "properties": {
                           "key": {
-                            "description": "The key to select.",
                             "type": "string"
                           },
                           "name": {
                             "default": "",
-                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                             "type": "string"
                           },
                           "optional": {
-                            "description": "Specify whether the ConfigMap or its key must be defined",
                             "type": "boolean"
                           }
                         },
@@ -532,19 +431,15 @@
                         "additionalProperties": false
                       },
                       "secret": {
-                        "description": "Secret containing data to use for the targets.",
                         "properties": {
                           "key": {
-                            "description": "The key of the secret to select from.  Must be a valid secret key.",
                             "type": "string"
                           },
                           "name": {
                             "default": "",
-                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                             "type": "string"
                           },
                           "optional": {
-                            "description": "Specify whether the Secret or its key must be defined",
                             "type": "boolean"
                           }
                         },
@@ -560,26 +455,20 @@
                     "additionalProperties": false
                   },
                   "caFile": {
-                    "description": "Path to the CA cert in the container to use for the targets.",
                     "type": "string"
                   },
                   "cert": {
-                    "description": "Struct containing the client cert file for the targets.",
                     "properties": {
                       "configMap": {
-                        "description": "ConfigMap containing data to use for the targets.",
                         "properties": {
                           "key": {
-                            "description": "The key to select.",
                             "type": "string"
                           },
                           "name": {
                             "default": "",
-                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                             "type": "string"
                           },
                           "optional": {
-                            "description": "Specify whether the ConfigMap or its key must be defined",
                             "type": "boolean"
                           }
                         },
@@ -591,19 +480,15 @@
                         "additionalProperties": false
                       },
                       "secret": {
-                        "description": "Secret containing data to use for the targets.",
                         "properties": {
                           "key": {
-                            "description": "The key of the secret to select from.  Must be a valid secret key.",
                             "type": "string"
                           },
                           "name": {
                             "default": "",
-                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                             "type": "string"
                           },
                           "optional": {
-                            "description": "Specify whether the Secret or its key must be defined",
                             "type": "boolean"
                           }
                         },
@@ -619,31 +504,24 @@
                     "additionalProperties": false
                   },
                   "certFile": {
-                    "description": "Path to the client cert file in the container for the targets.",
                     "type": "string"
                   },
                   "insecureSkipVerify": {
-                    "description": "Disable target certificate validation.",
                     "type": "boolean"
                   },
                   "keyFile": {
-                    "description": "Path to the client key file in the container for the targets.",
                     "type": "string"
                   },
                   "keySecret": {
-                    "description": "Secret containing the client key file for the targets.",
                     "properties": {
                       "key": {
-                        "description": "The key of the secret to select from.  Must be a valid secret key.",
                         "type": "string"
                       },
                       "name": {
                         "default": "",
-                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                         "type": "string"
                       },
                       "optional": {
-                        "description": "Specify whether the Secret or its key must be defined",
                         "type": "boolean"
                       }
                     },
@@ -655,7 +533,6 @@
                     "additionalProperties": false
                   },
                   "serverName": {
-                    "description": "Used to verify the hostname for the targets.",
                     "type": "string"
                   }
                 },
@@ -663,18 +540,14 @@
                 "additionalProperties": false
               },
               "vm_scrape_params": {
-                "description": "VMScrapeParams defines VictoriaMetrics specific scrape parameters",
                 "properties": {
                   "disable_compression": {
-                    "description": "DisableCompression",
                     "type": "boolean"
                   },
                   "disable_keep_alive": {
-                    "description": "disable_keepalive allows disabling HTTP keep-alive when scraping targets.\nBy default, HTTP keep-alive is enabled, so TCP connections to scrape targets\ncould be reused.\nSee https://docs.victoriametrics.com/victoriametrics/vmagent/#scrape_config-enhancements",
                     "type": "boolean"
                   },
                   "headers": {
-                    "description": "Headers allows sending custom headers to scrape targets\nmust be in of semicolon separated header with it's value\neg:\nheaderName: headerValue\nvmagent supports since 1.79.0 version",
                     "items": {
                       "type": "string"
                     },
@@ -684,25 +557,51 @@
                     "type": "boolean"
                   },
                   "proxy_client_config": {
-                    "description": "ProxyClientConfig configures proxy auth settings for scraping\nSee feature description https://docs.victoriametrics.com/victoriametrics/vmagent/#scraping-targets-via-a-proxy",
                     "properties": {
-                      "basic_auth": {
-                        "description": "BasicAuth allow an endpoint to authenticate over basic authentication",
+                      "authorization": {
                         "properties": {
-                          "password": {
-                            "description": "Password defines reference for secret with password value\nThe secret needs to be in the same namespace as scrape object",
+                          "credentials": {
                             "properties": {
                               "key": {
-                                "description": "The key of the secret to select from.  Must be a valid secret key.",
                                 "type": "string"
                               },
                               "name": {
                                 "default": "",
-                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                 "type": "string"
                               },
                               "optional": {
-                                "description": "Specify whether the Secret or its key must be defined",
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "credentialsFile": {
+                            "type": "string"
+                          },
+                          "type": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "basic_auth": {
+                        "properties": {
+                          "password": {
+                            "properties": {
+                              "key": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "default": "",
+                                "type": "string"
+                              },
+                              "optional": {
                                 "type": "boolean"
                               }
                             },
@@ -714,23 +613,18 @@
                             "additionalProperties": false
                           },
                           "password_file": {
-                            "description": "PasswordFile defines path to password file at disk\nmust be pre-mounted",
                             "type": "string"
                           },
                           "username": {
-                            "description": "Username defines reference for secret with username value\nThe secret needs to be in the same namespace as scrape object",
                             "properties": {
                               "key": {
-                                "description": "The key of the secret to select from.  Must be a valid secret key.",
                                 "type": "string"
                               },
                               "name": {
                                 "default": "",
-                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                 "type": "string"
                               },
                               "optional": {
-                                "description": "Specify whether the Secret or its key must be defined",
                                 "type": "boolean"
                               }
                             },
@@ -746,19 +640,16 @@
                         "additionalProperties": false
                       },
                       "bearer_token": {
-                        "description": "SecretKeySelector selects a key of a Secret.",
+                        "nullable": true,
                         "properties": {
                           "key": {
-                            "description": "The key of the secret to select from.  Must be a valid secret key.",
                             "type": "string"
                           },
                           "name": {
                             "default": "",
-                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                             "type": "string"
                           },
                           "optional": {
-                            "description": "Specify whether the Secret or its key must be defined",
                             "type": "boolean"
                           }
                         },
@@ -771,6 +662,107 @@
                       },
                       "bearer_token_file": {
                         "type": "string"
+                      },
+                      "oauth2": {
+                        "properties": {
+                          "client_id": {
+                            "properties": {
+                              "configMap": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "default": "",
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "secret": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "default": "",
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "client_secret": {
+                            "properties": {
+                              "key": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "default": "",
+                                "type": "string"
+                              },
+                              "optional": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "client_secret_file": {
+                            "type": "string"
+                          },
+                          "endpoint_params": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          },
+                          "proxy_url": {
+                            "type": "string"
+                          },
+                          "scopes": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "tls_config": {
+                            "x-kubernetes-preserve-unknown-fields": true
+                          },
+                          "token_url": {
+                            "minLength": 1,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "client_id",
+                          "token_url"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "tls_config": {
                         "x-kubernetes-preserve-unknown-fields": true
@@ -809,42 +801,33 @@
       "additionalProperties": false
     },
     "status": {
-      "description": "ScrapeObjectStatus defines the observed state of ScrapeObjects",
       "properties": {
         "conditions": {
-          "description": "Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"",
           "items": {
-            "description": "Condition defines status condition of the resource",
             "properties": {
               "lastTransitionTime": {
-                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.",
                 "format": "date-time",
                 "type": "string"
               },
               "lastUpdateTime": {
-                "description": "LastUpdateTime is the last time of given type update.\nThis value is used for status TTL update and removal",
                 "format": "date-time",
                 "type": "string"
               },
               "message": {
-                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
                 "maxLength": 32768,
                 "type": "string"
               },
               "observedGeneration": {
-                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
                 "format": "int64",
                 "minimum": 0,
                 "type": "integer"
               },
               "reason": {
-                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
                 "maxLength": 1024,
                 "minLength": 1,
                 "type": "string"
               },
               "status": {
-                "description": "status of the condition, one of True, False, Unknown.",
                 "enum": [
                   "True",
                   "False",
@@ -853,7 +836,6 @@
                 "type": "string"
               },
               "type": {
-                "description": "Type of condition in CamelCase or in name.namespace.resource.victoriametrics.com/CamelCase.",
                 "maxLength": 316,
                 "type": "string"
               }
@@ -875,16 +857,13 @@
           "x-kubernetes-list-type": "map"
         },
         "observedGeneration": {
-          "description": "ObservedGeneration defines current generation picked by operator for the\nreconcile",
           "format": "int64",
           "type": "integer"
         },
         "reason": {
-          "description": "Reason defines human readable error reason",
           "type": "string"
         },
         "updateStatus": {
-          "description": "UpdateStatus defines a status for update rollout",
           "type": "string"
         }
       },

--- a/operator.victoriametrics.com/vmuser_v1beta1.json
+++ b/operator.victoriametrics.com/vmuser_v1beta1.json
@@ -1,60 +1,47 @@
 {
-  "description": "VMUser is the Schema for the vmusers API",
   "properties": {
     "apiVersion": {
-      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
       "type": "string"
     },
     "kind": {
-      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
       "type": "string"
     },
     "metadata": {
       "type": "object"
     },
     "spec": {
-      "description": "VMUserSpec defines the desired state of VMUser",
       "properties": {
         "bearerToken": {
-          "description": "BearerToken Authorization header value for accessing protected endpoint.",
           "type": "string"
         },
         "default_url": {
-          "description": "DefaultURLs backend url for non-matching paths filter\nusually used for default backend with error message",
           "items": {
             "type": "string"
           },
           "type": "array"
         },
         "disable_secret_creation": {
-          "description": "DisableSecretCreation skips related secret creation for vmuser",
           "type": "boolean"
         },
         "discover_backend_ips": {
-          "description": "DiscoverBackendIPs instructs discovering URLPrefix backend IPs via DNS.",
           "type": "boolean"
         },
         "drop_src_path_prefix_parts": {
-          "description": "DropSrcPathPrefixParts is the number of `/`-delimited request path prefix parts to drop before proxying the request to backend.\nSee [here](https://docs.victoriametrics.com/victoriametrics/vmauth/#dropping-request-path-prefix) for more details.",
           "type": "integer"
         },
         "dump_request_on_errors": {
-          "description": "DumpRequestOnErrors instructs vmauth to return detailed request params to the client\nif routing rules don't allow to forward request to the backends.\nUseful for debugging `src_hosts` and `src_headers` based routing rules\n\navailable since v1.107.0 vmauth version",
           "type": "boolean"
         },
         "generatePassword": {
-          "description": "GeneratePassword instructs operator to generate password for user\nif spec.password if empty.",
           "type": "boolean"
         },
         "headers": {
-          "description": "Headers represent additional http headers, that vmauth uses\nin form of [\"header_key: header_value\"]\nmultiple values for header key:\n[\"header_key: value1,value2\"]\nit's available since 1.68.0 version of vmauth",
           "items": {
             "type": "string"
           },
           "type": "array"
         },
         "ip_filters": {
-          "description": "IPFilters defines per target src ip filters\nsupported only with enterprise version of [vmauth](https://docs.victoriametrics.com/victoriametrics/vmauth/#ip-filters)",
           "properties": {
             "allow_list": {
               "items": {
@@ -72,8 +59,63 @@
           "type": "object",
           "additionalProperties": false
         },
+        "jwt": {
+          "properties": {
+            "matchClaims": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "oidc": {
+              "properties": {
+                "issuer": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "issuer"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "publicKeyRefs": {
+              "items": {
+                "properties": {
+                  "key": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "default": "",
+                    "type": "string"
+                  },
+                  "optional": {
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "key"
+                ],
+                "type": "object",
+                "x-kubernetes-map-type": "atomic",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "publicKeys": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "skipVerify": {
+              "type": "boolean"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
         "load_balancing_policy": {
-          "description": "LoadBalancingPolicy defines load balancing policy to use for backend urls.\nSupported policies: least_loaded, first_available.\nSee [here](https://docs.victoriametrics.com/victoriametrics/vmauth/#load-balancing) for more details (default \"least_loaded\")",
           "enum": [
             "least_loaded",
             "first_available"
@@ -81,20 +123,17 @@
           "type": "string"
         },
         "managedMetadata": {
-          "description": "ManagedMetadata defines metadata that will be added to the all objects\ncreated by operator for the given CustomResource",
           "properties": {
             "annotations": {
               "additionalProperties": {
                 "type": "string"
               },
-              "description": "Annotations is an unstructured key value map stored with a resource that may be\nset by external tools to store and retrieve arbitrary metadata. They are not\nqueryable and should be preserved when modifying objects.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations",
               "type": "object"
             },
             "labels": {
               "additionalProperties": {
                 "type": "string"
               },
-              "description": "Labels Map of string keys and values that can be used to organize and categorize\n(scope and select) objects.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels",
               "type": "object"
             }
           },
@@ -102,38 +141,30 @@
           "additionalProperties": false
         },
         "max_concurrent_requests": {
-          "description": "MaxConcurrentRequests defines max concurrent requests per user\n300 is default value for vmauth",
           "type": "integer"
         },
         "metric_labels": {
           "additionalProperties": {
             "type": "string"
           },
-          "description": "MetricLabels - additional labels for metrics exported by vmauth for given user.",
           "type": "object"
         },
         "name": {
-          "description": "Name of the VMUser object.",
           "type": "string"
         },
         "password": {
-          "description": "Password basic auth password for accessing protected endpoint.",
           "type": "string"
         },
         "passwordRef": {
-          "description": "PasswordRef allows fetching password from user-create secret by its name and key.",
           "properties": {
             "key": {
-              "description": "The key of the secret to select from.  Must be a valid secret key.",
               "type": "string"
             },
             "name": {
               "default": "",
-              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
               "type": "string"
             },
             "optional": {
-              "description": "Specify whether the Secret or its key must be defined",
               "type": "boolean"
             }
           },
@@ -145,29 +176,23 @@
           "additionalProperties": false
         },
         "response_headers": {
-          "description": "ResponseHeaders represent additional http headers, that vmauth adds for request response\nin form of [\"header_key: header_value\"]\nmultiple values for header key:\n[\"header_key: value1,value2\"]\nit's available since 1.93.0 version of vmauth",
           "items": {
             "type": "string"
           },
           "type": "array"
         },
         "retry_status_codes": {
-          "description": "RetryStatusCodes defines http status codes in numeric format for request retries\ne.g. [429,503]",
           "items": {
             "type": "integer"
           },
           "type": "array"
         },
         "targetRefs": {
-          "description": "TargetRefs - reference to endpoints, which user may access.",
           "items": {
-            "description": "TargetRef describes target for user traffic forwarding.\none of target types can be chosen:\ncrd or static per targetRef.\nuser can define multiple targetRefs with different ref Types.",
             "properties": {
               "crd": {
-                "description": "CRD describes exist operator's CRD object,\noperator generates access url based on CRD params.",
                 "properties": {
                   "kind": {
-                    "description": "Kind one of:\nVMAgent,VMAlert, VMSingle, VMCluster/vmselect, VMCluster/vmstorage,VMCluster/vminsert,VMAlertManager, VLSingle, VLCluster/vlinsert, VLCluster/vlselect, VLCluster/vlstorage, VTSingle, VTCluster/vtinsert, VTCluster/vtselect, VTCluster/vtstorage and VLAgent",
                     "enum": [
                       "VMAgent",
                       "VMAlert",
@@ -186,17 +211,35 @@
                       "VTCluster/vtinsert",
                       "VTCluster/vtselect",
                       "VTCluster/vtstorage",
-                      "VTSingle"
+                      "VTSingle",
+                      "VMAnomaly"
                     ],
                     "type": "string"
                   },
                   "name": {
-                    "description": "Name target CRD object name",
                     "type": "string"
                   },
                   "namespace": {
-                    "description": "Namespace target CRD object namespace.",
                     "type": "string"
+                  },
+                  "objects": {
+                    "items": {
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name",
+                        "namespace"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
                   }
                 },
                 "required": [
@@ -208,15 +251,12 @@
                 "additionalProperties": false
               },
               "discover_backend_ips": {
-                "description": "DiscoverBackendIPs instructs discovering URLPrefix backend IPs via DNS.",
                 "type": "boolean"
               },
               "drop_src_path_prefix_parts": {
-                "description": "DropSrcPathPrefixParts is the number of `/`-delimited request path prefix parts to drop before proxying the request to backend.\nSee [here](https://docs.victoriametrics.com/victoriametrics/vmauth/#dropping-request-path-prefix) for more details.",
                 "type": "integer"
               },
               "headers": {
-                "description": "RequestHeaders represent additional http headers, that vmauth uses\nin form of [\"header_key: header_value\"]\nmultiple values for header key:\n[\"header_key: value1,value2\"]\nit's available since 1.68.0 version of vmauth",
                 "items": {
                   "type": "string"
                 },
@@ -229,31 +269,28 @@
                 "type": "array"
               },
               "load_balancing_policy": {
-                "description": "LoadBalancingPolicy defines load balancing policy to use for backend urls.\nSupported policies: least_loaded, first_available.\nSee [here](https://docs.victoriametrics.com/victoriametrics/vmauth/#load-balancing) for more details (default \"least_loaded\")",
                 "enum": [
                   "least_loaded",
                   "first_available"
                 ],
                 "type": "string"
               },
+              "name": {
+                "type": "string"
+              },
               "paths": {
-                "description": "Paths - matched path to route.",
                 "items": {
                   "type": "string"
                 },
                 "type": "array"
               },
               "query_args": {
-                "description": "QueryArgs appends list of query arguments to generated URL",
                 "items": {
-                  "description": "QueryArg defines item for query arguments",
                   "properties": {
                     "name": {
-                      "description": "Name of query argument",
                       "type": "string"
                     },
                     "values": {
-                      "description": "Values of query argument",
                       "items": {
                         "type": "string"
                       },
@@ -270,42 +307,35 @@
                 "type": "array"
               },
               "response_headers": {
-                "description": "ResponseHeaders represent additional http headers, that vmauth adds for request response\nin form of [\"header_key: header_value\"]\nmultiple values for header key:\n[\"header_key: value1,value2\"]\nit's available since 1.93.0 version of vmauth",
                 "items": {
                   "type": "string"
                 },
                 "type": "array"
               },
               "retry_status_codes": {
-                "description": "RetryStatusCodes defines http status codes in numeric format for request retries\nCan be defined per target or at VMUser.spec level\ne.g. [429,503]",
                 "items": {
                   "type": "integer"
                 },
                 "type": "array"
               },
               "src_headers": {
-                "description": "SrcHeaders is an optional list of headers, which must match request headers.",
                 "items": {
                   "type": "string"
                 },
                 "type": "array"
               },
               "src_query_args": {
-                "description": "SrcQueryArgs is an optional list of query args, which must match request URL query args.",
                 "items": {
                   "type": "string"
                 },
                 "type": "array"
               },
               "static": {
-                "description": "Static - user defined url for traffic forward,\nfor instance http://vmsingle:8428",
                 "properties": {
                   "url": {
-                    "description": "URL http url for given staticRef.",
                     "type": "string"
                   },
                   "urls": {
-                    "description": "URLs allows setting multiple urls for load-balancing at vmauth-side.",
                     "items": {
                       "type": "string"
                     },
@@ -316,26 +346,20 @@
                 "additionalProperties": false
               },
               "target_path_suffix": {
-                "description": "TargetPathSuffix allows to add some suffix to the target path\nIt allows to hide tenant configuration from user with crd as ref.\nit also may contain any url encoded params.",
                 "type": "string"
               },
               "targetRefBasicAuth": {
-                "description": "TargetRefBasicAuth allow an target endpoint to authenticate over basic authentication",
                 "properties": {
                   "password": {
-                    "description": "The secret in the service scrape namespace that contains the password\nfor authentication.\nIt must be at them same namespace as CRD",
                     "properties": {
                       "key": {
-                        "description": "The key of the secret to select from.  Must be a valid secret key.",
                         "type": "string"
                       },
                       "name": {
                         "default": "",
-                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                         "type": "string"
                       },
                       "optional": {
-                        "description": "Specify whether the Secret or its key must be defined",
                         "type": "boolean"
                       }
                     },
@@ -347,19 +371,15 @@
                     "additionalProperties": false
                   },
                   "username": {
-                    "description": "The secret in the service scrape namespace that contains the username\nfor authentication.\nIt must be at them same namespace as CRD",
                     "properties": {
                       "key": {
-                        "description": "The key of the secret to select from.  Must be a valid secret key.",
                         "type": "string"
                       },
                       "name": {
                         "default": "",
-                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                         "type": "string"
                       },
                       "optional": {
-                        "description": "Specify whether the Secret or its key must be defined",
                         "type": "boolean"
                       }
                     },
@@ -385,25 +405,19 @@
           "type": "array"
         },
         "tlsConfig": {
-          "description": "TLSConfig defines tls configuration for the backend connection",
           "properties": {
             "ca": {
-              "description": "Struct containing the CA cert to use for the targets.",
               "properties": {
                 "configMap": {
-                  "description": "ConfigMap containing data to use for the targets.",
                   "properties": {
                     "key": {
-                      "description": "The key to select.",
                       "type": "string"
                     },
                     "name": {
                       "default": "",
-                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                       "type": "string"
                     },
                     "optional": {
-                      "description": "Specify whether the ConfigMap or its key must be defined",
                       "type": "boolean"
                     }
                   },
@@ -415,19 +429,15 @@
                   "additionalProperties": false
                 },
                 "secret": {
-                  "description": "Secret containing data to use for the targets.",
                   "properties": {
                     "key": {
-                      "description": "The key of the secret to select from.  Must be a valid secret key.",
                       "type": "string"
                     },
                     "name": {
                       "default": "",
-                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                       "type": "string"
                     },
                     "optional": {
-                      "description": "Specify whether the Secret or its key must be defined",
                       "type": "boolean"
                     }
                   },
@@ -443,26 +453,20 @@
               "additionalProperties": false
             },
             "caFile": {
-              "description": "Path to the CA cert in the container to use for the targets.",
               "type": "string"
             },
             "cert": {
-              "description": "Struct containing the client cert file for the targets.",
               "properties": {
                 "configMap": {
-                  "description": "ConfigMap containing data to use for the targets.",
                   "properties": {
                     "key": {
-                      "description": "The key to select.",
                       "type": "string"
                     },
                     "name": {
                       "default": "",
-                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                       "type": "string"
                     },
                     "optional": {
-                      "description": "Specify whether the ConfigMap or its key must be defined",
                       "type": "boolean"
                     }
                   },
@@ -474,19 +478,15 @@
                   "additionalProperties": false
                 },
                 "secret": {
-                  "description": "Secret containing data to use for the targets.",
                   "properties": {
                     "key": {
-                      "description": "The key of the secret to select from.  Must be a valid secret key.",
                       "type": "string"
                     },
                     "name": {
                       "default": "",
-                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                       "type": "string"
                     },
                     "optional": {
-                      "description": "Specify whether the Secret or its key must be defined",
                       "type": "boolean"
                     }
                   },
@@ -502,31 +502,24 @@
               "additionalProperties": false
             },
             "certFile": {
-              "description": "Path to the client cert file in the container for the targets.",
               "type": "string"
             },
             "insecureSkipVerify": {
-              "description": "Disable target certificate validation.",
               "type": "boolean"
             },
             "keyFile": {
-              "description": "Path to the client key file in the container for the targets.",
               "type": "string"
             },
             "keySecret": {
-              "description": "Secret containing the client key file for the targets.",
               "properties": {
                 "key": {
-                  "description": "The key of the secret to select from.  Must be a valid secret key.",
                   "type": "string"
                 },
                 "name": {
                   "default": "",
-                  "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                   "type": "string"
                 },
                 "optional": {
-                  "description": "Specify whether the Secret or its key must be defined",
                   "type": "boolean"
                 }
               },
@@ -538,7 +531,6 @@
               "additionalProperties": false
             },
             "serverName": {
-              "description": "Used to verify the hostname for the targets.",
               "type": "string"
             }
           },
@@ -546,19 +538,15 @@
           "additionalProperties": false
         },
         "tokenRef": {
-          "description": "TokenRef allows fetching token from user-created secrets by its name and key.",
           "properties": {
             "key": {
-              "description": "The key of the secret to select from.  Must be a valid secret key.",
               "type": "string"
             },
             "name": {
               "default": "",
-              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
               "type": "string"
             },
             "optional": {
-              "description": "Specify whether the Secret or its key must be defined",
               "type": "boolean"
             }
           },
@@ -570,7 +558,6 @@
           "additionalProperties": false
         },
         "username": {
-          "description": "UserName basic auth user name for accessing protected endpoint,\nwill be replaced with metadata.name of VMUser if omitted.",
           "type": "string"
         }
       },
@@ -581,42 +568,33 @@
       "additionalProperties": false
     },
     "status": {
-      "description": "VMUserStatus defines the observed state of VMUser",
       "properties": {
         "conditions": {
-          "description": "Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"",
           "items": {
-            "description": "Condition defines status condition of the resource",
             "properties": {
               "lastTransitionTime": {
-                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.",
                 "format": "date-time",
                 "type": "string"
               },
               "lastUpdateTime": {
-                "description": "LastUpdateTime is the last time of given type update.\nThis value is used for status TTL update and removal",
                 "format": "date-time",
                 "type": "string"
               },
               "message": {
-                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
                 "maxLength": 32768,
                 "type": "string"
               },
               "observedGeneration": {
-                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
                 "format": "int64",
                 "minimum": 0,
                 "type": "integer"
               },
               "reason": {
-                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
                 "maxLength": 1024,
                 "minLength": 1,
                 "type": "string"
               },
               "status": {
-                "description": "status of the condition, one of True, False, Unknown.",
                 "enum": [
                   "True",
                   "False",
@@ -625,7 +603,6 @@
                 "type": "string"
               },
               "type": {
-                "description": "Type of condition in CamelCase or in name.namespace.resource.victoriametrics.com/CamelCase.",
                 "maxLength": 316,
                 "type": "string"
               }
@@ -647,16 +624,13 @@
           "x-kubernetes-list-type": "map"
         },
         "observedGeneration": {
-          "description": "ObservedGeneration defines current generation picked by operator for the\nreconcile",
           "format": "int64",
           "type": "integer"
         },
         "reason": {
-          "description": "Reason defines human readable error reason",
           "type": "string"
         },
         "updateStatus": {
-          "description": "UpdateStatus defines a status for update rollout",
           "type": "string"
         }
       },

--- a/operator.victoriametrics.com/vtsingle_v1.json
+++ b/operator.victoriametrics.com/vtsingle_v1.json
@@ -1,36 +1,31 @@
 {
-  "description": "VTSingle is fast, cost-effective and scalable traces database.\nVTSingle is the Schema for the API",
   "properties": {
     "apiVersion": {
-      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
       "type": "string"
     },
     "kind": {
-      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
       "type": "string"
     },
     "metadata": {
       "type": "object"
     },
     "spec": {
-      "description": "VTSingleSpec defines the desired state of VTSingle",
       "properties": {
         "affinity": {
-          "description": "Affinity If specified, the pod's scheduling constraints.",
           "type": "object",
           "x-kubernetes-preserve-unknown-fields": true
         },
+        "componentVersion": {
+          "type": "string"
+        },
         "configMaps": {
-          "description": "ConfigMaps is a list of ConfigMaps in the same namespace as the Application\nobject, which shall be mounted into the Application container\nat /etc/vm/configs/CONFIGMAP_NAME folder",
           "items": {
             "type": "string"
           },
           "type": "array"
         },
         "containers": {
-          "description": "Containers property allows to inject additions sidecars or to patch existing containers.\nIt can be useful for proxies, backup, etc.",
           "items": {
-            "description": "A single application container that you want to run within a pod.",
             "required": [
               "name"
             ],
@@ -40,21 +35,17 @@
           "type": "array"
         },
         "disableAutomountServiceAccountToken": {
-          "description": "DisableAutomountServiceAccountToken whether to disable serviceAccount auto mount by Kubernetes (available from v0.54.0).\nOperator will conditionally create volumes and volumeMounts for containers if it requires k8s API access.\nFor example, vmagent and vm-config-reloader requires k8s API access.\nOperator creates volumes with name: \"kube-api-access\", which can be used as volumeMount for extraContainers if needed.\nAnd also adds VolumeMounts at /var/run/secrets/kubernetes.io/serviceaccount.",
           "type": "boolean"
         },
         "disableSelfServiceScrape": {
-          "description": "DisableSelfServiceScrape controls creation of VMServiceScrape by operator\nfor the application.\nHas priority over `VM_DISABLESELFSERVICESCRAPECREATION` operator env variable",
           "type": "boolean"
         },
         "dnsConfig": {
-          "description": "Specifies the DNS parameters of a pod.\nParameters specified here will be merged to the generated DNS\nconfiguration based on DNSPolicy.",
           "items": {
             "x-kubernetes-preserve-unknown-fields": true
           },
           "properties": {
             "nameservers": {
-              "description": "A list of DNS name server IP addresses.\nThis will be appended to the base nameservers generated from DNSPolicy.\nDuplicated nameservers will be removed.",
               "items": {
                 "type": "string"
               },
@@ -62,16 +53,12 @@
               "x-kubernetes-list-type": "atomic"
             },
             "options": {
-              "description": "A list of DNS resolver options.\nThis will be merged with the base options generated from DNSPolicy.\nDuplicated entries will be removed. Resolution options given in Options\nwill override those that appear in the base DNSPolicy.",
               "items": {
-                "description": "PodDNSConfigOption defines DNS resolver options of a pod.",
                 "properties": {
                   "name": {
-                    "description": "Name is this DNS resolver option's name.\nRequired.",
                     "type": "string"
                   },
                   "value": {
-                    "description": "Value is this DNS resolver option's value.",
                     "type": "string"
                   }
                 },
@@ -82,7 +69,6 @@
               "x-kubernetes-list-type": "atomic"
             },
             "searches": {
-              "description": "A list of DNS search domains for host-name lookup.\nThis will be appended to the base search paths generated from DNSPolicy.\nDuplicated search paths will be removed.",
               "items": {
                 "type": "string"
               },
@@ -94,27 +80,21 @@
           "additionalProperties": false
         },
         "dnsPolicy": {
-          "description": "DNSPolicy sets DNS policy for the pod",
           "type": "string"
         },
         "extraArgs": {
           "additionalProperties": {
             "type": "string"
           },
-          "description": "ExtraArgs that will be passed to the application container\nfor example remoteWrite.tmpDataPath: /tmp",
           "type": "object"
         },
         "extraEnvs": {
-          "description": "ExtraEnvs that will be passed to the application container",
           "items": {
-            "description": "EnvVar represents an environment variable present in a Container.",
             "properties": {
               "name": {
-                "description": "Name of the environment variable.\nMay consist of any printable ASCII characters except '='.",
                 "type": "string"
               },
               "value": {
-                "description": "Variable references $(VAR_NAME) are expanded\nusing the previously defined environment variables in the container and\nany service environment variables. If a variable cannot be resolved,\nthe reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.\n\"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\".\nEscaped references will never be expanded, regardless of whether the variable\nexists or not.\nDefaults to \"\".",
                 "type": "string"
               }
             },
@@ -128,20 +108,15 @@
           "type": "array"
         },
         "extraEnvsFrom": {
-          "description": "ExtraEnvsFrom defines source of env variables for the application container\ncould either be secret or configmap",
           "items": {
-            "description": "EnvFromSource represents the source of a set of ConfigMaps or Secrets",
             "properties": {
               "configMapRef": {
-                "description": "The ConfigMap to select from",
                 "properties": {
                   "name": {
                     "default": "",
-                    "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                     "type": "string"
                   },
                   "optional": {
-                    "description": "Specify whether the ConfigMap must be defined",
                     "type": "boolean"
                   }
                 },
@@ -150,19 +125,15 @@
                 "additionalProperties": false
               },
               "prefix": {
-                "description": "Optional text to prepend to the name of each environment variable.\nMay consist of any printable ASCII characters except '='.",
                 "type": "string"
               },
               "secretRef": {
-                "description": "The Secret to select from",
                 "properties": {
                   "name": {
                     "default": "",
-                    "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                     "type": "string"
                   },
                   "optional": {
-                    "description": "Specify whether the Secret must be defined",
                     "type": "boolean"
                   }
                 },
@@ -177,17 +148,13 @@
           "type": "array"
         },
         "futureRetention": {
-          "description": "FutureRetention for the stored traces\nLog entries with timestamps bigger than now+futureRetention are rejected during data ingestion;\nsee https://docs.victoriametrics.com/victoriatraces/#configure-and-run-victoriatraces",
           "pattern": "^[0-9]+(h|d|y)?$",
           "type": "string"
         },
         "host_aliases": {
-          "description": "HostAliasesUnderScore provides mapping for ip and hostname,\nthat would be propagated to pod,\ncannot be used with HostNetwork.\nHas Priority over hostAliases field",
           "items": {
-            "description": "HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the\npod's hosts file.",
             "properties": {
               "hostnames": {
-                "description": "Hostnames for the above IP address.",
                 "items": {
                   "type": "string"
                 },
@@ -195,7 +162,6 @@
                 "x-kubernetes-list-type": "atomic"
               },
               "ip": {
-                "description": "IP address of the host file entry.",
                 "type": "string"
               }
             },
@@ -208,12 +174,9 @@
           "type": "array"
         },
         "hostAliases": {
-          "description": "HostAliases provides mapping for ip and hostname,\nthat would be propagated to pod,\ncannot be used with HostNetwork.",
           "items": {
-            "description": "HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the\npod's hosts file.",
             "properties": {
               "hostnames": {
-                "description": "Hostnames for the above IP address.",
                 "items": {
                   "type": "string"
                 },
@@ -221,7 +184,6 @@
                 "x-kubernetes-list-type": "atomic"
               },
               "ip": {
-                "description": "IP address of the host file entry.",
                 "type": "string"
               }
             },
@@ -234,22 +196,17 @@
           "type": "array"
         },
         "hostNetwork": {
-          "description": "HostNetwork controls whether the pod may use the node network namespace",
           "type": "boolean"
         },
         "image": {
-          "description": "Image - docker image settings\nif no specified operator uses default version from operator config",
           "properties": {
             "pullPolicy": {
-              "description": "PullPolicy describes how to pull docker image",
               "type": "string"
             },
             "repository": {
-              "description": "Repository contains name of docker image + it's repository if needed",
               "type": "string"
             },
             "tag": {
-              "description": "Tag contains desired docker image version",
               "type": "string"
             }
           },
@@ -257,13 +214,10 @@
           "additionalProperties": false
         },
         "imagePullSecrets": {
-          "description": "ImagePullSecrets An optional list of references to secrets in the same namespace\nto use for pulling images from registries\nsee https://kubernetes.io/docs/concepts/containers/images/#referring-to-an-imagepullsecrets-on-a-pod",
           "items": {
-            "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
             "properties": {
               "name": {
                 "default": "",
-                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                 "type": "string"
               }
             },
@@ -274,9 +228,7 @@
           "type": "array"
         },
         "initContainers": {
-          "description": "InitContainers allows adding initContainers to the pod definition.\nAny errors during the execution of an initContainer will lead to a restart of the Pod.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/",
           "items": {
-            "description": "A single application container that you want to run within a pod.",
             "required": [
               "name"
             ],
@@ -286,12 +238,10 @@
           "type": "array"
         },
         "livenessProbe": {
-          "description": "LivenessProbe that will be added CRD pod",
           "type": "object",
           "x-kubernetes-preserve-unknown-fields": true
         },
         "logFormat": {
-          "description": "LogFormat for VTSingle to be configured with.",
           "enum": [
             "default",
             "json"
@@ -299,11 +249,9 @@
           "type": "string"
         },
         "logIngestedRows": {
-          "description": "Whether to log all the ingested log entries; this can be useful for debugging of data ingestion;\nsee https://docs.victoriametrics.com/victoriatraces/#configure-and-run-victoriatraces",
           "type": "boolean"
         },
         "logLevel": {
-          "description": "LogLevel for VictoriaTraces to be configured with.",
           "enum": [
             "INFO",
             "WARN",
@@ -314,24 +262,20 @@
           "type": "string"
         },
         "logNewStreams": {
-          "description": "LogNewStreams Whether to log creation of new streams; this can be useful for debugging of high cardinality issues with log streams;\nsee https://docs.victoriametrics.com/victoriatraces/#configure-and-run-victoriatraces",
           "type": "boolean"
         },
         "managedMetadata": {
-          "description": "ManagedMetadata defines metadata that will be added to the all objects\ncreated by operator for the given CustomResource",
           "properties": {
             "annotations": {
               "additionalProperties": {
                 "type": "string"
               },
-              "description": "Annotations is an unstructured key value map stored with a resource that may be\nset by external tools to store and retrieve arbitrary metadata. They are not\nqueryable and should be preserved when modifying objects.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations",
               "type": "object"
             },
             "labels": {
               "additionalProperties": {
                 "type": "string"
               },
-              "description": "Labels Map of string keys and values that can be used to organize and categorize\n(scope and select) objects.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels",
               "type": "object"
             }
           },
@@ -339,7 +283,6 @@
           "additionalProperties": false
         },
         "minReadySeconds": {
-          "description": "MinReadySeconds defines a minimum number of seconds to wait before starting update next pod\nif previous in healthy state\nHas no effect for VLogs and VMSingle",
           "format": "int32",
           "type": "integer"
         },
@@ -347,32 +290,26 @@
           "additionalProperties": {
             "type": "string"
           },
-          "description": "NodeSelector Define which Nodes the Pods are scheduled on.",
           "type": "object"
         },
         "paused": {
-          "description": "Paused If set to true all actions on the underlying managed objects are not\ngoing to be performed, except for delete actions.",
           "type": "boolean"
         },
         "podMetadata": {
-          "description": "PodMetadata configures Labels and Annotations which are propagated to the VTSingle pods.",
           "properties": {
             "annotations": {
               "additionalProperties": {
                 "type": "string"
               },
-              "description": "Annotations is an unstructured key value map stored with a resource that may be\nset by external tools to store and retrieve arbitrary metadata. They are not\nqueryable and should be preserved when modifying objects.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations",
               "type": "object"
             },
             "labels": {
               "additionalProperties": {
                 "type": "string"
               },
-              "description": "Labels Map of string keys and values that can be used to organize and categorize\n(scope and select) objects. May match selectors of replication controllers\nand services.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels",
               "type": "object"
             },
             "name": {
-              "description": "Name must be unique within a namespace. Is required when creating resources, although\nsome resources may allow a client to request the generation of an appropriate name\nautomatically. Name is primarily intended for creation idempotence and configuration\ndefinition.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names",
               "type": "string"
             }
           },
@@ -380,20 +317,15 @@
           "additionalProperties": false
         },
         "port": {
-          "description": "Port listen address",
           "type": "string"
         },
         "priorityClassName": {
-          "description": "PriorityClassName class assigned to the Pods",
           "type": "string"
         },
         "readinessGates": {
-          "description": "ReadinessGates defines pod readiness gates",
           "items": {
-            "description": "PodReadinessGate contains the reference to a pod condition",
             "properties": {
               "conditionType": {
-                "description": "ConditionType refers to a condition in the pod's condition list with matching type.",
                 "type": "string"
               }
             },
@@ -406,29 +338,22 @@
           "type": "array"
         },
         "readinessProbe": {
-          "description": "ReadinessProbe that will be added CRD pod",
           "type": "object",
           "x-kubernetes-preserve-unknown-fields": true
         },
         "replicaCount": {
-          "description": "ReplicaCount is the expected size of the Application.",
           "format": "int32",
           "type": "integer"
         },
         "resources": {
-          "description": "Resources container resource request and limits, https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/\nif not defined default resources from operator config will be used",
           "properties": {
             "claims": {
-              "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis field depends on the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
               "items": {
-                "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
                 "properties": {
                   "name": {
-                    "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
                     "type": "string"
                   },
                   "request": {
-                    "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
                     "type": "string"
                   }
                 },
@@ -457,7 +382,6 @@
                 "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                 "x-kubernetes-int-or-string": true
               },
-              "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
               "type": "object"
             },
             "requests": {
@@ -473,7 +397,6 @@
                 "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                 "x-kubernetes-int-or-string": true
               },
-              "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
               "type": "object"
             }
           },
@@ -481,45 +404,36 @@
           "additionalProperties": false
         },
         "retentionMaxDiskSpaceUsageBytes": {
-          "description": "RetentionMaxDiskSpaceUsageBytes for the stored traces\nVictoriaTraces keeps at least two last days of data in order to guarantee that the traces for the last day can be returned in queries.\nThis means that the total disk space usage may exceed the -retention.maxDiskSpaceUsageBytes,\nif the size of the last two days of data exceeds the -retention.maxDiskSpaceUsageBytes.\nhttps://docs.victoriametrics.com/victoriatraces/#configure-and-run-victoriatraces",
           "type": "string"
         },
         "retentionPeriod": {
-          "description": "RetentionPeriod for the stored traces\nhttps://docs.victoriametrics.com/victoriatraces/#configure-and-run-victoriatraces",
           "pattern": "^[0-9]+(h|d|w|y)?$",
           "type": "string"
         },
         "revisionHistoryLimitCount": {
-          "description": "The number of old ReplicaSets to retain to allow rollback in deployment or\nmaximum number of revisions that will be maintained in the Deployment revision history.\nHas no effect at StatefulSets\nDefaults to 10.",
           "format": "int32",
           "type": "integer"
         },
         "runtimeClassName": {
-          "description": "RuntimeClassName - defines runtime class for kubernetes pod.\nhttps://kubernetes.io/docs/concepts/containers/runtime-class/",
           "type": "string"
         },
         "schedulerName": {
-          "description": "SchedulerName - defines kubernetes scheduler name",
           "type": "string"
         },
         "secrets": {
-          "description": "Secrets is a list of Secrets in the same namespace as the Application\nobject, which shall be mounted into the Application container\nat /etc/vm/secrets/SECRET_NAME folder",
           "items": {
             "type": "string"
           },
           "type": "array"
         },
         "securityContext": {
-          "description": "SecurityContext holds pod-level security attributes and common container settings.\nThis defaults to the default PodSecurityContext.",
           "type": "object",
           "x-kubernetes-preserve-unknown-fields": true
         },
         "serviceAccountName": {
-          "description": "ServiceAccountName is the name of the ServiceAccount to use to run the pods",
           "type": "string"
         },
         "serviceScrapeSpec": {
-          "description": "ServiceScrapeSpec that will be added to vtsingle VMServiceScrape spec",
           "required": [
             "endpoints"
           ],
@@ -527,27 +441,22 @@
           "x-kubernetes-preserve-unknown-fields": true
         },
         "serviceSpec": {
-          "description": "ServiceSpec that will be added to vtsingle service spec",
           "properties": {
             "metadata": {
-              "description": "EmbeddedObjectMetadata defines objectMeta for additional service.",
               "properties": {
                 "annotations": {
                   "additionalProperties": {
                     "type": "string"
                   },
-                  "description": "Annotations is an unstructured key value map stored with a resource that may be\nset by external tools to store and retrieve arbitrary metadata. They are not\nqueryable and should be preserved when modifying objects.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations",
                   "type": "object"
                 },
                 "labels": {
                   "additionalProperties": {
                     "type": "string"
                   },
-                  "description": "Labels Map of string keys and values that can be used to organize and categorize\n(scope and select) objects. May match selectors of replication controllers\nand services.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels",
                   "type": "object"
                 },
                 "name": {
-                  "description": "Name must be unique within a namespace. Is required when creating resources, although\nsome resources may allow a client to request the generation of an appropriate name\nautomatically. Name is primarily intended for creation idempotence and configuration\ndefinition.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names",
                   "type": "string"
                 }
               },
@@ -555,12 +464,10 @@
               "additionalProperties": false
             },
             "spec": {
-              "description": "ServiceSpec describes the attributes that a user creates on a service.\nMore info: https://kubernetes.io/docs/concepts/services-networking/service/",
               "type": "object",
               "x-kubernetes-preserve-unknown-fields": true
             },
             "useAsDefault": {
-              "description": "UseAsDefault applies changes from given service definition to the main object Service\nChanging from headless service to clusterIP or loadbalancer may break cross-component communication",
               "type": "boolean"
             }
           },
@@ -571,15 +478,12 @@
           "additionalProperties": false
         },
         "startupProbe": {
-          "description": "StartupProbe that will be added to CRD pod",
           "type": "object",
           "x-kubernetes-preserve-unknown-fields": true
         },
         "storage": {
-          "description": "Storage is the definition of how storage will be used by the VTSingle\nby default it`s empty dir",
           "properties": {
             "accessModes": {
-              "description": "accessModes contains the desired access modes the volume should have.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1",
               "items": {
                 "type": "string"
               },
@@ -587,18 +491,14 @@
               "x-kubernetes-list-type": "atomic"
             },
             "dataSource": {
-              "description": "dataSource field can be used to specify either:\n* An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)\n* An existing PVC (PersistentVolumeClaim)\nIf the provisioner or an external controller can support the specified data source,\nit will create a new volume based on the contents of the specified data source.\nWhen the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,\nand dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.\nIf the namespace is specified, then dataSourceRef will not be copied to dataSource.",
               "properties": {
                 "apiGroup": {
-                  "description": "APIGroup is the group for the resource being referenced.\nIf APIGroup is not specified, the specified Kind must be in the core API group.\nFor any other third-party types, APIGroup is required.",
                   "type": "string"
                 },
                 "kind": {
-                  "description": "Kind is the type of resource being referenced",
                   "type": "string"
                 },
                 "name": {
-                  "description": "Name is the name of resource being referenced",
                   "type": "string"
                 }
               },
@@ -611,22 +511,17 @@
               "additionalProperties": false
             },
             "dataSourceRef": {
-              "description": "dataSourceRef specifies the object from which to populate the volume with data, if a non-empty\nvolume is desired. This may be any object from a non-empty API group (non\ncore object) or a PersistentVolumeClaim object.\nWhen this field is specified, volume binding will only succeed if the type of\nthe specified object matches some installed volume populator or dynamic\nprovisioner.\nThis field will replace the functionality of the dataSource field and as such\nif both fields are non-empty, they must have the same value. For backwards\ncompatibility, when namespace isn't specified in dataSourceRef,\nboth fields (dataSource and dataSourceRef) will be set to the same\nvalue automatically if one of them is empty and the other is non-empty.\nWhen namespace is specified in dataSourceRef,\ndataSource isn't set to the same value and must be empty.\nThere are three important differences between dataSource and dataSourceRef:\n* While dataSource only allows two specific types of objects, dataSourceRef\n  allows any non-core object, as well as PersistentVolumeClaim objects.\n* While dataSource ignores disallowed values (dropping them), dataSourceRef\n  preserves all values, and generates an error if a disallowed value is\n  specified.\n* While dataSource only allows local objects, dataSourceRef allows objects\n  in any namespaces.\n(Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.\n(Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.",
               "properties": {
                 "apiGroup": {
-                  "description": "APIGroup is the group for the resource being referenced.\nIf APIGroup is not specified, the specified Kind must be in the core API group.\nFor any other third-party types, APIGroup is required.",
                   "type": "string"
                 },
                 "kind": {
-                  "description": "Kind is the type of resource being referenced",
                   "type": "string"
                 },
                 "name": {
-                  "description": "Name is the name of resource being referenced",
                   "type": "string"
                 },
                 "namespace": {
-                  "description": "Namespace is the namespace of resource being referenced\nNote that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.\n(Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.",
                   "type": "string"
                 }
               },
@@ -638,7 +533,6 @@
               "additionalProperties": false
             },
             "resources": {
-              "description": "resources represents the minimum resources the volume should have.\nIf RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements\nthat are lower than previous value but must still be higher than capacity recorded in the\nstatus field of the claim.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources",
               "properties": {
                 "limits": {
                   "additionalProperties": {
@@ -653,7 +547,6 @@
                     "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                     "x-kubernetes-int-or-string": true
                   },
-                  "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
                   "type": "object"
                 },
                 "requests": {
@@ -669,7 +562,6 @@
                     "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                     "x-kubernetes-int-or-string": true
                   },
-                  "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
                   "type": "object"
                 }
               },
@@ -677,23 +569,17 @@
               "additionalProperties": false
             },
             "selector": {
-              "description": "selector is a label query over volumes to consider for binding.",
               "properties": {
                 "matchExpressions": {
-                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
                   "items": {
-                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
                     "properties": {
                       "key": {
-                        "description": "key is the label key that the selector applies to.",
                         "type": "string"
                       },
                       "operator": {
-                        "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
                         "type": "string"
                       },
                       "values": {
-                        "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
                         "items": {
                           "type": "string"
                         },
@@ -715,7 +601,6 @@
                   "additionalProperties": {
                     "type": "string"
                   },
-                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                   "type": "object"
                 }
               },
@@ -724,19 +609,15 @@
               "additionalProperties": false
             },
             "storageClassName": {
-              "description": "storageClassName is the name of the StorageClass required by the claim.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1",
               "type": "string"
             },
             "volumeAttributesClassName": {
-              "description": "volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.\nIf specified, the CSI driver will create or update the volume with the attributes defined\nin the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,\nit can be changed after the claim is created. An empty string or nil value indicates that no\nVolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,\nthis field can be reset to its previous value (including nil) to cancel the modification.\nIf the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be\nset to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource\nexists.\nMore info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/",
               "type": "string"
             },
             "volumeMode": {
-              "description": "volumeMode defines what type of volume is required by the claim.\nValue of Filesystem is implied when not included in claim spec.",
               "type": "string"
             },
             "volumeName": {
-              "description": "volumeName is the binding reference to the PersistentVolume backing this claim.",
               "type": "string"
             }
           },
@@ -744,28 +625,23 @@
           "additionalProperties": false
         },
         "storageDataPath": {
-          "description": "StorageDataPath disables spec.storage option and overrides arg for victoria-traces binary --storageDataPath,\nits users responsibility to mount proper device into given path.",
           "type": "string"
         },
         "storageMetadata": {
-          "description": "StorageMeta defines annotations and labels attached to PVC for given vtsingle CR",
           "properties": {
             "annotations": {
               "additionalProperties": {
                 "type": "string"
               },
-              "description": "Annotations is an unstructured key value map stored with a resource that may be\nset by external tools to store and retrieve arbitrary metadata. They are not\nqueryable and should be preserved when modifying objects.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations",
               "type": "object"
             },
             "labels": {
               "additionalProperties": {
                 "type": "string"
               },
-              "description": "Labels Map of string keys and values that can be used to organize and categorize\n(scope and select) objects. May match selectors of replication controllers\nand services.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels",
               "type": "object"
             },
             "name": {
-              "description": "Name must be unique within a namespace. Is required when creating resources, although\nsome resources may allow a client to request the generation of an appropriate name\nautomatically. Name is primarily intended for creation idempotence and configuration\ndefinition.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names",
               "type": "string"
             }
           },
@@ -773,34 +649,26 @@
           "additionalProperties": false
         },
         "terminationGracePeriodSeconds": {
-          "description": "TerminationGracePeriodSeconds period for container graceful termination",
           "format": "int64",
           "type": "integer"
         },
         "tolerations": {
-          "description": "Tolerations If specified, the pod's tolerations.",
           "items": {
-            "description": "The pod this Toleration is attached to tolerates any taint that matches\nthe triple <key,value,effect> using the matching operator <operator>.",
             "properties": {
               "effect": {
-                "description": "Effect indicates the taint effect to match. Empty means match all taint effects.\nWhen specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
                 "type": "string"
               },
               "key": {
-                "description": "Key is the taint key that the toleration applies to. Empty means match all taint keys.\nIf the key is empty, operator must be Exists; this combination means to match all values and all keys.",
                 "type": "string"
               },
               "operator": {
-                "description": "Operator represents a key's relationship to the value.\nValid operators are Exists and Equal. Defaults to Equal.\nExists is equivalent to wildcard for value, so that a pod can\ntolerate all taints of a particular category.",
                 "type": "string"
               },
               "tolerationSeconds": {
-                "description": "TolerationSeconds represents the period of time the toleration (which must be\nof effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,\nit is not set, which means tolerate the taint forever (do not evict). Zero and\nnegative values will be treated as 0 (evict immediately) by the system.",
                 "format": "int64",
                 "type": "integer"
               },
               "value": {
-                "description": "Value is the taint value the toleration matches to.\nIf the operator is Exists, the value should be empty, otherwise just a regular string.",
                 "type": "string"
               }
             },
@@ -810,9 +678,7 @@
           "type": "array"
         },
         "topologySpreadConstraints": {
-          "description": "TopologySpreadConstraints embedded kubernetes pod configuration option,\ncontrols how pods are spread across your cluster among failure-domains\nsuch as regions, zones, nodes, and other user-defined topology domains\nhttps://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/",
           "items": {
-            "description": "TopologySpreadConstraint specifies how to spread matching pods among the given topology.",
             "required": [
               "maxSkew",
               "topologyKey",
@@ -824,44 +690,33 @@
           "type": "array"
         },
         "useDefaultResources": {
-          "description": "UseDefaultResources controls resource settings\nBy default, operator sets built-in resource requirements",
           "type": "boolean"
         },
         "useStrictSecurity": {
-          "description": "UseStrictSecurity enables strict security mode for component\nit restricts disk writes access\nuses non-root user out of the box\ndrops not needed security permissions",
           "type": "boolean"
         },
         "volumeMounts": {
-          "description": "VolumeMounts allows configuration of additional VolumeMounts on the output Deployment/StatefulSet definition.\nVolumeMounts specified will be appended to other VolumeMounts in the Application container",
           "items": {
-            "description": "VolumeMount describes a mounting of a Volume within a container.",
             "properties": {
               "mountPath": {
-                "description": "Path within the container at which the volume should be mounted.  Must\nnot contain ':'.",
                 "type": "string"
               },
               "mountPropagation": {
-                "description": "mountPropagation determines how mounts are propagated from the host\nto container and the other way around.\nWhen not set, MountPropagationNone is used.\nThis field is beta in 1.10.\nWhen RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified\n(which defaults to None).",
                 "type": "string"
               },
               "name": {
-                "description": "This must match the Name of a Volume.",
                 "type": "string"
               },
               "readOnly": {
-                "description": "Mounted read-only if true, read-write otherwise (false or unspecified).\nDefaults to false.",
                 "type": "boolean"
               },
               "recursiveReadOnly": {
-                "description": "RecursiveReadOnly specifies whether read-only mounts should be handled\nrecursively.\n\nIf ReadOnly is false, this field has no meaning and must be unspecified.\n\nIf ReadOnly is true, and this field is set to Disabled, the mount is not made\nrecursively read-only.  If this field is set to IfPossible, the mount is made\nrecursively read-only, if it is supported by the container runtime.  If this\nfield is set to Enabled, the mount is made recursively read-only if it is\nsupported by the container runtime, otherwise the pod will not be started and\nan error will be generated to indicate the reason.\n\nIf this field is set to IfPossible or Enabled, MountPropagation must be set to\nNone (or be unspecified, which defaults to None).\n\nIf this field is not specified, it is treated as an equivalent of Disabled.",
                 "type": "string"
               },
               "subPath": {
-                "description": "Path within the volume from which the container's volume should be mounted.\nDefaults to \"\" (volume's root).",
                 "type": "string"
               },
               "subPathExpr": {
-                "description": "Expanded path within the volume from which the container's volume should be mounted.\nBehaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.\nDefaults to \"\" (volume's root).\nSubPathExpr and SubPath are mutually exclusive.",
                 "type": "string"
               }
             },
@@ -875,9 +730,7 @@
           "type": "array"
         },
         "volumes": {
-          "description": "Volumes allows configuration of additional volumes on the output Deployment/StatefulSet definition.\nVolumes specified will be appended to other volumes that are generated.\n/ +optional",
           "items": {
-            "description": "Volume represents a named volume in a pod that may be accessed by any container in the pod.",
             "required": [
               "name"
             ],
@@ -891,42 +744,33 @@
       "additionalProperties": false
     },
     "status": {
-      "description": "VTSingleStatus defines the observed state of VTSingle",
       "properties": {
         "conditions": {
-          "description": "Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"",
           "items": {
-            "description": "Condition defines status condition of the resource",
             "properties": {
               "lastTransitionTime": {
-                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.",
                 "format": "date-time",
                 "type": "string"
               },
               "lastUpdateTime": {
-                "description": "LastUpdateTime is the last time of given type update.\nThis value is used for status TTL update and removal",
                 "format": "date-time",
                 "type": "string"
               },
               "message": {
-                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
                 "maxLength": 32768,
                 "type": "string"
               },
               "observedGeneration": {
-                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
                 "format": "int64",
                 "minimum": 0,
                 "type": "integer"
               },
               "reason": {
-                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
                 "maxLength": 1024,
                 "minLength": 1,
                 "type": "string"
               },
               "status": {
-                "description": "status of the condition, one of True, False, Unknown.",
                 "enum": [
                   "True",
                   "False",
@@ -935,7 +779,6 @@
                 "type": "string"
               },
               "type": {
-                "description": "Type of condition in CamelCase or in name.namespace.resource.victoriametrics.com/CamelCase.",
                 "maxLength": 316,
                 "type": "string"
               }
@@ -956,17 +799,17 @@
           ],
           "x-kubernetes-list-type": "map"
         },
+        "lastAppliedSpec": {
+          "x-kubernetes-preserve-unknown-fields": true
+        },
         "observedGeneration": {
-          "description": "ObservedGeneration defines current generation picked by operator for the\nreconcile",
           "format": "int64",
           "type": "integer"
         },
         "reason": {
-          "description": "Reason defines human readable error reason",
           "type": "string"
         },
         "updateStatus": {
-          "description": "UpdateStatus defines a status for update rollout",
           "type": "string"
         }
       },


### PR DESCRIPTION
The schemas are changed based on the chart version v0.63.1 which installs the operator v0.70.1.

## PR Checklist

- [x] I generated these CRs using the [CRD Extractor tool](https://github.com/datreeio/CRDs-catalog?tab=readme-ov-file#crd-extractor). If I used a different method, I have described the method in this PR.
- [x] I am updating existing schemas and have specified the updated schema version.
- [ ] I am adding new schemas and included a link to the GitHub repository that contains the source of these schemas.
