### PR TITLE
feat(kyverno): upgrade to resource versions based on 3.8.1

### DIFF
--- a/kyverno.io/cleanuppolicy_v2.json
+++ b/kyverno.io/cleanuppolicy_v2.json
@@ -291,7 +291,7 @@
                         "type": "array"
                       },
                       "secrets": {
-                        "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets must live in the Kyverno namespace.",
+                        "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets can be specified as a name (Kyverno namespace) or namespace/name.\nimagePullSecrets from the resource namespace are also used.",
                         "items": {
                           "type": "string"
                         },

--- a/kyverno.io/cleanuppolicy_v2beta1.json
+++ b/kyverno.io/cleanuppolicy_v2beta1.json
@@ -291,7 +291,7 @@
                         "type": "array"
                       },
                       "secrets": {
-                        "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets must live in the Kyverno namespace.",
+                        "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets can be specified as a name (Kyverno namespace) or namespace/name.\nimagePullSecrets from the resource namespace are also used.",
                         "items": {
                           "type": "string"
                         },

--- a/kyverno.io/clustercleanuppolicy_v2.json
+++ b/kyverno.io/clustercleanuppolicy_v2.json
@@ -291,7 +291,7 @@
                         "type": "array"
                       },
                       "secrets": {
-                        "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets must live in the Kyverno namespace.",
+                        "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets can be specified as a name (Kyverno namespace) or namespace/name.\nimagePullSecrets from the resource namespace are also used.",
                         "items": {
                           "type": "string"
                         },

--- a/kyverno.io/clustercleanuppolicy_v2beta1.json
+++ b/kyverno.io/clustercleanuppolicy_v2beta1.json
@@ -291,7 +291,7 @@
                         "type": "array"
                       },
                       "secrets": {
-                        "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets must live in the Kyverno namespace.",
+                        "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets can be specified as a name (Kyverno namespace) or namespace/name.\nimagePullSecrets from the resource namespace are also used.",
                         "items": {
                           "type": "string"
                         },

--- a/kyverno.io/clusterpolicy_v1.json
+++ b/kyverno.io/clusterpolicy_v1.json
@@ -271,7 +271,7 @@
                               "type": "array"
                             },
                             "secrets": {
-                              "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets must live in the Kyverno namespace.",
+                              "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets can be specified as a name (Kyverno namespace) or namespace/name.\nimagePullSecrets from the resource namespace are also used.",
                               "items": {
                                 "type": "string"
                               },
@@ -1324,7 +1324,7 @@
                                         "type": "array"
                                       },
                                       "secrets": {
-                                        "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets must live in the Kyverno namespace.",
+                                        "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets can be specified as a name (Kyverno namespace) or namespace/name.\nimagePullSecrets from the resource namespace are also used.",
                                         "items": {
                                           "type": "string"
                                         },
@@ -2402,7 +2402,7 @@
                                         "type": "array"
                                       },
                                       "secrets": {
-                                        "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets must live in the Kyverno namespace.",
+                                        "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets can be specified as a name (Kyverno namespace) or namespace/name.\nimagePullSecrets from the resource namespace are also used.",
                                         "items": {
                                           "type": "string"
                                         },
@@ -2793,7 +2793,7 @@
                                         "type": "array"
                                       },
                                       "secrets": {
-                                        "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets must live in the Kyverno namespace.",
+                                        "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets can be specified as a name (Kyverno namespace) or namespace/name.\nimagePullSecrets from the resource namespace are also used.",
                                         "items": {
                                           "type": "string"
                                         },
@@ -3423,7 +3423,7 @@
                                         "type": "array"
                                       },
                                       "secrets": {
-                                        "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets must live in the Kyverno namespace.",
+                                        "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets can be specified as a name (Kyverno namespace) or namespace/name.\nimagePullSecrets from the resource namespace are also used.",
                                         "items": {
                                           "type": "string"
                                         },
@@ -4711,7 +4711,7 @@
                           "type": "array"
                         },
                         "secrets": {
-                          "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets must live in the Kyverno namespace.",
+                          "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets can be specified as a name (Kyverno namespace) or namespace/name.\nimagePullSecrets from the resource namespace are also used.",
                           "items": {
                             "type": "string"
                           },
@@ -5178,7 +5178,7 @@
                                   "type": "array"
                                 },
                                 "secrets": {
-                                  "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets must live in the Kyverno namespace.",
+                                  "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets can be specified as a name (Kyverno namespace) or namespace/name.\nimagePullSecrets from the resource namespace are also used.",
                                   "items": {
                                     "type": "string"
                                   },
@@ -6231,7 +6231,7 @@
                                             "type": "array"
                                           },
                                           "secrets": {
-                                            "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets must live in the Kyverno namespace.",
+                                            "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets can be specified as a name (Kyverno namespace) or namespace/name.\nimagePullSecrets from the resource namespace are also used.",
                                             "items": {
                                               "type": "string"
                                             },
@@ -7309,7 +7309,7 @@
                                             "type": "array"
                                           },
                                           "secrets": {
-                                            "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets must live in the Kyverno namespace.",
+                                            "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets can be specified as a name (Kyverno namespace) or namespace/name.\nimagePullSecrets from the resource namespace are also used.",
                                             "items": {
                                               "type": "string"
                                             },
@@ -7700,7 +7700,7 @@
                                             "type": "array"
                                           },
                                           "secrets": {
-                                            "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets must live in the Kyverno namespace.",
+                                            "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets can be specified as a name (Kyverno namespace) or namespace/name.\nimagePullSecrets from the resource namespace are also used.",
                                             "items": {
                                               "type": "string"
                                             },
@@ -8330,7 +8330,7 @@
                                             "type": "array"
                                           },
                                           "secrets": {
-                                            "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets must live in the Kyverno namespace.",
+                                            "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets can be specified as a name (Kyverno namespace) or namespace/name.\nimagePullSecrets from the resource namespace are also used.",
                                             "items": {
                                               "type": "string"
                                             },
@@ -9618,7 +9618,7 @@
                               "type": "array"
                             },
                             "secrets": {
-                              "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets must live in the Kyverno namespace.",
+                              "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets can be specified as a name (Kyverno namespace) or namespace/name.\nimagePullSecrets from the resource namespace are also used.",
                               "items": {
                                 "type": "string"
                               },

--- a/kyverno.io/clusterpolicy_v2beta1.json
+++ b/kyverno.io/clusterpolicy_v2beta1.json
@@ -271,7 +271,7 @@
                               "type": "array"
                             },
                             "secrets": {
-                              "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets must live in the Kyverno namespace.",
+                              "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets can be specified as a name (Kyverno namespace) or namespace/name.\nimagePullSecrets from the resource namespace are also used.",
                               "items": {
                                 "type": "string"
                               },
@@ -1125,7 +1125,7 @@
                                         "type": "array"
                                       },
                                       "secrets": {
-                                        "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets must live in the Kyverno namespace.",
+                                        "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets can be specified as a name (Kyverno namespace) or namespace/name.\nimagePullSecrets from the resource namespace are also used.",
                                         "items": {
                                           "type": "string"
                                         },
@@ -2004,7 +2004,7 @@
                                         "type": "array"
                                       },
                                       "secrets": {
-                                        "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets must live in the Kyverno namespace.",
+                                        "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets can be specified as a name (Kyverno namespace) or namespace/name.\nimagePullSecrets from the resource namespace are also used.",
                                         "items": {
                                           "type": "string"
                                         },
@@ -2395,7 +2395,7 @@
                                         "type": "array"
                                       },
                                       "secrets": {
-                                        "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets must live in the Kyverno namespace.",
+                                        "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets can be specified as a name (Kyverno namespace) or namespace/name.\nimagePullSecrets from the resource namespace are also used.",
                                         "items": {
                                           "type": "string"
                                         },
@@ -3187,7 +3187,7 @@
                                         "type": "array"
                                       },
                                       "secrets": {
-                                        "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets must live in the Kyverno namespace.",
+                                        "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets can be specified as a name (Kyverno namespace) or namespace/name.\nimagePullSecrets from the resource namespace are also used.",
                                         "items": {
                                           "type": "string"
                                         },
@@ -4453,7 +4453,7 @@
                           "type": "array"
                         },
                         "secrets": {
-                          "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets must live in the Kyverno namespace.",
+                          "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets can be specified as a name (Kyverno namespace) or namespace/name.\nimagePullSecrets from the resource namespace are also used.",
                           "items": {
                             "type": "string"
                           },
@@ -4904,7 +4904,7 @@
                                   "type": "array"
                                 },
                                 "secrets": {
-                                  "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets must live in the Kyverno namespace.",
+                                  "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets can be specified as a name (Kyverno namespace) or namespace/name.\nimagePullSecrets from the resource namespace are also used.",
                                   "items": {
                                     "type": "string"
                                   },
@@ -5957,7 +5957,7 @@
                                             "type": "array"
                                           },
                                           "secrets": {
-                                            "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets must live in the Kyverno namespace.",
+                                            "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets can be specified as a name (Kyverno namespace) or namespace/name.\nimagePullSecrets from the resource namespace are also used.",
                                             "items": {
                                               "type": "string"
                                             },
@@ -7035,7 +7035,7 @@
                                             "type": "array"
                                           },
                                           "secrets": {
-                                            "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets must live in the Kyverno namespace.",
+                                            "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets can be specified as a name (Kyverno namespace) or namespace/name.\nimagePullSecrets from the resource namespace are also used.",
                                             "items": {
                                               "type": "string"
                                             },
@@ -7426,7 +7426,7 @@
                                             "type": "array"
                                           },
                                           "secrets": {
-                                            "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets must live in the Kyverno namespace.",
+                                            "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets can be specified as a name (Kyverno namespace) or namespace/name.\nimagePullSecrets from the resource namespace are also used.",
                                             "items": {
                                               "type": "string"
                                             },
@@ -8056,7 +8056,7 @@
                                             "type": "array"
                                           },
                                           "secrets": {
-                                            "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets must live in the Kyverno namespace.",
+                                            "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets can be specified as a name (Kyverno namespace) or namespace/name.\nimagePullSecrets from the resource namespace are also used.",
                                             "items": {
                                               "type": "string"
                                             },
@@ -9344,7 +9344,7 @@
                               "type": "array"
                             },
                             "secrets": {
-                              "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets must live in the Kyverno namespace.",
+                              "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets can be specified as a name (Kyverno namespace) or namespace/name.\nimagePullSecrets from the resource namespace are also used.",
                               "items": {
                                 "type": "string"
                               },

--- a/kyverno.io/policy_v1.json
+++ b/kyverno.io/policy_v1.json
@@ -271,7 +271,7 @@
                               "type": "array"
                             },
                             "secrets": {
-                              "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets must live in the Kyverno namespace.",
+                              "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets can be specified as a name (Kyverno namespace) or namespace/name.\nimagePullSecrets from the resource namespace are also used.",
                               "items": {
                                 "type": "string"
                               },
@@ -1324,7 +1324,7 @@
                                         "type": "array"
                                       },
                                       "secrets": {
-                                        "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets must live in the Kyverno namespace.",
+                                        "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets can be specified as a name (Kyverno namespace) or namespace/name.\nimagePullSecrets from the resource namespace are also used.",
                                         "items": {
                                           "type": "string"
                                         },
@@ -2402,7 +2402,7 @@
                                         "type": "array"
                                       },
                                       "secrets": {
-                                        "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets must live in the Kyverno namespace.",
+                                        "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets can be specified as a name (Kyverno namespace) or namespace/name.\nimagePullSecrets from the resource namespace are also used.",
                                         "items": {
                                           "type": "string"
                                         },
@@ -2793,7 +2793,7 @@
                                         "type": "array"
                                       },
                                       "secrets": {
-                                        "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets must live in the Kyverno namespace.",
+                                        "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets can be specified as a name (Kyverno namespace) or namespace/name.\nimagePullSecrets from the resource namespace are also used.",
                                         "items": {
                                           "type": "string"
                                         },
@@ -3423,7 +3423,7 @@
                                         "type": "array"
                                       },
                                       "secrets": {
-                                        "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets must live in the Kyverno namespace.",
+                                        "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets can be specified as a name (Kyverno namespace) or namespace/name.\nimagePullSecrets from the resource namespace are also used.",
                                         "items": {
                                           "type": "string"
                                         },
@@ -4711,7 +4711,7 @@
                           "type": "array"
                         },
                         "secrets": {
-                          "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets must live in the Kyverno namespace.",
+                          "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets can be specified as a name (Kyverno namespace) or namespace/name.\nimagePullSecrets from the resource namespace are also used.",
                           "items": {
                             "type": "string"
                           },
@@ -5178,7 +5178,7 @@
                                   "type": "array"
                                 },
                                 "secrets": {
-                                  "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets must live in the Kyverno namespace.",
+                                  "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets can be specified as a name (Kyverno namespace) or namespace/name.\nimagePullSecrets from the resource namespace are also used.",
                                   "items": {
                                     "type": "string"
                                   },
@@ -6231,7 +6231,7 @@
                                             "type": "array"
                                           },
                                           "secrets": {
-                                            "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets must live in the Kyverno namespace.",
+                                            "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets can be specified as a name (Kyverno namespace) or namespace/name.\nimagePullSecrets from the resource namespace are also used.",
                                             "items": {
                                               "type": "string"
                                             },
@@ -7309,7 +7309,7 @@
                                             "type": "array"
                                           },
                                           "secrets": {
-                                            "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets must live in the Kyverno namespace.",
+                                            "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets can be specified as a name (Kyverno namespace) or namespace/name.\nimagePullSecrets from the resource namespace are also used.",
                                             "items": {
                                               "type": "string"
                                             },
@@ -7700,7 +7700,7 @@
                                             "type": "array"
                                           },
                                           "secrets": {
-                                            "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets must live in the Kyverno namespace.",
+                                            "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets can be specified as a name (Kyverno namespace) or namespace/name.\nimagePullSecrets from the resource namespace are also used.",
                                             "items": {
                                               "type": "string"
                                             },
@@ -8330,7 +8330,7 @@
                                             "type": "array"
                                           },
                                           "secrets": {
-                                            "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets must live in the Kyverno namespace.",
+                                            "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets can be specified as a name (Kyverno namespace) or namespace/name.\nimagePullSecrets from the resource namespace are also used.",
                                             "items": {
                                               "type": "string"
                                             },
@@ -9618,7 +9618,7 @@
                               "type": "array"
                             },
                             "secrets": {
-                              "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets must live in the Kyverno namespace.",
+                              "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets can be specified as a name (Kyverno namespace) or namespace/name.\nimagePullSecrets from the resource namespace are also used.",
                               "items": {
                                 "type": "string"
                               },

--- a/kyverno.io/policy_v2beta1.json
+++ b/kyverno.io/policy_v2beta1.json
@@ -271,7 +271,7 @@
                               "type": "array"
                             },
                             "secrets": {
-                              "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets must live in the Kyverno namespace.",
+                              "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets can be specified as a name (Kyverno namespace) or namespace/name.\nimagePullSecrets from the resource namespace are also used.",
                               "items": {
                                 "type": "string"
                               },
@@ -1125,7 +1125,7 @@
                                         "type": "array"
                                       },
                                       "secrets": {
-                                        "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets must live in the Kyverno namespace.",
+                                        "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets can be specified as a name (Kyverno namespace) or namespace/name.\nimagePullSecrets from the resource namespace are also used.",
                                         "items": {
                                           "type": "string"
                                         },
@@ -2004,7 +2004,7 @@
                                         "type": "array"
                                       },
                                       "secrets": {
-                                        "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets must live in the Kyverno namespace.",
+                                        "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets can be specified as a name (Kyverno namespace) or namespace/name.\nimagePullSecrets from the resource namespace are also used.",
                                         "items": {
                                           "type": "string"
                                         },
@@ -2395,7 +2395,7 @@
                                         "type": "array"
                                       },
                                       "secrets": {
-                                        "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets must live in the Kyverno namespace.",
+                                        "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets can be specified as a name (Kyverno namespace) or namespace/name.\nimagePullSecrets from the resource namespace are also used.",
                                         "items": {
                                           "type": "string"
                                         },
@@ -3187,7 +3187,7 @@
                                         "type": "array"
                                       },
                                       "secrets": {
-                                        "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets must live in the Kyverno namespace.",
+                                        "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets can be specified as a name (Kyverno namespace) or namespace/name.\nimagePullSecrets from the resource namespace are also used.",
                                         "items": {
                                           "type": "string"
                                         },
@@ -4453,7 +4453,7 @@
                           "type": "array"
                         },
                         "secrets": {
-                          "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets must live in the Kyverno namespace.",
+                          "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets can be specified as a name (Kyverno namespace) or namespace/name.\nimagePullSecrets from the resource namespace are also used.",
                           "items": {
                             "type": "string"
                           },
@@ -4904,7 +4904,7 @@
                                   "type": "array"
                                 },
                                 "secrets": {
-                                  "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets must live in the Kyverno namespace.",
+                                  "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets can be specified as a name (Kyverno namespace) or namespace/name.\nimagePullSecrets from the resource namespace are also used.",
                                   "items": {
                                     "type": "string"
                                   },
@@ -5957,7 +5957,7 @@
                                             "type": "array"
                                           },
                                           "secrets": {
-                                            "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets must live in the Kyverno namespace.",
+                                            "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets can be specified as a name (Kyverno namespace) or namespace/name.\nimagePullSecrets from the resource namespace are also used.",
                                             "items": {
                                               "type": "string"
                                             },
@@ -7035,7 +7035,7 @@
                                             "type": "array"
                                           },
                                           "secrets": {
-                                            "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets must live in the Kyverno namespace.",
+                                            "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets can be specified as a name (Kyverno namespace) or namespace/name.\nimagePullSecrets from the resource namespace are also used.",
                                             "items": {
                                               "type": "string"
                                             },
@@ -7426,7 +7426,7 @@
                                             "type": "array"
                                           },
                                           "secrets": {
-                                            "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets must live in the Kyverno namespace.",
+                                            "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets can be specified as a name (Kyverno namespace) or namespace/name.\nimagePullSecrets from the resource namespace are also used.",
                                             "items": {
                                               "type": "string"
                                             },
@@ -8056,7 +8056,7 @@
                                             "type": "array"
                                           },
                                           "secrets": {
-                                            "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets must live in the Kyverno namespace.",
+                                            "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets can be specified as a name (Kyverno namespace) or namespace/name.\nimagePullSecrets from the resource namespace are also used.",
                                             "items": {
                                               "type": "string"
                                             },
@@ -9344,7 +9344,7 @@
                               "type": "array"
                             },
                             "secrets": {
-                              "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets must live in the Kyverno namespace.",
+                              "description": "Secrets specifies a list of secrets that are provided for credentials.\nSecrets can be specified as a name (Kyverno namespace) or namespace/name.\nimagePullSecrets from the resource namespace are also used.",
                               "items": {
                                 "type": "string"
                               },


### PR DESCRIPTION
The schemas are changed based on the chart version v3.8.1 which installs the operator v1.18.1.

## PR Checklist

- [x] I generated these CRs using the [CRD Extractor tool](https://github.com/datreeio/CRDs-catalog?tab=readme-ov-file#crd-extractor). If I used a different method, I have described the method in this PR.
- [x] I am updating existing schemas and have specified the updated schema version.
- [ ] I am adding new schemas and included a link to the GitHub repository that contains the source of these schemas.
